### PR TITLE
ref(ci): Disable self-hosted e2e ci due to resource constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,24 +609,25 @@ jobs:
           echo "Testing against ${RELAY_TEST_IMAGE}"
           make test-relay-integration
 
-  self-hosted-end-to-end:
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    needs: build-docker
+  # TODO: Re-enable this once CI is stable, seems to be running into issues potentially with resource constraints
+  # self-hosted-end-to-end:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 25
+  #   needs: build-docker
 
-    # - Skip redundant checks for library releases
-    # - Skip for dependabot or if it's a fork as the image cannot be uploaded to ghcr since this test attempts to pull
-    # the image from ghcr
-    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+  #   # - Skip redundant checks for library releases
+  #   # - Skip for dependabot or if it's a fork as the image cannot be uploaded to ghcr since this test attempts to pull
+  #   # the image from ghcr
+  #   if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
 
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@main
-        with:
-          project_name: relay
-          image_url: ghcr.io/getsentry/relay:${{ github.event.pull_request.head.sha || github.sha }}
-          docker_repo: getsentry/relay
-          docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+  #     - name: Run Sentry self-hosted e2e CI
+  #       uses: getsentry/action-self-hosted-e2e-tests@main
+  #       with:
+  #         project_name: relay
+  #         image_url: ghcr.io/getsentry/relay:${{ github.event.pull_request.head.sha || github.sha }}
+  #         docker_repo: getsentry/relay
+  #         docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}


### PR DESCRIPTION
Seeing self-hosted CI fail in numerous places, but it is not clear exactly what is causing these failures as the logs are not explanatory. Thinking it may be due to resource constraints from github runners. Either way, don't want to block CI until this can be investigated properly

https://github.com/getsentry/self-hosted/actions/runs/12179355335

In terms of the impact of turning this off, self-hosted e2e tests are still run in the self-hosted repo twice per day which should pick up changes from snuba master

#skip-changelog