### PR TITLE
ref(server): Remove global config from legacy project config service

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -294,7 +294,6 @@ impl ServiceState {
             legacy::ProjectCacheService::new(
                 project_cache_handle.clone(),
                 project_cache_services,
-                global_config_rx,
                 envelopes_rx,
             ),
             legacy_project_cache_rx,


### PR DESCRIPTION
Removes unused global config logic from the legacy cache.

#skip-changelog