### PR TITLE
fix(replays): Remove timestamp validation for dates from the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 **Bug Fixes**
 
 - Allow profile chunks without release. ([#4155](https://github.com/getsentry/relay/pull/4155))
-- Add validation for timestamps sent from the future. ([#4163](https://github.com/getsentry/relay/pull/4163))
 
 **Features:**
 

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -1,6 +1,5 @@
 //! Validation and normalization of [`Replay`] events.
 
-use chrono::Utc;
 use std::net::IpAddr as StdIpAddr;
 
 use relay_event_schema::processor::{self, ProcessingState, Processor};
@@ -36,10 +35,6 @@ pub enum ReplayError {
     /// This erorr is usually returned when the PII configuration fails to parse.
     #[error("failed to scrub PII: {0}")]
     CouldNotScrub(String),
-
-    /// Date in the future.
-    #[error("date was from the future")]
-    DateInTheFuture,
 }
 
 /// Checks if the Replay event is structurally valid.
@@ -79,14 +74,6 @@ pub fn validate(replay: &Replay) -> Result<(), ReplayError> {
         return Err(ReplayError::InvalidPayload(
             "Invalid trace-id specified.".to_string(),
         ));
-    }
-
-    if replay
-        .timestamp
-        .value()
-        .map_or(false, |v| v.into_inner() > Utc::now())
-    {
-        return Err(ReplayError::DateInTheFuture);
     }
 
     Ok(())
@@ -184,7 +171,7 @@ fn normalize_type(replay: &mut Replay) {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use chrono::{Duration, TimeZone, Utc};
+    use chrono::{TimeZone, Utc};
     use insta::assert_json_snapshot;
     use relay_protocol::{assert_annotated_snapshot, get_value, SerializableAnnotated};
     use uuid::Uuid;
@@ -448,40 +435,6 @@ mod tests {
 }"#;
 
         let mut replay = Annotated::<Replay>::from_json(json).unwrap();
-        let validation_result = validate(replay.value_mut().as_mut().unwrap());
-        assert!(validation_result.is_err());
-    }
-
-    #[test]
-    fn test_future_timestamp_validation() {
-        let future_time = Utc::now() + Duration::hours(1);
-        let json = format!(
-            r#"{{
-  "event_id": "52df9022835246eeb317dbd739ccd059",
-  "replay_id": "52df9022835246eeb317dbd739ccd059",
-  "segment_id": 0,
-  "replay_type": "session",
-  "error_sample_rate": 0.5,
-  "session_sample_rate": 0.5,
-  "timestamp": {},
-  "replay_start_timestamp": 946684800.0,
-  "urls": ["localhost:9000"],
-  "error_ids": ["test"],
-  "trace_ids": [],
-  "platform": "myplatform",
-  "release": "myrelease",
-  "dist": "mydist",
-  "environment": "myenv",
-  "tags": [
-    [
-      "tag",
-      "value"
-    ]
-  ]
-}}"#,
-            future_time.timestamp()
-        );
-        let mut replay = Annotated::<Replay>::from_json(&json).unwrap();
         let validation_result = validate(replay.value_mut().as_mut().unwrap());
         assert!(validation_result.is_err());
     }

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -450,9 +450,6 @@ pub enum DiscardReason {
     InvalidReplayRecordingEvent,
     InvalidReplayVideoEvent,
 
-    /// (Relay) The event's timestamp was too far in the future.
-    DateInTheFuture,
-
     /// (Relay) Profiling related discard reasons
     Profiling(&'static str),
 
@@ -506,7 +503,6 @@ impl DiscardReason {
             DiscardReason::Profiling(reason) => reason,
             DiscardReason::InvalidSpan => "invalid_span",
             DiscardReason::FeatureDisabled(_) => "feature_disabled",
-            DiscardReason::DateInTheFuture => "date_in_the_future",
         }
     }
 }

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -190,9 +190,6 @@ fn handle_replay_event_item(
                 ReplayError::InvalidPayload(_) => {
                     ProcessingError::InvalidReplay(DiscardReason::InvalidReplayEvent)
                 }
-                ReplayError::DateInTheFuture => {
-                    ProcessingError::InvalidReplay(DiscardReason::DateInTheFuture)
-                }
             })
         }
     }


### PR DESCRIPTION
A few customers were significantly impacted by this.  We're reverting for now.  We may re-introduce later with some grace period appended (e.g. an hour or a day) to make sure any clock drift on Relay doesn't impact ingestion.

Reverts getsentry/relay#4163

#skip-changelog