### PR TITLE
feat(devservices): Add restart setting and use devservices external network

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -34,7 +34,9 @@ services:
       - host.docker.internal:host-gateway
     networks:
       - devservices
+    restart: unless-stopped
 
 networks:
   devservices:
     name: devservices
+    external: true


### PR DESCRIPTION
This allows containers brought up by devservices to be automatically restarted if they crash for any reason. Also forces containers to use devservices external network since creating/removing networks through docker compose have race conditions

#skip-changelog