### PR TITLE
ref(project-cache): Schedule evictions

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1048,8 +1048,6 @@ struct Cache {
     batch_size: usize,
     /// Interval for watching local cache override files in seconds.
     file_interval: u32,
-    /// Interval for evicting outdated project configs from memory.
-    eviction_interval: u32,
     /// Interval for fetching new global configs from the upstream, in seconds.
     global_config_fetch_interval: u32,
 }
@@ -1068,7 +1066,6 @@ impl Default for Cache {
             downstream_relays_batch_interval: 100, // 100ms
             batch_size: 500,
             file_interval: 10,                // 10 seconds
-            eviction_interval: 10,            // 10 seconds
             global_config_fetch_interval: 10, // 10 seconds
         }
     }
@@ -2128,12 +2125,6 @@ impl Config {
     /// Returns the interval in seconds in which local project configurations should be reloaded.
     pub fn local_cache_interval(&self) -> Duration {
         Duration::from_secs(self.values.cache.file_interval.into())
-    }
-
-    /// Returns the interval in seconds in which projects configurations should be freed from
-    /// memory when expired.
-    pub fn cache_eviction_interval(&self) -> Duration {
-        Duration::from_secs(self.values.cache.eviction_interval.into())
     }
 
     /// Returns the interval in seconds in which fresh global configs should be

--- a/relay-server/src/services/projects/cache/service.rs
+++ b/relay-server/src/services/projects/cache/service.rs
@@ -170,10 +170,10 @@ impl ProjectCacheService {
         );
     }
 
