### PR TITLE
feat(profiling): Introduce additional continuous profiling feature flag

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -75,7 +75,7 @@ pub enum Feature {
     /// Serialized as `organizations:continuous-profiling-beta`.
     #[serde(rename = "organizations:continuous-profiling-beta")]
     ContinuousProfilingBeta,
-    /// Enabled for beta orgs
+    /// Enabled when only beta orgs are allowed to send continuous profiles.
     ///
     /// Serialized as `organizations:continuous-profiling-beta-ingest`.
     #[serde(rename = "organizations:continuous-profiling-beta-ingest")]

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -74,8 +74,8 @@ pub enum Feature {
     /// (beta orgs) during the date range (Nov 14th and Nov 18th)
     ///
     /// Serialized as `organizations:continuous-profiling-beta-org`.
-    #[serde(rename = "organizations:continuous-profiling-beta-org")]
-    ContinuousProfilingBetaOrg,
+    #[serde(rename = "organizations:continuous-profiling-allowed-ingest")]
+    ContinuousProfilingAllowedIngest,
     /// Enables metric extraction from spans for common modules.
     ///
     /// Serialized as `projects:span-metrics-extraction`.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -73,9 +73,9 @@ pub enum Feature {
     /// Enable continuous profiling ingestion.
     /// This handle the Nov. 14th Nov. 18th case specifically.
     ///
-    /// Serialized as `organizations:continuous-profiling-allowed-ingest`.
-    #[serde(rename = "organizations:continuous-profiling-allowed-ingest")]
-    ContinuousProfilingAllowedIngest,
+    /// Serialized as `organizations:continuous-profiling-beta`.
+    #[serde(rename = "organizations:continuous-profiling-beta")]
+    ContinuousProfilingBeta,
     /// Enables metric extraction from spans for common modules.
     ///
     /// Serialized as `projects:span-metrics-extraction`.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -70,12 +70,16 @@ pub enum Feature {
     /// Serialized as `organizations:continuous-profiling`.
     #[serde(rename = "organizations:continuous-profiling")]
     ContinuousProfiling,
-    /// Enable continuous profiling ingestion.
-    /// This handle the Nov. 14th Nov. 18th case specifically.
+    /// Enabled for beta orgs
     ///
     /// Serialized as `organizations:continuous-profiling-beta`.
     #[serde(rename = "organizations:continuous-profiling-beta")]
     ContinuousProfilingBeta,
+    /// Enabled for beta orgs
+    ///
+    /// Serialized as `organizations:continuous-profiling-beta-ingest`.
+    #[serde(rename = "organizations:continuous-profiling-beta-ingest")]
+    ContinuousProfilingBetaIngest,
     /// Enables metric extraction from spans for common modules.
     ///
     /// Serialized as `projects:span-metrics-extraction`.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -70,6 +70,12 @@ pub enum Feature {
     /// Serialized as `organizations:continuous-profiling`.
     #[serde(rename = "organizations:continuous-profiling")]
     ContinuousProfiling,
+    /// Enable continuous profiling ingestion only for EA
+    /// (beta orgs) during the date range (Nov 14th and Nov 18th)
+    ///
+    /// Serialized as `organizations:continuous-profiling-beta-org`.
+    #[serde(rename = "organizations:continuous-profiling-beta-org")]
+    ContinuousProfilingBetaOrg,
     /// Enables metric extraction from spans for common modules.
     ///
     /// Serialized as `projects:span-metrics-extraction`.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -70,10 +70,10 @@ pub enum Feature {
     /// Serialized as `organizations:continuous-profiling`.
     #[serde(rename = "organizations:continuous-profiling")]
     ContinuousProfiling,
-    /// Enable continuous profiling ingestion only for EA
-    /// (beta orgs) during the date range (Nov 14th and Nov 18th)
+    /// Enable continuous profiling ingestion.
+    /// This handle the Nov. 14th Nov. 18th case specifically.
     ///
-    /// Serialized as `organizations:continuous-profiling-beta-org`.
+    /// Serialized as `organizations:continuous-profiling-allowed-ingest`.
     #[serde(rename = "organizations:continuous-profiling-allowed-ingest")]
     ContinuousProfilingAllowedIngest,
     /// Enables metric extraction from spans for common modules.

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -16,14 +16,12 @@ use {
 
 /// Removes profile chunks from the envelope if the feature is not enabled.
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
-    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling);
-    let allowed_ingest = state
-        .project_info
-        .has_feature(Feature::ContinuousProfilingAllowedIngest);
+    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling)
+        && state
+            .project_info
+            .has_feature(Feature::ContinuousProfilingAllowedIngest);
     state.managed_envelope.retain_items(|item| match item.ty() {
-        ItemType::ProfileChunk if !continuous_profiling_enabled || !allowed_ingest => {
-            ItemAction::DropSilently
-        }
+        ItemType::ProfileChunk if !continuous_profiling_enabled => ItemAction::DropSilently,
         _ => ItemAction::Keep,
     });
 }
