### PR TITLE
feat(sentry): Add server_name option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Support inbound filters for profiles. ([#4176](https://github.com/getsentry/relay/pull/4176))
 - Scrub lower-case redis commands. ([#4235](https://github.com/getsentry/relay/pull/4235))
 - Make the maximum idle time of a HTTP connection configurable. ([#4248](https://github.com/getsentry/relay/pull/4248))
-- Allow configuring a Sentry server name ([#4251](https://github.com/getsentry/relay/pull/4251))
+- Allow configuring a Sentry server name with an option or the `RELAY_SERVER_NAME` environment variable. ([#4251](https://github.com/getsentry/relay/pull/4251))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Support inbound filters for profiles. ([#4176](https://github.com/getsentry/relay/pull/4176))
 - Scrub lower-case redis commands. ([#4235](https://github.com/getsentry/relay/pull/4235))
 - Make the maximum idle time of a HTTP connection configurable. ([#4248](https://github.com/getsentry/relay/pull/4248))
+- Allow configuring a Sentry server name ([#4251](https://github.com/getsentry/relay/pull/4251))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -250,6 +250,8 @@ pub struct OverridableConfig {
     pub outcome_source: Option<String>,
     /// shutdown timeout
     pub shutdown_timeout: Option<String>,
+    /// Server name reported in the Sentry SDK.
+    pub server_name: Option<String>,
 }
 
 /// The relay credentials
@@ -1767,6 +1769,10 @@ impl Config {
             if let Ok(shutdown_timeout) = shutdown_timeout.parse::<u64>() {
                 limits.shutdown_timeout = shutdown_timeout;
             }
+        }
+
+        if let Some(server_name) = overrides.server_name {
+            self.values.sentry.server_name = Some(server_name.into());
         }
 
         Ok(self)

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -12,10 +12,6 @@ use serde::{Deserialize, Serialize};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{prelude::*, EnvFilter, Layer};
 
-/// Name of the environment variable containing the Sentry
-/// [`server_name`](sentry::ClientOptions::server_name).
-const SERVER_NAME_VAR: &str = "RELAY_SERVER_NAME";
-
 /// The full release name including the Relay version and SHA.
 const RELEASE: &str = std::env!("RELAY_RELEASE");
 
@@ -298,17 +294,13 @@ pub fn init(config: &LogConfig, sentry: &SentryConfig) {
         .init();
 
     if let Some(dsn) = sentry.enabled_dsn() {
-        let server_name = env::var(SERVER_NAME_VAR)
-            .ok()
-            .map(Cow::from)
-            .or_else(|| sentry.server_name.clone());
         let mut options = sentry::ClientOptions {
             dsn: Some(dsn).cloned(),
             in_app_include: vec!["relay"],
             release: Some(RELEASE.into()),
             attach_stacktrace: config.enable_backtraces,
             environment: sentry.environment.clone(),
-            server_name,
+            server_name: sentry.server_name.clone(),
             traces_sample_rate: config.traces_sample_rate,
             ..Default::default()
         };

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -173,6 +173,9 @@ pub struct SentryConfig {
     /// Sets the environment for this service.
     pub environment: Option<Cow<'static, str>>,
 
+    /// Sets the server name for this service.
+    pub server_name: Option<Cow<'static, str>>,
+
     /// Add defaults tags to the events emitted by Relay
     pub default_tags: Option<BTreeMap<String, String>>,
 
@@ -196,6 +199,7 @@ impl Default for SentryConfig {
                 .ok(),
             enabled: false,
             environment: None,
+            server_name: None,
             default_tags: None,
             _crash_db: None,
         }
@@ -293,6 +297,7 @@ pub fn init(config: &LogConfig, sentry: &SentryConfig) {
             release: Some(RELEASE.into()),
             attach_stacktrace: config.enable_backtraces,
             environment: sentry.environment.clone(),
+            server_name: sentry.server_name.clone(),
             traces_sample_rate: config.traces_sample_rate,
             ..Default::default()
         };

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -120,7 +120,9 @@ pub fn extract_config_env_vars() -> OverridableConfig {
         outcome_source: None, //already extracted in params
         shutdown_timeout: env::var("SHUTDOWN_TIMEOUT").ok(),
         instance: env::var("RELAY_INSTANCE").ok(),
-        server_name: env::var("RELAY_SERVER_NAME").ok(),
+        server_name: env::var("RELAY_SERVER_NAME")
+            .ok()
+            .or_else(|| env::var("HOSTNAME").ok()),
     }
 }
 

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -119,6 +119,7 @@ pub fn extract_config_env_vars() -> OverridableConfig {
         outcome_source: None, //already extracted in params
         shutdown_timeout: env::var("SHUTDOWN_TIMEOUT").ok(),
         instance: env::var("RELAY_INSTANCE").ok(),
+        server_name: env::var("RELAY_SERVER_NAME").ok(),
     }
 }
 

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -98,7 +98,7 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
         outcome_source: matches.get_one("source_id").cloned(),
         shutdown_timeout: matches.get_one("shutdown_timeout").cloned(),
         instance: matches.get_one("instance").cloned(),
-        server_name: None,
+        server_name: matches.get_one("server_name").cloned(),
     }
 }
 

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -98,6 +98,7 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
         outcome_source: matches.get_one("source_id").cloned(),
         shutdown_timeout: matches.get_one("shutdown_timeout").cloned(),
         instance: matches.get_one("instance").cloned(),
+        server_name: None,
     }
 }
 

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -146,6 +146,11 @@ pub fn make_app() -> Command {
                         .long("instance")
                         .help("The instance type of this Relay.")
                 )
+                .arg(
+                    Arg::new("server_name")
+                        .long("server-name")
+                        .help("The server name reported to Sentry.")
+                )
         )
         .subcommand(
             Command::new("credentials")


### PR DESCRIPTION
Unlike `default_tags`, the `server_name` also gets set for transactions. This might aid in the investigation of https://github.com/getsentry/team-ingest/issues/587.