### PR TITLE
ref(processor): Remove event_fully_normalized from state

### DIFF
--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1174,6 +1174,14 @@ impl Envelope {
         }
     }
 
+    /// Returns `true` whether the event is fully normalized, `false`.
+    pub fn event_fully_normalized(&self) -> bool {
+        self.meta().is_from_internal_relay()
+            && self
+                .items()
+                .any(|item| item.creates_event() && item.fully_normalized())
+    }
+
     /// Returns reference to the [`EnvelopeHeaders`].
     pub fn headers(&self) -> &EnvelopeHeaders {
         &self.headers

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1174,14 +1174,6 @@ impl Envelope {
         }
     }
 
-    /// Returns `true` whether the event is fully normalized, `false`.
-    pub fn event_fully_normalized(&self) -> bool {
-        self.meta().is_from_internal_relay()
-            && self
-                .items()
-                .any(|item| item.creates_event() && item.fully_normalized())
-    }
-
     /// Returns reference to the [`EnvelopeHeaders`].
     pub fn headers(&self) -> &EnvelopeHeaders {
         &self.headers

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1156,7 +1156,7 @@ struct InnerProcessor {
 struct EventFullyNormalized(pub bool);
 
 impl EventFullyNormalized {
-    /// Returns `true` whether the event is fully normalized, `false`.
+    /// Returns `true` if the event is fully normalized, `false` otherwise.
     pub fn new(envelope: &Envelope) -> Self {
         let event_fully_normalized = envelope.meta().is_from_internal_relay()
             && envelope

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1611,8 +1611,7 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<ErrorGroup>,
     ) -> Result<(), ProcessingError> {
-        let mut event_fully_normalized =
-            EventFullyNormalized::event_fully_normalized(state.envelope());
+        let mut event_fully_normalized = EventFullyNormalized::new(state.envelope());
 
         // Events can also contain user reports.
         report::process_user_reports(state);
@@ -1672,8 +1671,7 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<TransactionGroup>,
     ) -> Result<(), ProcessingError> {
-        let mut event_fully_normalized =
-            EventFullyNormalized::event_fully_normalized(state.envelope());
+        let mut event_fully_normalized = EventFullyNormalized::new(state.envelope());
 
         let global_config = self.inner.global_config.current();
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1157,7 +1157,7 @@ struct EventFullyNormalized(pub bool);
 
 impl EventFullyNormalized {
     /// Returns `true` whether the event is fully normalized, `false`.
-    pub fn event_fully_normalized(envelope: &Envelope) -> Self {
+    pub fn new(envelope: &Envelope) -> Self {
         let event_fully_normalized = envelope.meta().is_from_internal_relay()
             && envelope
                 .items()

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -12,8 +12,8 @@ use crate::statsd::RelayTimers;
 
 #[cfg(feature = "processing")]
 use {
-    crate::services::processor::ErrorGroup, crate::utils, relay_event_schema::protocol::Event,
-    relay_protocol::Annotated,
+    crate::services::processor::ErrorGroup, crate::services::processor::EventFullyNormalized,
+    crate::utils, relay_event_schema::protocol::Event, relay_protocol::Annotated,
 };
 
 /// Adds processing placeholders for special attachments.

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -23,7 +23,9 @@ use {
 ///
 /// If the event payload was empty before, it is created.
 #[cfg(feature = "processing")]
-pub fn create_placeholders(state: &mut ProcessEnvelopeState<ErrorGroup>) -> Option<bool> {
+pub fn create_placeholders(
+    state: &mut ProcessEnvelopeState<ErrorGroup>,
+) -> Option<EventFullyNormalized> {
     let envelope = state.managed_envelope.envelope();
     let minidump_attachment =
         envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
@@ -34,12 +36,12 @@ pub fn create_placeholders(state: &mut ProcessEnvelopeState<ErrorGroup>) -> Opti
         let event = state.event.get_or_insert_with(Event::default);
         state.metrics.bytes_ingested_event_minidump = Annotated::new(item.len() as u64);
         utils::process_minidump(event, &item.payload());
-        return Some(false);
+        return Some(EventFullyNormalized(false));
     } else if let Some(item) = apple_crash_report_attachment {
         let event = state.event.get_or_insert_with(Event::default);
         state.metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
         utils::process_apple_crash_report(event, &item.payload());
-        return Some(false);
+        return Some(EventFullyNormalized(false));
     }
 
     None

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -23,7 +23,7 @@ use {
 ///
 /// If the event payload was empty before, it is created.
 #[cfg(feature = "processing")]
-pub fn create_placeholders(state: &mut ProcessEnvelopeState<ErrorGroup>) {
+pub fn create_placeholders(state: &mut ProcessEnvelopeState<ErrorGroup>) -> Option<bool> {
     let envelope = state.managed_envelope.envelope();
     let minidump_attachment =
         envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
@@ -34,13 +34,15 @@ pub fn create_placeholders(state: &mut ProcessEnvelopeState<ErrorGroup>) {
         let event = state.event.get_or_insert_with(Event::default);
         state.metrics.bytes_ingested_event_minidump = Annotated::new(item.len() as u64);
         utils::process_minidump(event, &item.payload());
-        state.event_fully_normalized = false;
+        return Some(false);
     } else if let Some(item) = apple_crash_report_attachment {
         let event = state.event.get_or_insert_with(Event::default);
         state.metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
         utils::process_apple_crash_report(event, &item.payload());
-        state.event_fully_normalized = false;
+        return Some(false);
     }
+
+    None
 }
 
 /// Apply data privacy rules to attachments in the envelope.

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -450,7 +450,6 @@ mod tests {
                 event_metrics_extracted: false,
                 reservoir: dummy_reservoir(),
                 spans_extracted: false,
-                event_fully_normalized: false,
             }
         };
 
@@ -752,7 +751,6 @@ mod tests {
             .try_into()
             .unwrap(),
             reservoir: dummy_reservoir(),
-            event_fully_normalized: false,
         };
 
         run(&mut state)

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -39,9 +39,9 @@ use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
 ///  5. If none match, `Annotated::empty()`.
 pub fn extract<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
+    event_fully_normalized: bool,
     config: &Config,
 ) -> Result<(), ProcessingError> {
-    let event_fully_normalized = state.event_fully_normalized;
     let envelope = &mut state.envelope_mut();
 
     // Remove all items first, and then process them. After this function returns, only
@@ -347,6 +347,7 @@ pub fn scrub<G: EventProcessing>(
 
 pub fn serialize<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
+    event_fully_normalized: bool,
 ) -> Result<(), ProcessingError> {
     if state.event.is_empty() {
         relay_log::error!("Cannot serialize empty event");
@@ -368,7 +369,7 @@ pub fn serialize<G: EventProcessing>(
     // If transaction metrics were extracted, set the corresponding item header
     event_item.set_metrics_extracted(state.event_metrics_extracted);
     event_item.set_spans_extracted(state.spans_extracted);
-    event_item.set_fully_normalized(state.event_fully_normalized);
+    event_item.set_fully_normalized(event_fully_normalized);
 
     state.envelope_mut().add_item(event_item);
 

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -866,7 +866,6 @@ mod tests {
             event_metrics_extracted: false,
             spans_extracted: false,
             reservoir: ReservoirEvaluator::new(ReservoirCounters::default()),
-            event_fully_normalized: false,
         }
     }
 

--- a/relay-server/src/services/processor/unreal.rs
+++ b/relay-server/src/services/processor/unreal.rs
@@ -37,11 +37,14 @@ pub fn expand(
 ///
 /// If the event does not contain an unreal context, this function does not perform any action.
 /// If there was no event payload prior to this function, it is created.
-pub fn process(state: &mut ProcessEnvelopeState<ErrorGroup>) -> Result<(), ProcessingError> {
+pub fn process(
+    state: &mut ProcessEnvelopeState<ErrorGroup>,
+) -> Result<Option<bool>, ProcessingError> {
     if utils::process_unreal_envelope(&mut state.event, state.managed_envelope.envelope_mut())
         .map_err(ProcessingError::InvalidUnrealReport)?
     {
-        state.event_fully_normalized = false;
+        return Ok(Some(false));
     }
-    Ok(())
+
+    Ok(None)
 }

--- a/relay-server/src/services/processor/unreal.rs
+++ b/relay-server/src/services/processor/unreal.rs
@@ -5,7 +5,9 @@
 use relay_config::Config;
 
 use crate::envelope::ItemType;
-use crate::services::processor::{ErrorGroup, ProcessEnvelopeState, ProcessingError};
+use crate::services::processor::{
+    ErrorGroup, EventFullyNormalized, ProcessEnvelopeState, ProcessingError,
+};
 use crate::utils;
 
 /// Expands Unreal 4 items inside an envelope.
@@ -39,11 +41,11 @@ pub fn expand(
 /// If there was no event payload prior to this function, it is created.
 pub fn process(
     state: &mut ProcessEnvelopeState<ErrorGroup>,
-) -> Result<Option<bool>, ProcessingError> {
+) -> Result<Option<EventFullyNormalized>, ProcessingError> {
     if utils::process_unreal_envelope(&mut state.event, state.managed_envelope.envelope_mut())
         .map_err(ProcessingError::InvalidUnrealReport)?
     {
-        return Ok(Some(false));
+        return Ok(Some(EventFullyNormalized(false)));
     }
 
     Ok(None)


### PR DESCRIPTION
This PR removes the `event_fully_normalized` from the state of the processor. It's part of a series of PRs that aim to get rid of the shared state, for improving the code quality of the processor.

#skip-changelog