### PR TITLE
feat(statsd): add config parameter to control metrics aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Promote some `span.data` fields to the top level. ([#4298](https://github.com/getsentry/relay/pull/4298))
 - Remove metrics summaries. ([#4278](https://github.com/getsentry/relay/pull/4278), [#4279](https://github.com/getsentry/relay/pull/4279), [#4296](https://github.com/getsentry/relay/pull/4296))
 - Use async `redis` for `projectconfig`. ([#4284](https://github.com/getsentry/relay/pull/4284))
+- Add config parameter to control metrics aggregation. ([#4376](https://github.com/getsentry/relay/pull/4376))
 
 ## 24.11.1
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -546,9 +546,9 @@ pub struct Metrics {
     /// Setting it to `0` seconds disables the periodic metrics.
     /// Defaults to 5 seconds.
     pub periodic_secs: u64,
-    /// Whether local metric aggregation using statdsproxy should be enabled
+    /// Whether local metric aggregation using statdsproxy should be enabled.
     ///
-    /// Defaults to `true`
+    /// Defaults to `true`.
     pub aggregate: bool,
 }
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -546,6 +546,10 @@ pub struct Metrics {
     /// Setting it to `0` seconds disables the periodic metrics.
     /// Defaults to 5 seconds.
     pub periodic_secs: u64,
+    /// Whether local metric aggregation using statdsproxy should be enabled
+    ///
+    /// Defaults to `true`
+    pub aggregate: bool,
 }
 
 impl Default for Metrics {
@@ -557,6 +561,7 @@ impl Default for Metrics {
             hostname_tag: None,
             sample_rate: 1.0,
             periodic_secs: 5,
+            aggregate: true,
         }
     }
 }
@@ -2028,6 +2033,11 @@ impl Config {
     /// Returns the global sample rate for all metrics.
     pub fn metrics_sample_rate(&self) -> f32 {
         self.values.metrics.sample_rate
+    }
+
+    /// Returns whether local metric aggregation should be enabled.
+    pub fn metrics_aggregate(&self) -> bool {
+        self.values.metrics.aggregate
     }
 
     /// Returns the interval for periodic metrics emitted from Relay.

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -87,6 +87,7 @@ pub fn init_metrics(config: &Config) -> Result<()> {
         &addrs[..],
         default_tags,
         config.metrics_sample_rate(),
+        config.metrics_aggregate(),
     );
 
     Ok(())


### PR DESCRIPTION
Adds a configuration flat to enable/disable local metric aggregation through statsdproxy.