### PR TITLE
ref(normalization): remove MongoDB query scrubbing feature flag

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -12,7 +12,6 @@ use std::sync::OnceLock;
 use chrono::{DateTime, Utc};
 use relay_cardinality::CardinalityLimit;
 use relay_dynamic_config::{normalize_json, GlobalConfig, ProjectConfig};
-use relay_event_normalization::span::description::ScrubMongoDescription;
 use relay_event_normalization::{
     normalize_event, validate_event, BreakdownsConfig, ClientHints, EventValidationConfig,
     GeoIpLookup, NormalizationConfig, RawUserAgentInfo,
@@ -273,8 +272,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         measurements: None,
         normalize_spans: config.normalize_spans,
         replay_id: config.replay_id,
-        span_allowed_hosts: &[], // only supported in relay
-        scrub_mongo_description: ScrubMongoDescription::Disabled, // only supported in relay
+        span_allowed_hosts: &[],              // only supported in relay
         span_op_defaults: Default::default(), // only supported in relay
     };
     normalize_event(&mut event, &normalization_config);

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub const GRADUATED_FEATURE_FLAGS: &[Feature] = &[
     Feature::UserReportV2Ingest,
     Feature::IngestUnsampledProfiles,
+    Feature::ScrubMongoDbDescriptions,
 ];
 
 /// Features exposed by project config.
@@ -96,12 +97,6 @@ pub enum Feature {
     /// Serialized as `organizations:indexed-spans-extraction`.
     #[serde(rename = "organizations:indexed-spans-extraction")]
     ExtractSpansFromEvent,
-    /// Enables description scrubbing for MongoDB spans (and consequently, their presence in the
-    /// Queries module inside Sentry).
-    ///
-    /// Serialized as `organizations:performance-queries-mongodb-extraction`.
-    #[serde(rename = "organizations:performance-queries-mongodb-extraction")]
-    ScrubMongoDbDescriptions,
     /// Indicate if the EAP consumers should ingest a span.
     ///
     /// Serialized as `organizations:ingest-spans-in-eap`
@@ -116,6 +111,10 @@ pub enum Feature {
     #[doc(hidden)]
     #[serde(rename = "organizations:user-feedback-ingest")]
     UserReportV2Ingest,
+    /// This feature has graduated and is hard-coded for external Relays.
+    #[doc(hidden)]
+    #[serde(rename = "organizations:performance-queries-mongodb-extraction")]
+    ScrubMongoDbDescriptions,
     /// Forward compatibility.
     #[doc(hidden)]
     #[serde(other)]

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -29,7 +29,6 @@ use uuid::Uuid;
 
 use crate::normalize::request;
 use crate::span::ai::normalize_ai_measurements;
-use crate::span::description::ScrubMongoDescription;
 use crate::span::tag_extraction::extract_span_tags_from_event;
 use crate::utils::{self, get_event_user_tag, MAX_DURATION_MOBILE_MS};
 use crate::{
@@ -159,9 +158,6 @@ pub struct NormalizationConfig<'a> {
     /// Controls list of hosts to be excluded from scrubbing
     pub span_allowed_hosts: &'a [String],
 
-    /// Controls whether or not MongoDB span descriptions will be scrubbed.
-    pub scrub_mongo_description: ScrubMongoDescription,
-
     /// Rules to infer `span.op` from other span fields.
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
 }
@@ -196,7 +192,6 @@ impl<'a> Default for NormalizationConfig<'a> {
             normalize_spans: true,
             replay_id: Default::default(),
             span_allowed_hosts: Default::default(),
-            scrub_mongo_description: ScrubMongoDescription::Disabled,
             span_op_defaults: Default::default(),
         }
     }
@@ -343,7 +338,6 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
             event,
             config.max_tag_value_length,
             config.span_allowed_hosts,
-            config.scrub_mongo_description,
         );
     }
 

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
 use relay_dynamic_config::CombinedMetricExtractionConfig;
-use relay_event_normalization::span::description::ScrubMongoDescription;
 use relay_event_schema::protocol::{Event, Span};
 use relay_metrics::{Bucket, BucketMetadata, BucketValue};
 use relay_quotas::DataCategory;
