### PR TITLE
ref(metrics): Remove unused delay metric

### DIFF
--- a/relay-metrics/src/aggregator/mod.rs
+++ b/relay-metrics/src/aggregator/mod.rs
@@ -470,12 +470,6 @@ fn get_flush_time(
     let initial_flush = bucket_key.timestamp + config.bucket_interval() + config.initial_delay();
     let backdated = initial_flush <= now;
 
-    let delay = now.as_secs() as i64 - bucket_key.timestamp.as_secs() as i64;
-    relay_statsd::metric!(
-        histogram(MetricHistograms::BucketsDelay) = delay as f64,
-        backdated = if backdated { "true" } else { "false" },
-    );
-
     let flush_timestamp = if backdated {
         // If the initial flush time has passed or can't be represented, we want to treat the
         // flush of the bucket as if it came in with the timestamp of current bucket based on

--- a/relay-metrics/src/statsd.rs
+++ b/relay-metrics/src/statsd.rs
@@ -75,18 +75,6 @@ impl TimerMetric for MetricTimers {
 /// Histogram metrics for Relay Metrics.
 #[allow(clippy::enum_variant_names)]
 pub enum MetricHistograms {
-    /// The reporting delay at which a bucket arrives in Relay.
-    ///
-    /// A positive delay indicates the bucket arrives after its stated timestamp. Large delays
-    /// indicate backdating, particularly all delays larger than `bucket_interval + initial_delay`.
-    /// Negative delays indicate that the bucket is dated into the future, likely due to clock drift
-    /// on the client.
-    ///
-    /// This metric is tagged with:
-    ///  - `backdated`: A flag indicating whether the metric was reported within the `initial_delay`
-    ///    time period (`false`) or after the initial delay has expired (`true`).
-    BucketsDelay,
-
     /// Distribution of invalid bucket timestamps observed, relative to the time of observation.
     ///
     /// This is a temporary metric to better understand why we see so many invalid timestamp errors.
@@ -96,7 +84,6 @@ pub enum MetricHistograms {
 impl HistogramMetric for MetricHistograms {
     fn name(&self) -> &'static str {
         match *self {
-            Self::BucketsDelay => "metrics.buckets.delay",
             Self::InvalidBucketTimestamp => "metrics.buckets.invalid_timestamp",
         }
     }


### PR DESCRIPTION
The metric is unused and generally currently not very informational but expensive to emit in a very hot path.

Ref: https://github.com/getsentry/team-ingest/issues/606

#skip-changelog