### PR TITLE
fix: Normalize "Google Chrome" to "Chrome"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update user agent parsing rules to fix some user agent identification issues. ([#4385](https://github.com/getsentry/relay/pull/4385))
 - Stop collecting the `has_profile` metrics tag & reporting outcomes for it. ([#4365](https://github.com/getsentry/relay/pull/4365))
 - Parse unreal logs into breadcrumbs from all attached log items not just the first. ([#4384](https://github.com/getsentry/relay/pull/4384))
+- Normalize "Google Chrome" browser name to "Chrome". ([#4386](https://github.com/getsentry/relay/pull/4386))
 
 **Features**:
 

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -332,7 +332,12 @@ impl FromUserAgentInfo for DeviceContext {
 
 impl FromUserAgentInfo for BrowserContext {
     fn parse_client_hints(client_hints: &ClientHints<&str>) -> Option<Self> {
-        let (browser, version) = browser_from_client_hints(client_hints.sec_ch_ua?)?;
+        let (mut browser, version) = browser_from_client_hints(client_hints.sec_ch_ua?)?;
+
+        // Normalize "Google Chrome" to just "Chrome"
+        if browser == "Google Chrome" {
+            browser = "Chrome".to_owned();
+        }
 
         Some(Self {
             name: Annotated::new(browser),
@@ -342,10 +347,15 @@ impl FromUserAgentInfo for BrowserContext {
     }
 
     fn parse_user_agent(user_agent: &str) -> Option<Self> {
-        let browser = relay_ua::parse_user_agent(user_agent);
+        let mut browser = relay_ua::parse_user_agent(user_agent);
 
         if !is_known(&browser.family) {
             return None;
+        }
+
+        // Normalize "Google Chrome" to just "Chrome"
+        if browser.family == "Google Chrome" {
+            browser.family = "Chrome".into();
         }
 
         Some(Self {
@@ -824,7 +834,7 @@ mod tests {
         insta::assert_debug_snapshot!(browser, @r###"
         BrowserContext {
             browser: ~,
-            name: "Google Chrome",
+            name: "Chrome",
             version: "109",
             other: {},
         }


### PR DESCRIPTION
The Chrome browser is sometimes tagged as "Google Chrome" and sometimes just "Chrome". This unifies the two into the latter.