### PR TITLE
feat(server): Implement zstd encoding for relay to relay communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Terminate the process when one of the services crashes. ([#4249](https://github.com/getsentry/relay/pull/4249))
 
+**Features**:
+
+- Implement zstd http encoding for Relay to Relay communication. ([#4266](https://github.com/getsentry/relay/pull/4266))
+
 ## 24.11.0
 
 **Breaking Changes**:

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -728,13 +728,17 @@ pub enum HttpEncoding {
     Gzip,
     /// A format using the [Brotli](https://en.wikipedia.org/wiki/Brotli) algorithm.
     Br,
+    /// A format using the [Zstd](https://en.wikipedia.org/wiki/Zstd) compression algorithm.
+    Zstd,
 }
 
 impl HttpEncoding {
     /// Parses a [`HttpEncoding`] from its `content-encoding` header value.
     pub fn parse(str: &str) -> Self {
         let str = str.trim();
-        if str.eq_ignore_ascii_case("br") {
+        if str.eq_ignore_ascii_case("zstd") {
+            Self::Zstd
+        } else if str.eq_ignore_ascii_case("br") {
             Self::Br
         } else if str.eq_ignore_ascii_case("gzip") || str.eq_ignore_ascii_case("x-gzip") {
             Self::Gzip
@@ -754,6 +758,7 @@ impl HttpEncoding {
             Self::Deflate => Some("deflate"),
             Self::Gzip => Some("gzip"),
             Self::Br => Some("br"),
+            Self::Zstd => Some("zstd"),
         }
     }
 }


### PR DESCRIPTION
Relay accepts zstd since #4089, this now also adds support for Relay<->Relay communication to use zstd.