### PR TITLE
test(ds): Remove unused global config option

### DIFF
--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -665,10 +665,6 @@ def test_relay_chain(
 def test_relay_chain_keep_unsampled_profile(
     mini_sentry, relay, relay_with_processing, profiles_consumer, mode
 ):
-    mini_sentry.global_config["options"] = {
-        "profiling.profile_metrics.unsampled_profiles.enabled": True,
-    }
-
     profiles_consumer = profiles_consumer()
 
     # Create an envelope with a profile:


### PR DESCRIPTION
When looking for where we have to remove that global config option, I noticed we still have a use in Relay itself. It was just removed.

#skip-changelog