### PR TITLE
feat(devservices): Bump devservices version to 1.0.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 black==24.3.0
 blinker==1.8.2
 click==8.1.7
-devservices==0.0.5
+devservices==1.0.3
 flake8==7.0.0
 confluent-kafka==2.1.1
 flask==3.0.3


### PR DESCRIPTION
This adds some new changes to the devservices tool. It shouldn't have any impact for relay mostly, but adds some color for terminal output. 

https://github.com/getsentry/devservices/releases/tag/1.0.3

#skip-changelog