### PR TITLE
feat(spooler): Add CachingEnvelopeStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add additional fields to the `Event` `Getter`. ([#4238](https://github.com/getsentry/relay/pull/4238))
 - Replace u64 with `OrganizationId` new-type struct for organization id. ([#4159](https://github.com/getsentry/relay/pull/4159))
 - Add computed contexts for `os`, `browser` and `runtime`. ([#4239](https://github.com/getsentry/relay/pull/4239))
+- Add `CachingEnvelopeStack` strategy to the buffer. ([#4242](https://github.com/getsentry/relay/pull/4242))
 
 ## 24.10.0
 

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -17,7 +17,7 @@ impl<S> CachingEnvelopeStack<S>
 where
     S: EnvelopeStack,
 {
-    /// Creates a new `CachingEnvelopeStack` wrapping the provided envelope stack
+    /// Creates a new [`CachingEnvelopeStack`] wrapping the provided envelope stack
     pub fn new(inner: S) -> Self {
         Self {
             inner,

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -59,7 +59,7 @@ where
 
     async fn flush(mut self) {
         if let Some(envelope) = self.cached {
-            if let Err(_) = self.inner.push(envelope).await {
+            if self.inner.push(envelope).await.is_err() {
                 relay_log::error!(
                     "error while pushing the cached envelope in the inner stack during flushing",
                 );

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -1,0 +1,101 @@
+use chrono::{DateTime, Utc};
+
+use super::EnvelopeStack;
+use crate::envelope::Envelope;
+
+/// An envelope stack implementation that caches one element in memory and delegates
+/// to another envelope stack for additional storage.
+#[derive(Debug)]
+pub struct CachingEnvelopeStack<S> {
+    /// The underlying envelope stack
+    inner: S,
+    /// The cached envelope (if any)
+    cached: Option<Box<Envelope>>,
+}
+
+impl<S> CachingEnvelopeStack<S>
+where
+    S: EnvelopeStack,
+{
+    /// Creates a new `CachingEnvelopeStack` wrapping the provided envelope stack
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            cached: None,
+        }
+    }
+}
+
+impl<S> EnvelopeStack for CachingEnvelopeStack<S>
+where
+    S: EnvelopeStack,
+{
+    type Error = S::Error;
+
+    async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), Self::Error> {
+        if self.cached.is_none() {
+            // If we don't have a cached envelope, store this one in cache
+            self.cached = Some(envelope);
+            Ok(())
+        } else {
+            // If we already have a cached envelope, push the current cached one
+            // to the inner stack and keep the new one in cache
+            let cached = self.cached.take().unwrap();
+            self.inner.push(cached).await?;
+            self.cached = Some(envelope);
+            Ok(())
+        }
+    }
+
+    async fn peek(&mut self) -> Result<Option<DateTime<Utc>>, Self::Error> {
+        if let Some(ref envelope) = self.cached {
+            Ok(Some(envelope.received_at()))
+        } else {
+            self.inner.peek().await
+        }
+    }
+
+    async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
+        if let Some(envelope) = self.cached.take() {
+            Ok(Some(envelope))
+        } else {
+            self.inner.pop().await
+        }
+    }
+
+    async fn flush(mut self) {
+        if let Some(envelope) = self.cached {
+            let _ = self.inner.push(envelope).await;
+        }
+        self.inner.flush().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::buffer::envelope_stack::memory::MemoryEnvelopeStack;
+    use crate::services::buffer::testutils::utils::mock_envelope;
+
+    #[tokio::test]
+    async fn test_caching_stack() {
+        let inner = MemoryEnvelopeStack::new();
+        let mut stack = CachingEnvelopeStack::new(inner);
+
+        // Create test envelopes with different timestamps
+        let env1 = mock_envelope(Utc::now());
+        let env2 = mock_envelope(Utc::now());
+        let env3 = mock_envelope(Utc::now());
+
+        // Push envelopes
+        stack.push(env1).await.unwrap();
+        stack.push(env2).await.unwrap();
+        stack.push(env3).await.unwrap();
+
+        // Pop them back
+        assert!(stack.pop().await.unwrap().is_some()); // Should come from cache
+        assert!(stack.pop().await.unwrap().is_some()); // Should come from inner
+        assert!(stack.pop().await.unwrap().is_some()); // Should come from inner
+        assert!(stack.pop().await.unwrap().is_none()); // Should be empty
+    }
+}

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -24,7 +24,7 @@ impl EnvelopeStack for MemoryEnvelopeStack {
     }
 
     async fn peek(&mut self) -> Result<Option<DateTime<Utc>>, Self::Error> {
-        Ok(self.0.last().map(|e| e.meta().received_at()))
+        Ok(self.0.last().map(|e| e.received_at()))
     }
 
     async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 
 use crate::envelope::Envelope;
 
+pub mod caching;
 pub mod memory;
 pub mod sqlite;
 

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -12,7 +12,7 @@ pub mod sqlite;
 pub trait EnvelopeStack: Send + std::fmt::Debug {
     /// The error type that is returned when an error is encountered during reading or writing the
     /// [`EnvelopeStack`].
-    type Error: std::fmt::Debug;
+    type Error: std::fmt::Debug + std::error::Error;
 
     /// Pushes an [`Envelope`] on top of the stack.
     fn push(&mut self, envelope: Box<Envelope>) -> impl Future<Output = Result<(), Self::Error>>;


### PR DESCRIPTION
This PR implements a new `CachingEnvelopeStack` which caches one element in memory before delegating to the inner `EnvelopeStack` implementation.

Closes: https://github.com/getsentry/team-ingest/issues/586