### PR TITLE
feat(gocd): Update timeout of pops gocd to 1h (temporarily)

### DIFF
--- a/gocd/templates/bash/deploy-pop-canary.sh
+++ b/gocd/templates/bash/deploy-pop-canary.sh
@@ -8,3 +8,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
     --label-selector="service=relay-pop,env=canary" \
     --image="us-central1-docker.pkg.dev/sentryio/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"
+    --wait-timeout-mins=60

--- a/gocd/templates/bash/deploy-pop.sh
+++ b/gocd/templates/bash/deploy-pop.sh
@@ -8,3 +8,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
     --label-selector="service=relay-pop" \
     --image="us-central1-docker.pkg.dev/sentryio/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"
+    --wait-timeout-mins=60


### PR DESCRIPTION
This PR temporarily bumps the timeout for the pops gocd pipeline. This change will be reverted once the slowness in the pipelines will be addressed, right now it's only done to allow us to deploy again.

#skip-changelog