### PR TITLE
feat(statsd): manually revert envelope item metrics

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -404,16 +404,6 @@ fn emit_envelope_metrics(envelope: &Envelope) {
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
             item_type = item.ty().name()
         );
-        metric!(
-            counter(RelayCounters::EnvelopeItems) += 1,
-            item_type = item.ty().name(),
-            sdk = client_name.name(),
-        );
-        metric!(
-            counter(RelayCounters::EnvelopeItemBytes) += item.payload().len() as u64,
-            item_type = item.ty().name(),
-            sdk = client_name.name(),
-        );
     }
 
     if has_transaction && has_attachment {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -642,10 +642,6 @@ pub enum RelayCounters {
     ///  - `handling`: Either `"success"` if the envelope was handled correctly, or `"failure"` if
     ///    there was an error or bug.
     EnvelopeRejected,
-    /// Number of items we processed per envelope.
-    EnvelopeItems,
-    /// Number of bytes we processed per envelope item.
-    EnvelopeItemBytes,
     /// Number of transactions with attachments seen in the request handler.
     TransactionsWithAttachments,
     /// Number of envelopes that were returned to the envelope buffer by the project cache.
@@ -842,9 +838,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EventCorrupted => "event.corrupted",
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",
-            RelayCounters::EnvelopeItems => "event.items",
             RelayCounters::TransactionsWithAttachments => "transactions_with_attachments",
-            RelayCounters::EnvelopeItemBytes => "event.item_bytes",
             RelayCounters::BufferEnvelopesReturned => "buffer.envelopes_returned",
             RelayCounters::BufferTryPop => "buffer.try_pop",
             RelayCounters::BufferSpooledEnvelopes => "buffer.spooled_envelopes",


### PR DESCRIPTION
Metrics have been moved in code so this needs a manual revert

#skip-changelog