### PR TITLE
fix(pattern): Handle empty alternates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Terminate the process when one of the services crashes. ([#4249](https://github.com/getsentry/relay/pull/4249))
 - Don't propagate trace sampling decisions from SDKs ([#4265](https://github.com/getsentry/relay/pull/4265))
 - Rate limit profile chunks. ([#4270](https://github.com/getsentry/relay/pull/4270))
+- Correctly handle empty alternates in patterns. ([#4277](https://github.com/getsentry/relay/pull/4277))
 
 **Features**:
 

--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -511,7 +511,7 @@ impl<'a> Parser<'a> {
                 },
                 ',' if self.alternates.is_some() => {
                     // If we encounter a ',' and we don't have a `current_alternate`,
-                    // we have to start one.
+                    // we have to start one to match the empty string.
                     self.current_alternate.get_or_insert_with(Tokens::default);
                     self.finish_alternate();
                     self.current_alternate = Some(Tokens::default());

--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -536,12 +536,10 @@ impl<'a> Parser<'a> {
     }
 
     fn end_alternates(&mut self) -> Result<(), ErrorKind> {
-        if self.alternates.is_none() {
-            return Err(ErrorKind::UnbalancedAlternates);
-        }
         self.finish_alternate();
-        // We checked above that this is safe to unwrap.
-        let alternates = self.alternates.take().unwrap();
+        let Some(alternates) = self.alternates.take() else {
+            return Err(ErrorKind::UnbalancedAlternates);
+        };
         if !alternates.is_empty() {
             self.complexity = self
                 .complexity


### PR DESCRIPTION
This changes the logic of the pattern parser so that an empty alternate matches the empty string. For example, the pattern `"foo{,/}"` now matches both `"foo"` and `"foo/"` where before it would only match `"foo/"` (because the empty part before the comma was discarded).