### PR TITLE
ref(metrics): Better timing metric for the aggregator service

### DIFF
--- a/relay-server/src/services/metrics/aggregator.rs
+++ b/relay-server/src/services/metrics/aggregator.rs
@@ -286,20 +286,13 @@ impl AggregatorService {
     }
 
     fn handle_message(&mut self, message: Aggregator) {
-        let ty = message.variant();
-        relay_statsd::metric!(
-            timer(RelayTimers::AggregatorServiceDuration),
-            message = ty,
-            {
-                match message {
-                    Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
-                    #[cfg(test)]
-                    Aggregator::BucketCountInquiry(_, sender) => {
-                        sender.send(self.aggregator.bucket_count())
-                    }
-                }
+        match message {
+            Aggregator::MergeBuckets(msg) => self.handle_merge_buckets(msg),
+            #[cfg(test)]
+            Aggregator::BucketCountInquiry(_, sender) => {
+                sender.send(self.aggregator.bucket_count())
             }
-        )
+        }
     }
 
     fn handle_shutdown(&mut self, message: Shutdown) {
@@ -316,13 +309,26 @@ impl Service for AggregatorService {
         let mut ticker = tokio::time::interval(Duration::from_millis(self.flush_interval_ms));
         let mut shutdown = Controller::shutdown_handle();
 
+        macro_rules! timed {
+            ($task:expr, $body:expr) => {{
+                let task_name = $task;
+                relay_statsd::metric!(
+                    timer(RelayTimers::AggregatorServiceDuration),
+                    task = task_name,
+                    aggregator = self.aggregator.name(),
+                    { $body }
+                )
+            }};
+        }
+
         // Note that currently this loop never exits and will run till the tokio runtime shuts
         // down. This is about to change with the refactoring for the shutdown process.
         loop {
             tokio::select! {
                 biased;
 
-                _ = ticker.tick() => {
+                _ = ticker.tick() => timed!(
+                    "try_flush",
                     if cfg!(test) {
                         // Tests are running in a single thread / current thread runtime,
                         // which is required for 'fast-forwarding' and `block_in_place`
@@ -332,9 +338,9 @@ impl Service for AggregatorService {
                     } else {
                         tokio::task::block_in_place(|| self.try_flush())
                     }
-                },
-                Some(message) = rx.recv() => self.handle_message(message),
-                shutdown = shutdown.notified() => self.handle_shutdown(shutdown),
+                ),
+                Some(message) = rx.recv() => timed!(message.variant(), self.handle_message(message)),
+                shutdown = shutdown.notified() => timed!("shutdown", self.handle_shutdown(shutdown)),
 
                 else => break,
             }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -502,10 +502,11 @@ pub enum RelayTimers {
     ///  - `count`: How many items matching the data category are contained in the batch.
     #[cfg(feature = "processing")]
     RateLimitBucketsDuration,
-    /// Timing in milliseconds for processing a message in the aggregator service.
+    /// Timing in milliseconds for processing a task in the aggregator service.
     ///
     /// This metric is tagged with:
-    ///  - `message`: The type of message that was processed.
+    ///  - `task`: The task being executed by the aggregator.
+    ///  - `aggregator`: The name of the aggregator.
     AggregatorServiceDuration,
     /// Timing in milliseconds for processing a message in the metric router service.
     ///


### PR DESCRIPTION
A single timer for all select branches and also tagged by aggregator.

Ref: https://github.com/getsentry/team-ingest/issues/606

#skip-changelog