### PR TITLE
feat(devservices): Use live healthcheck for relay container

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -28,7 +28,7 @@ services:
       - 127.0.0.1:7899:7899
     command: [run, --config, /etc/relay]
     healthcheck:
-      test: curl -f http://127.0.0.1:7899/api/relay/healthcheck/ready/
+      test: curl -f http://127.0.0.1:7899/api/relay/healthcheck/live/
       interval: 5s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Follow up to https://github.com/getsentry/relay/pull/4343

For now at least in the context of sentry, we do not want the relay container to be considered unhealthy if the devserver is not up and running. This means that instead of using the ready healthcheck, we should use the live healthcheck

#skip-changelog