### PR TITLE
feat(devservices): Only expose ports to localhost

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -25,7 +25,7 @@ services:
   relay:
     image: us-central1-docker.pkg.dev/sentryio/relay/relay:nightly
     ports:
-      - 7899:7899
+      - 127.0.0.1:7899:7899
     command: [run, --config, /etc/relay]
     volumes:
       - ./config/relay.yml:/etc/relay/config.yml


### PR DESCRIPTION
We should be exposing ports only to localhost as a security measure.

#skip-changelog