### PR TITLE
ref(relay): Fix Rust 1.83 lints

### DIFF
--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -322,7 +322,7 @@ impl Serialize for MetricResourceIdentifier<'_> {
     }
 }
 
-impl<'a> fmt::Display for MetricResourceIdentifier<'a> {
+impl fmt::Display for MetricResourceIdentifier<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // `<ty>:<ns>/<name>@<unit>`
         write!(

--- a/relay-cabi/src/core.rs
+++ b/relay-cabi/src/core.rs
@@ -81,7 +81,7 @@ impl From<String> for RelayStr {
     }
 }
 
-impl<'a> From<&'a str> for RelayStr {
+impl From<&str> for RelayStr {
     fn from(string: &str) -> RelayStr {
         RelayStr::new(string)
     }

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -250,7 +250,7 @@ pub struct CardinalityLimitsSplit<'a, T> {
     pub rejected: Vec<(T, &'a CardinalityLimit)>,
 }
 
-impl<'a, T> CardinalityLimitsSplit<'a, T> {
+impl<T> CardinalityLimitsSplit<'_, T> {
     /// Creates a new cardinality limits split with a given capacity for `accepted` and `rejected`
     /// elements.
     fn with_capacity(accepted_capacity: usize, rejected_capacity: usize) -> Self {

--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -153,7 +153,7 @@ pub struct CardinalityScriptPipeline<'a> {
     pipe: redis::Pipeline,
 }
 
-impl<'a> CardinalityScriptPipeline<'a> {
+impl CardinalityScriptPipeline<'_> {
     /// Adds another invocation of the script to the pipeline.
     pub fn add_invocation(
         &mut self,

--- a/relay-cardinality/src/redis/state.rs
+++ b/relay-cardinality/src/redis/state.rs
@@ -133,7 +133,7 @@ impl<'a> LimitState<'a> {
     }
 }
 
-impl<'a> Drop for LimitState<'a> {
+impl Drop for LimitState<'_> {
     fn drop(&mut self) {
         let passive = if self.cardinality_limit.passive {
             "true"

--- a/relay-cogs/src/test.rs
+++ b/relay-cogs/src/test.rs
@@ -2,10 +2,12 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use crate::{CogsMeasurement, CogsRecorder};
 
+/// A [`CogsRecorder`] for testing which allows access to all recorded measurements.
 #[derive(Clone, Default)]
 pub struct TestRecorder(Arc<Mutex<Vec<CogsMeasurement>>>);
 
 impl TestRecorder {
+    /// Returns the recorded measurements.
     pub fn measurements(&self) -> Vec<CogsMeasurement> {
         let inner = self.0.lock().unwrap_or_else(PoisonError::into_inner);
         inner.clone()

--- a/relay-common/src/time.rs
+++ b/relay-common/src/time.rs
@@ -174,7 +174,7 @@ impl Serialize for UnixTimestamp {
 
 struct UnixTimestampVisitor;
 
-impl<'de> serde::de::Visitor<'de> for UnixTimestampVisitor {
+impl serde::de::Visitor<'_> for UnixTimestampVisitor {
     type Value = UnixTimestamp;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/relay-config/src/byte_size.rs
+++ b/relay-config/src/byte_size.rs
@@ -137,7 +137,7 @@ impl<'de> de::Deserialize<'de> for ByteSize {
     {
         struct V;
 
-        impl<'de> de::Visitor<'de> for V {
+        impl de::Visitor<'_> for V {
             type Value = ByteSize;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1263,7 +1263,7 @@ impl Serialize for EmitOutcomes {
 
 struct EmitOutcomesVisitor;
 
-impl<'de> Visitor<'de> for EmitOutcomesVisitor {
+impl Visitor<'_> for EmitOutcomesVisitor {
     type Value = EmitOutcomes;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/relay-config/src/upstream.rs
+++ b/relay-config/src/upstream.rs
@@ -119,7 +119,7 @@ impl Default for UpstreamDescriptor<'static> {
     }
 }
 
-impl<'a> fmt::Display for UpstreamDescriptor<'a> {
+impl fmt::Display for UpstreamDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}://{}", &self.scheme, &self.host)?;
         if self.port() != self.scheme.default_port() {

--- a/relay-crash/src/lib.rs
+++ b/relay-crash/src/lib.rs
@@ -55,7 +55,7 @@ pub struct CrashHandler<'a> {
     environment: Option<&'a str>,
 }
 
-impl<'a> fmt::Debug for CrashHandler<'a> {
+impl fmt::Debug for CrashHandler<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let transport = match self.transport {
             Some(_) => "Some(fn)",

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -171,6 +171,7 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> TokenStream {
 
     s.gen_impl(quote! {
         #[automatically_derived]
+        #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
         gen impl crate::processor::ProcessValue for @Self {
             fn value_type(&self) -> enumset::EnumSet<crate::processor::ValueType> {
                 match *self {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -161,7 +161,7 @@ pub struct NormalizationConfig<'a> {
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
 }
 
-impl<'a> Default for NormalizationConfig<'a> {
+impl Default for NormalizationConfig<'_> {
     fn default() -> Self {
         Self {
             project_id: Default::default(),
@@ -1773,7 +1773,16 @@ mod tests {
         let ipaddr = IpAddr("213.164.1.114".to_string());
 
         let client_ip = Some(&ipaddr);
-        let user_agent = RawUserAgentInfo::new_test_dummy();
+
+        let user_agent = RawUserAgentInfo {
+            user_agent: Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0"),
+            client_hints: ClientHints {
+                sec_ch_ua_platform: Some("macOS"),
+                sec_ch_ua_platform_version: Some("13.2.0"),
+                sec_ch_ua: Some(r#""Chromium";v="110", "Not A(Brand";v="24", "Google Chrome";v="110""#),
+                sec_ch_ua_model: Some("some model"),
+            }
+        };
 
         // This call should fill the event headers with info from the user_agent which is
         // tested below.

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -134,7 +134,7 @@ impl<'a> CombinedMeasurementsConfig<'a> {
     /// there are no duplicates.
     pub fn builtin_measurement_keys(
         &'a self,
-    ) -> impl Iterator<Item = &'a BuiltinMeasurementKey> + '_ {
+    ) -> impl Iterator<Item = &'a BuiltinMeasurementKey> + 'a {
         let project = self
             .project
             .map(|p| p.builtin_measurements.as_slice())

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -441,7 +441,7 @@ fn scrub_resource(resource_type: &str, string: &str) -> Option<String> {
                 }
                 if COMMON_PATH_SEGMENTS.contains(segment) {
                     output_segments.push(segment);
-                } else if !output_segments.last().is_some_and(|s| *s == "*") {
+                } else if output_segments.last().is_none_or(|s| *s != "*") {
                     // only one asterisk
                     output_segments.push("*");
                 }

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -1082,21 +1082,6 @@ mod tests {
         assert_eq!(os.version.value().unwrap(), ">=10.15.7");
     }
 
-    impl RawUserAgentInfo<&str> {
-        pub fn new_test_dummy() -> Self {
-            Self {
-                user_agent: Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0"),
-                client_hints: ClientHints {
-                    sec_ch_ua_platform: Some("macOS"),
-                    sec_ch_ua_platform_version: Some("13.2.0"),
-                    sec_ch_ua: Some(r#""Chromium";v="110", "Not A(Brand";v="24", "Google Chrome";v="110""#),
-                    sec_ch_ua_model: Some("some model"),
-                }
-
-            }
-        }
-    }
-
     #[test]
     fn test_default_empty() {
         assert!(RawUserAgentInfo::<&str>::default().is_empty());

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -236,7 +236,7 @@ impl<'a> PartialEq for PathItem<'a> {
     }
 }
 
-impl<'a> PathItem<'a> {
+impl PathItem<'_> {
     /// Returns the key if there is one
     #[inline]
     pub fn key(&self) -> Option<&str> {
@@ -257,7 +257,7 @@ impl<'a> PathItem<'a> {
     }
 }
 
-impl<'a> fmt::Display for PathItem<'a> {
+impl fmt::Display for PathItem<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PathItem::StaticKey(s) => f.pad(s),
@@ -517,9 +517,9 @@ impl<'a> Iterator for ProcessingStateIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for ProcessingStateIter<'a> {}
+impl ExactSizeIterator for ProcessingStateIter<'_> {}
 
-impl<'a> Default for ProcessingState<'a> {
+impl Default for ProcessingState<'_> {
     fn default() -> Self {
         ProcessingState::root().clone()
     }
@@ -531,7 +531,7 @@ impl<'a> Default for ProcessingState<'a> {
 #[derive(Debug)]
 pub struct Path<'a>(&'a ProcessingState<'a>);
 
-impl<'a> Path<'a> {
+impl Path<'_> {
     /// Returns the current key if there is one
     #[inline]
     pub fn key(&self) -> Option<&str> {
@@ -560,7 +560,7 @@ impl<'a> Path<'a> {
     }
 }
 
-impl<'a> fmt::Display for Path<'a> {
+impl fmt::Display for Path<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut items = Vec::with_capacity(self.0.depth);
         for state in self.0.iter() {

--- a/relay-event-schema/src/processor/chunks.rs
+++ b/relay-event-schema/src/processor/chunks.rs
@@ -49,7 +49,7 @@ pub enum Chunk<'a> {
     },
 }
 
-impl<'a> Chunk<'a> {
+impl Chunk<'_> {
     /// The text of this chunk.
     pub fn as_str(&self) -> &str {
         match self {

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -688,7 +688,7 @@ mod serde_date_time_3339 {
     {
         struct DateTimeVisitor;
 
-        impl<'de> Visitor<'de> for DateTimeVisitor {
+        impl Visitor<'_> for DateTimeVisitor {
             type Value = Option<DateTime<Utc>>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/relay-event-schema/src/protocol/types.rs
+++ b/relay-event-schema/src/protocol/types.rs
@@ -185,7 +185,7 @@ where
     ///
     /// The key may be any borrowed form of the pairlist's key type. If there are multiple entries
     /// with the same key, the first is returned.
-    pub fn get<'a, Q>(&'a self, key: Q) -> Option<&Annotated<V>>
+    pub fn get<'a, Q>(&'a self, key: Q) -> Option<&'a Annotated<V>>
     where
         Q: AsRef<str>,
         K: 'a,
@@ -200,7 +200,7 @@ where
     ///
     /// The key may be any borrowed form of the pairlist's key type. If there are multiple entries
     /// with the same key, the first is returned.
-    pub fn get_value<'a, Q>(&'a self, key: Q) -> Option<&V>
+    pub fn get_value<'a, Q>(&'a self, key: Q) -> Option<&'a V>
     where
         Q: AsRef<str>,
         K: 'a,

--- a/relay-filter/src/generic.rs
+++ b/relay-filter/src/generic.rs
@@ -135,7 +135,7 @@ impl<'a> Iterator for DynamicGenericFiltersConfigIter<'a> {
     }
 }
 
-impl<'a> FusedIterator for DynamicGenericFiltersConfigIter<'a> {}
+impl FusedIterator for DynamicGenericFiltersConfigIter<'_> {}
 
 /// Merges the two filters with the same id, prioritizing values from the primary.
 ///

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -189,7 +189,7 @@ impl TopicAssignment {
         &'a self,
         default_config: &'a Vec<KafkaConfigParam>,
         secondary_configs: &'a BTreeMap<String, Vec<KafkaConfigParam>>,
-    ) -> Result<KafkaParams<'_>, ConfigError> {
+    ) -> Result<KafkaParams<'a>, ConfigError> {
         let kafka_config = match self {
             Self::Primary(topic_name) => KafkaParams {
                 topic_name,

--- a/relay-log/src/utils.rs
+++ b/relay-log/src/utils.rs
@@ -35,7 +35,7 @@ pub fn ensure_error<E: AsRef<dyn Error>>(error: E) {
 /// A wrapper around an error that prints its causes.
 struct LogError<'a, E: Error + ?Sized>(pub &'a E);
 
-impl<'a, E: Error + ?Sized> fmt::Display for LogError<'a, E> {
+impl<E: Error + ?Sized> fmt::Display for LogError<'_, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)?;
 

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -570,7 +570,7 @@ impl<'a> BucketView<'a> {
     }
 }
 
-impl<'a> fmt::Debug for BucketView<'a> {
+impl fmt::Debug for BucketView<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BucketView")
             .field("timestamp", &self.inner.timestamp)
@@ -588,7 +588,7 @@ impl<'a> From<&'a Bucket> for BucketView<'a> {
     }
 }
 
-impl<'a> Serialize for BucketView<'a> {
+impl Serialize for BucketView<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -701,13 +701,13 @@ impl<'a> SetView<'a> {
     }
 }
 
-impl<'a> PartialEq for SetView<'a> {
+impl PartialEq for SetView<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.iter().eq(other.iter())
     }
 }
 
-impl<'a> fmt::Debug for SetView<'a> {
+impl fmt::Debug for SetView<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SetView")
             .field(&self.iter().collect::<Vec<_>>())
@@ -715,7 +715,7 @@ impl<'a> fmt::Debug for SetView<'a> {
     }
 }
 
-impl<'a> Serialize for SetView<'a> {
+impl Serialize for SetView<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -184,7 +184,7 @@ pub struct PatternBuilder<'a> {
     options: Options,
 }
 
-impl<'a> PatternBuilder<'a> {
+impl PatternBuilder<'_> {
     /// If enabled matches the pattern case insensitive.
     ///
     /// This is disabled by default.

--- a/relay-pattern/src/wildmatch.rs
+++ b/relay-pattern/src/wildmatch.rs
@@ -409,10 +409,13 @@ struct AltAndTokens<'a> {
     tokens: &'a [Token],
 }
 
-impl<'a> TokenIndex for AltAndTokens<'a> {
+impl TokenIndex for AltAndTokens<'_> {
     // Type here does not matter, we implement `with_alternate` by returning the never type.
     // It just needs to satisfy the `TokenIndex` trait bound.
-    type WithAlternates<'b> = AltAndTokens<'b> where Self: 'b;
+    type WithAlternates<'b>
+        = AltAndTokens<'b>
+    where
+        Self: 'b;
 
     #[inline(always)]
     fn len(&self) -> usize {
@@ -434,7 +437,7 @@ impl<'a> TokenIndex for AltAndTokens<'a> {
     }
 }
 
-impl<'a> std::ops::Index<usize> for AltAndTokens<'a> {
+impl std::ops::Index<usize> for AltAndTokens<'_> {
     type Output = Token;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/relay-pii/src/attachments.rs
+++ b/relay-pii/src/attachments.rs
@@ -316,7 +316,7 @@ impl<'a> Iterator for WStrSegmentIter<'a> {
     }
 }
 
-impl<'a> FusedIterator for WStrSegmentIter<'a> {}
+impl FusedIterator for WStrSegmentIter<'_> {}
 
 /// An encoded string segment in a larger data block.
 ///
@@ -535,7 +535,7 @@ mod tests {
         },
     }
 
-    impl<'a> AttachmentBytesTestCase<'a> {
+    impl AttachmentBytesTestCase<'_> {
         fn run(self) {
             let (config, filename, value_type, input, expected, changed) = match self {
                 AttachmentBytesTestCase::Builtin {

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -182,8 +182,8 @@ mod tests {
     use super::to_pii_config as to_pii_config_impl;
     use super::*;
 
-    /// These tests are ported from Sentry's Python testsuite (test_data_scrubber). Each testcase
-    /// has an equivalent testcase in Python.
+    // These tests are ported from Sentry's Python testsuite (test_data_scrubber). Each testcase
+    // has an equivalent testcase in Python.
 
     fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiConfig> {
         let rv = to_pii_config_impl(datascrubbing_config).unwrap();

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -57,7 +57,7 @@ impl<'a> PiiProcessor<'a> {
     }
 }
 
-impl<'a> Processor for PiiProcessor<'a> {
+impl Processor for PiiProcessor<'_> {
     fn before_process<T: ProcessValue>(
         &mut self,
         value: Option<&T>,

--- a/relay-profiling/src/sample/v1.rs
+++ b/relay-profiling/src/sample/v1.rs
@@ -105,10 +105,10 @@ impl SampleProfile {
         let mut active_ranges: HashMap<u64, Range<usize>> = HashMap::new();
 
         for (i, sample) in self.samples.iter().enumerate() {
-            if !self
+            if self
                 .stacks
                 .get(sample.stack_id)
-                .is_some_and(|stack| !stack.is_empty())
+                .is_none_or(|stack| stack.is_empty())
             {
                 continue;
             }

--- a/relay-protocol-derive/src/lib.rs
+++ b/relay-protocol-derive/src/lib.rs
@@ -77,6 +77,7 @@ fn derive_empty(mut s: synstructure::Structure<'_>) -> TokenStream {
 
     s.gen_impl(quote! {
         #[automatically_derived]
+        #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
         gen impl ::relay_protocol::Empty for @Self {
             fn is_empty(&self) -> bool {
                 match *self {
@@ -139,6 +140,7 @@ fn derive_newtype_metastructure(
     Ok(match t {
         Trait::From => s.gen_impl(quote! {
             #[automatically_derived]
+            #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
             gen impl ::relay_protocol::FromValue for @Self {
                 fn from_value(
                     __value: ::relay_protocol::Annotated<::relay_protocol::Value>,
@@ -152,6 +154,7 @@ fn derive_newtype_metastructure(
         }),
         Trait::To => s.gen_impl(quote! {
             #[automatically_derived]
+            #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
             gen impl ::relay_protocol::IntoValue for @Self {
                 fn into_value(self) -> ::relay_protocol::Value {
                     ::relay_protocol::IntoValue::into_value(self.0)
@@ -267,6 +270,7 @@ fn derive_enum_metastructure(
         Trait::From => {
             s.gen_impl(quote! {
                 #[automatically_derived]
+                #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
                 gen impl ::relay_protocol::FromValue for @Self {
                     fn from_value(
                         __value: ::relay_protocol::Annotated<::relay_protocol::Value>,
@@ -287,6 +291,7 @@ fn derive_enum_metastructure(
         Trait::To => {
             s.gen_impl(quote! {
                 #[automatically_derived]
+                #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
                 gen impl ::relay_protocol::IntoValue for @Self {
                     fn into_value(self) -> ::relay_protocol::Value {
                         match self {
@@ -490,6 +495,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
 
             s.gen_impl(quote! {
                 #[automatically_derived]
+                #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
                 gen impl ::relay_protocol::FromValue for @Self {
                     fn from_value(
                         __value: ::relay_protocol::Annotated<::relay_protocol::Value>,
@@ -540,6 +546,7 @@ fn derive_metastructure(s: synstructure::Structure<'_>, t: Trait) -> TokenStream
 
             s.gen_impl(quote! {
                 #[automatically_derived]
+                #[expect(non_local_definitions, reason = "crate needs to be migrated to syn2")]
                 gen impl ::relay_protocol::IntoValue for @Self {
                     fn into_value(self) -> ::relay_protocol::Value {
                         #into_value

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -63,7 +63,7 @@ pub struct Annotated<T>(pub Option<T>, pub Meta);
 /// An utility to serialize annotated objects with payload.
 pub struct SerializableAnnotated<'a, T>(pub &'a Annotated<T>);
 
-impl<'a, T: IntoValue> Serialize for SerializableAnnotated<'a, T> {
+impl<T: IntoValue> Serialize for SerializableAnnotated<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/relay-protocol/src/impls.rs
+++ b/relay-protocol/src/impls.rs
@@ -12,7 +12,7 @@ use crate::value::{Array, Map, Object, Value};
 #[doc(hidden)]
 pub struct SerializePayload<'a, T>(pub &'a Annotated<T>, pub SkipSerialization);
 
-impl<'a, T: IntoValue> Serialize for SerializePayload<'a, T> {
+impl<T: IntoValue> Serialize for SerializePayload<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/relay-protocol/src/meta.rs
+++ b/relay-protocol/src/meta.rs
@@ -230,7 +230,7 @@ impl<'de> Deserialize<'de> for ErrorKind {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct ErrorKindVisitor;
 
-        impl<'de> de::Visitor<'de> for ErrorKindVisitor {
+        impl de::Visitor<'_> for ErrorKindVisitor {
             type Value = ErrorKind;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/relay-protocol/src/size.rs
+++ b/relay-protocol/src/size.rs
@@ -72,7 +72,7 @@ impl SizeEstimatingSerializer {
     }
 }
 
-impl<'a> ser::Serializer for &'a mut SizeEstimatingSerializer {
+impl ser::Serializer for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -286,7 +286,7 @@ impl<'a> ser::Serializer for &'a mut SizeEstimatingSerializer {
     }
 }
 
-impl<'a> ser::SerializeSeq for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeSeq for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -306,7 +306,7 @@ impl<'a> ser::SerializeSeq for &'a mut SizeEstimatingSerializer {
 }
 
 // Same thing but for tuples.
-impl<'a> ser::SerializeTuple for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeTuple for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -326,7 +326,7 @@ impl<'a> ser::SerializeTuple for &'a mut SizeEstimatingSerializer {
 }
 
 // Same thing but for tuple structs.
-impl<'a> ser::SerializeTupleStruct for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeTupleStruct for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -345,7 +345,7 @@ impl<'a> ser::SerializeTupleStruct for &'a mut SizeEstimatingSerializer {
     }
 }
 
-impl<'a> ser::SerializeTupleVariant for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeTupleVariant for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -364,7 +364,7 @@ impl<'a> ser::SerializeTupleVariant for &'a mut SizeEstimatingSerializer {
     }
 }
 
-impl<'a> ser::SerializeMap for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeMap for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -392,7 +392,7 @@ impl<'a> ser::SerializeMap for &'a mut SizeEstimatingSerializer {
     }
 }
 
-impl<'a> ser::SerializeStruct for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeStruct for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 
@@ -413,7 +413,7 @@ impl<'a> ser::SerializeStruct for &'a mut SizeEstimatingSerializer {
     }
 }
 
-impl<'a> ser::SerializeStructVariant for &'a mut SizeEstimatingSerializer {
+impl ser::SerializeStructVariant for &mut SizeEstimatingSerializer {
     type Ok = ();
     type Error = Error;
 

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -40,7 +40,7 @@ pub enum Value {
 /// Helper type that renders out a description of the value.
 pub struct ValueDescription<'a>(&'a Value);
 
-impl<'a> fmt::Display for ValueDescription<'a> {
+impl fmt::Display for ValueDescription<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.0 {
             Value::Bool(true) => f.pad("true"),

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -206,7 +206,7 @@ impl<'a, S> EventStreamVisitor<'a, S> {
     }
 }
 
-impl<'de, 'a, S> de::Visitor<'de> for EventStreamVisitor<'a, S>
+impl<'de, S> de::Visitor<'de> for EventStreamVisitor<'_, S>
 where
     S: ser::Serializer,
 {

--- a/relay-replays/src/transform.rs
+++ b/relay-replays/src/transform.rs
@@ -203,7 +203,7 @@ where
     }
 }
 
-impl<'de, 'a, D, T> de::Deserializer<'de> for Deserializer<'a, D, T>
+impl<'de, D, T> de::Deserializer<'de> for Deserializer<'_, D, T>
 where
     D: de::Deserializer<'de>,
     T: Transform<'de>,
@@ -606,7 +606,7 @@ impl<'a, V, T> Visitor<'a, V, T> {
     }
 }
 
-impl<'de, 'a, V, T> de::Visitor<'de> for Visitor<'a, V, T>
+impl<'de, V, T> de::Visitor<'de> for Visitor<'_, V, T>
 where
     V: de::Visitor<'de>,
     T: Transform<'de>,
@@ -824,7 +824,7 @@ where
 
 struct SeqAccess<'a, A, T>(A, &'a mut T);
 
-impl<'de, 'a, A, T> de::SeqAccess<'de> for SeqAccess<'a, A, T>
+impl<'de, A, T> de::SeqAccess<'de> for SeqAccess<'_, A, T>
 where
     A: de::SeqAccess<'de>,
     T: Transform<'de>,
@@ -845,7 +845,7 @@ where
 
 struct MapAccess<'a, A, T>(A, &'a mut T);
 
-impl<'de, 'a, A, T> de::MapAccess<'de> for MapAccess<'a, A, T>
+impl<'de, A, T> de::MapAccess<'de> for MapAccess<'_, A, T>
 where
     A: de::MapAccess<'de>,
     T: Transform<'de>,
@@ -870,7 +870,7 @@ where
 
 struct DeserializeValueSeed<'a, D, T>(D, &'a mut T);
 
-impl<'de, 'a, D, T> de::DeserializeSeed<'de> for DeserializeValueSeed<'a, D, T>
+impl<'de, D, T> de::DeserializeSeed<'de> for DeserializeValueSeed<'_, D, T>
 where
     D: de::DeserializeSeed<'de>,
     T: Transform<'de>,
@@ -891,7 +891,7 @@ where
 
 struct DeserializeKeySeed<'a, D, T>(D, &'a mut T);
 
-impl<'de, 'a, D, T> de::DeserializeSeed<'de> for DeserializeKeySeed<'a, D, T>
+impl<'de, D, T> de::DeserializeSeed<'de> for DeserializeKeySeed<'_, D, T>
 where
     D: de::DeserializeSeed<'de>,
     T: Transform<'de>,

--- a/relay-sampling/Cargo.toml
+++ b/relay-sampling/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["now"] }
 rand = { workspace = true }
 rand_pcg = { workspace = true }
 relay-base-schema = { workspace = true }

--- a/relay-sampling/src/dsc.rs
+++ b/relay-sampling/src/dsc.rs
@@ -190,7 +190,7 @@ mod sample_rate_as_string {
 
 struct BoolOptionVisitor;
 
-impl<'de> serde::de::Visitor<'de> for BoolOptionVisitor {
+impl serde::de::Visitor<'_> for BoolOptionVisitor {
     type Value = Option<bool>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -56,7 +56,7 @@ pub struct ReservoirEvaluator<'a> {
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a> ReservoirEvaluator<'a> {
+impl ReservoirEvaluator<'_> {
     /// Constructor for [`ReservoirEvaluator`].
     pub fn new(counters: ReservoirCounters) -> Self {
         Self {
@@ -70,14 +70,6 @@ impl<'a> ReservoirEvaluator<'a> {
     /// Gets shared ownership of the reservoir counters.
     pub fn counters(&self) -> ReservoirCounters {
         Arc::clone(&self.counters)
-    }
-
-    /// Sets the Redis pool and organization ID for the [`ReservoirEvaluator`].
-    ///
-    /// These values are needed to synchronize with Redis.
-    #[cfg(feature = "redis")]
-    pub fn set_redis(&mut self, org_id: OrganizationId, redis_pool: &'a RedisPool) {
-        self.org_id_and_redis_pool = Some((org_id, redis_pool));
     }
 
     #[cfg(feature = "redis")]
@@ -143,6 +135,16 @@ impl<'a> ReservoirEvaluator<'a> {
         }
 
         self.incr_local(rule, limit)
+    }
+}
+
+#[cfg(feature = "redis")]
+impl<'a> ReservoirEvaluator<'a> {
+    /// Sets the Redis pool and organization ID for the [`ReservoirEvaluator`].
+    ///
+    /// These values are needed to synchronize with Redis.
+    pub fn set_redis(&mut self, org_id: OrganizationId, redis_pool: &'a RedisPool) {
+        self.org_id_and_redis_pool = Some((org_id, redis_pool));
     }
 }
 

--- a/relay-server/src/metrics/bucket_encoding.rs
+++ b/relay-server/src/metrics/bucket_encoding.rs
@@ -98,7 +98,7 @@ pub enum ArrayEncoding<'a, T> {
     Dynamic(DynamicArrayEncoding<'a, T>),
 }
 
-impl<'a, T> ArrayEncoding<'a, T> {
+impl<T> ArrayEncoding<'_, T> {
     /// Name of the encoding.
     ///
     /// Should only be used for debugging purposes.
@@ -132,7 +132,7 @@ pub enum DynamicArrayEncoding<'a, T> {
     Zstd { data: &'a str },
 }
 
-impl<'a, T> DynamicArrayEncoding<'a, T> {
+impl<T> DynamicArrayEncoding<'_, T> {
     /// Returns the serialized format name.
     pub fn format(&self) -> &'static str {
         match self {
@@ -170,7 +170,7 @@ fn zstd<T: Encodable>(data: T, buffer: &mut String) -> io::Result<ArrayEncoding<
 
 struct EncoderWriteAdapter<'a>(pub data_encoding::Encoder<'a>);
 
-impl<'a> io::Write for EncoderWriteAdapter<'a> {
+impl io::Write for EncoderWriteAdapter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.append(buf);
         Ok(buf.len())

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -798,7 +798,7 @@ struct ProcessEnvelopeState<'a, Group> {
     event_fully_normalized: bool,
 }
 
-impl<'a, Group> ProcessEnvelopeState<'a, Group> {
+impl<Group> ProcessEnvelopeState<'_, Group> {
     /// Returns a reference to the contained [`Envelope`].
     fn envelope(&self) -> &Envelope {
         self.managed_envelope.envelope()
@@ -2840,7 +2840,7 @@ enum RateLimiter<'a> {
 }
 
 #[cfg(feature = "processing")]
-impl<'a> RateLimiter<'a> {
+impl RateLimiter<'_> {
     fn enforce<G>(
         &self,
         global_config: &GlobalConfig,

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -358,7 +358,7 @@ mod tests {
         extracted_metrics: Vec<Bucket>,
     }
 
-    impl<'a> TestProcessSessionArguments<'a> {
+    impl TestProcessSessionArguments<'_> {
         fn run_session_producer(&mut self) -> bool {
             process_session(
                 &mut self.item,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1144,7 +1144,7 @@ enum MetricValue<'a> {
     Gauge(GaugeValue),
 }
 
-impl<'a> MetricValue<'a> {
+impl MetricValue<'_> {
     fn variant(&self) -> &'static str {
         match self {
             Self::Counter(_) => "counter",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1034,7 +1034,7 @@ pub enum ClientName<'a> {
     Other(&'a str),
 }
 
-impl<'a> ClientName<'a> {
+impl ClientName<'_> {
     pub fn name(&self) -> &'static str {
         match self {
             Self::Ruby => "sentry-ruby",


### PR DESCRIPTION
Fixes all Clippy and rustfmt issues with 1.83.

This adds a bunch of ignores for the `non_local_definitions` lint, since `synstructure` generates code which causes the lint to fire. `synstructure` 0.13 has this fixed, but it depends on syn2, where we still use syn1 in the derive crates. Updating to syn2 is too much effort for the moment.

#skip-changelog