### PR TITLE
fix: Add dummy version to minidump SDK

### DIFF
--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -206,6 +206,7 @@ pub fn process_minidump(event: &mut Event, data: &[u8]) {
     // Add sdk information for analytics.
     event.client_sdk.get_or_insert_with(|| ClientSdkInfo {
         name: Annotated::new(client_sdk_name.to_owned()),
+        version: "0.0.0".to_owned().into(),
         ..ClientSdkInfo::default()
     });
 


### PR DESCRIPTION
The [corresponding Unreal code](https://github.com/getsentry/relay/blob/d12ff531fefca0b1c0dbe2b4efb72032abed74d2/relay-server/src/utils/unreal.rs#L281) always sets a version and the documentation of `ClientSdkInfo` notes that the version is required.

Not setting it causes Sentry minidump tests to fail, see https://github.com/getsentry/sentry/actions/runs/12087357149/job/33772836079?pr=81457.

#skip-changelog