### PR TITLE
feat(label): adding label to container

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -39,6 +39,8 @@ services:
       - host.docker.internal:host-gateway
     networks:
       - devservices
+    labels:
+      - orchestrator=devservices
     restart: unless-stopped
 
 networks:


### PR DESCRIPTION
Adding a label to the docker compose config to signify that devservices is the orchestrator.

#skip-changelog