### PR TITLE
instr(buffer): busy and idle time

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -719,7 +719,7 @@ mod tests {
 
         addr.send(EnvelopeBuffer::NotReady(project_key, envelope));
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
         assert_eq!(project_cache_handle.test_num_fetches(), 2);
 
         tokio::time::sleep(Duration::from_millis(1300)).await;

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -446,7 +446,7 @@ impl Service for EnvelopeBufferService {
                                 error = &error as &dyn std::error::Error,
                                 "failed to pop envelope"
                             );
-                            }
+                        }
                     }});
                 }
                 change = project_changes.recv() => {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -549,6 +549,16 @@ pub enum RelayTimers {
     StoreServiceDuration,
     /// Timing in milliseconds for the time it takes for initialize the buffer.
     BufferInitialization,
+    /// Timing in milliseconds for the time the buffer service is waiting for input.
+    ///
+    /// This metric is tagged with:
+    /// - `input`: The type of input that broke the idling.
+    BufferIdle,
+    /// Timing in milliseconds for the time the buffer service spends handling input.
+    ///
+    /// This metric is tagged with:
+    /// - `input`: The type of input that the service is handling.
+    BufferBusy,
     /// Timing in milliseconds for the time it takes for the buffer to spool data to disk.
     BufferSpool,
     /// Timing in milliseconds for the time it takes for the buffer to unspool data from disk.
@@ -615,6 +625,8 @@ impl TimerMetric for RelayTimers {
             #[cfg(feature = "processing")]
             RelayTimers::StoreServiceDuration => "store.message.duration",
             RelayTimers::BufferInitialization => "buffer.initialization.duration",
+            RelayTimers::BufferIdle => "buffer.idle",
+            RelayTimers::BufferBusy => "buffer.busy",
             RelayTimers::BufferSpool => "buffer.spool.duration",
             RelayTimers::BufferUnspool => "buffer.unspool.duration",
             RelayTimers::BufferPush => "buffer.push.duration",


### PR DESCRIPTION
Monitor busy and idle times in the buffer service.

We might not need both metrics in the future as they complement each other.

#skip-changelog