### PR TITLE
ref(relay): extract sdk name into own metric

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -338,9 +338,18 @@ pub async fn handle_envelope(
     for item in envelope.items() {
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
+            item_type = item.ty().name()
+        );
+        metric!(
+            counter(RelayCounters::EnvelopeItemsPerSdk) += 1,
             item_type = item.ty().name(),
             sdk = client_name.name(),
-        )
+        );
+        metric!(
+            counter(RelayCounters::EnvelopeItemBytesPerSdk) += item.payload().len() as u64,
+            item_type = item.ty().name(),
+            sdk = client_name.name(),
+        );
     }
 
     if state.memory_checker().check_memory().is_exceeded() {

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -341,12 +341,12 @@ pub async fn handle_envelope(
             item_type = item.ty().name()
         );
         metric!(
-            counter(RelayCounters::EnvelopeItemsPerSdk) += 1,
+            counter(RelayCounters::EnvelopeItems) += 1,
             item_type = item.ty().name(),
             sdk = client_name.name(),
         );
         metric!(
-            counter(RelayCounters::EnvelopeItemBytesPerSdk) += item.payload().len() as u64,
+            counter(RelayCounters::EnvelopeItemByteSize) += item.payload().len() as u64,
             item_type = item.ty().name(),
             sdk = client_name.name(),
         );

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -346,7 +346,7 @@ pub async fn handle_envelope(
             sdk = client_name.name(),
         );
         metric!(
-            counter(RelayCounters::EnvelopeItemByteSize) += item.payload().len() as u64,
+            counter(RelayCounters::EnvelopeItemBytes) += item.payload().len() as u64,
             item_type = item.ty().name(),
             sdk = client_name.name(),
         );

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -657,9 +657,9 @@ pub enum RelayCounters {
     ///  - `handling`: Either `"success"` if the envelope was handled correctly, or `"failure"` if
     ///    there was an error or bug.
     EnvelopeRejected,
-    /// Number of items we processed for an SDK
+    /// Number of items we processed per envelope.
     EnvelopeItemsPerSdk,
-    /// Number of bytes we processed for an envelope item.
+    /// Number of bytes we processed per envelope item.
     EnvelopeItemBytesPerSdk,
     /// Number of times the envelope buffer spools to disk.
     BufferWritesDisk,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -658,9 +658,9 @@ pub enum RelayCounters {
     ///    there was an error or bug.
     EnvelopeRejected,
     /// Number of items we processed per envelope.
-    EnvelopeItemsPerSdk,
+    EnvelopeItems,
     /// Number of bytes we processed per envelope item.
-    EnvelopeItemBytesPerSdk,
+    EnvelopeItemByteSize,
     /// Number of times the envelope buffer spools to disk.
     BufferWritesDisk,
     /// Number of times the envelope buffer reads back from disk.
@@ -879,8 +879,8 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EventCorrupted => "event.corrupted",
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",
-            RelayCounters::EnvelopeItemsPerSdk => "event.items",
-            RelayCounters::EnvelopeItemBytesPerSdk => "event.items.size_bytes",
+            RelayCounters::EnvelopeItems => "event.items",
+            RelayCounters::EnvelopeItemByteSize => "event.items.size_bytes",
             RelayCounters::BufferWritesDisk => "buffer.writes",
             RelayCounters::BufferReadsDisk => "buffer.reads",
             RelayCounters::BufferEnvelopesWritten => "buffer.envelopes_written",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -660,7 +660,7 @@ pub enum RelayCounters {
     /// Number of items we processed per envelope.
     EnvelopeItems,
     /// Number of bytes we processed per envelope item.
-    EnvelopeItemByteSize,
+    EnvelopeItemBytes,
     /// Number of times the envelope buffer spools to disk.
     BufferWritesDisk,
     /// Number of times the envelope buffer reads back from disk.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -880,7 +880,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",
             RelayCounters::EnvelopeItems => "event.items",
-            RelayCounters::EnvelopeItemByteSize => "event.items.size_bytes",
+            RelayCounters::EnvelopeItemBytes => "event.item_bytes",
             RelayCounters::BufferWritesDisk => "buffer.writes",
             RelayCounters::BufferReadsDisk => "buffer.reads",
             RelayCounters::BufferEnvelopesWritten => "buffer.envelopes_written",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -657,6 +657,10 @@ pub enum RelayCounters {
     ///  - `handling`: Either `"success"` if the envelope was handled correctly, or `"failure"` if
     ///    there was an error or bug.
     EnvelopeRejected,
+    /// Number of items we processed for an SDK
+    EnvelopeItemsPerSdk,
+    /// Number of bytes we processed for an envelope item.
+    EnvelopeItemBytesPerSdk,
     /// Number of times the envelope buffer spools to disk.
     BufferWritesDisk,
     /// Number of times the envelope buffer reads back from disk.
@@ -875,6 +879,8 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EventCorrupted => "event.corrupted",
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",
+            RelayCounters::EnvelopeItemsPerSdk => "event.items",
+            RelayCounters::EnvelopeItemBytesPerSdk => "event.items.size_bytes",
             RelayCounters::BufferWritesDisk => "buffer.writes",
             RelayCounters::BufferReadsDisk => "buffer.reads",
             RelayCounters::BufferEnvelopesWritten => "buffer.envelopes_written",


### PR DESCRIPTION
Adding the SDK tag to the item_size histogram metric gives us data analysis capabilities which are not necessary while producing more metrics.
This PR extracts all SDK related metrics into own metrics and moves them into counters

#skip-changelog