### PR TITLE
ref(server): Simplify scheduled queue implementation

### DIFF
--- a/relay-server/src/utils/scheduled/queue.rs
+++ b/relay-server/src/utils/scheduled/queue.rs
@@ -5,7 +5,7 @@ use std::collections::BinaryHeap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::stream::FusedStream;
@@ -39,10 +39,7 @@ impl<T> ScheduledQueue<T> {
 
     /// Schedules a new item to be yielded at `when`.
     pub fn schedule(&mut self, when: Instant, value: T) {
-        self.inner.modify(|q| {
-            q.push(Item { when, value });
-            true
-        })
+        self.inner.push(Item { when, value });
     }
 }
 
@@ -111,18 +108,12 @@ impl<T: std::hash::Hash + Eq> UniqueScheduledQueue<T> {
     /// If the item was net yet scheduled, it is inserted into the queue,
     /// otherwise the previous schedule is moved to the new deadline.
     pub fn schedule(&mut self, when: Instant, value: T) {
-        self.inner.modify(|q| match q.push(value, Reverse(when)) {
-            // Item was already in the queue, we only need to wake if the new value is earlier than
-            // the one which was already scheduled.
-            Some(Reverse(old)) => when < old,
-            // Item previously didn't exist, always wake just to be sure.
-            None => true,
-        });
+        self.inner.push(value, Reverse(when));
     }
 
     /// Removes a value from the queue.
     pub fn remove(&mut self, value: &T) {
-        self.inner.modify(|q| q.remove(value).is_some());
+        self.inner.remove(value);
     }
 }
 
