### PR TITLE
fix(buffer): Check status before marking stack not ready

### DIFF
--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -122,6 +122,11 @@ impl PolymorphicEnvelopeBuffer {
     /// The buffer re-prioritizes its envelopes based on this information.
     /// Returns `true` if at least one priority was changed.
     pub fn mark_ready(&mut self, project: &ProjectKey, is_ready: bool) -> bool {
+        relay_log::trace!(
+            project_key = project.as_str(),
+            "buffer marked {}",
+            if is_ready { "ready" } else { "not ready" }
+        );
         match self {
             Self::Sqlite(buffer) => buffer.mark_ready(project, is_ready),
             Self::InMemory(buffer) => buffer.mark_ready(project, is_ready),


### PR DESCRIPTION
There is a race condition when an envelope is returned with not ready that the stack in the meantime became ready through a project change, now the message resets it to not ready and stays that way until a project is updated again (which takes up to `$eviction_timeout`).

Before marking the buffer not ready, first check if the project is now available.

#skip-changelog