### PR TITLE
fix(ua): Update ua regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**:
 
+- Update user agent parsing rules to fix some user agent identification issues. ([#4385](https://github.com/getsentry/relay/pull/4385))
 - Stop collecting the `has_profile` metrics tag & reporting outcomes for it. ([#4365](https://github.com/getsentry/relay/pull/4365))
 
 **Features**:


### PR DESCRIPTION
The user agent `Mozilla/5.0 (Linux; Android 14; SC-53D Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.104 Mobile Safari/537.36 jp.pay2.app.android/4.72.1` is misidentified as `Phantom`, with the updated `uap-core` this is now correctly identified:

Before:
```
[relay-ua/src/lib.rs:58:5] parse_user_agent("Mozilla/5.0 (Linux; Android 14; SC-53D Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.104 Mobile Safari/537.36 jp.pay2.app.android/4.72.1") = UserAgent {
    family: "Phantom",
    major: Some(
        "4",
    ),
    minor: Some(
        "72",
    ),
    patch: Some(
        "1",
    ),
}
```

After:
```
[relay-ua/src/lib.rs:58:5] parse_user_agent("Mozilla/5.0 (Linux; Android 14; SC-53D Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.104 Mobile Safari/537.36 jp.pay2.app.android/4.72.1") = UserAgent {
    family: "Chrome Mobile WebView",
    major: Some(
        "131",
    ),
    minor: Some(
        "0",
    ),
    patch: Some(
        "6778",
    ),
}
```