@@ -160,58 +151,42 @@ impl<T: std::hash::Hash + Eq> Default for UniqueScheduledQueue<T> {
 trait Queue {
     type Value;
 
-    /// Peeks into the queue returning a reference to the first value.
-    fn peek(&self) -> Option<Item<&Self::Value>>;
+    /// Peeks into the queue returning the deadline of the first item.
+    fn peek_when(&self) -> Option<Instant>;
     /// Removes the first element from the queue returning its value.
     ///
-    /// A successful [`Self::peek`] followed by a [`Self::pop`] must not return `None`.
-    fn pop(&mut self) -> Option<Item<Self::Value>>;
+    /// A successful [`Self::peek_when`] followed by a [`Self::pop_value`] must not return `None`.
+    fn pop_value(&mut self) -> Option<Self::Value>;
 }
 
 impl<T> Queue for BinaryHeap<Item<T>> {
     type Value = T;
 
-    fn peek(&self) -> Option<Item<&Self::Value>> {
-        BinaryHeap::peek(self).map(|item| item.as_ref())
+    fn peek_when(&self) -> Option<Instant> {
+        self.peek().map(|item| item.when)
     }
 
-    fn pop(&mut self) -> Option<Item<Self::Value>> {
-        BinaryHeap::pop(self)
+    fn pop_value(&mut self) -> Option<Self::Value> {
+        self.pop().map(|item| item.value)
     }
 }
 
 impl<T: std::hash::Hash + Eq> Queue for priority_queue::PriorityQueue<T, Reverse<Instant>> {
     type Value = T;
 
-    fn peek(&self) -> Option<Item<&Self::Value>> {
-        PriorityQueue::peek(self).map(|(value, Reverse(when))| Item { when: *when, value })
+    fn peek_when(&self) -> Option<Instant> {
+        self.peek().map(|(_, Reverse(when))| *when)
     }
 
-    fn pop(&mut self) -> Option<Item<Self::Value>> {
-        PriorityQueue::pop(self).map(|(value, Reverse(when))| Item { when, value })
+    fn pop_value(&mut self) -> Option<Self::Value> {
+        self.pop().map(|(value, _)| value)
     }
 }
 
 #[derive(Debug)]
 struct Inner<Q> {
     inner: Q,
-    waker: Option<Waker>,
     sleep: Pin<Box<tokio::time::Sleep>>,
-}
-
-impl<Q> Inner<Q> {
-    /// Provides mutable access to the inner queue implementation.
-    ///
-    /// The closure `f` must return whether the modification requires a wakeup.
-    /// All modifications which changes the head of the queue must return `true`.
-    fn modify(&mut self, f: impl FnOnce(&mut Q) -> bool) {
-        let needs_wake = f(&mut self.inner);
-        if needs_wake {
-            if let Some(ref waker) = self.waker {
-                waker.wake_by_ref();
-            }
-        }
-    }
 }
 
 impl<Q> std::ops::Deref for Inner<Q> {
@@ -222,11 +197,16 @@ impl<Q> std::ops::Deref for Inner<Q> {
     }
 }
 
+impl<Q> std::ops::DerefMut for Inner<Q> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
 impl<Q: Default> Default for Inner<Q> {
     fn default() -> Self {
         Self {
             inner: Default::default(),
-            waker: None,
             sleep: Box::pin(tokio::time::sleep(Duration::MAX)),
         }
     }
@@ -238,52 +218,20 @@ impl<Q: Queue> Stream for Inner<Q> {
     type Item = Q::Value;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.waker = Some(cx.waker().clone());
-
-        let sleep = self.sleep.as_mut().poll(cx);
-
-        // No item means, we're pending until scheduled (through adding an item).
-        if let Some(next) = self.inner.peek() {
-            let when = next.when;
-
-            // TODO: maybe optimize here for `when` being in the past but the sleep
-            // is still in the future. This can happen when an item with a shorter
-            // deadline, than the item at the front of the queue, is inserted.
-            //
-            // With the current behaviour we will reset the sleep deadline (in the else branch)
-            // to a value which will immediately be ready.
-            // Only after the sleep yields ready, we yield the item.
-            //
-            // This is one more wakeup and sleep poll than necessary.
-            //
-            // The current design is much simpler and less prone to mistakes since
-            // the sleep is always synchronized to the first item in the queue.
-            if matches!(sleep, Poll::Ready(_)) && when <= Instant::now() {
-                // We already expired the first item, yield it.
-                let current = self.inner.pop().expect("pop after peek should never fail");
-
-                let next_deadline = self
-                    .inner
-                    .peek()
-                    .map(|item| item.when)
-                    .unwrap_or_else(far_future);
-                self.sleep.as_mut().reset(next_deadline);
-                // Immediately wake up to check the next item and to poll the new sleep deadline.
-                cx.waker().wake_by_ref();
-
-                return Poll::Ready(Some(current.value));
-            } else if self.sleep.deadline() != when {
-                // Somehow the deadline does not match the first item anymore, adjust the deadline.
-                // This may happen when there is a new item in the queue and we got woken to
-                // update the deadline or in the rare case where the first item got removed
-                // while we were getting woken from the sleep.
+        if let Some(when) = self.inner.peek_when() {
+            // The head of the queue changed, reset the deadline.
+            if self.sleep.deadline() != when {
                 self.sleep.as_mut().reset(when);
-                // Immediately wake to await the new deadline.
-                cx.waker().wake_by_ref();
+            }
+
+            // Poll and wait for the next item to be ready.
+            if self.sleep.as_mut().poll(cx).is_ready() {
+                // Item is ready, yield it.
+                let value = self.inner.pop_value().expect("pop after peek");
+                return Poll::Ready(Some(value));
             }
         }
 
-        // Next wake up already triggered or will be triggered by sleep.
         Poll::Pending
     }
 }
@@ -298,15 +246,6 @@ impl<Q: Queue> FusedStream for Inner<Q> {
 struct Item<T> {
     when: Instant,
     value: T,
-}
-
-impl<T> Item<T> {
-    fn as_ref(&self) -> Item<&T> {
-        Item {
-            when: self.when,
-            value: &self.value,
-        }
-    }
 }
 
 impl<T> PartialEq for Item<T> {
@@ -335,13 +274,6 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)
     }
-}
-
-/// Creates an instant in the far future which is not expected to be hit.
-///
-/// This follows an internal implementation detail for [`tokio::time::sleep`].
-fn far_future() -> Instant {
-    Instant::now() + Duration::from_secs(86400 * 365 * 30)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Simplifies the `poll_next` implementation, a lot of the previous impl was not necessary in a variant which does not allow concurrent modifications.

Collapses all duplicated code of the two implementations into a single macro instead of via generics.

#skip-changelog