### PR TITLE
instr(system): Tag idle time metric

### DIFF
--- a/relay-system/src/service.rs
+++ b/relay-system/src/service.rs
@@ -858,7 +858,8 @@ impl<I: Interface> Receiver<I> {
             }
         };
         relay_statsd::metric!(
-            counter(SystemCounters::ServiceIdleTime) += start.elapsed().as_nanos() as u64
+            counter(SystemCounters::ServiceIdleTime) += start.elapsed().as_nanos() as u64,
+            service = self.name
         );
         next_message
     }


### PR DESCRIPTION
I forgot to tag this metric. It is only useful per service.

#skip-changelog