### PR TITLE
ref(profiling): Always exempt profiles from DS

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -113,13 +113,6 @@ fn is_err_or_empty(filters_config: &ErrorBoundary<GenericFiltersConfig>) -> bool
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Options {
-    /// Kill switch for shutting down unsampled_profile metrics
-    #[serde(
-        rename = "profiling.profile_metrics.unsampled_profiles.enabled",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub unsampled_profiles_enabled: bool,
     /// Kill switch for shutting down profile function metrics
     /// ingestion in the generic-metrics platform
     #[serde(

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1710,17 +1710,13 @@ impl EnvelopeProcessorService {
         };
 
         if let Some(outcome) = sampling_result.into_dropped_outcome() {
-            let keep_profiles = global_config.options.unsampled_profiles_enabled;
             // Process profiles before dropping the transaction, if necessary.
             // Before metric extraction to make sure the profile count is reflected correctly.
-            let profile_id = match keep_profiles {
-                true => profile::process(state, &global_config),
-                false => profile_id,
-            };
+            let profile_id = profile::process(state, &global_config);
             // Extract metrics here, we're about to drop the event/transaction.
             self.extract_transaction_metrics(state, SamplingDecision::Drop, profile_id)?;
 
-            dynamic_sampling::drop_unsampled_items(state, outcome, keep_profiles);
+            dynamic_sampling::drop_unsampled_items(state, outcome);
 
             // At this point we have:
             //  - An empty envelope.

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1161,6 +1161,7 @@ def test_profile_outcomes(
     relay,
     relay_with_processing,
     outcomes_consumer,
+    profiles_consumer,
     num_intermediate_relays,
     metrics_consumer,
 ):
@@ -1173,6 +1174,7 @@ def test_profile_outcomes(
     """
     outcomes_consumer = outcomes_consumer(timeout=5)
     metrics_consumer = metrics_consumer()
+    profiles_consumer = profiles_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
@@ -1286,16 +1288,6 @@ def test_profile_outcomes(
             "reason": "Sampled:3000",
             "source": expected_source,
         },
-        {
-            "category": 11,  # ProfileIndexed
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 1,  # Filtered
-            "project_id": 42,
-            "quantity": 1,
-            "reason": "Sampled:3000",
-            "source": expected_source,
-        },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")
@@ -1309,6 +1301,9 @@ def test_profile_outcomes(
     assert sum(metric["value"] for metric in metrics) == 2
 
     assert outcomes == expected_outcomes, outcomes
+
+    assert profiles_consumer.get_profile()
+    assert profiles_consumer.get_profile()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We no longer have support for DS for profiles, this is all handled within Sentry now.

In a follow-up we need to remove the `has_profile` tag from the usage metric once the outcome accounting is full switched over.

#skip-changelog