### PR TITLE
fix(profiles): Rate limit profiles when transaction was sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Accept incoming requests even if there was an error fetching their project config. ([#4140](https://github.com/getsentry/relay/pull/4140))
+- Rate limit profiles when transaction was sampled. ([#4195](https://github.com/getsentry/relay/pull/4195))
 
 ## 24.11.1
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -680,11 +680,10 @@ where
 
             // Profiles can persist in envelopes without transaction if the transaction item
             // was dropped by dynamic sampling.
-            if profile_limits.is_empty() {
-                profile_limits.merge(self.check.apply(
-                    scoping.item(DataCategory::Transaction),
-                    summary.profile_quantity,
-                )?);
+            if profile_limits.is_empty() && summary.event_category.is_none() {
+                profile_limits = self
+                    .check
+                    .apply(scoping.item(DataCategory::Transaction), 0)?;
             }
 
             enforcement.profiles = CategoryLimit::new(
@@ -1447,7 +1446,7 @@ mod tests {
 
         assert!(enforcement.profiles.is_active());
         mock.assert_call(DataCategory::Profile, 1);
-        mock.assert_call(DataCategory::Transaction, 1);
+        mock.assert_call(DataCategory::Transaction, 0);
 
         assert_eq!(
             get_outcomes(enforcement),

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1428,6 +1428,28 @@ mod tests {
     }
 
     #[test]
+    fn test_enforce_transaction_standalone_profile_enforced() {
+        // When the transaction is sampled, the profile survives as standalone.
+        let mut envelope = envelope![Profile];
+
+        let mut mock = MockLimiter::default().deny(DataCategory::Transaction);
+        let (enforcement, _) = enforce_and_apply(&mut mock, &mut envelope, None);
+
+        assert!(enforcement.profiles.is_active());
+        mock.assert_call(DataCategory::Transaction, 1);
+
+        assert_eq!(
+            get_outcomes(enforcement),
+            vec![
+                (DataCategory::Transaction, 1),
+                (DataCategory::TransactionIndexed, 1),
+                (DataCategory::Profile, 1),
+                (DataCategory::ProfileIndexed, 1),
+            ]
+        );
+    }
+
+    #[test]
     fn test_enforce_transaction_attachment_enforced_indexing_quota() {
         let mut envelope = envelope![Transaction, Attachment];
         set_extracted(envelope.envelope_mut(), ItemType::Transaction);

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -677,6 +677,16 @@ where
                 scoping.item(DataCategory::Profile),
                 summary.profile_quantity,
             )?;
+
+            // Profiles can persist in envelopes without transaction if the transaction item
+            // was dropped by dynamic sampling.
+            if profile_limits.is_empty() {
+                profile_limits.merge(self.check.apply(
+                    scoping.item(DataCategory::Transaction),
+                    summary.profile_quantity,
+                )?);
+            }
+
             enforcement.profiles = CategoryLimit::new(
                 DataCategory::Profile,
                 summary.profile_quantity,
@@ -1436,13 +1446,12 @@ mod tests {
         let (enforcement, _) = enforce_and_apply(&mut mock, &mut envelope, None);
 
         assert!(enforcement.profiles.is_active());
+        mock.assert_call(DataCategory::Profile, 1);
         mock.assert_call(DataCategory::Transaction, 1);
 
         assert_eq!(
             get_outcomes(enforcement),
             vec![
-                (DataCategory::Transaction, 1),
-                (DataCategory::TransactionIndexed, 1),
                 (DataCategory::Profile, 1),
                 (DataCategory::ProfileIndexed, 1),
             ]

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1717,7 +1717,7 @@ def test_profile_outcomes_rate_limited_when_dynamic_sampling_drops(
     relay.send_envelope(project_id, envelope)
 
     if quota_category == "transaction":
-        (outcome1,) = mini_sentry.captured_outcomes.get()["outcomes"]
+        (outcome1,) = mini_sentry.captured_outcomes.get(timeout=10)["outcomes"]
         (outcome2,) = mini_sentry.captured_outcomes.get(timeout=1)["outcomes"]
         outcome1, outcome2 = sorted([outcome1, outcome2], key=lambda o: o["category"])
         assert outcome1["outcome"] == 2  # rate limited
@@ -1730,7 +1730,7 @@ def test_profile_outcomes_rate_limited_when_dynamic_sampling_drops(
         assert mini_sentry.captured_events.empty()
     else:
         # Do not rate limit if there is only a transaction_indexed quota.
-        envelope = mini_sentry.captured_events.get()
+        envelope = mini_sentry.captured_events.get(timeout=10)
         assert envelope.items[0].headers["type"] == "profile"
 
         assert mini_sentry.captured_outcomes.empty()


### PR DESCRIPTION
fixes: https://github.com/getsentry/relay/issues/4280