### PR TITLE
instr(buffer): Remove temporary metric

### DIFF
--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -209,9 +209,6 @@ struct EnvelopeBuffer<P: StackProvider> {
     /// This boolean is just used for tagging the metric that tracks the total count of envelopes
     /// in the buffer.
     total_count_initialized: bool,
-
-    /// Temporary field used to track compression gains.
-    push_count: usize,
 }
 
 impl EnvelopeBuffer<MemoryStackProvider> {
@@ -223,7 +220,6 @@ impl EnvelopeBuffer<MemoryStackProvider> {
             stack_provider: MemoryStackProvider::new(memory_checker),
             total_count: Arc::new(AtomicI64::new(0)),
             total_count_initialized: false,
-            push_count: 0,
         }
     }
 }
@@ -238,7 +234,6 @@ impl EnvelopeBuffer<SqliteStackProvider> {
             stack_provider: SqliteStackProvider::new(config).await?,
             total_count: Arc::new(AtomicI64::new(0)),
             total_count_initialized: false,
-            push_count: 0,
         })
     }
 }
@@ -264,32 +259,6 @@ where
     /// The priority of the stack is updated with the envelope's received_at time.
     pub async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), EnvelopeBufferError> {
         let received_at = envelope.meta().received_at();
-
-        // Temporary metric to verify compression gains
-        self.push_count += 1;
-        if 0 == (self.push_count % 100) {
-            if let Ok(serialized) = envelope.to_vec() {
-                let compression_level = (self.push_count % 3) as i32 + 1; // 1 = lowest, 3 = default
-                tokio::spawn(async move {
-                    relay_statsd::metric!(
-                        histogram(RelayHistograms::BufferEnvelopeSize) = serialized.len() as u64
-                    );
-
-                    let tag = compression_level.to_string();
-                    if let Ok(encoded) = relay_statsd::metric!(
-                        timer(RelayTimers::BufferEnvelopeCompression),
-                        compression_level = &tag,
-                        { zstd::encode_all(serialized.as_slice(), compression_level) }
-                    ) {
-                        relay_statsd::metric!(
-                            histogram(RelayHistograms::BufferEnvelopeSizeCompressed) =
-                                encoded.len() as u64,
-                            compression_level = &tag
-                        );
-                    }
-                });
-            }
-        }
 
         let project_key_pair = ProjectKeyPair::from_envelope(&envelope);
         if let Some((

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -186,10 +186,6 @@ pub enum RelayHistograms {
     /// This is not quite the same as the actual size of a serialized envelope, because it ignores
     /// the envelope header and item headers.
     BufferEnvelopeBodySize,
-    /// Size of a serialized envelope pushed to the envelope buffer (sampled).
-    BufferEnvelopeSize,
-    /// Size of a compressed envelope pushed to the envelope buffer (sampled).
-    BufferEnvelopeSizeCompressed,
     /// The number of batches emitted per partition.
     BatchesPerPartition,
     /// The number of buckets in a batch emitted.
@@ -319,8 +315,6 @@ impl HistogramMetric for RelayHistograms {
                 "buffer.backpressure_envelopes_count"
             }
             RelayHistograms::BufferEnvelopeBodySize => "buffer.envelope_body_size",
-            RelayHistograms::BufferEnvelopeSize => "buffer.envelope_size",
-            RelayHistograms::BufferEnvelopeSizeCompressed => "buffer.envelope_size.compressed",
             RelayHistograms::ProjectStatePending => "project_state.pending",
             RelayHistograms::ProjectStateAttempts => "project_state.attempts",
             RelayHistograms::ProjectStateRequestBatchSize => "project_state.request.batch_size",
@@ -552,8 +546,6 @@ pub enum RelayTimers {
     BufferDrain,
     /// Timing in milliseconds for the time it takes for the envelopes to be serialized.
     BufferEnvelopesSerialization,
-    /// Timing in milliseconds for the time it takes for the envelopes to be compressed (sampled).
-    BufferEnvelopeCompression,
 }
 
 impl TimerMetric for RelayTimers {
@@ -603,7 +595,6 @@ impl TimerMetric for RelayTimers {
             RelayTimers::BufferPop => "buffer.pop.duration",
             RelayTimers::BufferDrain => "buffer.drain.duration",
             RelayTimers::BufferEnvelopesSerialization => "buffer.envelopes_serialization",
-            RelayTimers::BufferEnvelopeCompression => "buffer.envelopes_compression",
         }
     }
 }


### PR DESCRIPTION
Revert https://github.com/getsentry/relay/pull/4162, we've collected enough data.

#skip-changelog