### PR TITLE
fix(relay): add SO_REUSEPORT flag to enable smooth restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Adds the UPTIME DataCategory ([#4363](https://github.com/getsentry/relay/pull/4363))
 - Promote some `span.data` fields to the top level. ([#4298](https://github.com/getsentry/relay/pull/4298))
-- Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278). [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
+- Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278), [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
 - Use async `redis` for `projectconfig`. ([#4284](https://github.com/getsentry/relay/pull/4284))
 - Set `SO_REUSEPORT` to enable smooth restarts. ([#4375](https://github.com/getsentry/relay/pull/4375))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix scrubbing user paths in minidump debug module names. ([#4351](https://github.com/getsentry/relay/pull/4351))
 - Stop collecting the `has_profile` metrics tag & reporting outcomes for it. ([#4365](https://github.com/getsentry/relay/pull/4365))
 - Scrub user fields in span.sentry_tags. ([#4364](https://github.com/getsentry/relay/pull/4364)), ([#4370](https://github.com/getsentry/relay/pull/4370))
+- Set `SO_REUSEPORT` to enable smooth restarts. ([#4375](https://github.com/getsentry/relay/pull/4375))
 
 **Features**:
 
@@ -26,7 +27,6 @@
 - Promote some `span.data` fields to the top level. ([#4298](https://github.com/getsentry/relay/pull/4298))
 - Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278), [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
 - Use async `redis` for `projectconfig`. ([#4284](https://github.com/getsentry/relay/pull/4284))
-- Set `SO_REUSEPORT` to enable smooth restarts. ([#4375](https://github.com/getsentry/relay/pull/4375))
 
 ## 24.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Promote some `span.data` fields to the top level. ([#4298](https://github.com/getsentry/relay/pull/4298))
 - Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278), [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
 - Use async `redis` for `projectconfig`. ([#4284](https://github.com/getsentry/relay/pull/4284))
+- Set `SO_REUSEPORT` to enable smooth restarts ([#4375](https://github.com/getsentry/relay/pull/4375))
 
 ## 24.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@
 
 - Adds the UPTIME DataCategory ([#4363](https://github.com/getsentry/relay/pull/4363))
 - Promote some `span.data` fields to the top level. ([#4298](https://github.com/getsentry/relay/pull/4298))
-- Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278), [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
+- Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278). [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
 - Use async `redis` for `projectconfig`. ([#4284](https://github.com/getsentry/relay/pull/4284))
-- Set `SO_REUSEPORT` to enable smooth restarts ([#4375](https://github.com/getsentry/relay/pull/4375))
+- Set `SO_REUSEPORT` to enable smooth restarts. ([#4375](https://github.com/getsentry/relay/pull/4375))
 
 ## 24.11.1
 

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -108,6 +108,7 @@ fn listen(config: &Config) -> Result<TcpListener, ServerError> {
         SocketAddr::V6(_) => TcpSocket::new_v6(),
     }?;
 
+    #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
     socket.set_reuseport(true)?;
     socket.bind(addr)?;
     Ok(socket.listen(config.tcp_listen_backlog())?.into_std()?)

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -108,6 +108,7 @@ fn listen(config: &Config) -> Result<TcpListener, ServerError> {
         SocketAddr::V6(_) => TcpSocket::new_v6(),
     }?;
 
+    socket.set_reuseport(true)?;
     socket.bind(addr)?;
     Ok(socket.listen(config.tcp_listen_backlog())?.into_std()?)
 }


### PR DESCRIPTION
This PR sets the SO_REUSEPORT flag to the TcpSocket to prevent `bind to interface failed: Address already in use (os error 98)
 ` errors when restarting