### PR TITLE
fix(protocol): Flatten Linux distribution fields into `os.context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+**Breaking Changes**:
+- Flatten Linux distribution fields into `os.context`([#4292](https://github.com/getsentry/relay/pull/4292))
+
 **Bug Fixes**:
 
 - Terminate the process when one of the services crashes. ([#4249](https://github.com/getsentry/relay/pull/4249))

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Breaking Changes**:
+- Flatten Linux distribution fields into `os.context`([#4292](https://github.com/getsentry/relay/pull/4292))
+
 ## 0.9.3
 
 - Add computed contexts for `os`, `browser` and `runtime` during normalization. ([#4239](https://github.com/getsentry/relay/pull/4239))

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -962,7 +962,9 @@ mod tests {
             build: ~,
             kernel_version: ~,
             rooted: ~,
-            distribution: ~,
+            distribution_name: ~,
+            distribution_version: ~,
+            distribution_pretty_name: ~,
             raw_description: ~,
             other: {},
         }
@@ -1035,7 +1037,9 @@ mod tests {
             build: ~,
             kernel_version: ~,
             rooted: ~,
-            distribution: ~,
+            distribution_name: ~,
+            distribution_version: ~,
+            distribution_pretty_name: ~,
             raw_description: ~,
             other: {},
         }

--- a/relay-event-schema/src/protocol/contexts/os.rs
+++ b/relay-event-schema/src/protocol/contexts/os.rs
@@ -32,8 +32,12 @@ pub struct OsContext {
     pub rooted: Annotated<bool>,
 
     /// Meta-data for the Linux Distribution.
-    #[metastructure(skip_serialization = "empty")]
-    pub distribution: Annotated<LinuxDistribution>,
+    #[metastructure(pii = "maybe")]
+    pub distribution_name: Annotated<String>,
+    #[metastructure(pii = "maybe")]
+    pub distribution_version: Annotated<String>,
+    #[metastructure(pii = "maybe")]
+    pub distribution_pretty_name: Annotated<String>,
 
     /// Unprocessed operating system info.
     ///
@@ -45,28 +49,6 @@ pub struct OsContext {
 
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = "true", pii = "maybe")]
-    pub other: Object<Value>,
-}
-
-/// Metadata for the Linux Distribution.
-#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
-pub struct LinuxDistribution {
-    /// An index-able name that is stable for each distribution.
-    pub name: Annotated<String>,
-    /// The version of the distribution (missing in distributions with solely rolling release).
-    #[metastructure(skip_serialization = "empty")]
-    pub version: Annotated<String>,
-    /// A full rendering of name + version + release name (not available in all distributions).
-    #[metastructure(skip_serialization = "empty")]
-    pub pretty_name: Annotated<String>,
-
-    /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(
-        additional_properties,
-        retain = "true",
-        pii = "maybe",
-        skip_serialization = "empty"
-    )]
     pub other: Object<Value>,
 }
 
@@ -127,7 +109,9 @@ mod tests {
             kernel_version: Annotated::new("17.4.0".to_string()),
             rooted: Annotated::new(true),
             raw_description: Annotated::new("iOS 11.4.2 FEEDFACE (17.4.0)".to_string()),
-            distribution: Annotated::empty(),
+            distribution_name: Annotated::empty(),
+            distribution_version: Annotated::empty(),
+            distribution_pretty_name: Annotated::empty(),
             other: {
                 let mut map = Object::new();
                 map.insert(
@@ -144,16 +128,14 @@ mod tests {
 
     #[test]
     fn test_os_context_linux_roundtrip() {
-        let json = r#"{
+        let json: &str = r#"{
   "os": "Linux 5.15.133",
   "name": "Linux",
   "version": "5.15.133",
   "build": "1-microsoft-standard-WSL2",
-  "distribution": {
-    "name": "ubuntu",
-    "version": "22.04",
-    "pretty_name": "Ubuntu 22.04.4 LTS"
-  },
+  "distribution_name": "ubuntu",
+  "distribution_version": "22.04",
+  "distribution_pretty_name": "Ubuntu 22.04.4 LTS",
   "type": "os"
 }"#;
         let context = Annotated::new(Context::Os(Box::new(OsContext {
@@ -164,12 +146,9 @@ mod tests {
             kernel_version: Annotated::empty(),
             rooted: Annotated::empty(),
             raw_description: Annotated::empty(),
-            distribution: Annotated::new(LinuxDistribution {
-                name: Annotated::new("ubuntu".to_string()),
-                version: Annotated::new("22.04".to_string()),
-                pretty_name: Annotated::new("Ubuntu 22.04.4 LTS".to_string()),
-                other: Object::default(),
-            }),
+            distribution_name: Annotated::new("ubuntu".to_string()),
+            distribution_version: Annotated::new("22.04".to_string()),
+            distribution_pretty_name: Annotated::new("Ubuntu 22.04.4 LTS".to_string()),
             other: Object::default(),
         })));
 

--- a/relay-server/tests/snapshots/test_fixtures__event_schema.snap
+++ b/relay-server/tests/snapshots/test_fixtures__event_schema.snap
@@ -2149,41 +2149,6 @@ expression: "relay_event_schema::protocol::event_json_schema()"
         "fatal"
       ]
     },
-    "LinuxDistribution": {
-      "description": " Metadata for the Linux Distribution.",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": " An index-able name that is stable for each distribution.",
-              "default": null,
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "pretty_name": {
-              "description": " A full rendering of name + version + release name (not available in all distributions).",
-              "default": null,
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "version": {
-              "description": " The version of the distribution (missing in distributions with solely rolling release).",
-              "default": null,
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "LockReason": {
       "description": " Represents an instance of a held lock (java monitor object) in a thread.",
       "anyOf": [
@@ -2770,16 +2735,28 @@ expression: "relay_event_schema::protocol::event_json_schema()"
                 "null"
               ]
             },
-            "distribution": {
-              "description": " Meta-data for the Linux Distribution.",
+            "distribution_name": {
+              "description": " An index-able name that is stable for each distribution.",
               "default": null,
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/LinuxDistribution"
-                },
-                {
-                  "type": "null"
-                }
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distribution_version": {
+              "description": " The version of the distribution (missing in distributions with solely rolling release).",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distribution_pretty_name": {
+              "description": " A full rendering of name + version + release name (not available in all distributions).",
+              "default": null,
+              "type": [
+                "string",
+                "null"
               ]
             },
             "kernel_version": {


### PR DESCRIPTION
(continuation of https://github.com/getsentry/relay/pull/3443 )

<!-- Describe your PR here. -->
To make these fields searchable, we had to change from a nested to a flattened approach. This is provided in sentry-native ([relevant PR](https://github.com/getsentry/sentry-native/pull/963)).

The update is also tracked on the docs side: https://github.com/getsentry/sentry-docs/pull/11936
