### PR TITLE
feat(spooler): Hash only own_key for partition routing

### DIFF
--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use crate::Envelope;
 
 /// Struct that represents two project keys.
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct ProjectKeyPair {
     pub own_key: ProjectKey,
     pub sampling_key: ProjectKey,

--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -32,9 +32,3 @@ impl ProjectKeyPair {
         std::iter::once(*own_key).chain((own_key != sampling_key).then_some(*sampling_key))
     }
 }
-
-impl Hash for ProjectKeyPair {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.own_key.hash(state);
-    }
-}

--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -1,9 +1,10 @@
 use relay_base_schema::project::ProjectKey;
+use std::hash::{Hash, Hasher};
 
 use crate::Envelope;
 
 /// Struct that represents two project keys.
-#[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialOrd, PartialEq)]
 pub struct ProjectKeyPair {
     pub own_key: ProjectKey,
     pub sampling_key: ProjectKey,
@@ -29,5 +30,11 @@ impl ProjectKeyPair {
             sampling_key,
         } = self;
         std::iter::once(*own_key).chain((own_key != sampling_key).then_some(*sampling_key))
+    }
+}
+
+impl Hash for ProjectKeyPair {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.own_key.hash(state);
     }
 }

--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -1,5 +1,5 @@
 use relay_base_schema::project::ProjectKey;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 use crate::Envelope;
 

--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -1,5 +1,4 @@
 use relay_base_schema::project::ProjectKey;
-use std::hash::Hash;
 
 use crate::Envelope;
 

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -153,7 +153,7 @@ impl PartitionedEnvelopeBuffer {
         }
 
         let mut hasher = FnvHasher::default();
-        project_key_pair.hash(&mut hasher);
+        project_key_pair.own_key.hash(&mut hasher);
         let buffer_index = (hasher.finish() % self.buffers.len() as u64) as usize;
         let buffer = self.buffers.get(buffer_index);
         buffer

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -609,6 +609,7 @@ mod tests {
     use chrono::Utc;
     use relay_dynamic_config::GlobalConfig;
     use relay_quotas::DataCategory;
+    use std::hash::DefaultHasher;
     use std::time::Duration;
     use tokio::sync::mpsc;
     use uuid::Uuid;

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -609,7 +609,6 @@ mod tests {
     use chrono::Utc;
     use relay_dynamic_config::GlobalConfig;
     use relay_quotas::DataCategory;
-    use std::hash::DefaultHasher;
     use std::time::Duration;
     use tokio::sync::mpsc;
     use uuid::Uuid;


### PR DESCRIPTION
This PR uses only the own_key to determine the partition. The reason for this change is that we noticed that a `ProjectKeyPair` with both keys the same, leads to a non-uniform distribution of partition values, especially for a low number of partitions.

#skip-changelog