### PR TITLE
ref(metrics): Split aggregator into multiple modules

### DIFF
--- a/relay-metrics/src/aggregator/buckets.rs
+++ b/relay-metrics/src/aggregator/buckets.rs
@@ -1,0 +1,217 @@
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
+
+use fnv::FnvHasher;
+use priority_queue::PriorityQueue;
+use relay_base_schema::project::ProjectKey;
+use relay_common::time::UnixTimestamp;
+use tokio::time::Instant;
+
+use crate::aggregator::{cost, AggregateMetricsError};
+use crate::bucket::BucketValue;
+use crate::{BucketMetadata, MetricName, MetricNamespace};
+
+/// Holds a collection of buckets and maintains flush order.
+#[derive(Debug, Default)]
+pub struct Buckets {
+    queue: PriorityQueue<BucketKey, QueuedBucket>,
+}
+
+impl Buckets {
+    /// Returns the current amount of buckets stored.
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Merge a new bucket into the existing collection of buckets.
+    pub fn merge<T>(
+        &mut self,
+        key: BucketKey,
+        value: T,
+        merge: impl FnOnce(&BucketKey, T, &mut QueuedBucket) -> Result<usize, AggregateMetricsError>,
+        create: impl FnOnce(&BucketKey, T) -> QueuedBucket,
+    ) -> Result<usize, AggregateMetricsError> {
+        let mut added_cost = 0;
+
+        // Need to do a bunch of shenanigans to work around the limitations of the priority queue
+        // API. There is no `entry` like API which would allow us to return errors on update
+        // as well as make the compiler recognize control flow to recognize that `bucket`
+        // is only used once.
+        //
+        // The following code never panics and prefers `expect` over a silent `if let Some(..)`
+        // to prevent errors in future refactors.
+        let mut value = Some(value);
+        let mut error = None;
+
+        let updated = self.queue.change_priority_by(&key, |existing| {
+            let value = value.take().expect("expected bucket to not be used");
+
+            match merge(&key, value, existing) {
+                Ok(cost) => added_cost = cost,
+                Err(err) => error = Some(err),
+            }
+        });
+
+        if let Some(error) = error {
+            return Err(error);
+        }
+
+        if !updated {
+            let value = create(
+                &key,
+                value.expect("expected bucket not to be used when the value was not updated"),
+            );
+
+            added_cost = key.cost() + value.value.cost();
+            self.queue.push(key, value);
+        }
+
+        Ok(added_cost)
+    }
+
+    /// Tries to pop the next element bucket to be flushed.
+    ///
+    /// Returns `None` if there are no more metric buckets or
+    /// if the passed filter `f` returns `False`.
+    pub fn try_pop(
+        &mut self,
+        f: impl FnOnce(&BucketKey, &QueuedBucket) -> bool,
+    ) -> Option<(BucketKey, QueuedBucket)> {
+        let (key, value) = self.queue.peek()?;
+        if !f(key, value) {
+            return None;
+        }
+        self.queue.pop()
+    }
+}
+
+impl IntoIterator for Buckets {
+    type Item = (BucketKey, QueuedBucket);
+    type IntoIter = priority_queue::core_iterators::IntoIter<BucketKey, QueuedBucket>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.queue.into_iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BucketKey {
+    pub project_key: ProjectKey,
+    pub timestamp: UnixTimestamp,
+    pub metric_name: MetricName,
+    pub tags: BTreeMap<String, String>,
+    pub extracted_from_indexed: bool,
+}
+
+impl BucketKey {
+    /// Creates a 64-bit hash of the bucket key using FnvHasher.
+    ///
+    /// This is used for partition key computation and statsd logging.
+    pub fn hash64(&self) -> u64 {
+        let mut hasher = FnvHasher::default();
+        std::hash::Hash::hash(self, &mut hasher);
+        hasher.finish()
+    }
+
+    /// Estimates the number of bytes needed to encode the bucket key.
+    ///
+    /// Note that this does not necessarily match the exact memory footprint of the key,
+    /// because data structures have a memory overhead.
+    pub fn cost(&self) -> usize {
+        std::mem::size_of::<Self>() + self.metric_name.len() + cost::tags_cost(&self.tags)
+    }
+
+    /// Returns the namespace of this bucket.
+    pub fn namespace(&self) -> MetricNamespace {
+        self.metric_name.namespace()
+    }
+
+    /// Computes a stable partitioning key for this [`crate::Bucket`].
+    ///
+    /// The partitioning key is inherently producing collisions, since the output of the hasher is
+    /// reduced into an interval of size `partitions`. This means that buckets with totally
+    /// different values might end up in the same partition.
+    ///
+    /// The role of partitioning is to let Relays forward the same metric to the same upstream
+    /// instance with the goal of increasing bucketing efficiency.
+    pub fn partition_key(&self, partitions: u64) -> u64 {
+        let key = (self.project_key, &self.metric_name, &self.tags);
+
+        let mut hasher = fnv::FnvHasher::default();
+        key.hash(&mut hasher);
+
+        let partitions = partitions.max(1);
+        hasher.finish() % partitions
+    }
+}
+
+/// Bucket in the [`crate::aggregator::Aggregator`] with a defined flush time.
+///
+/// This type implements an inverted total ordering. The maximum queued bucket has the lowest flush
+/// time, which is suitable for using it in a [`BinaryHeap`].
+///
+/// [`BinaryHeap`]: std::collections::BinaryHeap
+#[derive(Debug)]
+pub struct QueuedBucket {
+    pub flush_at: Instant,
+    pub value: BucketValue,
+    pub metadata: BucketMetadata,
+}
+
+impl QueuedBucket {
+    /// Creates a new `QueuedBucket` with a given flush time.
+    pub fn new(flush_at: Instant, value: BucketValue, metadata: BucketMetadata) -> Self {
+        Self {
+            flush_at,
+            value,
+            metadata,
+        }
+    }
+
+    /// Returns `true` if the flush time has elapsed.
+    pub fn elapsed(&self, now: Instant) -> bool {
+        now > self.flush_at
+    }
+
+    /// Merges a bucket into the current queued bucket.
+    ///
+    /// Returns the value cost increase on success,
+    /// otherwise returns an error if the passed bucket value type does not match
+    /// the contained type.
+    pub fn merge(
+        &mut self,
+        value: BucketValue,
+        metadata: BucketMetadata,
+    ) -> Result<usize, AggregateMetricsError> {
+        let cost_before = self.value.cost();
+
+        self.value
+            .merge(value)
+            .map_err(|_| AggregateMetricsError::InvalidTypes)?;
+        self.metadata.merge(metadata);
+
+        Ok(self.value.cost().saturating_sub(cost_before))
+    }
+}
+
+impl PartialEq for QueuedBucket {
+    fn eq(&self, other: &Self) -> bool {
+        self.flush_at.eq(&other.flush_at)
+    }
+}
+
+impl Eq for QueuedBucket {}
+
+impl PartialOrd for QueuedBucket {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        // Comparing order is reversed to convert the max heap into a min heap
+        Some(other.flush_at.cmp(&self.flush_at))
+    }
+}
+
+impl Ord for QueuedBucket {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Comparing order is reversed to convert the max heap into a min heap
+        other.flush_at.cmp(&self.flush_at)
+    }
+}

