### PR TITLE
fix(profiles): Rate limit profile chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Terminate the process when one of the services crashes. ([#4249](https://github.com/getsentry/relay/pull/4249))
 - Don't propagate trace sampling decisions from SDKs ([#4265](https://github.com/getsentry/relay/pull/4265))
+- Rate limit profile chunks. ([#4270](https://github.com/getsentry/relay/pull/4270))
 
 **Features**:
 

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -1,11 +1,9 @@
+import uuid
 from copy import deepcopy
 from pathlib import Path
 
 import pytest
-import uuid
-
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
-
 
 RELAY_ROOT = Path(__file__).parent.parent.parent
 
@@ -78,7 +76,8 @@ def test_profile_chunk_outcomes(
 
     upstream.send_envelope(project_id, envelope)
 
-    # no outcome since it's a successful ingestion
+    # No outcome is emitted in Relay since it's a successful ingestion.
+    # However, we will emit the outcome for PROFILE_DURATION in sentry.
     outcomes_consumer.assert_empty()
     assert profiles_consumer.get_profile()
 
@@ -131,7 +130,7 @@ def test_profile_chunk_outcomes_invalid(
 
     expected_outcomes = [
         {
-            "category": 18,
+            "category": 18,  # DataCategory::ProfileChunk
             "key_id": 123,
             "org_id": 1,
             "outcome": 3,  # Invalid
@@ -152,18 +151,33 @@ def test_profile_chunk_outcomes_rate_limited(
     mini_sentry,
     relay_with_processing,
     outcomes_consumer,
+    profiles_consumer,
 ):
+    """
+    Tests that Relay reports correct outcomes when profile chunks are rate limited.
+
+    This test verifies that when a profile chunk hits a rate limit:
+    1. The profile chunk is dropped and not forwarded to the profiles consumer
+    2. A rate limited outcome is emitted with the correct category and reason code
+    3. The rate limit is enforced at the project level
+    """
     outcomes_consumer = outcomes_consumer(timeout=2)
+    profiles_consumer = profiles_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
 
-    project_config.setdefault("features", []).append("organizations:profiling")
+    # Enable profiling feature flag
+    project_config.setdefault("features", []).append(
+        "organizations:continuous-profiling"
+    )
+
+    # Configure rate limiting quota that blocks all profile chunks
     project_config["quotas"] = [
         {
             "id": f"test_rate_limiting_{uuid.uuid4().hex}",
-            "categories": ["profile_chunk"],
-            "limit": 0,
+            "categories": ["profile_chunk"],  # Target profile chunks specifically
+            "limit": 0,  # Block all profile chunks
             "reasonCode": "profile_chunks_exceeded",
         }
     ]
@@ -186,22 +200,25 @@ def test_profile_chunk_outcomes_rate_limited(
 
     upstream = relay_with_processing(config)
 
+    # Load a valid profile chunk from test fixtures
     with open(
         RELAY_ROOT / "relay-profiling/tests/fixtures/sample/v2/valid.json",
         "rb",
     ) as f:
         profile = f.read()
 
+    # Create and send envelope containing the profile chunk
     envelope = Envelope()
     envelope.add_item(Item(payload=PayloadRef(bytes=profile), type="profile_chunk"))
     upstream.send_envelope(project_id, envelope)
 
+    # Verify the rate limited outcome was emitted with correct properties
     outcomes = outcomes_consumer.get_outcomes()
     outcomes.sort(key=lambda o: sorted(o.items()))
 
     expected_outcomes = [
         {
-            "category": 18,
+            "category": 18,  # DataCategory::ProfileChunk
             "key_id": 123,
             "org_id": 1,
             "outcome": 2,  # RateLimited
@@ -215,3 +232,97 @@ def test_profile_chunk_outcomes_rate_limited(
         outcome.pop("event_id", None)
 
     assert outcomes == expected_outcomes, outcomes
+
+    # Verify no profiles were forwarded to the consumer
+    profiles_consumer.assert_empty()
+
+
+def test_profile_chunk_outcomes_rate_limited_via_profile_duration_rate_limit(
+    mini_sentry,
+    relay_with_processing,
+    outcomes_consumer,
+    profiles_consumer,
+):
+    """
+    Tests that Relay reports correct outcomes when profile chunks are rate limited via profile duration quotas.
+
+    This test verifies that when a profile chunk hits a profile duration rate limit:
+    1. The profile chunk is dropped and not forwarded to the profiles consumer
+    2. A rate limited outcome is emitted with the correct category and reason code
+    3. The rate limit is enforced at the organization level
+    4. Both profile_chunk and profile_duration categories are affected
+    """
+    outcomes_consumer = outcomes_consumer(timeout=2)
+    profiles_consumer = profiles_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)["config"]
+
+    # Enable profiling feature flag
+    project_config.setdefault("features", []).append(
+        "organizations:continuous-profiling"
+    )
+
+    # Configure rate limiting quota that blocks all profile durations and profile chunks at org level
+    project_config["quotas"] = [
+        {
+            "categories": ["profile_duration", "profile_chunk"],
+            "limit": 0,  # Block all profile durations and profile chunks
+            "reasonCode": "profile_duration_usage_exceeded",
+            "scope": "organization",  # Apply at org level
+        },
+    ]
+
+    config = {
+        "outcomes": {
+            "emit_outcomes": True,
+            "batch_size": 1,
+            "batch_interval": 1,
+            "aggregator": {
+                "bucket_interval": 1,
+                "flush_interval": 0,
+            },
+        },
+        "aggregator": {
+            "bucket_interval": 1,
+            "initial_delay": 0,
+        },
+    }
+
+    upstream = relay_with_processing(config)
+
+    # Load a valid profile chunk from test fixtures
+    with open(
+        RELAY_ROOT / "relay-profiling/tests/fixtures/sample/v2/valid.json",
+        "rb",
+    ) as f:
+        profile = f.read()
+
+    # Create and send envelope containing the profile chunk
+    envelope = Envelope()
+    envelope.add_item(Item(payload=PayloadRef(bytes=profile), type="profile_chunk"))
+    upstream.send_envelope(project_id, envelope)
+
+    # Verify the rate limited outcome was emitted with correct properties
+    outcomes = outcomes_consumer.get_outcomes()
+    outcomes.sort(key=lambda o: sorted(o.items()))
+
+    expected_outcomes = [
+        {
+            "category": 18,  # DataCategory::ProfileChunk
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,  # RateLimited
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "profile_duration_usage_exceeded",
+        },
+    ]
+    for outcome in outcomes:
+        outcome.pop("timestamp")
+        outcome.pop("event_id", None)
+
+    assert outcomes == expected_outcomes, outcomes
+
+    # Verify no profiles were forwarded to the consumer
+    profiles_consumer.assert_empty()


### PR DESCRIPTION
Whenever we rate-limited profile chunks, we should not push the profile into the profile consumer.

I've also added/updated tests to verify this.