### PR TITLE
docs(cargo): add comment to describe why anyhow is version pinned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ relay-event-derive = { path = "relay-event-derive" }
 
 ahash = "0.8.11"
 android_trace_log = { version = "0.3.0", features = ["serde"] }
+# This version is pinned because upgrading it enables backtrace by default without the possibility to disable it
+# which will increase processing time for transactions massively.
+# Keep it pinned until it's possible to disable backtrace
 anyhow = "=1.0.69"
 axum = "0.7.9"
 axum-extra = "0.9.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ ahash = "0.8.11"
 android_trace_log = { version = "0.3.0", features = ["serde"] }
 # This version is pinned because upgrading it enables backtrace by default without the possibility to disable it
 # which will increase processing time for transactions massively.
-# Keep it pinned until it's possible to disable backtrace
+# Keep it pinned until it's possible to disable backtrace.
 anyhow = "=1.0.69"
 axum = "0.7.9"
 axum-extra = "0.9.6"


### PR DESCRIPTION
This PR adds a comment to explain why `anyhow` is version pinned and what needs to happen to allow updates again

#skip-changelog