### PR TITLE
ref(processor): Remove project id state field

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1793,7 +1793,7 @@ impl EnvelopeProcessorService {
     fn process_checkins(
         &self,
         #[allow(unused_variables)] state: &mut ProcessEnvelopeState<CheckInGroup>,
-        project_id: ProjectId,
+        #[allow(unused_variables)] project_id: ProjectId,
     ) -> Result<(), ProcessingError> {
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
@@ -1808,7 +1808,7 @@ impl EnvelopeProcessorService {
     fn process_standalone_spans(
         &self,
         state: &mut ProcessEnvelopeState<SpanGroup>,
-        project_id: ProjectId,
+        #[allow(unused_variables)] project_id: ProjectId,
         #[allow(unused_variables)] reservoir_counters: ReservoirCounters,
     ) -> Result<(), ProcessingError> {
         span::filter(state);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1869,16 +1869,15 @@ impl EnvelopeProcessorService {
         macro_rules! run {
             ($fn_name:ident $(, $args:expr)*) => {{
                 let managed_envelope = managed_envelope.try_into()?;
-
                 let mut state = ProcessEnvelopeState {
                     event: Annotated::empty(),
                     event_metrics_extracted: false,
                     spans_extracted: false,
                     metrics: Metrics::default(),
                     extracted_metrics: ProcessingExtractedMetrics::new(),
+                    config: self.inner.config.clone(),
                     project_info,
                     rate_limits,
-                    config,
                     sampling_project_info,
                     project_id,
                     managed_envelope,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -236,7 +236,7 @@ mod tests {
 
     use bytes::Bytes;
     use relay_base_schema::events::EventType;
-    use relay_base_schema::project::{ProjectId, ProjectKey};
+    use relay_base_schema::project::ProjectKey;
     use relay_dynamic_config::{MetricExtractionConfig, TransactionMetricsConfig};
     use relay_event_schema::protocol::{EventId, LenientString};
     use relay_protocol::RuleCondition;
@@ -441,7 +441,6 @@ mod tests {
                 project_info,
                 rate_limits: Default::default(),
                 sampling_project_info: None,
-                project_id: ProjectId::new(42),
                 managed_envelope: ManagedEnvelope::new(
                     envelope,
                     outcome_aggregator.clone(),
@@ -745,7 +744,6 @@ mod tests {
                 }));
                 Some(Arc::new(state))
             },
-            project_id: ProjectId::new(1),
             managed_envelope: ManagedEnvelope::new(
                 envelope,
                 Addr::dummy(),

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -4,6 +4,7 @@ use std::net::IpAddr;
 use relay_dynamic_config::{Feature, GlobalConfig};
 
 use relay_base_schema::events::EventType;
+use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_event_schema::protocol::{Contexts, Event, ProfileContext};
 use relay_filter::ProjectFiltersConfig;
@@ -18,7 +19,7 @@ use crate::utils::ItemAction;
 /// Filters out invalid and duplicate profiles.
 ///
 /// Returns the profile id of the single remaining profile, if there is one.
-pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) -> Option<ProfileId> {
+pub fn filter<G>(state: &mut ProcessEnvelopeState<G>, project_id: ProjectId) -> Option<ProfileId> {
     let profiling_disabled = state.should_filter(Feature::Profiling);
     let has_transaction = state.event_type() == Some(EventType::Transaction);
     let keep_unsampled_profiles = true;
@@ -38,7 +39,7 @@ pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) -> Option<ProfileId> {
                 return ItemAction::DropSilently;
             }
 
-            match relay_profiling::parse_metadata(&item.payload(), state.project_id) {
+            match relay_profiling::parse_metadata(&item.payload(), project_id) {
                 Ok(id) => {
                     profile_id = Some(id);
                     ItemAction::Keep

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -12,6 +12,7 @@ use crate::services::processor::{
 use crate::utils::{sample, ItemAction, ManagedEnvelope};
 use chrono::{DateTime, Utc};
 use relay_base_schema::events::EventType;
+use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_dynamic_config::{
     CombinedMetricExtractionConfig, ErrorBoundary, Feature, GlobalConfig, ProjectConfig,
@@ -43,6 +44,7 @@ struct ValidationError(#[from] anyhow::Error);
 
 pub fn process(
     state: &mut ProcessEnvelopeState<SpanGroup>,
+    project_id: ProjectId,
     global_config: &GlobalConfig,
     geo_lookup: Option<&GeoIpLookup>,
     reservoir_counters: &ReservoirEvaluator,
@@ -148,7 +150,7 @@ pub fn process(
                     transaction,
                     1,
                     sampling_decision,
-                    state.project_id,
+                    project_id,
                 );
                 state
                     .extracted_metrics
@@ -794,7 +796,6 @@ mod tests {
 
     use bytes::Bytes;
     use once_cell::sync::Lazy;
-    use relay_base_schema::project::ProjectId;
     use relay_event_schema::protocol::{
         Context, ContextInner, EventId, SpanId, Timestamp, TraceContext, TraceId,
     };
@@ -861,7 +862,6 @@ mod tests {
             project_info,
             rate_limits: Arc::new(RateLimits::default()),
             sampling_project_info: None,
-            project_id: ProjectId::new(42),
             managed_envelope: managed_envelope.try_into().unwrap(),
             event_metrics_extracted: false,
             spans_extracted: false,


### PR DESCRIPTION
This PR removes the `project_id` from the state and cleans up the code.

#skip-changelog