### PR TITLE
feat(service): Add notion of `State`

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -307,8 +307,8 @@ fn queue_envelope(
         envelope.scope(scoping);
 
         match state.envelope_buffer() {
-            Some(buffer) => {
-                if !buffer.has_capacity() {
+            Some((buffer_state, buffer)) => {
+                if !buffer_state.has_capacity() {
                     return Err(BadStoreRequest::QueueFailed);
                 }
 
@@ -316,9 +316,7 @@ fn queue_envelope(
                 // envelope's projects. See `handle_check_envelope`.
                 relay_log::trace!("Pushing envelope to V2 buffer");
 
-                buffer
-                    .addr()
-                    .send(EnvelopeBuffer::Push(envelope.into_envelope()));
+                buffer.send(EnvelopeBuffer::Push(envelope.into_envelope()));
             }
             None => {
                 relay_log::trace!("Sending envelope to project cache for V1 buffer");

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::metrics::{MetricOutcomes, MetricStats};
-use crate::services::buffer::{self, EnvelopeBufferService, ObservableEnvelopeBuffer};
+use crate::services::buffer::{self, EnvelopeBufferPublicState, EnvelopeBufferService};
 use crate::services::cogs::{CogsService, CogsServiceRecorder};
 use crate::services::global_config::{GlobalConfigManager, GlobalConfigService};
 use crate::services::health_check::{HealthCheck, HealthCheckService};
@@ -64,7 +64,7 @@ pub struct Registry {
     pub global_config: Addr<GlobalConfigManager>,
     pub project_cache: Addr<ProjectCache>,
     pub upstream_relay: Addr<UpstreamRelay>,
-    pub envelope_buffer: Option<ObservableEnvelopeBuffer>,
+    pub envelope_buffer: Option<EnvelopeBufferPublicState>,
 }
 
 impl fmt::Debug for Registry {
@@ -270,7 +270,9 @@ impl ServiceState {
 
         // Keep all the services in one context.
         let project_cache_services = Services {
-            envelope_buffer: envelope_buffer.as_ref().map(ObservableEnvelopeBuffer::addr),
+            envelope_buffer: envelope_buffer
+                .as_ref()
+                .map(EnvelopeBufferPublicState::addr),
             aggregator: aggregator.clone(),
             envelope_processor: processor.clone(),
             outcome_aggregator: outcome_aggregator.clone(),
@@ -348,7 +350,7 @@ impl ServiceState {
     }
 
     /// Returns the V2 envelope buffer, if present.
-    pub fn envelope_buffer(&self) -> Option<&ObservableEnvelopeBuffer> {
+    pub fn envelope_buffer(&self) -> Option<&EnvelopeBufferPublicState> {
         self.inner.registry.envelope_buffer.as_ref()
     }
 

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -72,12 +72,8 @@ impl FromMessage<Self> for EnvelopeBuffer {
     }
 }
 
-/// Contains the services [`Addr`] and a watch channel to observe its state.
-///
-/// This allows outside observers to check the capacity without having to send a message.
-///
-// NOTE: This pattern of combining an Addr with some observable state could be generalized into
-// `Service` itself.
+/// Public state of the [`EnvelopeBufferService`] which allows to check if the service has capacity
+/// to accept new [`Envelope`]s.
 #[derive(Debug, Clone)]
 pub struct EnvelopeBufferState {
     has_capacity: Arc<AtomicBool>,

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 
 use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
+use relay_system::Shutdown;
 use relay_system::{
     Addr, FromMessage, Interface, NoResponse, Receiver, Service, ShutdownHandle, State,
 };
-use relay_system::{Controller, Shutdown};
 use tokio::sync::mpsc::Permit;
 use tokio::sync::{mpsc, watch};
 use tokio::time::{timeout, Instant};
@@ -79,18 +79,18 @@ impl FromMessage<Self> for EnvelopeBuffer {
 // NOTE: This pattern of combining an Addr with some observable state could be generalized into
 // `Service` itself.
 #[derive(Debug, Clone)]
-pub struct EnvelopeBufferPublicState {
+pub struct EnvelopeBufferState {
     has_capacity: Arc<AtomicBool>,
 }
 
-impl EnvelopeBufferPublicState {
+impl EnvelopeBufferState {
     /// Returns `true` if the buffer has the capacity to accept more elements.
     pub fn has_capacity(&self) -> bool {
         self.has_capacity.load(Ordering::Relaxed)
     }
 }
 
-impl State for EnvelopeBufferPublicState {}
+impl State for EnvelopeBufferState {}
 
 /// Services that the buffer service communicates with.
 #[derive(Clone)]
@@ -362,10 +362,10 @@ impl EnvelopeBufferService {
 impl Service for EnvelopeBufferService {
     type Interface = EnvelopeBuffer;
 
-    type PublicState = EnvelopeBufferPublicState;
+    type PublicState = EnvelopeBufferState;
 
     fn pre_spawn(&self) -> Self::PublicState {
-        EnvelopeBufferPublicState {
+        EnvelopeBufferState {
             has_capacity: self.has_capacity.clone(),
         }
     }

--- a/relay-server/src/services/cogs.rs
+++ b/relay-server/src/services/cogs.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use relay_cogs::{CogsMeasurement, CogsRecorder, ResourceId};
 use relay_config::Config;
-use relay_system::{Addr, FromMessage, Interface, Service};
+use relay_system::{Addr, FromMessage, Interface, Service, ShutdownHandle};
 
 use crate::statsd::RelayCounters;
 
@@ -54,7 +54,15 @@ impl CogsService {
 impl Service for CogsService {
     type Interface = CogsReport;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        mut self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 self.handle_report(message);

--- a/relay-server/src/services/health_check.rs
+++ b/relay-server/src/services/health_check.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use tokio::sync::watch;
 use tokio::time::{timeout, Instant};
 
-use crate::services::buffer::ObservableEnvelopeBuffer;
+use crate::services::buffer::EnvelopeBufferPublicState;
 use crate::services::metrics::RouterHandle;
 use crate::services::upstream::{IsAuthenticated, UpstreamRelay};
 use crate::statsd::RelayTimers;
@@ -86,7 +86,7 @@ pub struct HealthCheckService {
     memory_checker: MemoryChecker,
     aggregator: RouterHandle,
     upstream_relay: Addr<UpstreamRelay>,
-    envelope_buffer: Option<ObservableEnvelopeBuffer>, // make non-optional once V1 has been removed
+    envelope_buffer: Option<EnvelopeBufferPublicState>, // make non-optional once V1 has been removed
 }
 
 impl HealthCheckService {
@@ -98,7 +98,7 @@ impl HealthCheckService {
         memory_checker: MemoryChecker,
         aggregator: RouterHandle,
         upstream_relay: Addr<UpstreamRelay>,
-        envelope_buffer: Option<ObservableEnvelopeBuffer>,
+        envelope_buffer: Option<EnvelopeBufferPublicState>,
     ) -> Self {
         Self {
             config,

--- a/relay-server/src/services/outcome_aggregator.rs
+++ b/relay-server/src/services/outcome_aggregator.rs
@@ -9,7 +9,7 @@ use relay_common::time::UnixTimestamp;
 use relay_config::{Config, EmitOutcomes};
 use relay_quotas::{DataCategory, Scoping};
 use relay_statsd::metric;
-use relay_system::{Addr, Controller, Service, Shutdown};
+use relay_system::{Addr, Controller, Service, Shutdown, ShutdownHandle};
 
 use crate::services::outcome::{Outcome, OutcomeProducer, TrackOutcome};
 use crate::statsd::RelayTimers;
@@ -138,7 +138,15 @@ impl OutcomeAggregator {
 impl Service for OutcomeAggregator {
     type Interface = TrackOutcome;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        mut self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         tokio::spawn(async move {
             let mut shutdown = Controller::shutdown_handle();
             relay_log::info!("outcome aggregator started");

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -38,7 +38,7 @@ use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::config::RuleId;
 use relay_sampling::evaluation::{ReservoirCounters, ReservoirEvaluator, SamplingDecision};
 use relay_statsd::metric;
-use relay_system::{Addr, FromMessage, NoResponse, Service};
+use relay_system::{Addr, FromMessage, NoResponse, Service, ShutdownHandle};
 use reqwest::header;
 use smallvec::{smallvec, SmallVec};
 
@@ -2926,7 +2926,15 @@ impl EnvelopeProcessorService {
 impl Service for EnvelopeProcessorService {
     type Interface = EnvelopeProcessor;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         tokio::spawn(async move {
             while let Some(message) = rx.recv().await {
                 let service = self.clone();

--- a/relay-server/src/services/projects/source/local.rs
+++ b/relay-server/src/services/projects/source/local.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_config::Config;
-use relay_system::{AsyncResponse, FromMessage, Interface, Receiver, Sender, Service};
+use relay_system::{
+    AsyncResponse, FromMessage, Interface, Receiver, Sender, Service, ShutdownHandle,
+};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 
@@ -171,7 +173,11 @@ async fn spawn_poll_local_states(
 impl Service for LocalProjectSourceService {
     type Interface = LocalProjectSource;
 
-    fn spawn_handler(mut self, mut rx: Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(mut self, mut rx: Receiver<Self::Interface>, _shutdown: ShutdownHandle) {
         // Use a channel with size 1. If the channel is full because the consumer does not
         // collect the result, the producer will block, which is acceptable.
         let (state_tx, mut state_rx) = mpsc::channel(1);

--- a/relay-server/src/services/projects/source/mod.rs
+++ b/relay-server/src/services/projects/source/mod.rs
@@ -47,8 +47,8 @@ impl ProjectSource {
         upstream_relay: Addr<UpstreamRelay>,
         _redis: Option<RedisPool>,
     ) -> Self {
-        let local_source = LocalProjectSourceService::new(config.clone()).start();
-        let upstream_source =
+        let (_, local_source) = LocalProjectSourceService::new(config.clone()).start();
+        let (_, upstream_source) =
             UpstreamProjectSourceService::new(config.clone(), upstream_relay).start();
 
         #[cfg(feature = "processing")]

--- a/relay-server/src/services/relays.rs
+++ b/relay-server/src/services/relays.rs
@@ -7,6 +7,7 @@ use relay_auth::{PublicKey, RelayId};
 use relay_config::{Config, RelayInfo};
 use relay_system::{
     Addr, BroadcastChannel, BroadcastResponse, BroadcastSender, FromMessage, Interface, Service,
+    ShutdownHandle,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -334,7 +335,15 @@ impl RelayCacheService {
 impl Service for RelayCacheService {
     type Interface = RelayCache;
 
-    fn spawn_handler(mut self, mut rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        mut self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         tokio::spawn(async move {
             relay_log::info!("key cache started");
 

--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -10,7 +10,7 @@ use axum_server::accept::Accept;
 use axum_server::Handle;
 use hyper_util::rt::TokioTimer;
 use relay_config::Config;
-use relay_system::{Controller, Service, Shutdown};
+use relay_system::{Controller, Service, Shutdown, ShutdownHandle};
 use socket2::TcpKeepalive;
 use tokio::net::{TcpSocket, TcpStream};
 use tower::ServiceBuilder;
@@ -227,7 +227,15 @@ impl HttpServer {
 impl Service for HttpServer {
     type Interface = ();
 
-    fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        self,
+        _rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         let Self {
             config,
             service,

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -4,7 +4,7 @@ use relay_config::{Config, RelayMode};
 #[cfg(feature = "processing")]
 use relay_redis::{RedisPool, RedisPools};
 use relay_statsd::metric;
-use relay_system::{Addr, Service};
+use relay_system::{Addr, Service, ShutdownHandle};
 use tokio::time::interval;
 
 use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
@@ -136,7 +136,15 @@ impl RelayStats {
 impl Service for RelayStats {
     type Interface = ();
 
-    fn spawn_handler(self, _rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        self,
+        _rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         let Some(mut ticker) = self.config.metrics_periodic_interval().map(interval) else {
             return;
         };

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -22,7 +22,7 @@ use relay_metrics::{
 };
 use relay_quotas::Scoping;
 use relay_statsd::metric;
-use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
+use relay_system::{Addr, FromMessage, Interface, NoResponse, Service, ShutdownHandle};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use serde_json::Deserializer;
@@ -1044,7 +1044,15 @@ impl StoreService {
 impl Service for StoreService {
     type Interface = Store;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         let this = Arc::new(self);
 
         tokio::spawn(async move {

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -22,6 +22,7 @@ use relay_quotas::{
 };
 use relay_system::{
     AsyncResponse, FromMessage, Interface, MessageResponse, NoResponse, Sender, Service,
+    ShutdownHandle,
 };
 use reqwest::header;
 pub use reqwest::Method;
@@ -1498,7 +1499,15 @@ impl UpstreamRelayService {
 impl Service for UpstreamRelayService {
     type Interface = UpstreamRelay;
 
-    fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
+    type PublicState = ();
+
+    fn pre_spawn(&self) -> Self::PublicState {}
+
+    fn spawn_handler(
+        self,
+        mut rx: relay_system::Receiver<Self::Interface>,
+        _shutdown: ShutdownHandle,
+    ) {
         let Self { config } = self;
 
         let client = SharedClient::build(config.clone());

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -121,7 +121,7 @@ impl ShutdownHandle {
 /// ### Example
 ///
 /// ```
-/// use relay_system::{Controller, Service, Shutdown, ShutdownMode};
+/// use relay_system::{Controller, Service, Shutdown, ShutdownMode, ShutdownHandle};
 /// use std::time::Duration;
 ///
 /// struct MyService;
@@ -129,10 +129,13 @@ impl ShutdownHandle {
 /// impl Service for MyService {
 ///     type Interface = ();
 ///
-///     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>) {
-///         tokio::spawn(async move {
-///             let mut shutdown = Controller::shutdown_handle();
+///     type PublicState = ();
 ///
+///     fn pre_spawn(&self) -> Self::PublicState { }
+///
+///     fn spawn_handler(self, mut rx: relay_system::Receiver<Self::Interface>, mut shutdown: ShutdownHandle) {
+///         use relay_system::ShutdownHandle;
+/// tokio::spawn(async move {
 ///             loop {
 ///                 tokio::select! {
 ///                     shutdown = shutdown.notified() => break, // Handle shutdown here

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -943,6 +943,8 @@ impl State for () {}
 ///
 ///     type PublicState = ();
 ///
+///     fn pre_spawn(&self) -> Self::PublicState { }
+///
 ///     fn spawn_handler(self, mut rx: Receiver<Self::Interface>, shutdown: ShutdownHandle) {
 ///         tokio::spawn(async move {
 ///             while let Some(message) = rx.recv().await {

--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -1032,19 +1032,6 @@ pub trait Service: Sized {
     ///
     /// This method should be used only when the `start` method can't be used because of some
     /// cyclic dependencies between services.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// // This is not possible because of the cyclic reference.
-    /// let a_tx = A::new(b_tx).start();
-    /// let b_tx = B::new(a_tx).start();
-    ///
-    /// // This is possible with `start_with_receiver`.
-    /// let (b_tx, b_rx) = channel();
-    /// let a_tx = A::new(b_tx).start();
-    /// B::new(a_tx).start_with_receiver(b_rx);
-    /// ```
     fn start_with_receiver(self, rx: Receiver<Self::Interface>) -> Self::PublicState {
         let shutdown = Controller::shutdown_handle();
         let public_state = self.pre_spawn();


### PR DESCRIPTION
This PR introduces the idea of `PublicState` to our services, adding the notion of state to them. Such a state is constructed before the `spawn_handler` is called and returned with the `Addr` of the `Service`. This abstraction aims to unify how services expose state (both readable and writable, depending on the implementation).

In addition to the state, this PR adds:
* `shutdown` parameter in the `spawn_handler` to make it more ergonomic to subscribe to shutdown signals in a service loop.
* `channel()` method to create the `tx` and `rx` channels for service communication directly on the service itself.
* `start_with_receiver()` method to handle the case in which a service has to be started with an injected `rx` channel due to circular dependencies between services.

_This PR is just the first small step towards improving our `Service` framework._

Closes: https://github.com/getsentry/relay/issues/4180