@@ -89,12 +88,7 @@ fn extract_span_metrics_for_event(
     relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {
         let mut span_count = 0;
 
-        if let Some(transaction_span) = extract_transaction_span(
-            event,
-            max_tag_value_size,
-            &[],
-            ScrubMongoDescription::Disabled,
-        ) {
+        if let Some(transaction_span) = extract_transaction_span(event, max_tag_value_size, &[]) {
             let (metrics, metrics_summary) =
                 metrics_summary::extract_and_summarize_metrics(&transaction_span, config);
             metrics_summary.apply_on(&mut event._metrics_summary);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -19,7 +19,6 @@ use relay_cogs::{AppFeature, Cogs, FeatureWeights, ResourceId, Token};
 use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding, NormalizationLevel, RelayMode};
 use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary, Feature};
-use relay_event_normalization::span::description::ScrubMongoDescription;
 use relay_event_normalization::{
     normalize_event, validate_event, ClockDriftProcessor, CombinedMeasurementsConfig,
     EventValidationConfig, GeoIpLookup, MeasurementsConfig, NormalizationConfig, RawUserAgentInfo,
@@ -1597,14 +1596,6 @@ impl EnvelopeProcessorService {
                     .dsc()
                     .and_then(|ctx| ctx.replay_id),
                 span_allowed_hosts: http_span_allowed_hosts,
-                scrub_mongo_description: if state
-                    .project_info
-                    .has_feature(Feature::ScrubMongoDbDescriptions)
-                {
-                    ScrubMongoDescription::Enabled
-                } else {
-                    ScrubMongoDescription::Disabled
-                },
                 span_op_defaults: global_config.span_op_defaults.borrow(),
             };
 

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -1,7 +1,6 @@
 //! Processor code related to standalone spans.
 
 use relay_dynamic_config::Feature;
-use relay_event_normalization::span::description::ScrubMongoDescription;
 use relay_event_normalization::span::tag_extraction;
 use relay_event_schema::protocol::{Event, Span};
 use relay_protocol::Annotated;
@@ -33,17 +32,10 @@ pub fn extract_transaction_span(
     event: &Event,
     max_tag_value_size: usize,
     span_allowed_hosts: &[String],
-    scrub_mongo_description: ScrubMongoDescription,
 ) -> Option<Span> {
     let mut spans = [Span::from(event).into()];
 
-    tag_extraction::extract_span_tags(
-        event,
-        &mut spans,
-        max_tag_value_size,
-        span_allowed_hosts,
-        scrub_mongo_description,
-    );
+    tag_extraction::extract_span_tags(event, &mut spans, max_tag_value_size, span_allowed_hosts);
     tag_extraction::extract_segment_span_tags(event, &mut spans);
 
     spans.into_iter().next().and_then(Annotated::into_value)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1434,83 +1434,7 @@ def test_span_metrics(
             assert metric["tags"]["span.group"] == expected_group, metric
 
 
-def test_mongodb_span_metrics_not_extracted_without_feature(
-    transactions_consumer,
-    metrics_consumer,
-    mini_sentry,
-    relay_with_processing,
-):
-    project_id = 42
-    mini_sentry.add_full_project_config(project_id)
-    config = mini_sentry.project_configs[project_id]["config"]
-    config["transactionMetrics"] = {
-        "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
-    }
-    config.setdefault("features", []).append("projects:span-metrics-extraction")
-
-    sent_description = '{"find": "documents", "foo": "bar"}'
-
-    transaction = {
-        "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",
-        "type": "transaction",
-        "transaction": "/organizations/:orgId/performance/:eventSlug/",
-        "transaction_info": {"source": "route"},
-        "start_timestamp": 1597976392.6542819,
-        "timestamp": 1597976400.6189718,
-        "user": {"id": "user123", "geo": {"country_code": "ES"}},
-        "contexts": {
-            "trace": {
-                "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
-                "span_id": "FA90FDEAD5F74052",
-                "type": "trace",
-                "op": "my-transaction-op",
-            }
-        },
-        "spans": [
-            {
-                "description": sent_description,
-                "op": "db",
-                "parent_span_id": "8f5a2b8768cafb4e",
-                "span_id": "bd429c44b67a3eb4",
-                "start_timestamp": 1597976393.4619668,
-                "timestamp": 1597976393.4718769,
-                "trace_id": "ff62a8b040f340bda5d830223def1d81",
-                "data": {
-                    "db.system": "mongodb",
-                    "db.collection.name": "documents",
-                    "db.operation": "find",
-                },
-            }
-        ],
-    }
-    # Default timestamp is so old that relay drops metrics, setting a more recent one avoids the drop.
-    timestamp = datetime.now(tz=timezone.utc)
-    transaction["timestamp"] = transaction["spans"][0]["timestamp"] = (
-        timestamp.isoformat()
-    )
-
-    metrics_consumer = metrics_consumer()
-    tx_consumer = transactions_consumer()
-    processing = relay_with_processing(options=TEST_CONFIG)
-    processing.send_transaction(project_id, transaction)
-
-    transaction, _ = tx_consumer.get_event()
-    assert transaction["spans"][0]["description"] == sent_description
-
-    metrics = metrics_consumer.get_metrics()
-    span_metrics = [
-        (metric, headers)
-        for metric, headers in metrics
-        if metric["name"].startswith("spans", 2)
-    ]
-    assert len(span_metrics) == 8
-
-    for metric, headers in span_metrics:
-        assert headers == [("namespace", b"spans")]
-        assert "span.description" not in metric["tags"]
-
-
-def test_mongodb_span_metrics_extracted_with_feature(
+def test_mongodb_span_metrics_extracted(
     transactions_consumer,
     metrics_consumer,
     mini_sentry,
@@ -1525,7 +1449,6 @@ def test_mongodb_span_metrics_extracted_with_feature(
     config.setdefault("features", []).extend(
         [
             "projects:span-metrics-extraction",
-            "organizations:performance-queries-mongodb-extraction",
         ]
     )
 


### PR DESCRIPTION
MongoDB support for the Query insights module is now in GA. Remove the feature flag that controlled whether or not to enable query scrubbing for Mongo queries, as it is now always required. This involved removing the `scrub_mongo_description` parameter down the call stack, and moving `Feature::ScrubMongoDbDescriptions` to the graduated feature list.

#skip-changelog