### PR TITLE
ref(server): group unknown SDKs into proprietary

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -345,7 +345,11 @@ pub async fn handle_envelope(
     state: &ServiceState,
     envelope: Box<Envelope>,
 ) -> Result<Option<EventId>, BadStoreRequest> {
-    let client_name = envelope.meta().client_name().unwrap_or("proprietary");
+    let client_name = envelope
+        .meta()
+        .client_name()
+        .filter(|name| name.starts_with("sentry") || name.starts_with("raven"))
+        .unwrap_or("proprietary");
     for item in envelope.items() {
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,


### PR DESCRIPTION
This PR attempts to reduce the number of different SDKs that are reported through metrics. Some use user defined names that are not very useful to evaluate for us

#skip-changelog