--- a/relay-metrics/src/aggregator/config.rs
+++ b/relay-metrics/src/aggregator/config.rs
@@ -1,0 +1,172 @@
+use std::time::Duration;
+
+use relay_common::time::UnixTimestamp;
+use serde::{Deserialize, Serialize};
+
+/// Configuration value for [`AggregatorConfig::flush_batching`].
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FlushBatching {
+    /// Shifts the flush time by an offset based on the project key.
+    ///
+    /// This allows buckets from the same project to be flushed together.
+    #[default]
+    Project,
+
+    /// Shifts the flush time by an offset based on the bucket key itself.
+    ///
+    /// This allows for a completely random distribution of bucket flush times.
+    ///
+    /// It should only be used in processing Relays since this flushing behavior it's better
+    /// suited for how Relay emits metrics to Kafka.
+    Bucket,
+
+    /// Shifts the flush time by an offset based on the partition key.
+    ///
+    /// This allows buckets belonging to the same partition to be flushed together. Requires
+    /// [`flush_partitions`](AggregatorConfig::flush_partitions) to be set, otherwise this will fall
+    /// back to [`FlushBatching::Project`].
+    ///
+    /// It should only be used in Relays with the `http.global_metrics` option set since when
+    /// encoding metrics via the global endpoint we can leverage partitioning.
+    Partition,
+
+    /// Do not apply shift.
+    None,
+}
+
+/// Parameters used by the [`crate::aggregator::Aggregator`].
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AggregatorConfig {
+    /// Determines the wall clock time interval for buckets in seconds.
+    ///
+    /// Defaults to `10` seconds. Every metric is sorted into a bucket of this size based on its
+    /// timestamp. This defines the minimum granularity with which metrics can be queried later.
+    pub bucket_interval: u64,
+
+    /// The initial delay in seconds to wait before flushing a bucket.
+    ///
+    /// Defaults to `30` seconds. Before sending an aggregated bucket, this is the time Relay waits
+    /// for buckets that are being reported in real time.
+    ///
+    /// Relay applies up to a full `bucket_interval` of additional jitter after the initial delay to spread out flushing real time buckets.
+    pub initial_delay: u64,
+
+    /// The age in seconds of the oldest allowed bucket timestamp.
+    ///
+    /// Defaults to 5 days.
+    pub max_secs_in_past: u64,
+
+    /// The time in seconds that a timestamp may be in the future.
+    ///
+    /// Defaults to 1 minute.
+    pub max_secs_in_future: u64,
+
+    /// The length the name of a metric is allowed to be.
+    ///
+    /// Defaults to `200` bytes.
+    pub max_name_length: usize,
+
+    /// The length the tag key is allowed to be.
+    ///
+    /// Defaults to `200` bytes.
+    pub max_tag_key_length: usize,
+
+    /// The length the tag value is allowed to be.
+    ///
+    /// Defaults to `200` chars.
+    pub max_tag_value_length: usize,
+
+    /// Maximum amount of bytes used for metrics aggregation per project key.
+    ///
+    /// Similar measuring technique to [`Self::max_total_bucket_bytes`], but instead of a
+    /// global/process-wide limit, it is enforced per project key.
+    ///
+    /// Defaults to `None`, i.e. no limit.
+    pub max_project_key_bucket_bytes: Option<usize>,
+
+    /// Maximum amount of bytes used for metrics aggregation.
+    ///
+    /// When aggregating metrics, Relay keeps track of how many bytes a metric takes in memory.
+    /// This is only an approximation and does not take into account things such as pre-allocation
+    /// in hashmaps.
+    ///
+    /// Defaults to `None`, i.e. no limit.
+    pub max_total_bucket_bytes: Option<usize>,
+
+    /// The number of logical partitions that can receive flushed buckets.
+    ///
+    /// If set, buckets are partitioned by (bucket key % flush_partitions), and routed
+    /// by setting the header `X-Sentry-Relay-Shard`.
+    ///
+    /// This setting will take effect only when paired with [`FlushBatching::Partition`].
+    pub flush_partitions: Option<u64>,
+
+    /// The batching mode for the flushing of the aggregator.
+    ///
+    /// Batching is applied via shifts to the flushing time that is determined when the first bucket
+    /// is inserted. Thanks to the shifts, Relay is able to prevent flushing all buckets from a
+    /// bucket interval at the same time.
+    ///
+    /// For example, the aggregator can choose to shift by the same value all buckets within a given
+    /// partition, effectively allowing all the elements of that partition to be flushed together.
+    #[serde(alias = "shift_key")]
+    pub flush_batching: FlushBatching,
+}
+
+impl AggregatorConfig {
+    /// Returns the time width buckets.
+    pub fn bucket_interval(&self) -> Duration {
+        Duration::from_secs(self.bucket_interval)
+    }
+
+    /// Returns the initial flush delay after the end of a bucket's original time window.
+    pub fn initial_delay(&self) -> Duration {
+        Duration::from_secs(self.initial_delay)
+    }
+
+    /// Determines the target bucket for an incoming bucket timestamp and bucket width.
+    ///
+    /// We select the output bucket which overlaps with the center of the incoming bucket.
+    /// Fails if timestamp is too old or too far into the future.
+    pub fn get_bucket_timestamp(
+        &self,
+        timestamp: UnixTimestamp,
+        bucket_width: u64,
+    ) -> UnixTimestamp {
+        // Find middle of the input bucket to select a target
+        let ts = timestamp.as_secs().saturating_add(bucket_width / 2);
+        // Align target_timestamp to output bucket width
+        let ts = (ts / self.bucket_interval) * self.bucket_interval;
+        UnixTimestamp::from_secs(ts)
+    }
+
+    /// Returns the valid range for metrics timestamps.
+    ///
+    /// Metrics or buckets outside of this range should be discarded.
+    pub fn timestamp_range(&self) -> std::ops::Range<UnixTimestamp> {
+        let now = UnixTimestamp::now().as_secs();
+        let min_timestamp = UnixTimestamp::from_secs(now.saturating_sub(self.max_secs_in_past));
+        let max_timestamp = UnixTimestamp::from_secs(now.saturating_add(self.max_secs_in_future));
+        min_timestamp..max_timestamp
+    }
+}
+
+impl Default for AggregatorConfig {
+    fn default() -> Self {
+        Self {
+            bucket_interval: 10,
+            initial_delay: 30,
+            max_secs_in_past: 5 * 24 * 60 * 60, // 5 days, as for sessions
+            max_secs_in_future: 60,             // 1 minute
+            max_name_length: 200,
+            max_tag_key_length: 200,
+            max_tag_value_length: 200,
+            max_project_key_bucket_bytes: None,
+            max_total_bucket_bytes: None,
+            flush_batching: FlushBatching::default(),
+            flush_partitions: None,
+        }
+    }
+}