@@ -38,13 +36,13 @@ pub fn process(
     let client_ip = state.managed_envelope.envelope().meta().client_addr();
     let filter_settings = &state.project_info.config.filter_settings;
 
-    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling);
-    let allowed_ingest = state
-        .project_info
-        .has_feature(Feature::ContinuousProfilingAllowedIngest);
+    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling)
+        && state
+            .project_info
+            .has_feature(Feature::ContinuousProfilingAllowedIngest);
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk => {
-            if !continuous_profiling_enabled || !allowed_ingest {
+            if !continuous_profiling_enabled {
                 return ItemAction::DropSilently;
             }
 

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -16,20 +16,16 @@ use {
 
 /// Removes profile chunks from the envelope if the feature is not enabled.
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
-    // if:
-    // (not "organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling")
-    // ||
-    // ("organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling-beta")
-    let continuous_profiling_enabled = (!state
+    let continuous_profiling_enabled = if state
         .project_info
         .has_feature(Feature::ContinuousProfilingBetaIngest)
-        && state.project_info.has_feature(Feature::ContinuousProfiling))
-        || (state
+    {
+        state
             .project_info
-            .has_feature(Feature::ContinuousProfilingBetaIngest)
-            && state
-                .project_info
-                .has_feature(Feature::ContinuousProfilingBeta));
+            .has_feature(Feature::ContinuousProfilingBeta)
+    } else {
+        state.project_info.has_feature(Feature::ContinuousProfiling)
+    };
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk if !continuous_profiling_enabled => ItemAction::DropSilently,
         _ => ItemAction::Keep,
@@ -45,20 +41,16 @@ pub fn process(
 ) {
     let client_ip = state.managed_envelope.envelope().meta().client_addr();
     let filter_settings = &state.project_info.config.filter_settings;
-    // if:
-    // (not "organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling")
-    // ||
-    // ("organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling-beta")
-    let continuous_profiling_enabled = (!state
+    let continuous_profiling_enabled = if state
         .project_info
         .has_feature(Feature::ContinuousProfilingBetaIngest)
-        && state.project_info.has_feature(Feature::ContinuousProfiling))
-        || (state
+    {
+        state
             .project_info
-            .has_feature(Feature::ContinuousProfilingBetaIngest)
-            && state
-                .project_info
-                .has_feature(Feature::ContinuousProfilingBeta));
+            .has_feature(Feature::ContinuousProfilingBeta)
+    } else {
+        state.project_info.has_feature(Feature::ContinuousProfiling)
+    };
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk => {
             if !continuous_profiling_enabled {

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -16,10 +16,20 @@ use {
 
 /// Removes profile chunks from the envelope if the feature is not enabled.
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
-    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling)
-        && state
+    // if:
+    // (not "organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling")
+    // ||
+    // ("organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling-beta")
+    let continuous_profiling_enabled = (!state
+        .project_info
+        .has_feature(Feature::ContinuousProfilingBetaIngest)
+        && state.project_info.has_feature(Feature::ContinuousProfiling))
+        || (state
             .project_info
-            .has_feature(Feature::ContinuousProfilingBeta);
+            .has_feature(Feature::ContinuousProfilingBetaIngest)
+            && state
+                .project_info
+                .has_feature(Feature::ContinuousProfilingBeta));
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk if !continuous_profiling_enabled => ItemAction::DropSilently,
         _ => ItemAction::Keep,
@@ -35,11 +45,20 @@ pub fn process(
 ) {
     let client_ip = state.managed_envelope.envelope().meta().client_addr();
     let filter_settings = &state.project_info.config.filter_settings;
-
-    let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling)
-        && state
+    // if:
+    // (not "organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling")
+    // ||
+    // ("organizations:continuous-profiling-beta-ingest" && "organizations:continuous-profiling-beta")
+    let continuous_profiling_enabled = (!state
+        .project_info
+        .has_feature(Feature::ContinuousProfilingBetaIngest)
+        && state.project_info.has_feature(Feature::ContinuousProfiling))
+        || (state
             .project_info
-            .has_feature(Feature::ContinuousProfilingBeta);
+            .has_feature(Feature::ContinuousProfilingBetaIngest)
+            && state
+                .project_info
+                .has_feature(Feature::ContinuousProfilingBeta));
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk => {
             if !continuous_profiling_enabled {

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -19,7 +19,7 @@ pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
     let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling)
         && state
             .project_info
-            .has_feature(Feature::ContinuousProfilingAllowedIngest);
+            .has_feature(Feature::ContinuousProfilingBeta);
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk if !continuous_profiling_enabled => ItemAction::DropSilently,
         _ => ItemAction::Keep,
@@ -39,7 +39,7 @@ pub fn process(
     let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling)
         && state
             .project_info
-            .has_feature(Feature::ContinuousProfilingAllowedIngest);
+            .has_feature(Feature::ContinuousProfilingBeta);
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk => {
             if !continuous_profiling_enabled {

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -23,7 +23,7 @@ static END: Lazy<DateTime<Utc>> =
 
 fn within_date_range() -> bool {
     let now = Utc::now();
-    return now >= *START && now < *END;
+    now >= *START && now < *END
 }
 
 fn allow_ingest<G>(state: &ProcessEnvelopeState<G>) -> bool {
@@ -32,7 +32,7 @@ fn allow_ingest<G>(state: &ProcessEnvelopeState<G>) -> bool {
             .project_info
             .has_feature(Feature::ContinuousProfilingBetaOrg);
     }
-    return true;
+    true
 }
 
 /// Removes profile chunks from the envelope if the feature is not enabled.

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -1,4 +1,6 @@
 //! Profile chunks processor code.
+use chrono::{DateTime, TimeZone, Utc};
+use once_cell::sync::Lazy;
 use relay_dynamic_config::Feature;
 
 use crate::envelope::ItemType;
@@ -14,11 +16,33 @@ use {
     relay_dynamic_config::GlobalConfig,
 };
 
+static START: Lazy<DateTime<Utc>> =
+    Lazy::new(|| Utc.with_ymd_and_hms(2024, 11, 14, 0, 0, 0).unwrap());
+static END: Lazy<DateTime<Utc>> =
+    Lazy::new(|| Utc.with_ymd_and_hms(2024, 11, 19, 0, 0, 0).unwrap());
+
+fn within_date_range() -> bool {
+    let now = Utc::now();
+    return now >= *START && now < *END;
+}
+
+fn allow_ingest<G>(state: &ProcessEnvelopeState<G>) -> bool {
+    if within_date_range() {
+        return state
+            .project_info
+            .has_feature(Feature::ContinuousProfilingBetaOrg);
+    }
+    return true;
+}
+
 /// Removes profile chunks from the envelope if the feature is not enabled.
 pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) {
     let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling);
+    let allowed_ingest = allow_ingest(state);
     state.managed_envelope.retain_items(|item| match item.ty() {
-        ItemType::ProfileChunk if !continuous_profiling_enabled => ItemAction::DropSilently,
+        ItemType::ProfileChunk if !continuous_profiling_enabled || !allowed_ingest => {
+            ItemAction::DropSilently
+        }
         _ => ItemAction::Keep,
     });
 }
@@ -34,9 +58,10 @@ pub fn process(
     let filter_settings = &state.project_info.config.filter_settings;
 
     let continuous_profiling_enabled = state.project_info.has_feature(Feature::ContinuousProfiling);
+    let allowed_ingest = allow_ingest(state);
     state.managed_envelope.retain_items(|item| match item.ty() {
         ItemType::ProfileChunk => {
-            if !continuous_profiling_enabled {
+            if !continuous_profiling_enabled || !allowed_ingest {
                 return ItemAction::DropSilently;
             }
 

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -497,7 +497,6 @@ def test_filters_are_applied_to_profiles(
         [
             "organizations:profiling",
             "organizations:continuous-profiling",
-            "organizations:continuous-profiling-beta",
         ]
     )
     filter_settings = project_config["config"]["filterSettings"]

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -497,6 +497,7 @@ def test_filters_are_applied_to_profiles(
         [
             "organizations:profiling",
             "organizations:continuous-profiling",
+            "organizations:continuous-profiling-allowed-ingest",
         ]
     )
     filter_settings = project_config["config"]["filterSettings"]

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -497,7 +497,7 @@ def test_filters_are_applied_to_profiles(
         [
             "organizations:profiling",
             "organizations:continuous-profiling",
-            "organizations:continuous-profiling-allowed-ingest",
+            "organizations:continuous-profiling-beta",
         ]
     )
     filter_settings = project_config["config"]["filterSettings"]


### PR DESCRIPTION
Add logic to allow the ingestion of continuous profiles only for beta orgs if `continuous-profile-beta-ingest` feature is enabled.

This depends on:

- https://github.com/getsentry/sentry-options-automator/pull/2610
- https://github.com/getsentry/sentry/pull/80236

#skip-changelog