### PR TITLE
ref(server): Send metrics from aggregator directly to processor

### DIFF
--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -6,7 +6,7 @@ use rand::SeedableRng;
 use relay_base_schema::project::ProjectKey;
 use relay_common::time::UnixTimestamp;
 use relay_metrics::{
-    aggregator::{Aggregator, AggregatorConfig},
+    aggregator::{Aggregator, AggregatorConfig, FlushDecision},
     Bucket, BucketValue, DistributionValue, FiniteF64,
 };
 use std::cell::RefCell;
@@ -224,7 +224,11 @@ fn bench_insert_and_flush(c: &mut Criterion) {
                     |mut aggregator| {
                         // XXX: Ideally we'd want to test the entire try_flush here, but spawning
                         // a service is too much work here.
-                        black_box(aggregator.pop_flush_buckets(black_box(false)));
+                        black_box(aggregator.pop_flush_buckets(
+                            black_box(false),
+                            |_| FlushDecision::Flush(Vec::new()),
+                            Vec::push,
+                        ));
                     },
                     BatchSize::SmallInput,
                 )

--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -224,11 +224,9 @@ fn bench_insert_and_flush(c: &mut Criterion) {
                     |mut aggregator| {
                         // XXX: Ideally we'd want to test the entire try_flush here, but spawning
                         // a service is too much work here.
-                        black_box(aggregator.pop_flush_buckets(
-                            black_box(false),
-                            |_| FlushDecision::Flush(Vec::new()),
-                            Vec::push,
-                        ));
+                        black_box(aggregator.pop_flush_buckets(black_box(false), |_| {
+                            FlushDecision::Flush(Vec::new())
+                        }));
                     },
                     BatchSize::SmallInput,
                 )

--- a/relay-metrics/src/aggregator/buckets.rs
+++ b/relay-metrics/src/aggregator/buckets.rs
@@ -23,15 +23,6 @@ impl Buckets {
         self.queue.len()
     }
 
-    /// Inserts an entry back into the collection.
-    ///
-    /// Note: this should only be used to return values back to the queue
-    /// after removing them, otherwise use [`Self::merge`].
-    pub fn insert(&mut self, key: BucketKey, value: QueuedBucket) {
-        let _old = self.queue.push(key, value);
-        debug_assert!(_old.is_none());
-    }
-
     /// Merge a new bucket into the existing collection of buckets.
     pub fn merge<T>(
         &mut self,
@@ -91,6 +82,17 @@ impl Buckets {
             return None;
         }
         self.queue.pop()
+    }
+
+    /// Inserts an entry back into the collection.
+    ///
+    /// The intended use is to return bucket after [`Self::try_pop`].
+    ///
+    /// Note: this should only be used to return values back to the queue
+    /// after removing them, otherwise use [`Self::merge`].
+    pub fn re_add(&mut self, key: BucketKey, value: QueuedBucket) {
+        let _old = self.queue.push(key, value);
+        debug_assert!(_old.is_none());
     }
 }
 

--- a/relay-metrics/src/aggregator/buckets.rs
+++ b/relay-metrics/src/aggregator/buckets.rs
@@ -23,6 +23,15 @@ impl Buckets {
         self.queue.len()
     }
 