-    fn handle_eviction(&mut self, evicition: Eviction) {
-        let project_key = evicition.project_key();
+    fn handle_eviction(&mut self, eviction: Eviction) {
+        let project_key = eviction.project_key();
 
-        self.store.evict(evicition);
+        self.store.evict(eviction);
 
         let _ = self
             .project_events_tx

--- a/relay-server/src/services/projects/cache/service.rs
+++ b/relay-server/src/services/projects/cache/service.rs
@@ -9,10 +9,10 @@ use relay_system::Service;
 use tokio::sync::broadcast;
 
 use crate::services::projects::cache::handle::ProjectCacheHandle;
-use crate::services::projects::cache::state::{CompletedFetch, Fetch, ProjectStore};
+use crate::services::projects::cache::state::{CompletedFetch, Eviction, Fetch, ProjectStore};
 use crate::services::projects::project::ProjectState;
 use crate::services::projects::source::ProjectSource;
-use crate::statsd::{RelayGauges, RelayTimers};
+use crate::statsd::{RelayCounters, RelayGauges, RelayTimers};
 use crate::utils::FuturesScheduled;
 
 /// Size of the broadcast channel for project events.
@@ -170,14 +170,17 @@ impl ProjectCacheService {
         );
     }
 
-    fn handle_evict_stale_projects(&mut self) {
-        let on_evict = |project_key| {
-            let _ = self
-                .project_events_tx
-                .send(ProjectChange::Evicted(project_key));
-        };
+    fn handle_eviction(&mut self, evicition: Eviction) {
+        let project_key = evicition.project_key();
 
-        self.store.evict_stale_projects(&self.config, on_evict);
+        self.store.evict(evicition);
+
+        let _ = self
+            .project_events_tx
+            .send(ProjectChange::Evicted(project_key));
+
+        relay_log::trace!(tags.project_key = project_key.as_str(), "project evicted");
+        metric!(counter(RelayCounters::EvictingStaleProjectCaches) += 1);
     }
 
     fn handle_message(&mut self, message: ProjectCache) {
@@ -203,9 +206,6 @@ impl relay_system::Service for ProjectCacheService {
         }
 
         tokio::spawn(async move {
-            let mut eviction_ticker = tokio::time::interval(self.config.cache_eviction_interval());
-            eviction_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
             loop {
                 tokio::select! {
                     biased;
@@ -218,9 +218,9 @@ impl relay_system::Service for ProjectCacheService {
                         message.variant(),
                         self.handle_message(message)
                     ),
-                    _ = eviction_ticker.tick() => timed!(
-                        "evict_stale_projects",
-                        self.handle_evict_stale_projects()
+                    Some(eviction) = self.store.next_eviction() => timed!(
+                        "eviction",
+                        self.handle_eviction(eviction)
                     ),
                 }
             }

--- a/relay-server/src/services/projects/cache/state.rs
+++ b/relay-server/src/services/projects/cache/state.rs
@@ -1,3 +1,4 @@
+use futures::StreamExt;
 use std::fmt;
 use std::sync::Arc;
 use tokio::time::Instant;
@@ -12,7 +13,7 @@ use relay_statsd::metric;
 use crate::services::projects::project::{ProjectState, Revision};
 use crate::services::projects::source::SourceProjectState;
 use crate::statsd::{RelayCounters, RelayHistograms};
-use crate::utils::RetryBackoff;
+use crate::utils::{RetryBackoff, UniqueScheduledQueue};
 
 /// The backing storage for a project cache.
 ///
@@ -30,6 +31,8 @@ pub struct ProjectStore {
     shared: Arc<Shared>,
     /// The private, mutably exclusive state, used to maintain the project state.
     private: hashbrown::HashMap<ProjectKey, PrivateProjectState>,
+    /// Scheduled queue tracking all evictions.
+    evictions: UniqueScheduledQueue<ProjectKey>,
 }
 
 impl ProjectStore {
@@ -44,8 +47,15 @@ impl ProjectStore {
     /// A returned [`Fetch`] must be scheduled and completed with [`Fetch::complete`] and
     /// [`Self::complete_fetch`].
     pub fn try_begin_fetch(&mut self, project_key: ProjectKey, config: &Config) -> Option<Fetch> {
-        self.get_or_create(project_key, config)
-            .try_begin_fetch(config)
+        let fetch = self
+            .get_or_create(project_key, config)
+            .try_begin_fetch(config);
+
+        if fetch.is_some() {
+            self.evictions.remove(&project_key);
+        }
+
+        fetch
     }
 
     /// Completes a [`CompletedFetch`] started with [`Self::try_begin_fetch`].
@@ -54,54 +64,26 @@ impl ProjectStore {
     /// [`ProjectState`] is still pending or already deemed expired.
     #[must_use = "an incomplete fetch must be retried"]
     pub fn complete_fetch(&mut self, fetch: CompletedFetch, config: &Config) -> Option<Fetch> {
+        let project_key = fetch.project_key;
+
         // Eviction is not possible for projects which are currently being fetched.
         // Hence if there was a started fetch, the project state must always exist at this stage.
-        debug_assert!(self.shared.projects.pin().get(&fetch.project_key).is_some());
-        debug_assert!(self.private.get(&fetch.project_key).is_some());
+        debug_assert!(self.shared.projects.pin().get(&project_key).is_some());
+        debug_assert!(self.private.get(&project_key).is_some());
 
-        let mut project = self.get_or_create(fetch.project_key, config);
-        project.complete_fetch(fetch);
+        let mut project = self.get_or_create(project_key, config);
+        let expiry = project.complete_fetch(fetch, config);
         // Schedule another fetch if necessary, usually should only happen if
         // the completed fetch is pending.
-        project.try_begin_fetch(config)
-    }
+        let new_fetch = project.try_begin_fetch(config);
 
-    /// Evicts all stale, expired projects from the cache.
-    ///
-    /// Evicted projects are passed to the `on_evict` callback. Returns the total amount of evicted
-    /// projects.
-    pub fn evict_stale_projects<F>(&mut self, config: &Config, mut on_evict: F) -> usize
-    where
-        F: FnMut(ProjectKey),
-    {
-        let eviction_start = Instant::now();
-
-        let expired = self.private.extract_if(|_, private| {
-            // We only evict projects which have fully expired and are not currently being fetched.
-            //
-            // This relies on the fact that a project should never remain in the `pending` state
-            // for long and is either always being fetched or successfully fetched.
-            private.last_fetch().map_or(false, |ts| {
-                ts.check_expiry(eviction_start, config).is_expired()
-            })
-        });
-
-        let mut evicted = 0;
-
-        let shared = self.shared.projects.pin();
-        for (project_key, _) in expired {
-            let _removed = shared.remove(&project_key);
+        if let Some(ExpiryTime(when)) = expiry {
             debug_assert!(
-                _removed.is_some(),
-                "an expired project must exist in the shared state"
+                new_fetch.is_none(),
+                "there cannot be a new fetch and a scheduled expiry"
             );
-            relay_log::trace!(tags.project_key = project_key.as_str(), "project evicted");
-
-            evicted += 1;
-
-            on_evict(project_key);
+            self.evictions.schedule(when, project_key);
         }
-        drop(shared);
 
         metric!(
             histogram(RelayHistograms::ProjectStateCacheSize) = self.shared.projects.len() as u64,
@@ -111,9 +93,53 @@ impl ProjectStore {
             histogram(RelayHistograms::ProjectStateCacheSize) = self.private.len() as u64,
             storage = "private"
         );
-        metric!(counter(RelayCounters::EvictingStaleProjectCaches) += evicted as u64);
 
-        evicted
+        new_fetch
+    }
+
+    /// Waits for the next scheduled eviction and returns an [`Eviction`] token.
+    ///
+    /// The returned [`Eviction`] token must be immediately turned in using [`Self::evict`].
+    pub async fn next_eviction(&mut self) -> Option<Eviction> {
+        if self.evictions.is_empty() {
+            return None;
+        }
+        self.evictions.next().await.map(Eviction)
+    }
+
+    /// Evicts a project using an [`Eviction`] token returned from [`Self::next_eviction`].
+    pub fn evict(&mut self, Eviction(project_key): Eviction) {
+        let private = match self.private.entry_ref(&project_key) {
+            hashbrown::hash_map::EntryRef::Occupied(private) => private,
+            hashbrown::hash_map::EntryRef::Vacant(_) => {
+                debug_assert!(false, "no private state for evicition");
+                // Don't modify the shared state here.
+                //
+                // A potentially queued double eviction may have happened.
+                // In which case the shared state could have already been re-created between
+                // evictions.
+                return;
+            }
+        };
+
+        #[cfg(debug_assertions)]
+        {
+            let private = private.get();
+            assert!(
+                matches!(private.state, FetchState::Complete { .. }),
+                "private state must be completed"
+            );
+        }
+
+        // Remove the private part.
+        let _ = private.remove();
+        // Remove the shared part.
+        let shared = self.shared.projects.pin();
+        let _removed = shared.remove(&project_key);
+        debug_assert!(
+            _removed.is_some(),
+            "an expired project must exist in the shared state"
+        );
     }
 
     /// Get a reference to the current project or create a new project.
@@ -256,7 +282,7 @@ impl ProjectRef<'_> {
             .map(|fetch| fetch.with_revision(self.shared.revision()))
     }
 
-    fn complete_fetch(&mut self, fetch: CompletedFetch) {
+    fn complete_fetch(&mut self, fetch: CompletedFetch, config: &Config) -> Option<ExpiryTime> {
         let now = Instant::now();
         self.private.complete_fetch(&fetch, now);
 
@@ -268,6 +294,21 @@ impl ProjectRef<'_> {
             }
             _ => {}
         }
+
+        self.private.expiry_time(config)
+    }
+}
+
+/// A [`Eviction`] token.
+///
+/// The token must be turned in using [`ProjectStore::evict`].
+#[must_use = "an eviction must be used"]
+pub struct Eviction(ProjectKey);
+
+impl Eviction {
+    /// Returns the [`ProjectKey`] of the project that needs to be evicted.
+    pub fn project_key(&self) -> ProjectKey {
+        self.0
     }
 }
 
@@ -442,11 +483,9 @@ impl PrivateProjectState {
         }
     }
 
-    /// Returns the [`LastFetch`] if there is currently no fetch in progress and the project
-    /// was fetched successfully before.
-    fn last_fetch(&self) -> Option<LastFetch> {
+    fn expiry_time(&self, config: &Config) -> Option<ExpiryTime> {
         match &self.state {
-            FetchState::Complete { last_fetch } => Some(*last_fetch),
+            FetchState::Complete { last_fetch } => Some(last_fetch.expiry_time(config)),
             _ => None,
         }
     }
@@ -542,6 +581,11 @@ impl LastFetch {
             Expiry::Fresh
         }
     }
+
+    /// Returns when the project is based to expire based on the current [`LastFetch`].
+    fn expiry_time(&self, config: &Config) -> ExpiryTime {
+        ExpiryTime(self.0 + config.project_grace_period() + config.project_cache_expiry())
+    }
 }
 
 /// Expiry state of a project.
@@ -562,12 +606,11 @@ impl Expiry {
     fn is_fresh(&self) -> bool {
         matches!(self, Self::Fresh)
     }
-
-    /// Returns `true` if the project is expired and can be evicted.
-    fn is_expired(&self) -> bool {
-        matches!(self, Self::Expired)
-    }
 }
+
+/// Instant when a project is scheduled for expiry.
+#[must_use = "an expiry time must be used to schedule an evicition"]
+struct ExpiryTime(Instant);
 
 #[cfg(test)]
 mod tests {
@@ -575,10 +618,15 @@ mod tests {
 
     use super::*;
 
-    fn collect_evicted(store: &mut ProjectStore, config: &Config) -> Vec<ProjectKey> {
+    async fn collect_evicted(store: &mut ProjectStore) -> Vec<ProjectKey> {
         let mut evicted = Vec::new();
-        let num_evicted = store.evict_stale_projects(config, |pk| evicted.push(pk));
-        assert_eq!(evicted.len(), num_evicted);
+        // Small timeout to really only get what is ready to be evicted right now.
+        while let Ok(Some(eviction)) =
+            tokio::time::timeout(Duration::from_nanos(5), store.next_eviction()).await
+        {
+            evicted.push(eviction.0);
+            store.evict(eviction);
+        }
         evicted
     }
 
@@ -591,8 +639,8 @@ mod tests {
         };
     }
 
-    #[test]
-    fn test_store_fetch() {
+    #[tokio::test(start_paused = true)]
+    async fn test_store_fetch() {
         let project_key = ProjectKey::parse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
         let mut store = ProjectStore::default();
         let config = Default::default();
@@ -681,13 +729,13 @@ mod tests {
         let fetch = fetch.complete(ProjectState::Disabled.into());
         assert!(store.complete_fetch(fetch, &config).is_none());
 
-        assert_eq!(collect_evicted(&mut store, &config), Vec::new());
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
         assert_state!(store, project_key1, ProjectState::Disabled);
 
         // 3 seconds is not enough to expire any project.
         tokio::time::advance(Duration::from_secs(3)).await;
 
-        assert_eq!(collect_evicted(&mut store, &config), Vec::new());
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
         assert_state!(store, project_key1, ProjectState::Disabled);
 
         let fetch = store.try_begin_fetch(project_key2, &config).unwrap();
@@ -697,7 +745,7 @@ mod tests {
         // A total of 6 seconds should expire the first project.
         tokio::time::advance(Duration::from_secs(3)).await;
 
-        assert_eq!(collect_evicted(&mut store, &config), vec![project_key1]);
+        assert_eq!(collect_evicted(&mut store).await, vec![project_key1]);
         assert_state!(store, project_key1, ProjectState::Pending);
         assert_state!(store, project_key2, ProjectState::Disabled);
     }
@@ -722,21 +770,21 @@ mod tests {
         tokio::time::advance(Duration::from_secs(6)).await;
 
         // No evictions, project is pending.
-        assert_eq!(collect_evicted(&mut store, &config), Vec::new());
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
 
         // Complete the project.
         let fetch = fetch.complete(ProjectState::Disabled.into());
         assert!(store.complete_fetch(fetch, &config).is_none());
 
         // Still should not be evicted, because we do have 5 seconds to expire since completion.
-        assert_eq!(collect_evicted(&mut store, &config), Vec::new());
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
         tokio::time::advance(Duration::from_secs(4)).await;
-        assert_eq!(collect_evicted(&mut store, &config), Vec::new());
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
         assert_state!(store, project_key1, ProjectState::Disabled);
 
         // Just enough to expire the project.
         tokio::time::advance(Duration::from_millis(1001)).await;
-        assert_eq!(collect_evicted(&mut store, &config), vec![project_key1]);
+        assert_eq!(collect_evicted(&mut store).await, vec![project_key1]);
         assert_state!(store, project_key1, ProjectState::Pending);
         assert_state!(store, project_key2, ProjectState::Pending);
     }
@@ -760,13 +808,57 @@ mod tests {
         // This is in the grace period, but not yet expired.
         tokio::time::advance(Duration::from_millis(9500)).await;
 
-        assert_eq!(collect_evicted(&mut store, &config), Vec::new());
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
         assert_state!(store, project_key, ProjectState::Disabled);
 
         // Now it's expired.
         tokio::time::advance(Duration::from_secs(1)).await;
 
-        assert_eq!(collect_evicted(&mut store, &config), vec![project_key]);
+        assert_eq!(collect_evicted(&mut store).await, vec![project_key]);
+        assert_state!(store, project_key, ProjectState::Pending);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_store_no_eviction_during_fetch() {
+        let project_key = ProjectKey::parse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        let mut store = ProjectStore::default();
+        let config = Config::from_json_value(serde_json::json!({
+            "cache": {
+                "project_expiry": 5,
+                "project_grace_period": 5,
+            }
+        }))
+        .unwrap();
+
+        let fetch = store.try_begin_fetch(project_key, &config).unwrap();
+
+        // Project is expired, but there is an ongoing fetch.
+        tokio::time::advance(Duration::from_millis(10500)).await;
+        // No evictions, there is a fetch ongoing!
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
+
+        // Complete the project.
+        let fetch = fetch.complete(ProjectState::Disabled.into());
+        assert!(store.complete_fetch(fetch, &config).is_none());
+        // But start a new fetch asap (after grace period).
+        tokio::time::advance(Duration::from_millis(5001)).await;
+        let fetch = store.try_begin_fetch(project_key, &config).unwrap();
+
+        // Again, expire the project.
+        tokio::time::advance(Duration::from_millis(10500)).await;
+        // No evictions, there is a fetch ongoing!
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
+
+        // Complete the project.
+        let fetch = fetch.complete(ProjectState::Disabled.into());
+        assert!(store.complete_fetch(fetch, &config).is_none());
+
+        // Not quite yet expired.
+        tokio::time::advance(Duration::from_millis(9500)).await;
+        assert_eq!(collect_evicted(&mut store).await, Vec::new());
+        // Now it's expired.
+        tokio::time::advance(Duration::from_millis(501)).await;
+        assert_eq!(collect_evicted(&mut store).await, vec![project_key]);
         assert_state!(store, project_key, ProjectState::Pending);
     }
 }

--- a/relay-server/src/utils/scheduled/mod.rs
+++ b/relay-server/src/utils/scheduled/mod.rs
@@ -2,4 +2,4 @@ mod futures;
 mod queue;
 
 pub use self::futures::FuturesScheduled;
-pub use self::queue::ScheduledQueue;
+pub use self::queue::{ScheduledQueue, UniqueScheduledQueue};

--- a/relay-server/src/utils/scheduled/queue.rs
+++ b/relay-server/src/utils/scheduled/queue.rs
@@ -1,3 +1,6 @@
+use futures::StreamExt as _;
+use priority_queue::PriorityQueue;
+use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::fmt;
 use std::future::Future;
@@ -11,11 +14,8 @@ use tokio::time::Instant;
 use futures::Stream;
 
 /// A scheduled queue that can be polled for when the next item is ready.
-#[derive(Debug)]
 pub struct ScheduledQueue<T> {
-    inner: BinaryHeap<Item<T>>,
-    waker: Option<Waker>,
-    sleep: Pin<Box<tokio::time::Sleep>>,
+    inner: Inner<BinaryHeap<Item<T>>>,
 }
 
 impl<T> ScheduledQueue<T> {
@@ -23,8 +23,6 @@ impl<T> ScheduledQueue<T> {
     pub fn new() -> Self {
         Self {
             inner: Default::default(),
-            waker: None,
-            sleep: Box::pin(tokio::time::sleep(Duration::MAX)),
         }
     }
 
@@ -41,17 +39,199 @@ impl<T> ScheduledQueue<T> {
 
     /// Schedules a new item to be yielded at `when`.
     pub fn schedule(&mut self, when: Instant, value: T) {
-        self.inner.push(Item { when, value });
-        if let Some(ref waker) = self.waker {
-            waker.wake_by_ref();
+        self.inner.modify(|q| {
+            q.push(Item { when, value });
+            true
+        })
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for ScheduledQueue<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let now = Instant::now();
+        let mut f = f.debug_list();
+        for Item { when, value } in self.inner.iter() {
+            f.entry(&(when.saturating_duration_since(now), value));
+        }
+        f.finish()
+    }
+}
+
+impl<T> Stream for ScheduledQueue<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<T> FusedStream for ScheduledQueue<T> {
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
+    }
+}
+
+impl<T> Default for ScheduledQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A scheduled queue that can be polled for when the next item is ready.
+///
+/// Unlike [`ScheduledQueue`] every unique `T` can only be scheduled once,
+/// scheduling a value again moves the deadline instead.
+pub struct UniqueScheduledQueue<T>
+where
+    T: std::hash::Hash + Eq,
+{
+    inner: Inner<PriorityQueue<T, Reverse<Instant>>>,
+}
+
+impl<T: std::hash::Hash + Eq> UniqueScheduledQueue<T> {
+    /// Creates a new, empty [`UniqueScheduledQueue`].
+    pub fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+
+    /// Returns the current size of the queue.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if there are no items in the queue.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Schedules an item to be yielded at `when`.
+    ///
+    /// If the item was net yet scheduled, it is inserted into the queue,
+    /// otherwise the previous schedule is moved to the new deadline.
+    pub fn schedule(&mut self, when: Instant, value: T) {
+        self.inner.modify(|q| match q.push(value, Reverse(when)) {
+            // Item was already in the queue, we only need to wake if the new value is earlier than
+            // the one which was already scheduled.
+            Some(Reverse(old)) => when < old,
+            // Item previously didn't exist, always wake just to be sure.
+            None => true,
+        });
+    }
+
+    /// Removes a value from the queue.
+    pub fn remove(&mut self, value: &T) {
+        self.inner.modify(|q| q.remove(value).is_some());
+    }
+}
+
+impl<T: fmt::Debug + std::hash::Hash + Eq> fmt::Debug for UniqueScheduledQueue<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let now = Instant::now();
+        let mut f = f.debug_list();
+        for (value, Reverse(when)) in self.inner.iter() {
+            f.entry(&(when.saturating_duration_since(now), value));
+        }
+        f.finish()
+    }
+}
+
+impl<T: std::hash::Hash + Eq> Stream for UniqueScheduledQueue<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<T: std::hash::Hash + Eq> FusedStream for UniqueScheduledQueue<T> {
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
+    }
+}
+//
+impl<T: std::hash::Hash + Eq> Default for UniqueScheduledQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+trait Queue {
+    type Value;
+
+    /// Peeks into the queue returning a reference to the first value.
+    fn peek(&self) -> Option<Item<&Self::Value>>;
+    /// Removes the first element from the queue returning its value.
+    ///
+    /// A successful [`Self::peek`] followed by a [`Self::pop`] must not return `None`.
+    fn pop(&mut self) -> Option<Item<Self::Value>>;
+}
+
+impl<T> Queue for BinaryHeap<Item<T>> {
+    type Value = T;
+
+    fn peek(&self) -> Option<Item<&Self::Value>> {
+        BinaryHeap::peek(self).map(|item| item.as_ref())
+    }
+
+    fn pop(&mut self) -> Option<Item<Self::Value>> {
+        BinaryHeap::pop(self)
+    }
+}
+
+impl<T: std::hash::Hash + Eq> Queue for priority_queue::PriorityQueue<T, Reverse<Instant>> {
+    type Value = T;
+
+    fn peek(&self) -> Option<Item<&Self::Value>> {
+        PriorityQueue::peek(self).map(|(value, Reverse(when))| Item { when: *when, value })
+    }
+
+    fn pop(&mut self) -> Option<Item<Self::Value>> {
+        PriorityQueue::pop(self).map(|(value, Reverse(when))| Item { when, value })
+    }
+}
+
+#[derive(Debug)]
+struct Inner<Q> {
+    inner: Q,
+    waker: Option<Waker>,
+    sleep: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl<Q> Inner<Q> {
+    pub fn modify(&mut self, f: impl FnOnce(&mut Q) -> bool) {
+        let needs_wake = f(&mut self.inner);
+        if needs_wake {
+            if let Some(ref waker) = self.waker {
+                waker.wake_by_ref();
+            }
         }
     }
 }
 
-impl<T> Unpin for ScheduledQueue<T> {}
+impl<Q> std::ops::Deref for Inner<Q> {
+    type Target = Q;
 
-impl<T> Stream for ScheduledQueue<T> {
-    type Item = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<Q: Default> Default for Inner<Q> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            waker: None,
+            sleep: Box::pin(tokio::time::sleep(Duration::MAX)),
+        }
+    }
+}
+
+impl<Q> Unpin for Inner<Q> {}
+
+impl<Q: Queue> Stream for Inner<Q> {
+    type Item = Q::Value;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.waker = Some(cx.waker().clone());
@@ -104,22 +284,25 @@ impl<T> Stream for ScheduledQueue<T> {
     }
 }
 
-impl<T> FusedStream for ScheduledQueue<T> {
+impl<Q: Queue> FusedStream for Inner<Q> {
     fn is_terminated(&self) -> bool {
         // The stream never returns `Poll::Ready(None)`.
         false
     }
 }
 
-impl<T> Default for ScheduledQueue<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 struct Item<T> {
     when: Instant,
     value: T,
+}
+
+impl<T> Item<T> {
+    fn as_ref(&self) -> Item<&T> {
+        Item {
+            when: self.when,
+            value: &self.value,
+        }
+    }
 }
 
 impl<T> PartialEq for Item<T> {
@@ -163,8 +346,8 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_squeue() {
+    #[tokio::test(start_paused = true)]
+    async fn test_scheduled_queue() {
         let mut s = ScheduledQueue::new();
 
         let start = Instant::now();
@@ -172,19 +355,62 @@ mod tests {
         s.schedule(start + Duration::from_millis(100), 4);
         s.schedule(start + Duration::from_millis(150), 5);
 
+        s.schedule(start + Duration::from_nanos(3), 2);
         s.schedule(start + Duration::from_nanos(2), 2);
         s.schedule(start + Duration::from_nanos(1), 1);
 
-        for i in 1..6 {
-            let value = s.next().await.unwrap();
-            assert_eq!(value, i);
+        assert_eq!(s.len(), 5);
+        assert_eq!(s.next().await, Some(1));
+        assert_eq!(s.next().await, Some(2));
+        assert_eq!(s.next().await, Some(2));
 
-            if i == 2 {
-                // schedule now!
-                s.schedule(start, 3);
-            }
-        }
+        // Schedule immediately!
+        s.schedule(start, 3);
 
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.next().await, Some(3));
+        assert_eq!(s.next().await, Some(4));
+        assert_eq!(s.next().await, Some(5));
+
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_unique_scheduled_queue() {
+        let mut s = UniqueScheduledQueue::new();
+
+        let start = Instant::now();
+
+        s.schedule(start, "xxx");
+        s.schedule(start + Duration::from_nanos(1), "a");
+        s.schedule(start + Duration::from_nanos(2), "b");
+        s.schedule(start + Duration::from_millis(100), "c");
+        s.schedule(start + Duration::from_millis(150), "d");
+        s.schedule(start + Duration::from_millis(200), "e");
+
+        assert_eq!(s.len(), 6);
+        s.remove(&"xxx");
+        assert_eq!(s.len(), 5);
+
+        assert_eq!(s.next().await, Some("a"));
+        assert_eq!(s.len(), 4);
+
+        // Move `b` to the end.
+        s.schedule(start + Duration::from_secs(1), "b");
+        // Move `d` before `c`.
+        s.schedule(start + Duration::from_millis(99), "d");
+        // Immediately schedule a new element.
+        s.schedule(start, "x");
+
+        assert_eq!(s.len(), 5);
+        assert_eq!(s.next().await, Some("x"));
+        assert_eq!(s.next().await, Some("d"));
+        assert_eq!(s.next().await, Some("c"));
+        assert_eq!(s.next().await, Some("e"));
+        assert_eq!(s.next().await, Some("b"));
+
+        assert_eq!(s.len(), 0);
         assert!(s.is_empty());
     }
 }

--- a/relay-server/src/utils/scheduled/queue.rs
+++ b/relay-server/src/utils/scheduled/queue.rs
@@ -200,7 +200,11 @@ struct Inner<Q> {
 }
 
 impl<Q> Inner<Q> {
-    pub fn modify(&mut self, f: impl FnOnce(&mut Q) -> bool) {
+    /// Provides mutable access to the inner queue implementation.
+    ///
+    /// The closure `f` must return whether the modification requires a wakeup.
+    /// All modifications which changes the head of the queue must return `true`.
+    fn modify(&mut self, f: impl FnOnce(&mut Q) -> bool) {
         let needs_wake = f(&mut self.inner);
         if needs_wake {
             if let Some(ref waker) = self.waker {

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -20,7 +20,6 @@ def test_local_project_config(mini_sentry, relay):
             "file_interval": 1,
             "project_expiry": 1,
             "project_grace_period": 0,
-            "eviction_interval": 1,
         }
     }
     relay = relay(mini_sentry, relay_config, wait_health_check=False)
@@ -82,7 +81,6 @@ def test_project_grace_period(mini_sentry, relay, grace_period):
                 "miss_expiry": 1,
                 "project_expiry": 1,
                 "project_grace_period": grace_period,
-                "eviction_interval": 1,
             }
         },
     )
@@ -328,7 +326,6 @@ def test_project_fetch_revision(mini_sentry, relay, with_revision_support):
                 "miss_expiry": 1,
                 "project_expiry": 1,
                 "project_grace_period": 5,
-                "eviction_interval": 1,
             }
         },
     )


### PR DESCRIPTION
The hunt for tail latencies continues.

Project cache evictions for large project caches are quite costly, we're seeing a max latency for evictions of > 50ms. Timing the evictions of each project is not just much faster (log(n) inserts instead of full scans through projects), but also much shorter individually, giving the runtime opportunities to schedule other tasks.

Implementation is largely the same as in #4233, just backed by a `PriorityQueue` instead of a `BinaryHeap`, the future scheduling code is shared and not changed.

#skip-changelog