### PR TITLE
ref(server): Remove envelope item metrics

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -334,21 +334,10 @@ pub async fn handle_envelope(
     state: &ServiceState,
     envelope: Box<Envelope>,
 ) -> Result<Option<EventId>, BadStoreRequest> {
-    let client_name = envelope.meta().client_name();
     for item in envelope.items() {
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
             item_type = item.ty().name()
-        );
-        metric!(
-            counter(RelayCounters::EnvelopeItems) += 1,
-            item_type = item.ty().name(),
-            sdk = client_name.name(),
-        );
-        metric!(
-            counter(RelayCounters::EnvelopeItemBytes) += item.payload().len() as u64,
-            item_type = item.ty().name(),
-            sdk = client_name.name(),
         );
     }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -657,10 +657,6 @@ pub enum RelayCounters {
     ///  - `handling`: Either `"success"` if the envelope was handled correctly, or `"failure"` if
     ///    there was an error or bug.
     EnvelopeRejected,
-    /// Number of items we processed per envelope.
-    EnvelopeItems,
-    /// Number of bytes we processed per envelope item.
-    EnvelopeItemBytes,
     /// Number of times the envelope buffer spools to disk.
     BufferWritesDisk,
     /// Number of times the envelope buffer reads back from disk.
@@ -881,8 +877,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EventCorrupted => "event.corrupted",
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",
-            RelayCounters::EnvelopeItems => "event.items",
-            RelayCounters::EnvelopeItemBytes => "event.item_bytes",
             RelayCounters::BufferWritesDisk => "buffer.writes",
             RelayCounters::BufferReadsDisk => "buffer.reads",
             RelayCounters::BufferEnvelopesWritten => "buffer.envelopes_written",


### PR DESCRIPTION
For some reason these added metrics add an error to all other counter metrics. While reverting doesn't fix the underlying issue, it at least fixes the metrics for now.

Reverts: #4246

#skip-changelog