### PR TITLE
ref(profiling): remove support for accepting profile metrics

### DIFF
--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -112,8 +112,6 @@ pub enum MetricNamespace {
     Transactions,
     /// Metrics extracted from spans.
     Spans,
-    /// Metrics extracted from profile functions.
-    Profiles,
     /// User-defined metrics directly sent by SDKs and applications.
     Custom,
     /// Metric stats.
@@ -134,12 +132,11 @@ pub enum MetricNamespace {
 
 impl MetricNamespace {
     /// Returns all namespaces/variants of this enum.
-    pub fn all() -> [Self; 7] {
+    pub fn all() -> [Self; 6] {
         [
             Self::Sessions,
             Self::Transactions,
             Self::Spans,
-            Self::Profiles,
             Self::Custom,
             Self::Stats,
             Self::Unsupported,
@@ -157,7 +154,6 @@ impl MetricNamespace {
             Self::Sessions => "sessions",
             Self::Transactions => "transactions",
             Self::Spans => "spans",
-            Self::Profiles => "profiles",
             Self::Custom => "custom",
             Self::Stats => "metric_stats",
             Self::Unsupported => "unsupported",
@@ -173,7 +169,6 @@ impl std::str::FromStr for MetricNamespace {
             "sessions" => Ok(Self::Sessions),
             "transactions" => Ok(Self::Transactions),
             "spans" => Ok(Self::Spans),
-            "profiles" => Ok(Self::Profiles),
             "custom" => Ok(Self::Custom),
             "metric_stats" => Ok(Self::Stats),
             _ => Ok(Self::Unsupported),

--- a/relay-cogs/src/lib.rs
+++ b/relay-cogs/src/lib.rs
@@ -136,8 +136,6 @@ pub enum AppFeature {
     MetricsTransactions,
     /// Metrics in the spans namespace.
     MetricsSpans,
-    /// Metrics in the profiles namespace.
-    MetricsProfiles,
     /// Metrics in the sessions namespace.
     MetricsSessions,
     /// Metrics in the custom namespace.
@@ -167,7 +165,6 @@ impl AppFeature {
             Self::Replays => "replays",
             Self::MetricsTransactions => "metrics_transactions",
             Self::MetricsSpans => "metrics_spans",
-            Self::MetricsProfiles => "metrics_profiles",
             Self::MetricsSessions => "metrics_sessions",
             Self::MetricsCustom => "metrics_custom",
             Self::MetricsStats => "metrics_metric_stats",

--- a/relay-metrics/src/cogs.rs
+++ b/relay-metrics/src/cogs.rs
@@ -40,7 +40,6 @@ fn to_app_feature(ns: MetricNamespace) -> AppFeature {
         MetricNamespace::Sessions => AppFeature::MetricsSessions,
         MetricNamespace::Transactions => AppFeature::MetricsTransactions,
         MetricNamespace::Spans => AppFeature::MetricsSpans,
-        MetricNamespace::Profiles => AppFeature::MetricsProfiles,
         MetricNamespace::Custom => AppFeature::MetricsCustom,
         MetricNamespace::Stats => AppFeature::MetricsStats,
         MetricNamespace::Unsupported => AppFeature::MetricsUnsupported,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1905,44 +1905,6 @@ def test_missing_global_filters_enables_metric_extraction(
     assert metrics_consumer.get_metrics()
 
 
-def test_profiles_metrics(mini_sentry, relay):
-    relay = relay(mini_sentry, options=TEST_CONFIG)
-
-    project_id = 42
-    mini_sentry.add_basic_project_config(project_id)
-
-    timestamp = int(datetime.now(tz=timezone.utc).timestamp())
-    metrics_payload = f"profiles/foo:42|c|T{timestamp}\nprofiles/bar:17|c|T{timestamp}"
-
-    relay.send_metrics(project_id, metrics_payload)
-
-    envelope = mini_sentry.captured_events.get(timeout=3)
-    assert len(envelope.items) == 1
-
-    metrics_item = envelope.items[0]
-    assert metrics_item.type == "metric_buckets"
-
-    received_metrics = metrics_without_keys(
-        json.loads(metrics_item.get_bytes().decode()), keys={"metadata"}
-    )
-    assert received_metrics == [
-        {
-            "timestamp": time_after(timestamp),
-            "width": 1,
-            "name": "c:profiles/bar@none",
-            "value": 17.0,
-            "type": "c",
-        },
-        {
-            "timestamp": time_after(timestamp),
-            "width": 1,
-            "name": "c:profiles/foo@none",
-            "value": 42.0,
-            "type": "c",
-        },
-    ]
-
-
 def test_metrics_with_denied_names(
     mini_sentry, relay_with_processing, metrics_consumer
 ):


### PR DESCRIPTION
As we moved away from `generic-metrics`, we won't need to accept metrics with `profile` _namespace_ anymore. 