### PR TITLE
feat(devservices): Remove devservices from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@
 black==24.3.0
 blinker==1.8.2
 click==8.1.7
-devservices==0.0.4
 flake8==7.0.0
 confluent-kafka==2.1.1
 flask==3.0.3


### PR DESCRIPTION
Now that we have a clear update command for devservices that bumps the version in place, let's get rid of this. It removes ambiguity between using venv installs and global binary installs through PATH. 

Installation instructions here:
https://github.com/getsentry/devservices?tab=readme-ov-file#installation