### PR TITLE
ref(project-cache): Yield back to runtime in expensive branches

### DIFF
--- a/relay-server/src/services/projects/cache/service.rs
+++ b/relay-server/src/services/projects/cache/service.rs
@@ -212,7 +212,10 @@ impl relay_system::Service for ProjectCacheService {
 
                     Some(fetch) = self.scheduled_fetches.next() => timed!(
                         "completed_fetch",
-                        self.handle_completed_fetch(fetch)
+                        {
+                            self.handle_completed_fetch(fetch);
+                            tokio::task::yield_now().await;
+                        }
                     ),
                     Some(message) = rx.recv() => timed!(
                         message.variant(),
@@ -220,7 +223,10 @@ impl relay_system::Service for ProjectCacheService {
                     ),
                     _ = eviction_ticker.tick() => timed!(
                         "evict_stale_projects",
-                        self.handle_evict_stale_projects()
+                        {
+                            self.handle_evict_stale_projects();
+                            tokio::task::yield_now().await;
+                        }
                     ),
                 }
             }


### PR DESCRIPTION
Be a bit more cooperative for the runtime and yield back after expensive messages.

Eviction is quite costly for large projects, and with scheduled fetches being biased towards it's possible that we do this a lot before being force yielded by the runtime.

#skip-changelog