### PR TITLE
ref(server): make idle time of a http connection configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Allow `sample_rate` to be float type when deserializing `DynamicSamplingContext`. ([#4181](https://github.com/getsentry/relay/pull/4181))
 - Support inbound filters for profiles. ([#4176](https://github.com/getsentry/relay/pull/4176))
 - Scrub lower-case redis commands. ([#4235](https://github.com/getsentry/relay/pull/4235))
-- Makes the maximum idle time of a HTTP connection configurable. ([#4248](https://github.com/getsentry/relay/pull/4248))
+- Make the maximum idle time of a HTTP connection configurable. ([#4248](https://github.com/getsentry/relay/pull/4248))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Allow `sample_rate` to be float type when deserializing `DynamicSamplingContext`. ([#4181](https://github.com/getsentry/relay/pull/4181))
 - Support inbound filters for profiles. ([#4176](https://github.com/getsentry/relay/pull/4176))
 - Scrub lower-case redis commands. ([#4235](https://github.com/getsentry/relay/pull/4235))
+- Makes the maximum idle time of a HTTP connection configurable. ([#4248](https://github.com/getsentry/relay/pull/4248))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -633,10 +633,17 @@ struct Limits {
     /// The maximum number of seconds to wait for pending envelopes after receiving a shutdown
     /// signal.
     shutdown_timeout: u64,
-    /// server keep-alive timeout in seconds.
+    /// Server keep-alive timeout in seconds.
     ///
     /// By default keep-alive is set to a 5 seconds.
     keepalive_timeout: u64,
+    /// Server idle timeout in seconds.
+    ///
+    /// The idle timeout limits the amount of time a connection is kept open without activity.
+    /// Setting this too short may abort connections before Relay is able to send a response.
+    ///
+    /// By default there is no idle timeout.
+    idle_timeout: Option<u64>,
     /// The TCP listen backlog.
     ///
     /// Configures the TCP listen backlog for the listening socket of Relay.
@@ -673,6 +680,7 @@ impl Default for Limits {
             query_timeout: 30,
             shutdown_timeout: 10,
             keepalive_timeout: 5,
+            idle_timeout: None,
             tcp_listen_backlog: 1024,
         }
     }
@@ -2317,6 +2325,11 @@ impl Config {
     /// By default keep alive is set to a 5 seconds.
     pub fn keepalive_timeout(&self) -> Duration {
         Duration::from_secs(self.values.limits.keepalive_timeout)
+    }
+
+    /// Returns the server idle timeout in seconds.
+    pub fn idle_timeout(&self) -> Option<Duration> {
+        self.values.limits.idle_timeout.map(Duration::from_secs)
     }
 
     /// TCP listen backlog to configure on Relay's listening socket.

--- a/relay-server/src/services/server/acceptor.rs
+++ b/relay-server/src/services/server/acceptor.rs
@@ -1,7 +1,7 @@
 use std::io;
+use std::time::Duration;
 
 use axum_server::accept::Accept;
-use relay_config::Config;
 use socket2::TcpKeepalive;
 use tokio::net::TcpStream;
 
@@ -9,17 +9,63 @@ use crate::services::server::io::IdleTimeout;
 use crate::statsd::RelayCounters;
 
 #[derive(Clone, Debug, Default)]
-pub struct RelayAcceptor(Option<TcpKeepalive>);
+pub struct RelayAcceptor {
+    tcp_keepalive: Option<TcpKeepalive>,
+    idle_timeout: Option<Duration>,
+}
 
 impl RelayAcceptor {
-    /// Create a new acceptor that sets `TCP_NODELAY` and keep-alive.
-    pub fn new(config: &Config, keepalive_retries: u32) -> Self {
-        Self(build_keepalive(config, keepalive_retries))
+    /// Creates a new [`RelayAcceptor`] which only configures `TCP_NODELAY`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Configures the acceptor to enable TCP keep-alive.
+    ///
+    /// The `timeout` is used to configure the keep-alive time as well as interval.
+    /// A zero duration timeout disables TCP keep-alive.
+    ///
+    /// `retries` configures the amount of keep-alive probes.
+    pub fn tcp_keepalive(mut self, timeout: Duration, retries: u32) -> Self {
+        if timeout.is_zero() {
+            self.tcp_keepalive = None;
+            return self;
+        }
+
+        let mut ka = socket2::TcpKeepalive::new().with_time(timeout);
+        #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
+        {
+            ka = ka.with_interval(timeout);
+        }
+        #[cfg(not(any(
+            target_os = "openbsd",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "windows"
+        )))]
+        {
+            ka = ka.with_retries(retries);
+        }
+        self.tcp_keepalive = Some(ka);
+
+        self
+    }
+
+    /// Configures an idle timeout for the connection.
+    ///
+    /// Whenever there is no activity on a connection for the specified timeout,
+    /// the connection is closed.
+    ///
+    /// Note: This limits the total idle time of a duration and unlike read and write timeouts
+    /// also limits the time a connection is kept alive without requests.
+    pub fn idle_timeout(mut self, idle_timeout: Option<Duration>) -> Self {
+        self.idle_timeout = idle_timeout;
+        self
     }
 }
 
 impl<S> Accept<TcpStream, S> for RelayAcceptor {
-    type Stream = std::pin::Pin<Box<IdleTimeout<TcpStream>>>;
+    type Stream = IdleTimeout<TcpStream>;
     type Service = S;
     type Future = std::future::Ready<io::Result<(Self::Stream, Self::Service)>>;
 
@@ -27,7 +73,7 @@ impl<S> Accept<TcpStream, S> for RelayAcceptor {
         let mut keepalive = "ok";
         let mut nodelay = "ok";
 
-        if let Self(Some(ref tcp_keepalive)) = self {
+        if let Some(tcp_keepalive) = &self.tcp_keepalive {
             let sock_ref = socket2::SockRef::from(&stream);
             if let Err(e) = sock_ref.set_tcp_keepalive(tcp_keepalive) {
                 relay_log::trace!("error trying to set TCP keepalive: {e}");
@@ -46,32 +92,7 @@ impl<S> Accept<TcpStream, S> for RelayAcceptor {
             nodelay = nodelay
         );
 
-        let stream = Box::pin(IdleTimeout::new(stream, std::time::Duration::from_secs(5)));
+        let stream = IdleTimeout::new(stream, self.idle_timeout);
         std::future::ready(Ok((stream, service)))
     }
-}
-
-fn build_keepalive(config: &Config, keepalive_retries: u32) -> Option<TcpKeepalive> {
-    let ka_timeout = config.keepalive_timeout();
-    if ka_timeout.is_zero() {
-        return None;
-    }
-
-    let mut ka = TcpKeepalive::new().with_time(ka_timeout);
-    #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
-    {
-        ka = ka.with_interval(ka_timeout);
-    }
-
-    #[cfg(not(any(
-        target_os = "openbsd",
-        target_os = "redox",
-        target_os = "solaris",
-        target_os = "windows"
-    )))]
-    {
-        ka = ka.with_retries(keepalive_retries);
-    }
-
-    Some(ka)
 }

--- a/relay-server/src/services/server/acceptor.rs
+++ b/relay-server/src/services/server/acceptor.rs
@@ -1,0 +1,77 @@
+use std::io;
+
+use axum_server::accept::Accept;
+use relay_config::Config;
+use socket2::TcpKeepalive;
+use tokio::net::TcpStream;
+
+use crate::services::server::io::IdleTimeout;
+use crate::statsd::RelayCounters;
+
+#[derive(Clone, Debug, Default)]
+pub struct RelayAcceptor(Option<TcpKeepalive>);
+
+impl RelayAcceptor {
+    /// Create a new acceptor that sets `TCP_NODELAY` and keep-alive.
+    pub fn new(config: &Config, keepalive_retries: u32) -> Self {
+        Self(build_keepalive(config, keepalive_retries))
+    }
+}
+
+impl<S> Accept<TcpStream, S> for RelayAcceptor {
+    type Stream = std::pin::Pin<Box<IdleTimeout<TcpStream>>>;
+    type Service = S;
+    type Future = std::future::Ready<io::Result<(Self::Stream, Self::Service)>>;
+
+    fn accept(&self, stream: TcpStream, service: S) -> Self::Future {
+        let mut keepalive = "ok";
+        let mut nodelay = "ok";
+
+        if let Self(Some(ref tcp_keepalive)) = self {
+            let sock_ref = socket2::SockRef::from(&stream);
+            if let Err(e) = sock_ref.set_tcp_keepalive(tcp_keepalive) {
+                relay_log::trace!("error trying to set TCP keepalive: {e}");
+                keepalive = "error";
+            }
+        }
+
+        if let Err(e) = stream.set_nodelay(true) {
+            relay_log::trace!("failed to set TCP_NODELAY: {e}");
+            nodelay = "error";
+        }
+
+        relay_statsd::metric!(
+            counter(RelayCounters::ServerSocketAccept) += 1,
+            keepalive = keepalive,
+            nodelay = nodelay
+        );
+
+        let stream = Box::pin(IdleTimeout::new(stream, std::time::Duration::from_secs(5)));
+        std::future::ready(Ok((stream, service)))
+    }
+}
+
+fn build_keepalive(config: &Config, keepalive_retries: u32) -> Option<TcpKeepalive> {
+    let ka_timeout = config.keepalive_timeout();
+    if ka_timeout.is_zero() {
+        return None;
+    }
+
+    let mut ka = TcpKeepalive::new().with_time(ka_timeout);
+    #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
+    {
+        ka = ka.with_interval(ka_timeout);
+    }
+
+    #[cfg(not(any(
+        target_os = "openbsd",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "windows"
+    )))]
+    {
+        ka = ka.with_retries(keepalive_retries);
+    }
+
+    Some(ka)
+}

--- a/relay-server/src/services/server/acceptor.rs
+++ b/relay-server/src/services/server/acceptor.rs
@@ -32,10 +32,10 @@ impl RelayAcceptor {
             return self;
         }
 
-        let mut ka = socket2::TcpKeepalive::new().with_time(timeout);
+        let mut keepalive = socket2::TcpKeepalive::new().with_time(timeout);
         #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
         {
-            ka = ka.with_interval(timeout);
+            keepalive = keepalive.with_interval(timeout);
         }
         #[cfg(not(any(
             target_os = "openbsd",
@@ -44,9 +44,9 @@ impl RelayAcceptor {
             target_os = "windows"
         )))]
         {
-            ka = ka.with_retries(retries);
+            keepalive = keepalive.with_retries(retries);
         }
-        self.tcp_keepalive = Some(ka);
+        self.tcp_keepalive = Some(keepalive);
 
         self
     }

--- a/relay-server/src/services/server/io.rs
+++ b/relay-server/src/services/server/io.rs
@@ -1,0 +1,114 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::Sleep;
+
+use crate::statsd::RelayCounters;
+
+pin_project_lite::pin_project! {
+    pub struct IdleTimeout<T> {
+        #[pin]
+        inner: T,
+        timeout: Duration,
+        #[pin]
+        sleep: Option<Sleep>,
+    }
+}
+
+impl<T> IdleTimeout<T> {
+    pub fn new(inner: T, timeout: Duration) -> Self {
+        Self {
+            inner,
+            timeout,
+            sleep: None,
+        }
+    }
+
+    fn wrap_poll<F, R>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        poll_fn: F,
+    ) -> Poll<std::io::Result<R>>
+    where
+        F: FnOnce(Pin<&mut T>, &mut Context<'_>) -> Poll<std::io::Result<R>>,
+    {
+        let mut this = self.project();
+        match poll_fn(this.inner, cx) {
+            Poll::Ready(ret) => {
+                // Any activity on the stream resets the timeout.
+                this.sleep.set(None);
+                Poll::Ready(ret)
+            }
+            Poll::Pending => {
+                // No activity on the stream, start the idle timeout.
+                if this.sleep.is_none() {
+                    this.sleep.set(Some(tokio::time::sleep(*this.timeout)));
+                }
+
+                let sleep = this.sleep.as_pin_mut().expect("sleep timer was just set");
+                match sleep.poll(cx) {
+                    Poll::Ready(_) => {
+                        relay_log::trace!("closing idle server connection");
+                        relay_statsd::metric!(
+                            counter(RelayCounters::ServerConnectionIdleTimeout) += 1
+                        );
+                        Poll::Ready(Err(std::io::ErrorKind::TimedOut.into()))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+        }
+    }
+}
+
+impl<T> AsyncRead for IdleTimeout<T>
+where
+    T: AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        self.wrap_poll(cx, |stream, cx| stream.poll_read(cx, buf))
+    }
+}
+
+impl<T> AsyncWrite for IdleTimeout<T>
+where
+    T: AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.wrap_poll(cx, |stream, cx| stream.poll_write(cx, buf))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        self.wrap_poll(cx, |stream, cx| stream.poll_flush(cx))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.wrap_poll(cx, |stream, cx| stream.poll_shutdown(cx))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.wrap_poll(cx, |stream, cx| stream.poll_write_vectored(cx, bufs))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -115,11 +115,12 @@ fn listen(config: &Config) -> Result<TcpListener, ServerError> {
 fn serve(listener: TcpListener, app: App, config: Arc<Config>) {
     let handle = Handle::new();
 
+    let acceptor = self::acceptor::RelayAcceptor::new()
+        .tcp_keepalive(config.keepalive_timeout(), KEEPALIVE_RETRIES)
+        .idle_timeout(config.idle_timeout());
+
     let mut server = axum_server::from_tcp(listener)
-        .acceptor(self::acceptor::RelayAcceptor::new(
-            &config,
-            KEEPALIVE_RETRIES,
-        ))
+        .acceptor(acceptor)
         .handle(handle.clone());
 
     server

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 use std::time::Duration;
@@ -6,13 +5,11 @@ use std::time::Duration;
 use axum::extract::Request;
 use axum::http::{header, HeaderName, HeaderValue};
 use axum::ServiceExt;
-use axum_server::accept::Accept;
 use axum_server::Handle;
 use hyper_util::rt::TokioTimer;
 use relay_config::Config;
 use relay_system::{Controller, Service, Shutdown};
-use socket2::TcpKeepalive;
-use tokio::net::{TcpSocket, TcpStream};
+use tokio::net::TcpSocket;
 use tower::ServiceBuilder;
 use tower_http::compression::predicate::SizeAbove;
 use tower_http::compression::{CompressionLayer, DefaultPredicate, Predicate};
@@ -25,6 +22,9 @@ use crate::middlewares::{
 };
 use crate::service::ServiceState;
 use crate::statsd::{RelayCounters, RelayGauges};
+
+mod acceptor;
+mod io;
 
 /// Set the number of keep-alive retransmissions to be carried out before declaring that remote end
 /// is not available.
@@ -47,7 +47,7 @@ const COMPRESSION_MIN_SIZE: u16 = 128;
 pub enum ServerError {
     /// Binding failed.
     #[error("bind to interface failed")]
-    BindFailed(#[from] io::Error),
+    BindFailed(#[from] std::io::Error),
 
     /// TLS support was not compiled in.
     #[error("SSL is no longer supported by Relay, please use a proxy in front")]
@@ -112,78 +112,14 @@ fn listen(config: &Config) -> Result<TcpListener, ServerError> {
     Ok(socket.listen(config.tcp_listen_backlog())?.into_std()?)
 }
 
-fn build_keepalive(config: &Config) -> Option<TcpKeepalive> {
-    let ka_timeout = config.keepalive_timeout();
-    if ka_timeout.is_zero() {
-        return None;
-    }
-
-    let mut ka = TcpKeepalive::new().with_time(ka_timeout);
-    #[cfg(not(any(target_os = "openbsd", target_os = "redox", target_os = "solaris")))]
-    {
-        ka = ka.with_interval(ka_timeout);
-    }
-
-    #[cfg(not(any(
-        target_os = "openbsd",
-        target_os = "redox",
-        target_os = "solaris",
-        target_os = "windows"
-    )))]
-    {
-        ka = ka.with_retries(KEEPALIVE_RETRIES);
-    }
-
-    Some(ka)
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct KeepAliveAcceptor(Option<TcpKeepalive>);
-
-impl KeepAliveAcceptor {
-    /// Create a new acceptor that sets `TCP_NODELAY` and keep-alive.
-    pub fn new(config: &Config) -> Self {
-        Self(build_keepalive(config))
-    }
-}
-
-impl<S> Accept<TcpStream, S> for KeepAliveAcceptor {
-    type Stream = TcpStream;
-    type Service = S;
-    type Future = std::future::Ready<io::Result<(Self::Stream, Self::Service)>>;
-
-    fn accept(&self, stream: TcpStream, service: S) -> Self::Future {
-        let mut keepalive = "ok";
-        let mut nodelay = "ok";
-
-        if let Self(Some(ref tcp_keepalive)) = self {
-            let sock_ref = socket2::SockRef::from(&stream);
-            if let Err(e) = sock_ref.set_tcp_keepalive(tcp_keepalive) {
-                relay_log::trace!("error trying to set TCP keepalive: {e}");
-                keepalive = "error";
-            }
-        }
-
-        if let Err(e) = stream.set_nodelay(true) {
-            relay_log::trace!("failed to set TCP_NODELAY: {e}");
-            nodelay = "error";
-        }
-
-        relay_statsd::metric!(
-            counter(RelayCounters::ServerSocketAccept) += 1,
-            keepalive = keepalive,
-            nodelay = nodelay
-        );
-
-        std::future::ready(Ok((stream, service)))
-    }
-}
-
 fn serve(listener: TcpListener, app: App, config: Arc<Config>) {
     let handle = Handle::new();
 
     let mut server = axum_server::from_tcp(listener)
-        .acceptor(KeepAliveAcceptor::new(&config))
+        .acceptor(self::acceptor::RelayAcceptor::new(
+            &config,
+            KEEPALIVE_RETRIES,
+        ))
         .handle(handle.clone());
 
     server

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -867,6 +867,8 @@ pub enum RelayCounters {
     ReplayExceededSegmentLimit,
     /// Incremented every time the server accepts a new connection.
     ServerSocketAccept,
+    /// Incremented every time the server aborts a connection because of an idle timeout.
+    ServerConnectionIdleTimeout,
 }
 
 impl CounterMetric for RelayCounters {
@@ -913,6 +915,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::BucketsDropped => "metrics.buckets.dropped",
             RelayCounters::ReplayExceededSegmentLimit => "replay.segment_limit_exceeded",
             RelayCounters::ServerSocketAccept => "server.http.accepted",
+            RelayCounters::ServerConnectionIdleTimeout => "server.http.idle_timeout",
         }
     }
 }


### PR DESCRIPTION
With the idle time configurable we can prevent a pile up of open connections which never see any activity.

See also on the hyper issue tracker:
```
https://github.com/hyperium/hyper/pull/3743
https://github.com/hyperium/hyper/issues/1628
https://github.com/hyperium/hyper/issues/2355
https://github.com/hyperium/hyper/pull/2827
```