### PR TITLE
feat(devservices): Bump devservices version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 black==24.3.0
 blinker==1.8.2
 click==8.1.7
-devservices==0.0.4
+devservices==0.0.5
 flake8==7.0.0
 confluent-kafka==2.1.1
 flask==3.0.3


### PR DESCRIPTION
Picks up latest changes for devservices here:

https://github.com/getsentry/devservices/releases/tag/0.0.5

#skip-changelog