### PR TITLE
ref(redis): add async redis client that uses the same pattern as sync redis

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -35,7 +35,7 @@ use relay_config::{RedisConfigRef, RedisPoolConfigs};
 #[cfg(feature = "processing")]
 use relay_redis::redis::Script;
 #[cfg(feature = "processing")]
-use relay_redis::AsyncRedisConnection;
+use relay_redis::AsyncRedisClient;
 #[cfg(feature = "processing")]
 use relay_redis::{PooledClient, RedisError, RedisPool, RedisPools, RedisScripts};
 use relay_system::{channel, Addr, Service, ServiceRunner};
@@ -477,14 +477,14 @@ pub async fn create_redis_pools(configs: RedisPoolConfigs<'_>) -> Result<RedisPo
 #[cfg(feature = "processing")]
 async fn create_async_connection(
     config: &RedisConfigRef<'_>,
-) -> Result<AsyncRedisConnection, RedisError> {
+) -> Result<AsyncRedisClient, RedisError> {
     match config {
         RedisConfigRef::Cluster {
             cluster_nodes,
             options,
-        } => AsyncRedisConnection::cluster(cluster_nodes.iter().map(|s| s.as_str()), options).await,
+        } => AsyncRedisClient::cluster(cluster_nodes.iter().map(|s| s.as_str()), options).await,
         RedisConfigRef::Single { server, options } => {
-            AsyncRedisConnection::single(server, options).await
+            AsyncRedisClient::single(server, options).await
         }
         RedisConfigRef::MultiWrite { .. } => {
             Err(RedisError::MultiWriteNotSupported("projectconfig"))

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
 use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
 use relay_config::{Config, RelayMode};
-#[cfg(feature = "processing")]
-use relay_redis::AsyncRedisConnection;
+use relay_redis::AsyncRedisClient;
 #[cfg(feature = "processing")]
 use relay_redis::{RedisPool, RedisPools, Stats};
 use relay_statsd::metric;
@@ -126,8 +125,8 @@ impl RelayStats {
     }
 
     #[cfg(feature = "processing")]
-    fn async_redis_connection(conn: &AsyncRedisConnection, name: &str) {
-        Self::stats_metrics(conn.stats(), name);
+    fn async_redis_connection(client: &AsyncRedisClient, name: &str) {
+        Self::stats_metrics(client.stats(), name);
     }
 
     #[cfg(feature = "processing")]

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
 use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
 use relay_config::{Config, RelayMode};
+#[cfg(feature = "processing")]
 use relay_redis::AsyncRedisClient;
 #[cfg(feature = "processing")]
 use relay_redis::{RedisPool, RedisPools, Stats};


### PR DESCRIPTION
This PR introduces a `AsyncRedisClient` instead of exposing the connection directly. The motivation behind this is to share a common pattern between sync and async 

#skip-changelog