### PR TITLE
ref(metrics): Rename body read metric

### DIFF
--- a/relay-server/src/middlewares/body_timing.rs
+++ b/relay-server/src/middlewares/body_timing.rs
@@ -92,7 +92,7 @@ impl TimedBody {
 
     fn emit_metric(&self, duration: Duration, status: &str) {
         metric!(
-            timer(RelayTimers::BodyReading) = duration,
+            timer(RelayTimers::BodyReadDuration) = duration,
             route = self.route.as_ref().map_or("unknown", |p| p.as_str()),
             size = size_category(self.size),
             status = status
@@ -183,7 +183,7 @@ mod tests {
         });
         assert_eq!(
             captures,
-            ["body.reading.duration:0|ms|#route:unknown,size:<1KB,status:completed"]
+            ["requests.body_read.duration:0|ms|#route:unknown,size:<1KB,status:completed"]
         );
     }
 
@@ -202,7 +202,7 @@ mod tests {
         });
         assert_eq!(
             captures,
-            ["body.reading.duration:0|ms|#route:unknown,size:<1KB,status:completed"]
+            ["requests.body_read.duration:0|ms|#route:unknown,size:<1KB,status:completed"]
         );
     }
 
@@ -220,7 +220,7 @@ mod tests {
         });
         assert_eq!(
             captures,
-            ["body.reading.duration:0|ms|#route:unknown,size:<1KB,status:dropped"]
+            ["requests.body_read.duration:0|ms|#route:unknown,size:<1KB,status:dropped"]
         )
     }
 
@@ -247,7 +247,7 @@ mod tests {
         });
         assert_eq!(
             captures,
-            ["body.reading.duration:0|ms|#route:unknown,size:<1KB,status:failed"]
+            ["requests.body_read.duration:0|ms|#route:unknown,size:<1KB,status:failed"]
         )
     }
 
@@ -267,7 +267,7 @@ mod tests {
         });
         assert_eq!(
             captures,
-            ["body.reading.duration:0|ms|#route:unknown,size:<10KB,status:completed"]
+            ["requests.body_read.duration:0|ms|#route:unknown,size:<10KB,status:completed"]
         )
     }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -552,7 +552,7 @@ pub enum RelayTimers {
     /// Timing in milliseconds for the time it takes for the envelopes to be serialized.
     BufferEnvelopesSerialization,
     /// Timing in milliseconds to the time it takes to read an HTTP body.
-    BodyReading,
+    BodyReadDuration,
 }
 
 impl TimerMetric for RelayTimers {
@@ -604,7 +604,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::BufferPop => "buffer.pop.duration",
             RelayTimers::BufferDrain => "buffer.drain.duration",
             RelayTimers::BufferEnvelopesSerialization => "buffer.envelopes_serialization",
-            RelayTimers::BodyReading => "body.reading.duration",
+            RelayTimers::BodyReadDuration => "requests.body_read.duration",
         }
     }
 }


### PR DESCRIPTION
The previous metric had a small cardinality explosion, it's easier to start fresh also aligns the naming more with the other metrics we're already tracking.

#skip-changelog