+    /// Inserts an entry back into the collection.
+    ///
+    /// Note: this should only be used to return values back to the queue
+    /// after removing them, otherwise use [`Self::merge`].
+    pub fn insert(&mut self, key: BucketKey, value: QueuedBucket) {
+        let _old = self.queue.push(key, value);
+        debug_assert!(_old.is_none());
+    }
+
     /// Merge a new bucket into the existing collection of buckets.
     pub fn merge<T>(
         &mut self,

--- a/relay-metrics/src/aggregator/mod.rs
+++ b/relay-metrics/src/aggregator/mod.rs
@@ -15,7 +15,7 @@ use crate::bucket::Bucket;
 use crate::statsd::{MetricCounters, MetricGauges, MetricHistograms, MetricSets, MetricTimers};
 use crate::MetricName;
 
-use hashbrown::{Equivalent, HashMap};
+use hashbrown::HashMap;
 
 mod buckets;
 mod config;

--- a/relay-metrics/src/aggregator/mod.rs
+++ b/relay-metrics/src/aggregator/mod.rs
@@ -5,6 +5,7 @@ use std::hash::Hasher;
 use std::time::Duration;
 
 use fnv::FnvHasher;
+use hashbrown::hash_map::Entry;
 use relay_base_schema::project::ProjectKey;
 use relay_common::time::UnixTimestamp;
 use thiserror::Error;
@@ -130,13 +131,21 @@ impl Aggregator {
     /// Pop and return the partitions with buckets that are eligible for flushing out according to
     /// bucket interval.
     ///
-    /// If no partitioning is enabled, the function will return a single `None` partition.
+    /// For each project `flush_decision` is called, which can influence the flush decision
+    /// for buckets of that project. The decision can also return metadata for the project
+    /// on which all flushed buckets for the project are merged with the `merge` function.
     ///
-    /// Note that this function is primarily intended for tests.
-    pub fn pop_flush_buckets(
+    /// `flush_decision` is only called once if the decision is [`FlushDecision::Flush`],
+    /// but may be called multiple times otherwise. The `flush_decision` should be consistent
+    /// for each project key passed.
+    ///
+    /// If no partitioning is enabled, the function will return a single `None` partition.
+    pub fn pop_flush_buckets<T>(
         &mut self,
         force: bool,
-    ) -> HashMap<Option<u64>, HashMap<ProjectKey, Vec<Bucket>>> {
+        mut flush_decision: impl FnMut(ProjectKey) -> FlushDecision<T>,
+        mut merge: impl FnMut(&mut T, Bucket),
+    ) -> HashMap<Option<u64>, HashMap<ProjectKey, T>> {
         relay_statsd::metric!(
             gauge(MetricGauges::Buckets) = self.bucket_count() as u64,
             aggregator = &self.name,
@@ -155,7 +164,10 @@ impl Aggregator {
         let mut partitions = HashMap::new();
         let mut stats = HashMap::new();
 
+        let mut ret = Vec::new();
+
         let now = Instant::now();
+        let ts = UnixTimestamp::from_instant(now.into_std());
 
         relay_statsd::metric!(
             timer(MetricTimers::BucketsScanDuration),
@@ -165,8 +177,53 @@ impl Aggregator {
                 let cost_tracker = &mut self.cost_tracker;
 
                 while let Some((key, entry)) =
-                    self.buckets.try_pop(|_, entry| entry.elapsed(now) || force)
+                    self.buckets.try_pop(|_, entry| force || entry.elapsed(now))
                 {
+                    let partition = self.config.flush_partitions.map(|p| key.partition_key(p));
+
+                    let partition = partitions.entry(partition).or_insert_with(HashMap::new);
+
+                    let buckets = match partition.entry(key.project_key) {
+                        Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+                        Entry::Vacant(vacant_entry) => {
+                            match flush_decision(key.project_key) {
+                                FlushDecision::Flush(v) => vacant_entry.insert(v),
+                                FlushDecision::Delay => {
+                                    if force {
+                                        // If `force` we cannot directly return into the buckets,
+                                        // since this would produce and infinite loop.
+                                        //
+                                        // Instead we remember items to return and return them afterwards,
+                                        // the next flush cycle will then re-evaluate the condition.
+                                        //
+                                        // No point in re-calculating the flush time here, we can still
+                                        // do it on a flush without force.
+                                        ret.push((key, entry));
+                                    } else {
+                                        // Return the bucket back into the aggregator but adjust the flush time.
+                                        //
+                                        // It was popped because it was ready, but the filter decided it shouldn't
+                                        // be flushed yet -> return with a delayed timestamp.
+                                        //
+                                        // Adjusting the flush time will prevent the endless loop.
+                                        let flush_at = get_flush_time(
+                                            &self.config,
+                                            ts,
+                                            self.reference_time,
+                                            &key,
+                                        );
+                                        let entry = QueuedBucket { flush_at, ..entry };
+                                        // New flush time should not be elapsed.
+                                        debug_assert!(!entry.elapsed(now));
+                                        self.buckets.insert(key, entry);
+                                    }
+                                    continue;
+                                }
+                                FlushDecision::Drop => continue, // Drop the bucket
+                            }
+                        }
+                    };
+
                     cost_tracker.subtract_cost(key.namespace(), key.project_key, key.cost());
                     cost_tracker.subtract_cost(
                         key.namespace(),
@@ -180,8 +237,6 @@ impl Aggregator {
                     *bucket_count += 1;
                     *item_count += entry.value.len();
 
-                    let partition = self.config.flush_partitions.map(|p| key.partition_key(p));
-
                     let bucket = Bucket {
                         timestamp: key.timestamp,
                         width: bucket_interval,
@@ -191,15 +246,14 @@ impl Aggregator {
                         metadata: entry.metadata,
                     };
 
-                    partitions
-                        .entry(partition)
-                        .or_insert_with(HashMap::new)
-                        .entry(key.project_key)
-                        .or_insert_with(Vec::new)
-                        .push(bucket);
+                    merge(buckets, bucket);
                 }
             }
         );
+
+        for (key, entry) in ret {
+            self.buckets.insert(key, entry);
+        }
 
         for ((ty, namespace), (bucket_count, item_count)) in stats.into_iter() {
             relay_statsd::metric!(
@@ -348,6 +402,16 @@ impl fmt::Debug for Aggregator {
             .field("receiver", &format_args!("Recipient<FlushBuckets>"))
             .finish()
     }
+}
+
+/// Decision what to do with a bucket when flushing.
+pub enum FlushDecision<T> {
+    /// Flush the bucket with the provided metadata.
+    Flush(T),
+    /// Drop the bucket.
+    Drop,
+    /// Delay flushing the bucket into the future, it's not ready.
+    Delay,
 }
 
 /// Validates the metric name and its tags are correct.
@@ -755,21 +819,20 @@ mod tests {
             assert_eq!(total_cost, current_cost + expected_added_cost);
         }
 
-        aggregator.pop_flush_buckets(true);
+        aggregator.pop_flush_buckets(true, |_| FlushDecision::Flush(Vec::new()), |a, b| a.push(b));
         assert_eq!(aggregator.cost_tracker.total_cost(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_aggregator_flush() {
         // Make sure that the right cost is added / subtracted
         let mut aggregator: Aggregator = Aggregator::new(AggregatorConfig {
             bucket_interval: 10,
             ..test_config()
         });
-        let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
 
+        let project_key = ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fed").unwrap();
         let now = UnixTimestamp::now();
-        tokio::time::pause();
 
         for i in 0..3u32 {
             for (name, offset) in [("foo", 30), ("bar", 15)] {
@@ -789,7 +852,13 @@ mod tests {
 
         let mut flush_buckets = || {
             let mut result = Vec::new();
-            for (partition, v) in aggregator.pop_flush_buckets(false) {
+
+            let partitions = aggregator.pop_flush_buckets(
+                false,
+                |_| FlushDecision::Flush(Vec::new()),
+                Vec::push,
+            );
+            for (partition, v) in partitions {
                 assert!(partition.is_none());
                 for (pk, buckets) in v {
                     assert_eq!(pk, project_key);

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -214,7 +214,8 @@ impl ServiceState {
         let aggregator = RouterService::new(
             config.default_aggregator_config().clone(),
             config.secondary_aggregator_configs().clone(),
-            Some(legacy_project_cache.clone().recipient()),
+            Some(processor.clone().recipient()),
+            project_cache_handle.clone(),
         );
         let aggregator_handle = aggregator.handle();
         let aggregator = runner.start(aggregator);
@@ -284,7 +285,6 @@ impl ServiceState {
         // Keep all the services in one context.
         let project_cache_services = legacy::Services {
             envelope_buffer: envelope_buffer.clone(),
-            aggregator: aggregator.clone(),
             envelope_processor: processor.clone(),
             outcome_aggregator: outcome_aggregator.clone(),
             test_store: test_store.clone(),

--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -96,6 +96,12 @@ pub struct ProjectBuckets {
     pub rate_limits: Arc<RateLimits>,
 }
 
+impl Extend<Bucket> for ProjectBuckets {
+    fn extend<T: IntoIterator<Item = Bucket>>(&mut self, iter: T) {
+        self.buckets.extend(iter)
+    }
+}
+
 enum AggregatorState {
     Running,
     ShuttingDown,
@@ -195,7 +201,7 @@ impl AggregatorService {
 
         let partitions = self
             .aggregator
-            .pop_flush_buckets(force_flush, flush_decision, |pb, b| pb.buckets.push(b));
+            .pop_flush_buckets(force_flush, flush_decision);
 
         self.can_accept_metrics
             .store(!self.aggregator.totals_cost_exceeded(), Ordering::Relaxed);

--- a/relay-server/src/services/metrics/router.rs
+++ b/relay-server/src/services/metrics/router.rs
@@ -9,6 +9,7 @@ use relay_system::{Addr, NoResponse, Recipient, Service, ServiceRunner};
 use crate::services::metrics::{
     Aggregator, AggregatorHandle, AggregatorService, FlushBuckets, MergeBuckets,
 };
+use crate::services::projects::cache::ProjectCacheHandle;
 use crate::statsd::RelayTimers;
 use crate::utils;
 
@@ -28,15 +29,17 @@ impl RouterService {
         default_config: AggregatorServiceConfig,
         secondary_configs: Vec<ScopedAggregatorConfig>,
         receiver: Option<Recipient<FlushBuckets, NoResponse>>,
+        project_cache: ProjectCacheHandle,
     ) -> Self {
         let mut secondary = Vec::new();
 
         for c in secondary_configs {
-            let service = AggregatorService::named(c.name, c.config, receiver.clone());
+            let service =
+                AggregatorService::named(c.name, c.config, receiver.clone(), project_cache.clone());
             secondary.push((service, c.condition));
         }
 
-        let default = AggregatorService::new(default_config, receiver);
+        let default = AggregatorService::new(default_config, receiver, project_cache);
         Self { default, secondary }
     }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -69,7 +69,7 @@ use crate::metrics_extraction::transactions::types::ExtractMetricsError;
 use crate::metrics_extraction::transactions::{ExtractedMetrics, TransactionExtractor};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
-use crate::services::metrics::{Aggregator, MergeBuckets};
+use crate::services::metrics::{Aggregator, FlushBuckets, MergeBuckets, ProjectMetrics};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::event::FiltersStatus;
 use crate::services::projects::cache::ProjectCacheHandle;
@@ -1019,24 +1019,6 @@ impl BucketSource {
     }
 }
 
-/// Metric buckets with additional project.
-#[derive(Debug, Clone)]
-pub struct ProjectMetrics {
-    /// The metric buckets to encode.
-    pub buckets: Vec<Bucket>,
-    /// Project info for extracting quotas.
-    pub project_info: Arc<ProjectInfo>,
-    /// Currently cached rate limits.
-    pub rate_limits: Arc<RateLimits>,
-}
-
-/// Encodes metrics into an envelope ready to be sent upstream.
-#[derive(Debug)]
-pub struct EncodeMetrics {
-    pub partition_key: Option<u64>,
-    pub scopes: BTreeMap<Scoping, ProjectMetrics>,
-}
-
 /// Sends an envelope to the upstream or Kafka.
 #[derive(Debug)]
 pub struct SubmitEnvelope {
@@ -1058,7 +1040,7 @@ pub enum EnvelopeProcessor {
     ProcessEnvelope(Box<ProcessEnvelope>),
     ProcessProjectMetrics(Box<ProcessMetrics>),
     ProcessBatchedMetrics(Box<ProcessBatchedMetrics>),
-    EncodeMetrics(Box<EncodeMetrics>),
+    FlushBuckets(Box<FlushBuckets>),
     SubmitEnvelope(Box<SubmitEnvelope>),
     SubmitClientReports(Box<SubmitClientReports>),
 }
@@ -1070,7 +1052,7 @@ impl EnvelopeProcessor {
             EnvelopeProcessor::ProcessEnvelope(_) => "ProcessEnvelope",
             EnvelopeProcessor::ProcessProjectMetrics(_) => "ProcessProjectMetrics",
             EnvelopeProcessor::ProcessBatchedMetrics(_) => "ProcessBatchedMetrics",
-            EnvelopeProcessor::EncodeMetrics(_) => "EncodeMetrics",
+            EnvelopeProcessor::FlushBuckets(_) => "FlushBuckets",
             EnvelopeProcessor::SubmitEnvelope(_) => "SubmitEnvelope",
             EnvelopeProcessor::SubmitClientReports(_) => "SubmitClientReports",
         }
@@ -1103,11 +1085,11 @@ impl FromMessage<ProcessBatchedMetrics> for EnvelopeProcessor {
     }
 }
 
-impl FromMessage<EncodeMetrics> for EnvelopeProcessor {
+impl FromMessage<FlushBuckets> for EnvelopeProcessor {
     type Response = NoResponse;
 
-    fn from_message(message: EncodeMetrics, _: ()) -> Self {
-        Self::EncodeMetrics(Box::new(message))
+    fn from_message(message: FlushBuckets, _: ()) -> Self {
+        Self::FlushBuckets(Box::new(message))
     }
 }
 
@@ -2569,17 +2551,17 @@ impl EnvelopeProcessorService {
     ///  - rate limiting
     ///  - submit to `StoreForwarder`
     #[cfg(feature = "processing")]
-    fn encode_metrics_processing(&self, message: EncodeMetrics, store_forwarder: &Addr<Store>) {
+    fn encode_metrics_processing(&self, message: FlushBuckets, store_forwarder: &Addr<Store>) {
         use crate::constants::DEFAULT_EVENT_RETENTION;
         use crate::services::store::StoreMetrics;
 
-        for (scoping, message) in message.scopes {
-            let ProjectMetrics {
-                buckets,
-                project_info,
-                rate_limits: _,
-            } = message;
-
+        for ProjectMetrics {
+            buckets,
+            scoping,
+            project_info,
+            ..
+        } in message.buckets.into_values()
+        {
             let buckets = self.rate_limit_buckets(scoping, &project_info, buckets);
 
             let limits = project_info.get_cardinality_limits();
@@ -2615,26 +2597,27 @@ impl EnvelopeProcessorService {
     /// Cardinality limiting and rate limiting run only in processing Relays as they both require
     /// access to the central Redis instance. Cached rate limits are applied in the project cache
     /// already.
-    fn encode_metrics_envelope(&self, message: EncodeMetrics) {
-        let EncodeMetrics {
+    fn encode_metrics_envelope(&self, message: FlushBuckets) {
+        let FlushBuckets {
             partition_key,
-            scopes,
+            buckets,
         } = message;
 
         let batch_size = self.inner.config.metrics_max_batch_size_bytes();
         let upstream = self.inner.config.upstream_descriptor();
 
-        for (scoping, message) in scopes {
-            let ProjectMetrics { buckets, .. } = message;
-
-            let dsn = PartialDsn::outbound(&scoping, upstream);
+        for ProjectMetrics {
+            buckets, scoping, ..
+        } in buckets.values()
+        {
+            let dsn = PartialDsn::outbound(scoping, upstream);
 
             if let Some(key) = partition_key {
                 relay_statsd::metric!(histogram(RelayHistograms::PartitionKeys) = key);
             }
 
             let mut num_batches = 0;
-            for batch in BucketsView::from(&buckets).by_size(batch_size) {
+            for batch in BucketsView::from(buckets).by_size(batch_size) {
                 let mut envelope = Envelope::from_request(None, RequestMeta::outbound(dsn.clone()));
 
                 let mut item = Item::new(ItemType::MetricBuckets);
@@ -2648,7 +2631,7 @@ impl EnvelopeProcessorService {
                     self.inner.addrs.test_store.clone(),
                     ProcessingGroup::Metrics,
                 );
-                envelope.set_partition_key(partition_key).scope(scoping);
+                envelope.set_partition_key(partition_key).scope(*scoping);
 
                 relay_statsd::metric!(
                     histogram(RelayHistograms::BucketsPerBatch) = batch.len() as u64
@@ -2707,19 +2690,20 @@ impl EnvelopeProcessorService {
     /// Cardinality limiting and rate limiting run only in processing Relays as they both require
     /// access to the central Redis instance. Cached rate limits are applied in the project cache
     /// already.
-    fn encode_metrics_global(&self, message: EncodeMetrics) {
-        let EncodeMetrics {
+    fn encode_metrics_global(&self, message: FlushBuckets) {
+        let FlushBuckets {
             partition_key,
-            scopes,
+            buckets,
         } = message;
 
         let batch_size = self.inner.config.metrics_max_batch_size_bytes();
         let mut partition = Partition::new(batch_size);
         let mut partition_splits = 0;
 
-        for (scoping, message) in &scopes {
-            let ProjectMetrics { buckets, .. } = message;
-
+        for ProjectMetrics {
+            buckets, scoping, ..
+        } in buckets.values()
+        {
             for bucket in buckets {
                 let mut remaining = Some(BucketView::new(bucket));
 
@@ -2743,15 +2727,11 @@ impl EnvelopeProcessorService {
         self.send_global_partition(partition_key, &mut partition);
     }
 
-    fn handle_encode_metrics(&self, mut message: EncodeMetrics) {
-        for (scoping, pm) in message.scopes.iter_mut() {
+    fn handle_flush_buckets(&self, mut message: FlushBuckets) {
+        for (project_key, pm) in message.buckets.iter_mut() {
             let buckets = std::mem::take(&mut pm.buckets);
-            pm.buckets = self.check_buckets(
-                scoping.project_key,
-                &pm.project_info,
-                &pm.rate_limits,
-                buckets,
-            );
+            pm.buckets =
+                self.check_buckets(*project_key, &pm.project_info, &pm.rate_limits, buckets);
         }
 
         #[cfg(feature = "processing")]
@@ -2788,7 +2768,7 @@ impl EnvelopeProcessorService {
                 EnvelopeProcessor::ProcessBatchedMetrics(m) => {
                     self.handle_process_batched_metrics(&mut cogs, *m)
                 }
-                EnvelopeProcessor::EncodeMetrics(m) => self.handle_encode_metrics(*m),
+                EnvelopeProcessor::FlushBuckets(m) => self.handle_flush_buckets(*m),
                 EnvelopeProcessor::SubmitEnvelope(m) => self.handle_submit_envelope(*m),
                 EnvelopeProcessor::SubmitClientReports(m) => self.handle_submit_client_reports(*m),
             }
@@ -2800,8 +2780,8 @@ impl EnvelopeProcessorService {
             EnvelopeProcessor::ProcessEnvelope(v) => AppFeature::from(v.envelope.group()).into(),
             EnvelopeProcessor::ProcessProjectMetrics(_) => AppFeature::Unattributed.into(),
             EnvelopeProcessor::ProcessBatchedMetrics(_) => AppFeature::Unattributed.into(),
-            EnvelopeProcessor::EncodeMetrics(v) => v
-                .scopes
+            EnvelopeProcessor::FlushBuckets(v) => v
+                .buckets
                 .values()
                 .map(|s| {
                     if self.inner.config.processing_enabled() {
@@ -3011,7 +2991,7 @@ impl UpstreamRequest for SendEnvelope {
 /// A container for metric buckets from multiple projects.
 ///
 /// This container is used to send metrics to the upstream in global batches as part of the
-/// [`EncodeMetrics`] message if the `http.global_metrics` option is enabled. The container monitors
+/// [`FlushBuckets`] message if the `http.global_metrics` option is enabled. The container monitors
 /// the size of all metrics and allows to split them into multiple batches. See
 /// [`insert`](Self::insert) for more information.
 #[derive(Debug)]
@@ -3300,15 +3280,26 @@ mod tests {
         assert!(quota_ids.eq(["foo", "bar", "baz", "qux"]));
     }
 
-    /// Ensures that if we ratelimit one batch of buckets in [`EncodeMetrics`] message, it won't
+    /// Ensures that if we ratelimit one batch of buckets in [`FlushBuckets`] message, it won't
     /// also ratelimit the next batches in the same message automatically.
     #[cfg(feature = "processing")]
     #[tokio::test]
     async fn test_ratelimit_per_batch() {
         use relay_base_schema::organization::OrganizationId;
 
-        let rate_limited_org = OrganizationId::new(1);
-        let not_ratelimited_org = OrganizationId::new(2);
+        let rate_limited_org = Scoping {
+            organization_id: OrganizationId::new(1),
+            project_id: ProjectId::new(21),
+            project_key: ProjectKey::parse("00000000000000000000000000000000").unwrap(),
+            key_id: Some(17),
+        };
+
+        let not_rate_limited_org = Scoping {
+            organization_id: OrganizationId::new(2),
+            project_id: ProjectId::new(21),
+            project_key: ProjectKey::parse("11111111111111111111111111111111").unwrap(),
+            key_id: Some(17),
+        };
 
         let message = {
             let project_info = {
@@ -3316,7 +3307,7 @@ mod tests {
                     id: Some("testing".into()),
                     categories: vec![DataCategory::MetricBucket].into(),
                     scope: relay_quotas::QuotaScope::Organization,
-                    scope_id: Some(rate_limited_org.to_string()),
+                    scope_id: Some(rate_limited_org.organization_id.to_string()),
                     limit: Some(0),
                     window: None,
                     reason_code: Some(ReasonCode::new("test")),
@@ -3332,7 +3323,7 @@ mod tests {
                 })
             };
 
-            let project_metrics = ProjectMetrics {
+            let project_metrics = |scoping| ProjectMetrics {
                 buckets: vec![Bucket {
                     name: "d:transactions/bar".into(),
                     value: BucketValue::Counter(relay_metrics::FiniteF64::new(1.0).unwrap()),
@@ -3342,31 +3333,29 @@ mod tests {
                     metadata: BucketMetadata::default(),
                 }],
                 rate_limits: Default::default(),
-                project_info,
+                project_info: project_info.clone(),
+                scoping,
             };
 
-            let scoping_by_org_id = |org_id: OrganizationId| Scoping {
-                organization_id: org_id,
-                project_id: ProjectId::new(21),
-                project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
-                key_id: Some(17),
-            };
+            let buckets = hashbrown::HashMap::from([
+                (
+                    rate_limited_org.project_key,
+                    project_metrics(rate_limited_org),
+                ),
+                (
+                    not_rate_limited_org.project_key,
+                    project_metrics(not_rate_limited_org),
+                ),
+            ]);
 
-            let mut scopes = BTreeMap::<Scoping, ProjectMetrics>::new();
-            scopes.insert(scoping_by_org_id(rate_limited_org), project_metrics.clone());
-            scopes.insert(scoping_by_org_id(not_ratelimited_org), project_metrics);
-
-            EncodeMetrics {
+            FlushBuckets {
                 partition_key: None,
-                scopes,
+                buckets,
             }
         };
 
         // ensure the order of the map while iterating is as expected.
-        let mut iter = message.scopes.keys();
-        assert_eq!(iter.next().unwrap().organization_id, rate_limited_org);
-        assert_eq!(iter.next().unwrap().organization_id, not_ratelimited_org);
-        assert!(iter.next().is_none());
+        assert_eq!(message.buckets.keys().count(), 2);
 
         let config = {
             let config_json = serde_json::json!({
@@ -3401,7 +3390,10 @@ mod tests {
         drop(store);
         let orgs_not_ratelimited = handle.await.unwrap();
 
-        assert_eq!(orgs_not_ratelimited, vec![not_ratelimited_org]);
+        assert_eq!(
+            orgs_not_ratelimited,
+            vec![not_rate_limited_org.organization_id]
+        );
     }
 
     #[tokio::test]

--- a/relay-server/src/services/projects/cache/legacy.rs
+++ b/relay-server/src/services/projects/cache/legacy.rs
@@ -1,24 +1,18 @@
-use std::collections::BTreeMap;
-use std::sync::Arc;
-
 use crate::services::buffer::{
     EnvelopeBuffer, EnvelopeBufferError, PartitionedEnvelopeBuffer, ProjectKeyPair,
 };
-use crate::services::processor::{
-    EncodeMetrics, EnvelopeProcessor, ProcessEnvelope, ProcessingGroup, ProjectMetrics,
-};
+use crate::services::processor::{EnvelopeProcessor, ProcessEnvelope, ProcessingGroup};
 use crate::services::projects::cache::{CheckedEnvelope, ProjectCacheHandle};
 use crate::Envelope;
 use relay_statsd::metric;
-use relay_system::{Addr, FromMessage, Interface, Service};
+use relay_system::{Addr, Interface, Service};
 use tokio::sync::mpsc;
 
-use crate::services::metrics::{Aggregator, FlushBuckets, MergeBuckets};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::projects::project::ProjectState;
 use crate::services::test_store::TestStore;
 
-use crate::statsd::{RelayCounters, RelayTimers};
+use crate::statsd::RelayTimers;
 use crate::utils::ManagedEnvelope;
 
 /// Handle an envelope that was popped from the envelope buffer.
@@ -27,35 +21,24 @@ pub struct DequeuedEnvelope(pub Box<Envelope>);
 
 /// The legacy project cache.
 ///
-/// It manages spool v1 and some remaining messages which handle project state.
+/// It currently just does some project routing from the spool to the processor,
+/// which eventually will be moved into the spool and processor, making this service
+/// obsolete.
 #[derive(Debug)]
-pub enum ProjectCache {
-    FlushBuckets(FlushBuckets),
-}
+pub enum ProjectCache {}
 
 impl ProjectCache {
     pub fn variant(&self) -> &'static str {
-        match self {
-            Self::FlushBuckets(_) => "FlushBuckets",
-        }
+        match *self {}
     }
 }
 
 impl Interface for ProjectCache {}
 
-impl FromMessage<FlushBuckets> for ProjectCache {
-    type Response = relay_system::NoResponse;
-
-    fn from_message(message: FlushBuckets, _: ()) -> Self {
-        Self::FlushBuckets(message)
-    }
-}
-
 /// Holds the addresses of all services required for [`ProjectCache`].
 #[derive(Debug, Clone)]
 pub struct Services {
     pub envelope_buffer: PartitionedEnvelopeBuffer,
-    pub aggregator: Addr<Aggregator>,
     pub envelope_processor: Addr<EnvelopeProcessor>,
     pub outcome_aggregator: Addr<TrackOutcome>,
     pub test_store: Addr<TestStore>,
@@ -72,67 +55,6 @@ struct ProjectCacheBroker {
 }
 
 impl ProjectCacheBroker {
-    fn handle_flush_buckets(&mut self, message: FlushBuckets) {
-        let aggregator = self.services.aggregator.clone();
-
-        let mut no_project = 0;
-        let mut scoped_buckets = BTreeMap::new();
-        for (project_key, buckets) in message.buckets {
-            let project = self.projects.get(project_key);
-
-            let project_info = match project.state() {
-                ProjectState::Pending => {
-                    no_project += 1;
-
-                    // Return the buckets to the aggregator.
-                    aggregator.send(MergeBuckets::new(project_key, buckets));
-                    continue;
-                }
-                ProjectState::Disabled => {
-                    // Project loaded and disabled, discard the buckets.
-                    //
-                    // Ideally we log outcomes for the metrics here, but currently for metric
-                    // outcomes we need a valid scoping, which we cannot construct for disabled
-                    // projects.
-                    continue;
-                }
-                ProjectState::Enabled(project_info) => project_info,
-            };
-
-            let Some(scoping) = project_info.scoping(project_key) else {
-                relay_log::error!(
-                    tags.project_key = project_key.as_str(),
-                    "there is no scoping: dropping {} buckets",
-                    buckets.len(),
-                );
-                continue;
-            };
-
-            use std::collections::btree_map::Entry::*;
-            match scoped_buckets.entry(scoping) {
-                Vacant(entry) => {
-                    entry.insert(ProjectMetrics {
-                        project_info: Arc::clone(project_info),
-                        rate_limits: project.rate_limits().current_limits(),
-                        buckets,
-                    });
-                }
-                Occupied(entry) => {
-                    entry.into_mut().buckets.extend(buckets);
-                }
-            }
-        }
-
-        self.services.envelope_processor.send(EncodeMetrics {
-            partition_key: message.partition_key,
-            scopes: scoped_buckets,
-        });
-
-        relay_statsd::metric!(
-            counter(RelayCounters::ProjectStateFlushMetricsNoProject) += no_project
-        );
-    }
-
     fn handle_dequeued_envelope(
         &mut self,
         envelope: Box<Envelope>,
@@ -216,19 +138,6 @@ impl ProjectCacheBroker {
         Ok(())
     }
 
-    fn handle_message(&mut self, message: ProjectCache) {
-        let ty = message.variant();
-        metric!(
-            timer(RelayTimers::LegacyProjectCacheMessageDuration),
-            message = ty,
-            {
-                match message {
-                    ProjectCache::FlushBuckets(message) => self.handle_flush_buckets(message),
-                }
-            }
-        )
-    }
-
     fn handle_envelope(&mut self, dequeued_envelope: DequeuedEnvelope) {
         let project_key_pair = ProjectKeyPair::from_envelope(&dequeued_envelope.0);
         let envelope_buffer = self
@@ -291,11 +200,7 @@ impl Service for ProjectCacheService {
             tokio::select! {
                 biased;
 
-                Some(message) = rx.recv() => {
-                    metric!(timer(RelayTimers::LegacyProjectCacheTaskDuration), task = "handle_message", {
-                        broker.handle_message(message)
-                    })
-                }
+                Some(message) = rx.recv() => { match message {} }
                 Some(message) = envelopes_rx.recv() => {
                     metric!(timer(RelayTimers::LegacyProjectCacheTaskDuration), task = "handle_envelope", {
                         broker.handle_envelope(message)

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -480,11 +480,6 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     /// - `task`: The type of the task the project cache does.
     ProjectCacheTaskDuration,
-    /// Timing in milliseconds for handling a legacy project cache message.
-    ///
-    /// This metric is tagged with:
-    ///  - `message`: The type of message that was processed.
-    LegacyProjectCacheMessageDuration,
     /// Timing in milliseconds for processing a task in the legacy project cache service.
     ///
     /// A task is a unit of work the service does. Each branch of the
@@ -592,9 +587,6 @@ impl TimerMetric for RelayTimers {
             RelayTimers::GlobalConfigRequestDuration => "global_config.requests.duration",
             RelayTimers::ProcessMessageDuration => "processor.message.duration",
             RelayTimers::ProjectCacheTaskDuration => "project_cache.task.duration",
-            RelayTimers::LegacyProjectCacheMessageDuration => {
-                "legacy_project_cache.message.duration"
-            }
             RelayTimers::LegacyProjectCacheTaskDuration => "legacy_project_cache.task.duration",
             RelayTimers::HealthCheckDuration => "health.message.duration",
             #[cfg(feature = "processing")]


### PR DESCRIPTION
Instead of sending metrics from the aggregator to the 'legacy project cache` to check the project status there and either return the metrics to the aggregator or send them onwards, we can directly only flush metrics for projects which are ready and then directly send them to the processor.

Fixes: #4232

#skip-changelog