### PR TITLE
fix(tests): Check errors in minidump and Unreal tests

### DIFF
--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -463,6 +463,8 @@ def test_minidump_with_processing(
         }
     ]
 
+    assert "errors" not in event
+
 
 def test_minidump_with_processing_invalid(
     mini_sentry, relay_with_processing, attachments_consumer

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -129,6 +129,7 @@ def test_unreal_minidump_with_processing(
             mini_dump_process_marker_found = True
 
     assert mini_dump_process_marker_found
+    assert "errors" not in event
 
 
 def test_unreal_apple_crash_with_processing(
@@ -234,6 +235,7 @@ def test_unreal_apple_crash_with_processing(
             apple_crash_report_marker_found = True
 
     assert apple_crash_report_marker_found
+    assert "errors" not in event
 
 
 def test_unreal_minidump_with_config_and_processing(
@@ -326,6 +328,7 @@ def test_unreal_minidump_with_config_and_processing(
             mini_dump_process_marker_found = True
 
     assert mini_dump_process_marker_found
+    assert "errors" not in event
 
 
 def test_unreal_crash_too_large(mini_sentry, relay_with_processing, outcomes_consumer):


### PR DESCRIPTION
Explicitly checking that there were no errors should prevent problems like https://github.com/getsentry/relay/pull/4316.

#skip-changelog