### PR TITLE
ref(project-cache): Remove hit/miss metric, add schedules metric

### DIFF
--- a/relay-server/src/services/projects/cache/service.rs
+++ b/relay-server/src/services/projects/cache/service.rs
@@ -134,6 +134,7 @@ impl ProjectCacheService {
         };
         self.scheduled_fetches.schedule(when, Box::pin(task));
 
+        metric!(counter(RelayCounters::ProjectCacheSchedule) += 1);
         metric!(
             gauge(RelayGauges::ProjectCacheScheduledFetches) = self.scheduled_fetches.len() as u64
         );

--- a/relay-server/src/services/projects/cache/state.rs
+++ b/relay-server/src/services/projects/cache/state.rs
@@ -12,7 +12,7 @@ use relay_statsd::metric;
 
 use crate::services::projects::project::{ProjectState, Revision};
 use crate::services::projects::source::SourceProjectState;
-use crate::statsd::{RelayCounters, RelayHistograms};
+use crate::statsd::RelayHistograms;
 use crate::utils::{RetryBackoff, UniqueScheduledQueue};
 
 /// The backing storage for a project cache.
@@ -151,13 +151,7 @@ impl ProjectStore {
         let private = self
             .private
             .entry(project_key)
-            .and_modify(|_| {
-                metric!(counter(RelayCounters::ProjectCacheHit) += 1);
-            })
-            .or_insert_with(|| {
-                metric!(counter(RelayCounters::ProjectCacheMiss) += 1);
-                PrivateProjectState::new(project_key, config)
-            });
+            .or_insert_with(|| PrivateProjectState::new(project_key, config));
 
         let shared = self
             .shared

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -725,15 +725,8 @@ pub enum RelayCounters {
     ///     - `false`: the request will be sent to the sentry endpoint.
     #[cfg(feature = "processing")]
     ProjectStateRedis,
-    /// Number of times a project is looked up from the cache.
-    ///
-    /// The cache may contain and outdated or expired project state. In that case, the project state
-    /// is updated even after a cache hit.
-    ProjectCacheHit,
-    /// Number of times a project lookup failed.
-    ///
-    /// A cache entry is created immediately and the project state requested from the upstream.
-    ProjectCacheMiss,
+    /// Number of times a project had a fetch scheduled.
+    ProjectCacheSchedule,
     /// Number of times an upstream request for a project config is completed.
     ///
     /// Completion can be because a result was returned or because the config request was
@@ -894,8 +887,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProjectStateRedis => "project_state.redis.requests",
             RelayCounters::ProjectUpstreamCompleted => "project_upstream.completed",
             RelayCounters::ProjectUpstreamFailed => "project_upstream.failed",
-            RelayCounters::ProjectCacheHit => "project_cache.hit",
-            RelayCounters::ProjectCacheMiss => "project_cache.miss",
+            RelayCounters::ProjectCacheSchedule => "project_cache.schedule",
             RelayCounters::ServerStarting => "server.starting",
             #[cfg(feature = "processing")]
             RelayCounters::ProcessingMessageProduced => "processing.event.produced",


### PR DESCRIPTION
The hit/miss metrics are not useful but very high volume, the schedule rate is a better metric.

#skip-changelog