### PR TITLE
ref(server): Emit metric counting accepted connections

### DIFF
--- a/relay-server/src/services/server.rs
+++ b/relay-server/src/services/server.rs
@@ -141,7 +141,7 @@ fn build_keepalive(config: &Config) -> Option<TcpKeepalive> {
 pub struct KeepAliveAcceptor(Option<TcpKeepalive>);
 
 impl KeepAliveAcceptor {
-    /// Create a new acceptor that sets TCP_NODELAY and keep-alive.
+    /// Create a new acceptor that sets `TCP_NODELAY` and keep-alive.
     pub fn new(config: &Config) -> Self {
         Self(build_keepalive(config))
     }
@@ -153,16 +153,27 @@ impl<S> Accept<TcpStream, S> for KeepAliveAcceptor {
     type Future = std::future::Ready<io::Result<(Self::Stream, Self::Service)>>;
 
     fn accept(&self, stream: TcpStream, service: S) -> Self::Future {
+        let mut keepalive = "ok";
+        let mut nodelay = "ok";
+
         if let Self(Some(ref tcp_keepalive)) = self {
             let sock_ref = socket2::SockRef::from(&stream);
             if let Err(e) = sock_ref.set_tcp_keepalive(tcp_keepalive) {
                 relay_log::trace!("error trying to set TCP keepalive: {e}");
+                keepalive = "error";
             }
         }
 
         if let Err(e) = stream.set_nodelay(true) {
             relay_log::trace!("failed to set TCP_NODELAY: {e}");
+            nodelay = "error";
         }
+
+        relay_statsd::metric!(
+            counter(RelayCounters::ServerSocketAccept) += 1,
+            keepalive = keepalive,
+            nodelay = nodelay
+        );
 
         std::future::ready(Ok((stream, service)))
     }
@@ -180,6 +191,7 @@ fn serve(listener: TcpListener, app: App, config: Arc<Config>) {
         .http1()
         .timer(TokioTimer::new())
         .half_close(true)
+        .keep_alive(true)
         .header_read_timeout(CLIENT_HEADER_TIMEOUT)
         .writev(true);
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -859,6 +859,8 @@ pub enum RelayCounters {
     BucketsDropped,
     /// Incremented every time a segment exceeds the expected limit.
     ReplayExceededSegmentLimit,
+    /// Incremented every time the server accepts a new connection.
+    ServerSocketAccept,
 }
 
 impl CounterMetric for RelayCounters {
@@ -904,6 +906,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProjectStateFlushMetricsNoProject => "project_state.metrics.no_project",
             RelayCounters::BucketsDropped => "metrics.buckets.dropped",
             RelayCounters::ReplayExceededSegmentLimit => "replay.segment_limit_exceeded",
+            RelayCounters::ServerSocketAccept => "server.http.accepted",
         }
     }
 }


### PR DESCRIPTION
The `keepalive(true)` is not a change, it is already the default, I just added it to make it explicit.

#skip-changelog