--- a/relay-metrics/src/aggregator/cost.rs
+++ b/relay-metrics/src/aggregator/cost.rs
@@ -1,0 +1,232 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use relay_base_schema::project::ProjectKey;
+
+use crate::aggregator::AggregateMetricsError;
+use crate::MetricNamespace;
+use hashbrown::HashMap;
+
+/// Estimates the number of bytes needed to encode the tags.
+///
+/// Note that this does not necessarily match the exact memory footprint of the tags,
+/// because data structures or their serialization have overheads.
+pub fn tags_cost(tags: &BTreeMap<String, String>) -> usize {
+    tags.iter().map(|(k, v)| k.len() + v.len()).sum()
+}
+
+#[derive(Default)]
+pub struct Tracker {
+    total_cost: usize,
+    cost_per_project_key: HashMap<ProjectKey, usize>,
+    cost_per_namespace: BTreeMap<MetricNamespace, usize>,
+}
+
+impl Tracker {
+    #[cfg(test)]
+    pub fn total_cost(&self) -> usize {
+        self.total_cost
+    }
+
+    pub fn cost_per_namespace(&self) -> impl Iterator<Item = (MetricNamespace, usize)> + use<'_> {
+        self.cost_per_namespace.iter().map(|(k, v)| (*k, *v))
+    }
+
+    pub fn totals_cost_exceeded(&self, max_total_cost: Option<usize>) -> bool {
+        if let Some(max_total_cost) = max_total_cost {
+            if self.total_cost >= max_total_cost {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn check_limits_exceeded(
+        &self,
+        project_key: ProjectKey,
+        max_total_cost: Option<usize>,
+        max_project_cost: Option<usize>,
+    ) -> Result<(), AggregateMetricsError> {
+        if self.totals_cost_exceeded(max_total_cost) {
+            relay_log::configure_scope(|scope| {
+                scope.set_extra("bucket.project_key", project_key.as_str().to_owned().into());
+            });
+            return Err(AggregateMetricsError::TotalLimitExceeded);
+        }
+
+        if let Some(max_project_cost) = max_project_cost {
+            let project_cost = self
+                .cost_per_project_key
+                .get(&project_key)
+                .cloned()
+                .unwrap_or(0);
+            if project_cost >= max_project_cost {
+                relay_log::configure_scope(|scope| {
+                    scope.set_extra("bucket.project_key", project_key.as_str().to_owned().into());
+                });
+                return Err(AggregateMetricsError::ProjectLimitExceeded);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn add_cost(&mut self, namespace: MetricNamespace, project_key: ProjectKey, cost: usize) {
+        *self.cost_per_project_key.entry(project_key).or_insert(0) += cost;
+        *self.cost_per_namespace.entry(namespace).or_insert(0) += cost;
+        self.total_cost += cost;
+    }
+
+    pub fn subtract_cost(
+        &mut self,
+        namespace: MetricNamespace,
+        project_key: ProjectKey,
+        cost: usize,
+    ) {
+        let project_cost = self.cost_per_project_key.get_mut(&project_key);
+        let namespace_cost = self.cost_per_namespace.get_mut(&namespace);
+        match (project_cost, namespace_cost) {
+            (Some(project_cost), Some(namespace_cost))
+                if *project_cost >= cost && *namespace_cost >= cost =>
+            {
+                *project_cost -= cost;
+                if *project_cost == 0 {
+                    self.cost_per_project_key.remove(&project_key);
+                }
+                *namespace_cost -= cost;
+                if *namespace_cost == 0 {
+                    self.cost_per_namespace.remove(&namespace);
+                }
+                self.total_cost -= cost;
+            }
+            _ => {
+                relay_log::error!(
+                    namespace = namespace.as_str(),
+                    project_key = project_key.to_string(),
+                    cost = cost.to_string(),
+                    "Cost mismatch",
+                );
+            }
+        }
+    }
+}
+
+impl fmt::Debug for Tracker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CostTracker")
+            .field("total_cost", &self.total_cost)
+            // Convert HashMap to BTreeMap to guarantee order:
+            .field(
+                "cost_per_project_key",
+                &BTreeMap::from_iter(self.cost_per_project_key.iter()),
+            )
+            .field("cost_per_namespace", &self.cost_per_namespace)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cost_tracker() {
+        let namespace = MetricNamespace::Custom;
+        let project_key1 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
+        let project_key2 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap();
+        let project_key3 = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fef").unwrap();
+        let mut cost_tracker = Tracker::default();
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 0,
+            cost_per_project_key: {},
+            cost_per_namespace: {},
+        }
+        "#);
+        cost_tracker.add_cost(MetricNamespace::Custom, project_key1, 50);
+        cost_tracker.add_cost(MetricNamespace::Profiles, project_key1, 50);
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 100,
+            cost_per_project_key: {
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fed"): 100,
+            },
+            cost_per_namespace: {
+                Profiles: 50,
+                Custom: 50,
+            },
+        }
+        "#);
+        cost_tracker.add_cost(namespace, project_key2, 200);
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 300,
+            cost_per_project_key: {
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fed"): 100,
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 200,
+            },
+            cost_per_namespace: {
+                Profiles: 50,
+                Custom: 250,
+            },
+        }
+        "#);
+        // Unknown project: bail
+        cost_tracker.subtract_cost(namespace, project_key3, 666);
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 300,
+            cost_per_project_key: {
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fed"): 100,
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 200,
+            },
+            cost_per_namespace: {
+                Profiles: 50,
+                Custom: 250,
+            },
+        }
+        "#);
+        // Subtract too much: bail
+        cost_tracker.subtract_cost(namespace, project_key1, 666);
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 300,
+            cost_per_project_key: {
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fed"): 100,
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 200,
+            },
+            cost_per_namespace: {
+                Profiles: 50,
+                Custom: 250,
+            },
+        }
+        "#);
+        cost_tracker.subtract_cost(namespace, project_key2, 20);
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 280,
+            cost_per_project_key: {
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fed"): 100,
+                ProjectKey("a94ae32be2584e0bbd7a4cbb95971fee"): 180,
+            },
+            cost_per_namespace: {
+                Profiles: 50,
+                Custom: 230,
+            },
+        }
+        "#);
+
+        // Subtract all
+        cost_tracker.subtract_cost(MetricNamespace::Profiles, project_key1, 50);
+        cost_tracker.subtract_cost(MetricNamespace::Custom, project_key1, 50);
+        cost_tracker.subtract_cost(MetricNamespace::Custom, project_key2, 180);
+        insta::assert_debug_snapshot!(cost_tracker, @r#"
+        CostTracker {
+            total_cost: 0,
+            cost_per_project_key: {},
+            cost_per_namespace: {},
+        }
+        "#);
+    }
+}


### PR DESCRIPTION
Just a small refactor splitting the huge aggregator module into smaller modules. A preparation for #4232.

No functional changes, the only new data-structure is `Buckets` which exposes a better API for the aggregator than the priority queue directly.

#skip-changelog