### PR TITLE
feat(quota): Rate limit attachments by item count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Features**:
 
 - Add data categories for Uptime and Attachment Items. ([#4363](https://github.com/getsentry/relay/pull/4363), [#4374](https://github.com/getsentry/relay/pull/4374))
+- Add ability to rate limit attachments by count (not just by the number of bytes). ([#4377](https://github.com/getsentry/relay/pull/4377))
 
 ## 24.11.2
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -201,9 +201,9 @@ impl CategoryUnit {
             | DataCategory::ProfileChunk
             | DataCategory::Uptime
             | DataCategory::MetricSecond
-            | DataCategory::AttachmentItem => Some(Self::Count),
+            | DataCategory::AttachmentItem
+            | DataCategory::Session => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
-            DataCategory::Session => None,
             DataCategory::ProfileDuration => Some(Self::Milliseconds),
 
             DataCategory::Unknown => None,

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -170,10 +170,12 @@ impl ItemScoping<'_> {
 
 /// The unit in which a data category is measured.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CategoryUnit {
+pub enum CategoryUnit {
+    /// Counts the number of items.
     Count,
+    /// Counts the number of bytes across items.
     Bytes,
-    Batched,
+    /// Counts the accumulated times across items.
     Milliseconds,
 }
 
@@ -201,7 +203,7 @@ impl CategoryUnit {
             | DataCategory::MetricSecond
             | DataCategory::AttachmentItem => Some(Self::Count),
             DataCategory::Attachment => Some(Self::Bytes),
-            DataCategory::Session => Some(Self::Batched),
+            DataCategory::Session => None,
             DataCategory::ProfileDuration => Some(Self::Milliseconds),
 
             DataCategory::Unknown => None,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -100,18 +100,16 @@ pub fn drop_unsampled_items(state: &mut ProcessEnvelopeState<TransactionGroup>, 
         .take_items_by(|item| *item.ty() != ItemType::Profile);
 
     for item in dropped_items {
-        let Some(category) = item.outcome_category() else {
-            continue;
-        };
+        for (category, quantity) in item.quantities() {
+            // Dynamic sampling only drops indexed items. Upgrade the category to the index
+            // category if one exists for this category, for example profiles will be upgraded to profiles indexed,
+            // but attachments are still emitted as attachments.
+            let category = category.index_category().unwrap_or(category);
 
-        // Dynamic sampling only drops indexed items. Upgrade the category to the index
-        // category if one exists for this category, for example profiles will be upgraded to profiles indexed,
-        // but attachments are still emitted as attachments.
-        let category = category.index_category().unwrap_or(category);
-
-        state
-            .managed_envelope
-            .track_outcome(outcome.clone(), category, item.quantity());
+            state
+                .managed_envelope
+                .track_outcome(outcome.clone(), category, quantity);
+        }
     }
 
     // Mark all remaining items in the envelope as un-sampled.

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -11,7 +11,7 @@ use relay_sampling::config::RuleType;
 use relay_sampling::evaluation::{ReservoirEvaluator, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 
-use crate::envelope::ItemType;
+use crate::envelope::{CountFor, ItemType};
 use crate::services::outcome::Outcome;
 use crate::services::processor::{
     EventProcessing, ProcessEnvelopeState, Sampling, TransactionGroup,
@@ -100,7 +100,7 @@ pub fn drop_unsampled_items(state: &mut ProcessEnvelopeState<TransactionGroup>, 
         .take_items_by(|item| *item.ty() != ItemType::Profile);
 
     for item in dropped_items {
-        for (category, quantity) in item.quantities() {
+        for (category, quantity) in item.quantities(CountFor::Outcomes) {
             // Dynamic sampling only drops indexed items. Upgrade the category to the index
             // category if one exists for this category, for example profiles will be upgraded to profiles indexed,
             // but attachments are still emitted as attachments.

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 
-use crate::envelope::{Envelope, Item};
+use crate::envelope::{CountFor, Envelope, Item};
 use crate::extractors::RequestMeta;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::{Processed, ProcessingGroup};
@@ -263,7 +263,7 @@ impl ManagedEnvelope {
             ItemAction::Keep => true,
             ItemAction::DropSilently => false,
             ItemAction::Drop(outcome) => {
-                for (category, quantity) in item.quantities() {
+                for (category, quantity) in item.quantities(CountFor::Outcomes) {
                     if let Some(indexed) = category.index_category() {
                         outcomes.push((outcome.clone(), indexed, quantity));
                     };

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -263,12 +263,13 @@ impl ManagedEnvelope {
             ItemAction::Keep => true,
             ItemAction::DropSilently => false,
             ItemAction::Drop(outcome) => {
-                if let Some(category) = item.outcome_category() {
+                for (category, quantity) in item.quantities() {
                     if let Some(indexed) = category.index_category() {
-                        outcomes.push((outcome.clone(), indexed, item.quantity()));
+                        outcomes.push((outcome.clone(), indexed, quantity));
                     };
-                    outcomes.push((outcome, category, item.quantity()));
-                };
+                    outcomes.push((outcome.clone(), category, quantity));
+                }
+
                 false
             }
         });
@@ -360,7 +361,7 @@ impl ManagedEnvelope {
                     tags.has_transactions = summary.secondary_transaction_quantity > 0,
                     tags.has_span_metrics = summary.secondary_span_quantity > 0,
                     tags.has_replays = summary.replay_quantity > 0,
-                    tags.has_checkins = summary.checkin_quantity > 0,
+                    tags.has_checkins = summary.monitor_quantity > 0,
                     tags.event_category = ?summary.event_category,
                     cached_summary = ?summary,
                     recomputed_summary = ?EnvelopeSummary::compute(self.envelope()),

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -52,7 +52,6 @@ pub enum ItemAction {
     /// Keep the item.
     Keep,
     /// Drop the item and log an outcome for it.
-    /// The outcome will only be logged if the item has a corresponding [`Item::outcome_category()`].
     Drop(Outcome),
     /// Drop the item without logging an outcome.
     DropSilently,

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -643,7 +643,10 @@ where
         // Handle attachments.
         if let Some(limit) = enforcement.active_event() {
             let limit1 = limit.clone_for(DataCategory::Attachment, summary.attachment_quantity);
-            let limit2 = limit.clone_for(DataCategory::AttachmentItem, summary.attachment_quantity);
+            let limit2 = limit.clone_for(
+                DataCategory::AttachmentItem,
+                summary.attachment_item_quantity,
+            );
             enforcement.attachments = limit1;
             enforcement.attachment_items = limit2;
         } else {
@@ -1506,6 +1509,7 @@ mod tests {
         assert!(!enforcement.event.is_active());
         assert!(enforcement.event_indexed.is_active());
         assert!(enforcement.attachments.is_active());
+        assert!(enforcement.attachment_items.is_active());
         mock.assert_call(DataCategory::Transaction, 1);
         mock.assert_call(DataCategory::TransactionIndexed, 1);
 
@@ -1513,7 +1517,8 @@ mod tests {
             get_outcomes(enforcement),
             vec![
                 (DataCategory::TransactionIndexed, 1),
-                (DataCategory::Attachment, 10)
+                (DataCategory::Attachment, 10),
+                (DataCategory::AttachmentItem, 1)
             ]
         );
     }

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -651,31 +651,30 @@ where
             if summary.attachment_quantity > 0 {
                 let item_scoping = scoping.item(DataCategory::Attachment);
 
+                let attachment_byte_limits = self
+                    .check
+                    .apply(item_scoping, summary.attachment_quantity)?;
+
                 enforcement.attachments = CategoryLimit::new(
                     DataCategory::Attachment,
                     summary.attachment_quantity,
-                    attachment_limits.longest(),
+                    attachment_byte_limits.longest(),
                 );
-
-                attachment_limits.merge(
-                    self.check
-                        .apply(item_scoping, summary.attachment_quantity)?,
-                );
+                attachment_limits.merge(attachment_byte_limits);
             }
             if !attachment_limits.is_limited() && summary.attachment_item_quantity > 0 {
-                "CHECKING ATTACHMENT ITEM LIMITS";
                 let item_scoping = scoping.item(DataCategory::AttachmentItem);
+
+                let attachment_item_limits = self
+                    .check
+                    .apply(item_scoping, summary.attachment_item_quantity)?;
 
                 enforcement.attachment_items = CategoryLimit::new(
                     DataCategory::AttachmentItem,
                     summary.attachment_item_quantity,
-                    attachment_limits.longest(),
+                    attachment_item_limits.longest(),
                 );
-
-                attachment_limits.merge(
-                    self.check
-                        .apply(item_scoping, summary.attachment_item_quantity)?,
-                );
+                attachment_limits.merge(attachment_item_limits);
             }
 
             // Only record rate limits for plain attachments. For all other attachments, it's

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -640,7 +640,7 @@ where
                 limit.clone_for(DataCategory::Attachment, summary.attachment_quantity);
         } else if summary.attachment_quantity > 0 {
             let item_scoping = scoping.item(DataCategory::Attachment);
-            let attachment_limits = self
+            let mut attachment_limits = self
                 .check
                 .apply(item_scoping, summary.attachment_quantity)?;
 
@@ -652,7 +652,7 @@ where
 
             if !attachment_limits.is_limited() {
                 let item_scoping = scoping.item(DataCategory::AttachmentItem);
-                let attachment_limits = self
+                attachment_limits = self
                     .check
                     .apply(item_scoping, summary.attachment_item_quantity)?;
 
@@ -670,8 +670,10 @@ where
             // can continue to send them.
             if summary.has_plain_attachments {
                 rate_limits.merge(attachment_limits);
+                &rate_limits;
             }
         } else if summary.attachment_item_quantity > 0 {
+            // TODO: remove special case
             let item_scoping = scoping.item(DataCategory::AttachmentItem);
             let attachment_limits = self
                 .check

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -5,7 +5,7 @@ use relay_quotas::{
     ReasonCode, Scoping,
 };
 
-use crate::envelope::{Envelope, Item, ItemType};
+use crate::envelope::{CountFor, Envelope, Item, ItemType};
 use crate::services::outcome::Outcome;
 use crate::utils::ManagedEnvelope;
 
@@ -221,7 +221,7 @@ impl EnvelopeSummary {
             }
 
             summary.payload_size += item.len();
-            for (category, quantity) in item.quantities() {
+            for (category, quantity) in item.quantities(CountFor::RateLimits) {
                 summary.add_quantity(category, quantity);
             }
         }

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -272,7 +272,7 @@ class OutcomesConsumer(ConsumerBase):
 
         if quantity is not None:
             count = sum(outcome["quantity"] for outcome in outcomes)
-            assert count == quantity
+            assert count == quantity, (count, quantity)
 
 
 @pytest.fixture

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -268,7 +268,7 @@ class OutcomesConsumer(ConsumerBase):
             assert outcome["outcome"] == 2, outcome
             assert outcome["reason"] == reason, outcome["reason"]
             if key_id is not None:
-                assert outcome["key_id"] == key_id
+                assert outcome["key_id"] == key_id, (outcome["key_id"], key_id)
 
         if quantity is not None:
             count = sum(outcome["quantity"] for outcome in outcomes)

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -232,13 +232,13 @@ def test_attachments_quotas_items(
     # First attachment returns 200 but is rate limited in processing
     relay.send_attachments(project_id, event_id, attachments)
 
-    outcomes_consumer.assert_rate_limited("attachments_exceeded", 1)
+    outcomes_consumer.assert_rate_limited("attachments_exceeded", quantity=1)
 
     # Second attachment returns 429 in endpoint
     with pytest.raises(HTTPError) as excinfo:
         relay.send_attachments(42, event_id, attachments)
     assert excinfo.value.response.status_code == 429
-    outcomes_consumer.assert_rate_limited("attachments_exceeded", 1)
+    outcomes_consumer.assert_rate_limited("attachments_exceeded", quantity=1)
 
 
 def test_view_hierarchy_processing(

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -232,13 +232,18 @@ def test_attachments_quotas_items(
     # First attachment returns 200 but is rate limited in processing
     relay.send_attachments(project_id, event_id, attachments)
 
-    outcomes_consumer.assert_rate_limited("attachments_exceeded", quantity=1)
+    outcomes_consumer.assert_rate_limited(
+        "attachments_exceeded", categories=["attachment_item"], quantity=1
+    )
 
     # Second attachment returns 429 in endpoint
     with pytest.raises(HTTPError) as excinfo:
         relay.send_attachments(42, event_id, attachments)
     assert excinfo.value.response.status_code == 429
-    outcomes_consumer.assert_rate_limited("attachments_exceeded", quantity=1)
+
+    outcomes_consumer.assert_rate_limited(
+        "attachments_exceeded", categories=["attachment_item"], quantity=1
+    )
 
 
 def test_view_hierarchy_processing(

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -131,7 +131,7 @@ def test_attachments_ratelimit(
     relay = relay_with_processing()
 
     outcomes_consumer = outcomes_consumer()
-    attachments = [("att_1", "foo.txt", b"")]
+    attachments = [("att_1", "foo.txt", b"this is an attachment")]
 
     # First attachment returns 200 but is rate limited in processing
     relay.send_attachments(project_id, event_id, attachments)

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -528,13 +528,13 @@ def test_minidump_ratelimit(
     # First minidump returns 200 but is rate limited in processing
     relay.send_minidump(project_id=project_id, files=attachments)
     outcomes_consumer.assert_rate_limited(
-        "static_disabled_quota", categories=["error", "attachment"]
+        "static_disabled_quota", categories=["error", "attachment", "attachment_item"]
     )
 
     # Minidumps never return rate limits
     relay.send_minidump(project_id=project_id, files=attachments)
     outcomes_consumer.assert_rate_limited(
-        "static_disabled_quota", categories=["error", "attachment"]
+        "static_disabled_quota", categories=["error", "attachment", "attachment_item"]
     )
 
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1288,6 +1288,16 @@ def test_profile_outcomes(
             "reason": "Sampled:3000",
             "source": expected_source,
         },
+        {
+            "category": 22,  # attachment item
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 1,
+            "project_id": 42,
+            "quantity": 1,  # number of attachments
+            "reason": "Sampled:3000",
+            "source": expected_source,
+        },
     ]
     for outcome in outcomes:
         outcome.pop("timestamp")


### PR DESCRIPTION
Attachment quotas and rate limits are currently defined in bytes, so we have no way to prevent an abusively high number of very small (or even empty) attachments.

ref: https://github.com/getsentry/relay/issues/4175