### PR TITLE
ref(projectconfig): remove async connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,29 +421,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bb8"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
-dependencies = [
- "async-trait",
- "futures-util",
- "parking_lot",
- "tokio",
-]
-
-[[package]]
-name = "bb8-redis"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1781f22daa0ae97d934fdf04a5c66646f154a164c4bdc157ec8d3c11166c05cc"
-dependencies = [
- "async-trait",
- "bb8",
- "redis",
-]
-
-[[package]]
 name = "bench-buffer"
 version = "0.1.0"
 dependencies = [
@@ -2907,22 +2884,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3249,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6baebe319ef5e4b470f248335620098d1c2e9261e995be05f56f719ca4bdb2"
+checksum = "81cccf17a692ce51b86564334614d72dcae1def0fd5ecebc9f02956da74352b5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3273,6 +3250,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-native-tls",
+ "tokio-retry2",
  "tokio-util",
  "url",
 ]
@@ -3794,8 +3772,6 @@ dependencies = [
 name = "relay-redis"
 version = "24.11.1"
 dependencies = [
- "async-trait",
- "bb8-redis",
  "r2d2",
  "redis",
  "relay-log",
@@ -5228,7 +5204,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5254,6 +5229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903934dba1c4c2f2e9cb460ef10b5695e0b0ecad3bf9ee7c8675e540c5e8b2d1"
+dependencies = [
+ "pin-project",
+ "rand",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,11 @@ relay-event-derive = { path = "relay-event-derive" }
 ahash = "0.8.11"
 android_trace_log = { version = "0.3.0", features = ["serde"] }
 anyhow = "1.0.66"
-async-trait = "0.1.83"
 axum = "0.7.5"
 axum-extra = "0.9.3"
 axum-server = "0.7.1"
 arc-swap = "1.7.1"
 backoff = "0.4.0"
-bb8-redis = "0.17.0"
 bindgen = "0.70.1"
 brotli = "6.0.0"
 bytecount = "0.6.0"
@@ -142,7 +140,7 @@ rand_pcg = "0.3.1"
 rayon = "1.10"
 rdkafka = "0.36.2"
 rdkafka-sys = "4.3.0"
-redis = { version = "0.27.4", default-features = false }
+redis = { version = "0.27.5", default-features = false }
 regex = "1.10.2"
 regex-lite = "0.1.6"
 reqwest = "0.12.7"

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 r2d2 = { workspace = true, optional = true }
-bb8-redis = { workspace = true, optional = true }
 redis = { workspace = true, optional = true, features = [
     "cluster",
     "r2d2",
@@ -22,16 +21,16 @@ redis = { workspace = true, optional = true, features = [
     "keep-alive",
     "script",
     "tokio-native-tls-comp",
-    "cluster-async"
+    "cluster-async",
+    "connection-manager"
 ], default-features = false }
 relay-log = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-async-trait = { workspace = true, optional = true }
 
 [features]
 default = []
-impl = ["dep:r2d2", "dep:redis", "dep:bb8-redis", "dep:async-trait"]
+impl = ["dep:r2d2", "dep:redis"]
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -465,4 +465,15 @@ impl AsyncRedisConnection {
                 .map_err(RedisError::Redis),
         }
     }
+
+    /// Return [`Stats`] for [`AsyncRedisConnection`].
+    ///
+    /// It will always return 0 for `idle_connections` and 1 for `connections` since we
+    /// are re-using the same connection.
+    pub fn stats(&self) -> Stats {
+        Stats {
+            idle_connections: 0,
+            connections: 1,
+        }
+    }
 }

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -417,7 +417,7 @@ impl Debug for ConnectionManagerDebug {
 pub enum AsyncRedisConnection {
     /// Variant for [`ClusterConnection`]
     Cluster(ClusterConnectionDebug),
-    /// Variant for [`ConnectionManager`] using [`MultiplexedConnection`]
+    /// Variant for [`ConnectionManager`] using [`redis::aio::MultiplexedConnection`]
     Single(ConnectionManagerDebug),
 }
 

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -415,9 +415,9 @@ impl Debug for ConnectionManagerDebug {
 /// are thread safe.
 #[derive(Debug, Clone)]
 pub enum AsyncRedisConnection {
-    /// Variant for [`ClusterConnection`]
+    /// Variant for [`ClusterConnection`].
     Cluster(ClusterConnectionDebug),
-    /// Variant for [`ConnectionManager`] using [`redis::aio::MultiplexedConnection`]
+    /// Variant for [`ConnectionManager`] using [`redis::aio::MultiplexedConnection`].
     Single(ConnectionManagerDebug),
 }
 

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -1,15 +1,12 @@
 use crate::config::RedisConfigOptions;
-use async_trait::async_trait;
-use bb8_redis::bb8::RunError;
-use bb8_redis::{bb8, RedisConnectionManager};
 use r2d2::{Builder, ManageConnection, Pool, PooledConnection};
 pub use redis;
-use redis::aio::MultiplexedConnection;
-use redis::cluster::{ClusterClient, ClusterClientBuilder};
+use redis::aio::{ConnectionManager, ConnectionManagerConfig};
+use redis::cluster::ClusterClientBuilder;
 use redis::cluster_async::ClusterConnection;
-use redis::{Cmd, ConnectionLike, ErrorKind, FromRedisValue, RedisResult};
+use redis::{Client, Cmd, ConnectionLike, FromRedisValue};
 use std::error::Error;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::thread::Scope;
 use std::time::Duration;
 use std::{fmt, thread};
@@ -25,10 +22,6 @@ pub enum RedisError {
     /// Failure in r2d2 pool.
     #[error("failed to pool redis connection")]
     Pool(#[source] r2d2::Error),
-
-    /// Failure in bb8 pool.
-    #[error("failed to pool async redis connections")]
-    AsyncPool(#[source] RunError<redis::RedisError>),
 
     /// Failure in Redis communication.
     #[error("failed to communicate with redis")]
@@ -382,7 +375,7 @@ impl RedisPool {
 #[derive(Debug, Clone)]
 pub struct RedisPools {
     /// The pool used for project configurations
-    pub project_configs: AsyncRedisPool,
+    pub project_configs: AsyncRedisConnection,
     /// The pool used for cardinality limits.
     pub cardinality: RedisPool,
     /// The pool used for rate limiting/quotas.
@@ -397,89 +390,39 @@ pub struct Stats {
     pub idle_connections: u32,
 }
 
-/// [`bb8::CustomizeConnection`] that calls `set_response_timeout` on connections.
-#[derive(Debug)]
-pub struct ResponseTimeoutCustomConnection(Duration);
+/// Wrapper for a [`ClusterConnection`] that implements `Debug`.
+#[derive(Clone)]
+pub struct ClusterConnectionDebug(ClusterConnection);
 
-#[async_trait]
-impl bb8::CustomizeConnection<MultiplexedConnection, redis::RedisError>
-    for ResponseTimeoutCustomConnection
-{
-    async fn on_acquire(
-        &self,
-        connection: &mut MultiplexedConnection,
-    ) -> Result<(), redis::RedisError> {
-        connection.set_response_timeout(self.0);
-        Ok(())
+impl Debug for ClusterConnectionDebug {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ClusterConnection").finish()
     }
 }
 
-/// [`bb8::ManageConnection`] for an async redis cluster.
-pub struct RedisClusterConnectionManager {
-    client: ClusterClient,
-}
+/// Wrapper for a [`ConnectionManager`] that implements `Debug`.
+#[derive(Clone)]
+pub struct ConnectionManagerDebug(ConnectionManager);
 
-impl RedisClusterConnectionManager {
-    /// Creates a new [`bb8::ManageConnection`] with the provided [`ClusterClient`]
-    pub fn new(client: ClusterClient) -> Self {
-        Self { client }
+impl Debug for ConnectionManagerDebug {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ConnectionManagerDebug").finish()
     }
 }
 
-#[async_trait]
-impl bb8::ManageConnection for RedisClusterConnectionManager {
-    type Connection = ClusterConnection;
-    type Error = redis::RedisError;
-
-    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        self.client.get_async_connection().await
-    }
-
-    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        check_redis_is_valid(conn).await
-    }
-
-    fn has_broken(&self, _: &mut Self::Connection) -> bool {
-        false
-    }
-}
-
-async fn check_redis_is_valid<C: redis::aio::ConnectionLike>(conn: &mut C) -> RedisResult<()> {
-    let pong: String = redis::cmd("PING").query_async(conn).await?;
-    match pong.as_str() {
-        "PONG" => Ok(()),
-        _ => Err((ErrorKind::ResponseError, "ping request").into()),
-    }
-}
-
-/// An abstraction over Single and Cluster redis connections.
+/// A wrapper Type for async redis connections. Conceptually it's similar to [`RedisPool`]
+/// but async redis does not require a pool since the connections can just be cloned and
+/// are thread safe.
 #[derive(Debug, Clone)]
-pub enum AsyncRedisPool {
-    /// Represents a connection pool to a clustered redis instance.
-    Cluster(bb8::Pool<RedisClusterConnectionManager>, RedisConfigOptions),
-    /// Represents a connection pool to a single redis server.
-    Single(bb8::Pool<RedisConnectionManager>, RedisConfigOptions),
+pub enum AsyncRedisConnection {
+    /// Variant for [`ClusterConnection`]
+    Cluster(ClusterConnectionDebug),
+    /// Variant for [`ConnectionManager`] using [`MultiplexedConnection`]
+    Single(ConnectionManagerDebug),
 }
 
-impl AsyncRedisPool {
-    /// Takes a command and executes it on redis.
-    pub async fn query_async<T: FromRedisValue>(&self, cmd: Cmd) -> Result<T, RedisError> {
-        match self {
-            Self::Cluster(pool, ..) => {
-                let mut conn = pool.get().await.map_err(RedisError::AsyncPool)?;
-                cmd.query_async(&mut *conn).await.map_err(RedisError::Redis)
-            }
-            Self::Single(pool, ..) => {
-                let mut conn = pool.get().await.map_err(RedisError::AsyncPool)?;
-                cmd.query_async(&mut *conn).await.map_err(RedisError::Redis)
-            }
-        }
-    }
-
-    /// Creates a new cluster based [`AsyncRedisPool`].
-    ///
-    /// It will set the `response_timeout` to the provided `read_timeout`.
-    /// `write_timeout` is not used at all in the async pool
+impl AsyncRedisConnection {
+    /// Creates a [`AsyncRedisConnection`] in cluster mode.
     pub async fn cluster<'a>(
         servers: impl IntoIterator<Item = &'a str>,
         opts: &RedisConfigOptions,
@@ -487,53 +430,39 @@ impl AsyncRedisPool {
         // connection timeout is set in `base_pool_builder` on the pool level
         let client = ClusterClientBuilder::new(servers)
             .response_timeout(Duration::from_secs(opts.read_timeout))
+            .connection_timeout(Duration::from_secs(opts.connection_timeout))
             .build()
             .map_err(RedisError::Redis)?;
-        let manager = RedisClusterConnectionManager::new(client);
-        let pool = Self::base_pool_builder(opts)
-            .build(manager)
+        let connection = client
+            .get_async_connection()
             .await
             .map_err(RedisError::Redis)?;
-        Ok(AsyncRedisPool::Cluster(pool, opts.clone()))
+        Ok(Self::Cluster(ClusterConnectionDebug(connection)))
     }
 
-    /// Creates a new [`AsyncRedisPool`] backed by a single redis server.
-    ///
-    /// It will set the `response_timeout` to the provided `read_timeout`.
-    /// `write_timeout` is not used at all in the async pool
+    /// Create a [`AsyncRedisConnection`] in single mode.
     pub async fn single(server: &str, opts: &RedisConfigOptions) -> Result<Self, RedisError> {
-        let manager = RedisConnectionManager::new(server).map_err(RedisError::Redis)?;
-        let customizer = Box::new(ResponseTimeoutCustomConnection(Duration::from_secs(
-            opts.read_timeout,
-        )));
-        // `connection_timeout` is set in `base_pool_builder` on the pool level
-        let pool = Self::base_pool_builder(opts)
-            .connection_customizer(customizer)
-            .build(manager)
+        let client = Client::open(server).map_err(RedisError::Redis)?;
+        let config = ConnectionManagerConfig::new()
+            .set_response_timeout(Duration::from_secs(opts.read_timeout))
+            .set_connection_timeout(Duration::from_secs(opts.connection_timeout));
+        let connection_manager = ConnectionManager::new_with_config(client, config)
             .await
             .map_err(RedisError::Redis)?;
-        Ok(AsyncRedisPool::Single(pool, opts.clone()))
+        Ok(Self::Single(ConnectionManagerDebug(connection_manager)))
     }
 
-    /// Returns information about the current state of the pool.
-    pub fn stats(&self) -> Stats {
-        let state = match self {
-            AsyncRedisPool::Cluster(pool, _) => pool.state(),
-            AsyncRedisPool::Single(pool, _) => pool.state(),
-        };
-        Stats {
-            connections: state.connections,
-            idle_connections: state.idle_connections,
+    /// Runs the given command on redis and returns the result.
+    pub async fn query_async<T: FromRedisValue>(&self, cmd: Cmd) -> Result<T, RedisError> {
+        match self {
+            Self::Cluster(conn, ..) => cmd
+                .query_async(&mut conn.0.clone())
+                .await
+                .map_err(RedisError::Redis),
+            Self::Single(conn, ..) => cmd
+                .query_async(&mut conn.0.clone())
+                .await
+                .map_err(RedisError::Redis),
         }
-    }
-
-    fn base_pool_builder<M: bb8::ManageConnection>(opts: &RedisConfigOptions) -> bb8::Builder<M> {
-        bb8::Pool::builder()
-            .max_size(opts.max_connections)
-            .min_idle(opts.min_idle.unwrap_or(opts.max_connections))
-            .test_on_check_out(false)
-            .max_lifetime(Some(Duration::from_secs(opts.max_lifetime)))
-            .idle_timeout(Some(Duration::from_secs(opts.idle_timeout)))
-            .connection_timeout(Duration::from_secs(opts.connection_timeout))
     }
 }

--- a/relay-server/src/services/projects/source/redis.rs
+++ b/relay-server/src/services/projects/source/redis.rs
@@ -1,6 +1,6 @@
 use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
-use relay_redis::{AsyncRedisPool, RedisError};
+use relay_redis::{AsyncRedisConnection, RedisError};
 use relay_statsd::metric;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use relay_redis::redis::cmd;
 #[derive(Clone, Debug)]
 pub struct RedisProjectSource {
     config: Arc<Config>,
-    redis: AsyncRedisPool,
+    redis: AsyncRedisConnection,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -50,7 +50,7 @@ fn parse_redis_response(raw_response: &[u8]) -> Result<ParsedProjectState, Redis
 }
 
 impl RedisProjectSource {
-    pub fn new(config: Arc<Config>, redis: AsyncRedisPool) -> Self {
+    pub fn new(config: Arc<Config>, redis: AsyncRedisConnection) -> Self {
         RedisProjectSource { config, redis }
     }
 

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -4,7 +4,7 @@ use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
 use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
 use relay_config::{Config, RelayMode};
 #[cfg(feature = "processing")]
-use relay_redis::{AsyncRedisPool, RedisPool, RedisPools, Stats};
+use relay_redis::{RedisPool, RedisPools, Stats};
 use relay_statsd::metric;
 use relay_system::{Addr, RuntimeMetrics, Service};
 use tokio::time::interval;
@@ -127,11 +127,6 @@ impl RelayStats {
     }
 
     #[cfg(feature = "processing")]
-    fn redis_pool_async(async_redis_pool: &AsyncRedisPool, name: &str) {
-        Self::stats_metrics(async_redis_pool.stats(), name)
-    }
-
-    #[cfg(feature = "processing")]
     fn stats_metrics(stats: Stats, name: &str) {
         metric!(
             gauge(RelayGauges::RedisPoolConnections) = u64::from(stats.connections),
@@ -149,12 +144,11 @@ impl RelayStats {
     #[cfg(feature = "processing")]
     async fn redis_pools(&self) {
         if let Some(RedisPools {
-            project_configs,
             cardinality,
             quotas,
+            ..
         }) = self.redis_pools.as_ref()
         {
-            Self::redis_pool_async(project_configs, "project_configs");
             Self::redis_pool(cardinality, "cardinality");
             Self::redis_pool(quotas, "quotas");
         }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
 use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
 use relay_config::{Config, RelayMode};
+#[cfg(feature = "processing")]
 use relay_redis::AsyncRedisConnection;
 #[cfg(feature = "processing")]
 use relay_redis::{RedisPool, RedisPools, Stats};


### PR DESCRIPTION
It turned out that async redis does not need a connection pool. This PR removes the pool

#skip-changelog