### PR TITLE
ref(processor): Remove project info and sampling project info

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -762,19 +762,12 @@ struct ProcessEnvelopeState<Group> {
     /// configuration objects in the project config.
     extracted_metrics: ProcessingExtractedMetrics,
 
-    /// The state of the project that this envelope belongs to.
-    project_info: Arc<ProjectInfo>,
-
     /// Currently active cached rate limits of the project this envelope belongs to.
     #[cfg_attr(not(feature = "processing"), expect(dead_code))]
     rate_limits: Arc<RateLimits>,
 
     /// The config of this Relay instance.
     config: Arc<Config>,
-
-    /// The state of the project that initiated the current trace.
-    /// This is the config used for trace-based dynamic sampling.
-    sampling_project_info: Option<Arc<ProjectInfo>>,
 
     /// The managed envelope before processing.
     managed_envelope: TypedEnvelope<Group>,
@@ -826,10 +819,10 @@ impl<Group> ProcessEnvelopeState<Group> {
     /// based on a feature flag.
     ///
     /// If the project config did not come from the upstream, we keep the items.
-    fn should_filter(&self, feature: Feature) -> bool {
+    fn should_filter(&self, feature: Feature, project_info: &ProjectInfo) -> bool {
         match self.config.relay_mode() {
             RelayMode::Proxy | RelayMode::Static | RelayMode::Capture => false,
-            RelayMode::Managed => !self.project_info.has_feature(feature),
+            RelayMode::Managed => !project_info.has_feature(feature),
         }
     }
 }
@@ -1286,6 +1279,7 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<TransactionGroup>,
         project_id: ProjectId,
+        project_info: Arc<ProjectInfo>,
         sampling_decision: SamplingDecision,
     ) -> Result<(), ProcessingError> {
         if state.event_metrics_extracted {
@@ -1300,7 +1294,7 @@ impl EnvelopeProcessorService {
         // it is not present in the actual project config payload.
         let global = self.inner.global_config.current();
         let combined_config = {
-            let config = match &state.project_info.config.metric_extraction {
+            let config = match &project_info.config.metric_extraction {
                 ErrorBoundary::Ok(ref config) if config.is_supported() => config,
                 _ => return Ok(()),
             };
@@ -1325,7 +1319,7 @@ impl EnvelopeProcessorService {
         };
 
         // Require a valid transaction metrics config.
-        let tx_config = match &state.project_info.config.transaction_metrics {
+        let tx_config = match &project_info.config.transaction_metrics {
             Some(ErrorBoundary::Ok(tx_config)) => tx_config,
             Some(ErrorBoundary::Err(e)) => {
                 relay_log::debug!("Failed to parse legacy transaction metrics config: {e}");
@@ -1353,7 +1347,7 @@ impl EnvelopeProcessorService {
 
         // If spans were already extracted for an event, we rely on span processing to extract metrics.
         let extract_spans = !state.spans_extracted
-            && state.project_info.config.features.produces_spans()
+            && project_info.config.features.produces_spans()
             && utils::sample(global.options.span_extraction_sample_rate.unwrap_or(1.0));
 
         let metrics = crate::metrics_extraction::event::extract_metrics(
@@ -1373,7 +1367,7 @@ impl EnvelopeProcessorService {
             .extracted_metrics
             .extend(metrics, Some(sampling_decision));
 
-        if !state.project_info.has_feature(Feature::DiscardTransaction) {
+        if !project_info.has_feature(Feature::DiscardTransaction) {
             let transaction_from_dsc = state
                 .managed_envelope
                 .envelope()
@@ -1402,6 +1396,7 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<G>,
         project_id: ProjectId,
+        project_info: Arc<ProjectInfo>,
         mut event_fully_normalized: EventFullyNormalized,
     ) -> Result<Option<EventFullyNormalized>, ProcessingError> {
         if !state.has_event() {
@@ -1435,8 +1430,7 @@ impl EnvelopeProcessorService {
         let ai_model_costs = global_config.ai_model_costs.clone().ok();
         let http_span_allowed_hosts = global_config.options.http_span_allowed_hosts.as_slice();
 
-        let retention_days: i64 = state
-            .project_info
+        let retention_days: i64 = project_info
             .config
             .event_retention
             .unwrap_or(DEFAULT_EVENT_RETENTION)
@@ -1453,8 +1447,7 @@ impl EnvelopeProcessorService {
                 is_validated: false,
             };
 
-            let key_id = state
-                .project_info
+            let key_id = project_info
                 .get_public_key_config()
                 .and_then(|key| Some(key.numeric_id?.to_string()));
             if full_normalization && key_id.is_none() {
@@ -1469,7 +1462,7 @@ impl EnvelopeProcessorService {
                 client: request_meta.client().map(str::to_owned),
                 key_id,
                 protocol_version: Some(request_meta.version().to_string()),
-                grouping_config: state.project_info.config.grouping_config.clone(),
+                grouping_config: project_info.config.grouping_config.clone(),
                 client_ip: client_ipaddr.as_ref(),
                 client_sample_rate: state
                     .managed_envelope
@@ -1486,21 +1479,16 @@ impl EnvelopeProcessorService {
                         .max_name_length
                         .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),
                 ),
-                breakdowns_config: state.project_info.config.breakdowns_v2.as_ref(),
-                performance_score: state.project_info.config.performance_score.as_ref(),
+                breakdowns_config: project_info.config.breakdowns_v2.as_ref(),
+                performance_score: project_info.config.performance_score.as_ref(),
                 normalize_user_agent: Some(true),
                 transaction_name_config: TransactionNameConfig {
-                    rules: &state.project_info.config.tx_name_rules,
+                    rules: &project_info.config.tx_name_rules,
                 },
-                device_class_synthesis_config: state
-                    .project_info
+                device_class_synthesis_config: project_info
                     .has_feature(Feature::DeviceClassSynthesis),
-                enrich_spans: state
-                    .project_info
-                    .has_feature(Feature::ExtractSpansFromEvent)
-                    || state
-                        .project_info
-                        .has_feature(Feature::ExtractCommonSpanMetricsFromEvent),
+                enrich_spans: project_info.has_feature(Feature::ExtractSpansFromEvent)
+                    || project_info.has_feature(Feature::ExtractCommonSpanMetricsFromEvent),
                 max_tag_value_length: self
                     .inner
                     .config
@@ -1510,12 +1498,12 @@ impl EnvelopeProcessorService {
                 is_renormalize: false,
                 remove_other: full_normalization,
                 emit_event_errors: full_normalization,
-                span_description_rules: state.project_info.config.span_description_rules.as_ref(),
+                span_description_rules: project_info.config.span_description_rules.as_ref(),
                 geoip_lookup: self.inner.geoip_lookup.as_ref(),
                 ai_model_costs: ai_model_costs.as_ref(),
                 enable_trimming: true,
                 measurements: Some(CombinedMeasurementsConfig::new(
-                    state.project_info.config().measurements.as_ref(),
+                    project_info.config().measurements.as_ref(),
                     global_config.measurements.as_ref(),
                 )),
                 normalize_spans: true,
@@ -1549,6 +1537,8 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<ErrorGroup>,
         project_id: ProjectId,
+        project_info: Arc<ProjectInfo>,
+        sampling_project_info: Option<Arc<ProjectInfo>>,
     ) -> Result<(), ProcessingError> {
         let mut event_fully_normalized = EventFullyNormalized::new(state.envelope());
 
@@ -1571,15 +1561,26 @@ impl EnvelopeProcessorService {
         });
 
         event::finalize(state, &self.inner.config)?;
-        if let Some(inner_event_fully_normalized) =
-            self.normalize_event(state, project_id, event_fully_normalized)?
-        {
+        if let Some(inner_event_fully_normalized) = self.normalize_event(
+            state,
+            project_id,
+            project_info.clone(),
+            event_fully_normalized,
+        )? {
             event_fully_normalized = inner_event_fully_normalized;
         };
-        let filter_run = event::filter(state, &self.inner.global_config.current())?;
+        let filter_run = event::filter(
+            state,
+            project_info.clone(),
+            &self.inner.global_config.current(),
+        )?;
 
         if self.inner.config.processing_enabled() || matches!(filter_run, FiltersStatus::Ok) {
-            dynamic_sampling::tag_error_with_sampling_decision(state, &self.inner.config);
+            dynamic_sampling::tag_error_with_sampling_decision(
+                state,
+                sampling_project_info,
+                &self.inner.config,
+            );
         }
 
         if_processing!(self.inner.config, {
@@ -1587,12 +1588,12 @@ impl EnvelopeProcessorService {
         });
 
         if state.has_event() {
-            event::scrub(state)?;
+            event::scrub(state, project_info.clone())?;
             event::serialize(state, event_fully_normalized)?;
             event::emit_feedback_metrics(state.envelope());
         }
 
-        attachment::scrub(state);
+        attachment::scrub(state, project_info.clone());
 
         if self.inner.config.processing_enabled() && !event_fully_normalized.0 {
             relay_log::error!(
@@ -1610,6 +1611,8 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<TransactionGroup>,
         project_id: ProjectId,
+        project_info: Arc<ProjectInfo>,
+        mut sampling_project_info: Option<Arc<ProjectInfo>>,
         reservoir_counters: ReservoirCounters,
     ) -> Result<(), ProcessingError> {
         let mut event_fully_normalized = EventFullyNormalized::new(state.envelope());
@@ -1618,19 +1621,30 @@ impl EnvelopeProcessorService {
 
         event::extract(state, event_fully_normalized, &self.inner.config)?;
 
-        let profile_id = profile::filter(state, project_id);
+        let profile_id = profile::filter(state, project_id, project_info.clone());
         profile::transfer_id(state, profile_id);
 
         event::finalize(state, &self.inner.config)?;
-        if let Some(inner_event_fully_normalized) =
-            self.normalize_event(state, project_id, event_fully_normalized)?
-        {
+        if let Some(inner_event_fully_normalized) = self.normalize_event(
+            state,
+            project_id,
+            project_info.clone(),
+            event_fully_normalized,
+        )? {
             event_fully_normalized = inner_event_fully_normalized;
         }
 
-        dynamic_sampling::ensure_dsc(state);
+        if let Some(inner_sampling_project_info) =
+            dynamic_sampling::ensure_dsc(state, project_info.clone(), sampling_project_info.clone())
+        {
+            sampling_project_info = inner_sampling_project_info;
+        }
 
-        let filter_run = event::filter(state, &self.inner.global_config.current())?;
+        let filter_run = event::filter(
+            state,
+            project_info.clone(),
+            &self.inner.global_config.current(),
+        )?;
 
         // Always run dynamic sampling on processing Relays,
         // but delay decision until inbound filters have been fully processed.
@@ -1643,7 +1657,12 @@ impl EnvelopeProcessorService {
         );
 
         let sampling_result = match run_dynamic_sampling {
-            true => dynamic_sampling::run(state, &reservoir),
+            true => dynamic_sampling::run(
+                state,
+                project_info.clone(),
+                sampling_project_info,
+                &reservoir,
+            ),
             false => SamplingResult::Pending,
         };
 
@@ -1656,9 +1675,14 @@ impl EnvelopeProcessorService {
         if let Some(outcome) = sampling_result.into_dropped_outcome() {
             // Process profiles before dropping the transaction, if necessary.
             // Before metric extraction to make sure the profile count is reflected correctly.
-            profile::process(state, &global_config);
+            profile::process(state, project_info.clone(), &global_config);
             // Extract metrics here, we're about to drop the event/transaction.
-            self.extract_transaction_metrics(state, project_id, SamplingDecision::Drop)?;
+            self.extract_transaction_metrics(
+                state,
+                project_id,
+                project_info.clone(),
+                SamplingDecision::Drop,
+            )?;
 
             dynamic_sampling::drop_unsampled_items(state, outcome);
 
@@ -1676,21 +1700,23 @@ impl EnvelopeProcessorService {
         // Need to scrub the transaction before extracting spans.
         //
         // Unconditionally scrub to make sure PII is removed as early as possible.
-        event::scrub(state)?;
-        attachment::scrub(state);
+        event::scrub(state, project_info.clone())?;
+        attachment::scrub(state, project_info.clone());
 
         if_processing!(self.inner.config, {
             // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
-            let profile_id = profile::process(state, &global_config);
+            let profile_id = profile::process(state, project_info.clone(), &global_config);
             profile::transfer_id(state, profile_id);
 
             // Always extract metrics in processing Relays for sampled items.
-            self.extract_transaction_metrics(state, project_id, SamplingDecision::Keep)?;
+            self.extract_transaction_metrics(
+                state,
+                project_id,
+                project_info.clone(),
+                SamplingDecision::Keep,
+            )?;
 
-            if state
-                .project_info
-                .has_feature(Feature::ExtractSpansFromEvent)
-            {
+            if project_info.has_feature(Feature::ExtractSpansFromEvent) {
                 span::extract_from_event(state, &global_config, server_sample_rate);
             }
 
@@ -1718,11 +1744,13 @@ impl EnvelopeProcessorService {
     fn process_profile_chunks(
         &self,
         state: &mut ProcessEnvelopeState<ProfileChunkGroup>,
+        project_info: Arc<ProjectInfo>,
     ) -> Result<(), ProcessingError> {
-        profile_chunk::filter(state);
+        profile_chunk::filter(state, project_info.clone());
         if_processing!(self.inner.config, {
             profile_chunk::process(
                 state,
+                project_info,
                 &self.inner.global_config.current(),
                 &self.inner.config,
             );
@@ -1735,15 +1763,16 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<StandaloneGroup>,
         project_id: ProjectId,
+        project_info: Arc<ProjectInfo>,
     ) -> Result<(), ProcessingError> {
-        profile::filter(state, project_id);
+        profile::filter(state, project_id, project_info.clone());
 
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
         });
 
         report::process_user_reports(state);
-        attachment::scrub(state);
+        attachment::scrub(state, project_info);
         Ok(())
     }
 
@@ -1751,8 +1780,9 @@ impl EnvelopeProcessorService {
     fn process_sessions(
         &self,
         state: &mut ProcessEnvelopeState<SessionGroup>,
+        project_info: Arc<ProjectInfo>,
     ) -> Result<(), ProcessingError> {
-        session::process(state, &self.inner.config);
+        session::process(state, project_info, &self.inner.config);
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
         });
@@ -1763,12 +1793,17 @@ impl EnvelopeProcessorService {
     fn process_client_reports(
         &self,
         state: &mut ProcessEnvelopeState<ClientReportGroup>,
+        project_info: Arc<ProjectInfo>,
     ) -> Result<(), ProcessingError> {
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
         });
 
-        report::process_client_reports(state, self.inner.addrs.outcome_aggregator.clone());
+        report::process_client_reports(
+            state,
+            project_info,
+            self.inner.addrs.outcome_aggregator.clone(),
+        );
 
         Ok(())
     }
@@ -1777,9 +1812,11 @@ impl EnvelopeProcessorService {
     fn process_replays(
         &self,
         state: &mut ProcessEnvelopeState<ReplayGroup>,
+        project_info: Arc<ProjectInfo>,
     ) -> Result<(), ProcessingError> {
         replay::process(
             state,
+            project_info,
             &self.inner.global_config.current(),
             self.inner.geoip_lookup.as_ref(),
         )?;
@@ -1809,9 +1846,10 @@ impl EnvelopeProcessorService {
         &self,
         state: &mut ProcessEnvelopeState<SpanGroup>,
         #[allow(unused_variables)] project_id: ProjectId,
+        project_info: Arc<ProjectInfo>,
         #[allow(unused_variables)] reservoir_counters: ReservoirCounters,
     ) -> Result<(), ProcessingError> {
-        span::filter(state);
+        span::filter(state, project_info);
         span::convert_otel_traces_data(state);
 
         if_processing!(self.inner.config, {
@@ -1881,9 +1919,7 @@ impl EnvelopeProcessorService {
                     metrics: Metrics::default(),
                     extracted_metrics: ProcessingExtractedMetrics::new(),
                     config: self.inner.config.clone(),
-                    project_info,
                     rate_limits,
-                    sampling_project_info,
                     managed_envelope,
                 };
 
@@ -1907,17 +1943,33 @@ impl EnvelopeProcessorService {
         relay_log::trace!("Processing {group} group", group = group.variant());
 
         match group {
-            ProcessingGroup::Error => run!(process_errors, project_id),
+            ProcessingGroup::Error => run!(
+                process_errors,
+                project_id,
+                project_info,
+                sampling_project_info
+            ),
             ProcessingGroup::Transaction => {
-                run!(process_transactions, project_id, reservoir_counters)
+                run!(
+                    process_transactions,
+                    project_id,
+                    project_info,
+                    sampling_project_info,
+                    reservoir_counters
+                )
             }
-            ProcessingGroup::Session => run!(process_sessions),
-            ProcessingGroup::Standalone => run!(process_standalone, project_id),
-            ProcessingGroup::ClientReport => run!(process_client_reports),
-            ProcessingGroup::Replay => run!(process_replays),
+            ProcessingGroup::Session => run!(process_sessions, project_info),
+            ProcessingGroup::Standalone => run!(process_standalone, project_id, project_info),
+            ProcessingGroup::ClientReport => run!(process_client_reports, project_info),
+            ProcessingGroup::Replay => run!(process_replays, project_info),
             ProcessingGroup::CheckIn => run!(process_checkins, project_id),
-            ProcessingGroup::Span => run!(process_standalone_spans, project_id, reservoir_counters),
-            ProcessingGroup::ProfileChunk => run!(process_profile_chunks),
+            ProcessingGroup::Span => run!(
+                process_standalone_spans,
+                project_id,
+                project_info,
+                reservoir_counters
+            ),
+            ProcessingGroup::ProfileChunk => run!(process_profile_chunks, project_info),
             // Currently is not used.
             ProcessingGroup::Metrics => {
                 // In proxy mode we simply forward the metrics.
@@ -2836,12 +2888,13 @@ impl RateLimiter<'_> {
         &self,
         global_config: &GlobalConfig,
         state: &mut ProcessEnvelopeState<G>,
+        project_info: Arc<ProjectInfo>,
     ) -> Result<RateLimits, ProcessingError> {
         if state.envelope().is_empty() && !state.has_event() {
             return Ok(RateLimits::default());
         }
 
-        let quotas = CombinedQuotas::new(global_config, state.project_info.get_quotas());
+        let quotas = CombinedQuotas::new(global_config, project_info.get_quotas());
         if quotas.is_empty() {
             return Ok(RateLimits::default());
         }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1793,7 +1793,7 @@ impl EnvelopeProcessorService {
     fn process_checkins(
         &self,
         #[allow(unused_variables)] state: &mut ProcessEnvelopeState<CheckInGroup>,
-        project_id: ProjectId,
+        #[allow(unused_variables)] project_id: ProjectId,
     ) -> Result<(), ProcessingError> {
         if_processing!(self.inner.config, {
             self.enforce_quotas(state)?;
@@ -1808,7 +1808,7 @@ impl EnvelopeProcessorService {
     fn process_standalone_spans(
         &self,
         state: &mut ProcessEnvelopeState<SpanGroup>,
-        project_id: ProjectId,
+        #[allow(unused_variables)] project_id: ProjectId,
         #[allow(unused_variables)] reservoir_counters: ReservoirCounters,
     ) -> Result<(), ProcessingError> {
         span::filter(state);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1869,16 +1869,15 @@ impl EnvelopeProcessorService {
         macro_rules! run {
             ($fn_name:ident $(, $args:expr)*) => {{
                 let managed_envelope = managed_envelope.try_into()?;
-
                 let mut state = ProcessEnvelopeState {
                     event: Annotated::empty(),
                     event_metrics_extracted: false,
                     spans_extracted: false,
                     metrics: Metrics::default(),
                     extracted_metrics: ProcessingExtractedMetrics::new(),
+                    config: self.inner.config.clone(),
                     project_info,
                     rate_limits,
-                    config,
                     sampling_project_info,
                     project_id,
                     managed_envelope,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1838,7 +1838,7 @@ impl EnvelopeProcessorService {
         &self,
         #[allow(unused_variables)] state: &mut ProcessEnvelopeState<CheckInGroup>,
         #[allow(unused_variables)] project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
+        #[allow(unused_variables)] project_info: Arc<ProjectInfo>,
     ) -> Result<(), ProcessingError> {
         if_processing!(self.inner.config, {
             self.enforce_quotas(state, project_info)?;
@@ -1855,7 +1855,7 @@ impl EnvelopeProcessorService {
         state: &mut ProcessEnvelopeState<SpanGroup>,
         #[allow(unused_variables)] project_id: ProjectId,
         project_info: Arc<ProjectInfo>,
-        sampling_project_info: Option<Arc<ProjectInfo>>,
+        #[allow(unused_variables)] sampling_project_info: Option<Arc<ProjectInfo>>,
         #[allow(unused_variables)] reservoir_counters: ReservoirCounters,
     ) -> Result<(), ProcessingError> {
         span::filter(state, project_info.clone());

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1636,11 +1636,11 @@ impl EnvelopeProcessorService {
             event_fully_normalized = inner_event_fully_normalized;
         }
 
-        if let Some(inner_sampling_project_info) =
-            dynamic_sampling::ensure_dsc(state, project_info.clone(), sampling_project_info.clone())
-        {
-            sampling_project_info = inner_sampling_project_info;
-        }
+        sampling_project_info = dynamic_sampling::validate_and_set_dsc(
+            state,
+            project_info.clone(),
+            sampling_project_info.clone(),
+        );
 
         let filter_run = event::filter(
             state,

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -1,6 +1,7 @@
 //! Attachments processor code.
 
 use std::error::Error;
+use std::sync::Arc;
 use std::time::Instant;
 
 use relay_pii::PiiAttachmentsProcessor;
@@ -10,6 +11,7 @@ use crate::envelope::{AttachmentType, ContentType};
 use crate::services::processor::ProcessEnvelopeState;
 use crate::statsd::RelayTimers;
 
+use crate::services::projects::project::ProjectInfo;
 #[cfg(feature = "processing")]
 use {
     crate::services::processor::ErrorGroup, crate::services::processor::EventFullyNormalized,
@@ -52,9 +54,9 @@ pub fn create_placeholders(
 /// This only applies the new PII rules that explicitly select `ValueType::Binary` or one of the
 /// attachment types. When special attachments are detected, these are scrubbed with custom
 /// logic; otherwise the entire attachment is treated as a single binary blob.
-pub fn scrub<G>(state: &mut ProcessEnvelopeState<G>) {
+pub fn scrub<G>(state: &mut ProcessEnvelopeState<G>, project_info: Arc<ProjectInfo>) {
     let envelope = state.managed_envelope.envelope_mut();
-    if let Some(ref config) = state.project_info.config.pii_config {
+    if let Some(ref config) = project_info.config.pii_config {
         let minidump = envelope
             .get_item_by_mut(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -1,4 +1,6 @@
 //! Dynamic sampling processor related code.
+use std::ops::ControlFlow;
+use std::sync::Arc;
 
 use chrono::Utc;
 use relay_config::Config;
@@ -8,8 +10,6 @@ use relay_protocol::{Annotated, Empty};
 use relay_sampling::config::RuleType;
 use relay_sampling::evaluation::{ReservoirEvaluator, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
-use std::ops::ControlFlow;
-use std::sync::Arc;
 
 use crate::envelope::ItemType;
 use crate::services::outcome::Outcome;

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -236,7 +236,7 @@ mod tests {
 
     use bytes::Bytes;
     use relay_base_schema::events::EventType;
-    use relay_base_schema::project::{ProjectId, ProjectKey};
+    use relay_base_schema::project::ProjectKey;
     use relay_dynamic_config::{MetricExtractionConfig, TransactionMetricsConfig};
     use relay_event_schema::protocol::{EventId, LenientString};
     use relay_protocol::RuleCondition;
@@ -441,7 +441,6 @@ mod tests {
                 project_info,
                 rate_limits: Default::default(),
                 sampling_project_info: None,
-                project_id: ProjectId::new(42),
                 managed_envelope: ManagedEnvelope::new(
                     envelope,
                     outcome_aggregator.clone(),
@@ -745,7 +744,6 @@ mod tests {
                 }));
                 Some(Arc::new(state))
             },
-            project_id: ProjectId::new(1),
             managed_envelope: ManagedEnvelope::new(
                 envelope,
                 Addr::dummy(),

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -39,6 +39,10 @@ use crate::utils::{self, SamplingResult};
 /// the main project state.
 ///
 /// If there is no transaction event in the envelope, this function will do nothing.
+///
+/// The function will return the sampling project information of the root project for the event. If
+/// no sampling project information is specified, the project information of the event’s project
+/// will be returned.
 pub fn validate_and_set_dsc(
     state: &mut ProcessEnvelopeState<TransactionGroup>,
     project_info: Arc<ProjectInfo>,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -1,7 +1,5 @@
 //! Dynamic sampling processor related code.
 
-use std::ops::ControlFlow;
-
 use chrono::Utc;
 use relay_config::Config;
 use relay_dynamic_config::ErrorBoundary;
@@ -10,12 +8,15 @@ use relay_protocol::{Annotated, Empty};
 use relay_sampling::config::RuleType;
 use relay_sampling::evaluation::{ReservoirEvaluator, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
+use std::ops::ControlFlow;
+use std::sync::Arc;
 
 use crate::envelope::ItemType;
 use crate::services::outcome::Outcome;
 use crate::services::processor::{
     EventProcessing, ProcessEnvelopeState, Sampling, TransactionGroup,
 };
+use crate::services::projects::project::ProjectInfo;
 use crate::utils::{self, SamplingResult};
 
 /// Ensures there is a valid dynamic sampling context and corresponding project state.
@@ -38,44 +39,50 @@ use crate::utils::{self, SamplingResult};
 /// the main project state.
 ///
 /// If there is no transaction event in the envelope, this function will do nothing.
-pub fn ensure_dsc(state: &mut ProcessEnvelopeState<TransactionGroup>) {
-    if state.envelope().dsc().is_some() && state.sampling_project_info.is_some() {
-        return;
+///
+/// Returns the
+pub fn ensure_dsc(
+    state: &mut ProcessEnvelopeState<TransactionGroup>,
+    project_info: Arc<ProjectInfo>,
+    sampling_project_info: Option<Arc<ProjectInfo>>,
+) -> Option<Option<Arc<ProjectInfo>>> {
+    if state.envelope().dsc().is_some() && sampling_project_info.is_some() {
+        return None;
     }
 
     // The DSC can only be computed if there's a transaction event. Note that `dsc_from_event`
     // below already checks for the event type.
-    let Some(event) = state.event.value() else {
-        return;
-    };
-    let Some(key_config) = state.project_info.get_public_key_config() else {
-        return;
-    };
+    let event = state.event.value()?;
+    let key_config = project_info.get_public_key_config()?;
 
     if let Some(dsc) = utils::dsc_from_event(key_config.public_key, event) {
         state.envelope_mut().set_dsc(dsc);
-        state.sampling_project_info = Some(state.project_info.clone());
+        return Some(Some(project_info.clone()));
     }
+
+    None
 }
 
 /// Computes the sampling decision on the incoming event
 pub fn run<Group>(
     state: &mut ProcessEnvelopeState<Group>,
+    project_info: Arc<ProjectInfo>,
+    sampling_project_info: Option<Arc<ProjectInfo>>,
     reservoir: &ReservoirEvaluator,
 ) -> SamplingResult
 where
     Group: Sampling,
 {
-    if !Group::supports_sampling(&state.project_info) {
+    if !Group::supports_sampling(&project_info) {
         return SamplingResult::Pending;
     }
 
-    let sampling_config = match state.project_info.config.sampling {
+    let sampling_config = match project_info.config.sampling {
         Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
         _ => None,
     };
 
-    let root_state = state.sampling_project_info.as_ref();
+    let root_state = sampling_project_info.as_ref();
     let root_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
         Some(ErrorBoundary::Ok(ref config)) if !config.unsupported() => Some(config),
         _ => None,
@@ -187,6 +194,7 @@ fn compute_sampling_decision(
 /// only for tagging errors and not for actually sampling incoming events.
 pub fn tag_error_with_sampling_decision<G: EventProcessing>(
     state: &mut ProcessEnvelopeState<G>,
+    sampling_project_info: Option<Arc<ProjectInfo>>,
     config: &Config,
 ) {
     let (Some(dsc), Some(event)) = (
@@ -196,7 +204,7 @@ pub fn tag_error_with_sampling_decision<G: EventProcessing>(
         return;
     };
 
-    let root_state = state.sampling_project_info.as_ref();
+    let root_state = sampling_project_info.as_ref();
     let sampling_config = match root_state.and_then(|s| s.config.sampling.as_ref()) {
         Some(ErrorBoundary::Ok(ref config)) => config,
         _ => return,
@@ -433,14 +441,12 @@ mod tests {
             let project_info = Arc::new(project_info);
             let envelope = new_envelope(false, "foo");
 
-            ProcessEnvelopeState::<TransactionGroup> {
+            let state = ProcessEnvelopeState::<TransactionGroup> {
                 event: Annotated::from(event),
                 metrics: Default::default(),
                 extracted_metrics: ProcessingExtractedMetrics::new(),
                 config: config.clone(),
-                project_info,
                 rate_limits: Default::default(),
-                sampling_project_info: None,
                 managed_envelope: ManagedEnvelope::new(
                     envelope,
                     outcome_aggregator.clone(),
@@ -451,24 +457,26 @@ mod tests {
                 .unwrap(),
                 event_metrics_extracted: false,
                 spans_extracted: false,
-            }
+            };
+
+            (state, project_info)
         };
 
         let reservoir = dummy_reservoir();
 
         // None represents no TransactionMetricsConfig, DS will not be run
-        let mut state = get_state(None);
-        let sampling_result = run(&mut state, &reservoir);
+        let (mut state, project_info) = get_state(None);
+        let sampling_result = run(&mut state, project_info, None, &reservoir);
         assert_eq!(sampling_result.decision(), SamplingDecision::Keep);
 
         // Current version is 3, so it won't run DS if it's outdated
-        let mut state = get_state(Some(2));
-        let sampling_result = run(&mut state, &reservoir);
+        let (mut state, project_info) = get_state(Some(2));
+        let sampling_result = run(&mut state, project_info, None, &reservoir);
         assert_eq!(sampling_result.decision(), SamplingDecision::Keep);
 
         // Dynamic sampling is run, as the transactionmetrics version is up to date.
-        let mut state = get_state(Some(3));
-        let sampling_result = run(&mut state, &reservoir);
+        let (mut state, project_info) = get_state(Some(3));
+        let sampling_result = run(&mut state, project_info, None, &reservoir);
         assert_eq!(sampling_result.decision(), SamplingDecision::Drop);
     }
 
@@ -712,38 +720,7 @@ mod tests {
             metrics: Default::default(),
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),
-            project_info,
             rate_limits: Default::default(),
-            sampling_project_info: {
-                let mut state = ProjectInfo::default();
-                state.config.metric_extraction =
-                    ErrorBoundary::Ok(MetricExtractionConfig::default());
-                state.config.sampling = Some(ErrorBoundary::Ok(SamplingConfig {
-                    version: 2,
-                    rules: vec![
-                        // Set up a reservoir (only used for transactions):
-                        SamplingRule {
-                            condition: RuleCondition::all(),
-                            sampling_value: SamplingValue::Reservoir { limit: 100 },
-                            ty: RuleType::Trace,
-                            id: RuleId(1),
-                            time_range: Default::default(),
-                            decaying_fn: Default::default(),
-                        },
-                        // Reject everything that does not go into the reservoir:
-                        SamplingRule {
-                            condition: RuleCondition::all(),
-                            sampling_value: SamplingValue::SampleRate { value: 0.0 },
-                            ty: RuleType::Trace,
-                            id: RuleId(2),
-                            time_range: Default::default(),
-                            decaying_fn: Default::default(),
-                        },
-                    ],
-                    rules_v2: vec![],
-                }));
-                Some(Arc::new(state))
-            },
             managed_envelope: ManagedEnvelope::new(
                 envelope,
                 Addr::dummy(),
@@ -754,8 +731,38 @@ mod tests {
             .unwrap(),
         };
 
+        let sampling_project_info = {
+            let mut state = ProjectInfo::default();
+            state.config.metric_extraction = ErrorBoundary::Ok(MetricExtractionConfig::default());
+            state.config.sampling = Some(ErrorBoundary::Ok(SamplingConfig {
+                version: 2,
+                rules: vec![
+                    // Set up a reservoir (only used for transactions):
+                    SamplingRule {
+                        condition: RuleCondition::all(),
+                        sampling_value: SamplingValue::Reservoir { limit: 100 },
+                        ty: RuleType::Trace,
+                        id: RuleId(1),
+                        time_range: Default::default(),
+                        decaying_fn: Default::default(),
+                    },
+                    // Reject everything that does not go into the reservoir:
+                    SamplingRule {
+                        condition: RuleCondition::all(),
+                        sampling_value: SamplingValue::SampleRate { value: 0.0 },
+                        ty: RuleType::Trace,
+                        id: RuleId(2),
+                        time_range: Default::default(),
+                        decaying_fn: Default::default(),
+                    },
+                ],
+                rules_v2: vec![],
+            }));
+            Some(Arc::new(state))
+        };
+
         let reservoir = dummy_reservoir();
-        run(&mut state, &reservoir)
+        run(&mut state, project_info, sampling_project_info, &reservoir)
     }
 
     #[test]

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -3,16 +3,6 @@
 use std::error::Error;
 use std::sync::{Arc, OnceLock};
 
-use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
-use crate::extractors::RequestMeta;
-use crate::services::outcome::Outcome;
-use crate::services::processor::{
-    EventFullyNormalized, EventProcessing, ExtractedEvent, ProcessEnvelopeState, ProcessingError,
-    MINIMUM_CLOCK_DRIFT,
-};
-use crate::services::projects::project::ProjectInfo;
-use crate::statsd::{PlatformTag, RelayCounters, RelayHistograms, RelayTimers};
-use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
 use chrono::Duration as SignedDuration;
 use relay_auth::RelayVersion;
 use relay_base_schema::events::EventType;
@@ -29,6 +19,17 @@ use relay_protocol::{Annotated, Array, Empty, Object, Value};
 use relay_quotas::DataCategory;
 use relay_statsd::metric;
 use serde_json::Value as SerdeValue;
+
+use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
+use crate::extractors::RequestMeta;
+use crate::services::outcome::Outcome;
+use crate::services::processor::{
+    EventFullyNormalized, EventProcessing, ExtractedEvent, ProcessEnvelopeState, ProcessingError,
+    MINIMUM_CLOCK_DRIFT,
+};
+use crate::services::projects::project::ProjectInfo;
+use crate::statsd::{PlatformTag, RelayCounters, RelayHistograms, RelayTimers};
+use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
 
 /// Extracts the primary event payload from an envelope.
 ///

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -4,6 +4,7 @@ use std::net::IpAddr;
 use relay_dynamic_config::{Feature, GlobalConfig};
 
 use relay_base_schema::events::EventType;
+use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_event_schema::protocol::{Contexts, Event, ProfileContext};
 use relay_filter::ProjectFiltersConfig;
@@ -18,7 +19,7 @@ use crate::utils::ItemAction;
 /// Filters out invalid and duplicate profiles.
 ///
 /// Returns the profile id of the single remaining profile, if there is one.
-pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) -> Option<ProfileId> {
+pub fn filter<G>(state: &mut ProcessEnvelopeState<G>, project_id: ProjectId) -> Option<ProfileId> {
     let profiling_disabled = state.should_filter(Feature::Profiling);
     let has_transaction = state.event_type() == Some(EventType::Transaction);
     let keep_unsampled_profiles = true;
@@ -38,7 +39,7 @@ pub fn filter<G>(state: &mut ProcessEnvelopeState<G>) -> Option<ProfileId> {
                 return ItemAction::DropSilently;
             }
 
-            match relay_profiling::parse_metadata(&item.payload(), state.project_id) {
+            match relay_profiling::parse_metadata(&item.payload(), project_id) {
                 Ok(id) => {
                     profile_id = Some(id);
                     ItemAction::Keep

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -1,4 +1,8 @@
 //! Replay related processor code.
+use std::error::Error;
+use std::net::IpAddr;
+use std::sync::Arc;
+
 use bytes::Bytes;
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
@@ -12,9 +16,6 @@ use relay_protocol::Annotated;
 use relay_replays::recording::RecordingScrubber;
 use relay_statsd::metric;
 use serde::{Deserialize, Serialize};
-use std::error::Error;
-use std::net::IpAddr;
-use std::sync::Arc;
 
 use crate::envelope::{ContentType, ItemType};
 use crate::services::outcome::DiscardReason;

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -1,7 +1,4 @@
 //! Replay related processor code.
-use std::error::Error;
-use std::net::IpAddr;
-
 use bytes::Bytes;
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
@@ -15,30 +12,33 @@ use relay_protocol::Annotated;
 use relay_replays::recording::RecordingScrubber;
 use relay_statsd::metric;
 use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::net::IpAddr;
+use std::sync::Arc;
 
 use crate::envelope::{ContentType, ItemType};
 use crate::services::outcome::DiscardReason;
 use crate::services::processor::{ProcessEnvelopeState, ProcessingError, ReplayGroup};
+use crate::services::projects::project::ProjectInfo;
 use crate::statsd::{RelayCounters, RelayTimers};
 use crate::utils::sample;
 
 /// Removes replays if the feature flag is not enabled.
 pub fn process(
     state: &mut ProcessEnvelopeState<ReplayGroup>,
+    project_info: Arc<ProjectInfo>,
     global_config: &GlobalConfig,
     geoip_lookup: Option<&GeoIpLookup>,
 ) -> Result<(), ProcessingError> {
     // If the replay feature is not enabled drop the items silenty.
-    if state.should_filter(Feature::SessionReplay) {
+    if state.should_filter(Feature::SessionReplay, &project_info) {
         state.managed_envelope.drop_items_silently();
         return Ok(());
     }
 
     // If the replay video feature is not enabled check the envelope items for a
     // replay video event.
-    if state
-        .project_info
-        .has_feature(Feature::SessionReplayVideoDisabled)
+    if project_info.has_feature(Feature::SessionReplayVideoDisabled)
         && count_replay_video_events(state) > 0
     {
         state.managed_envelope.drop_items_silently();
@@ -49,12 +49,12 @@ pub fn process(
         let meta = state.envelope().meta();
 
         ReplayProcessingConfig {
-            config: &state.project_info.config,
+            config: &project_info.config,
             global_config,
             geoip_lookup,
             event_id: state.envelope().event_id(),
-            project_id: state.project_info.project_id,
-            organization_id: state.project_info.organization_id,
+            project_id: project_info.project_id,
+            organization_id: project_info.organization_id,
             client_addr: meta.client_addr(),
             user_agent: RawUserAgentInfo {
                 user_agent: meta.user_agent().map(|s| s.to_owned()),
@@ -63,10 +63,7 @@ pub fn process(
         }
     };
 
-    let mut scrubber = if state
-        .project_info
-        .has_feature(Feature::SessionReplayRecordingScrubbing)
-    {
+    let mut scrubber = if project_info.has_feature(Feature::SessionReplayRecordingScrubbing) {
         let datascrubbing_config = rpc
             .config
             .datascrubbing_settings
@@ -84,10 +81,7 @@ pub fn process(
     };
 
     for item in state.managed_envelope.envelope_mut().items_mut() {
-        if state
-            .project_info
-            .has_feature(Feature::SessionReplayCombinedEnvelopeItems)
-        {
+        if project_info.has_feature(Feature::SessionReplayCombinedEnvelopeItems) {
             item.set_replay_combined_payload(true);
         }
 

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -1,5 +1,9 @@
 //! Contains code related to validation and normalization of the user and client reports.
 
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::sync::Arc;
+
 use chrono::{Duration as SignedDuration, Utc};
 use relay_common::time::UnixTimestamp;
 use relay_event_normalization::ClockDriftProcessor;
@@ -8,9 +12,6 @@ use relay_filter::FilterStatKey;
 use relay_quotas::ReasonCode;
 use relay_sampling::evaluation::MatchedRuleIds;
 use relay_system::Addr;
-use std::collections::BTreeMap;
-use std::error::Error;
-use std::sync::Arc;
 
 use crate::constants::DEFAULT_EVENT_RETENTION;
 use crate::envelope::{ContentType, ItemType};

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -1,8 +1,5 @@
 //! Contains the sessions related processor code.
 
-use std::error::Error;
-use std::net;
-
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use relay_config::Config;
 use relay_dynamic_config::SessionMetricsConfig;
@@ -12,9 +9,13 @@ use relay_event_schema::protocol::{
 };
 use relay_metrics::Bucket;
 use relay_statsd::metric;
+use std::error::Error;
+use std::net;
+use std::sync::Arc;
 
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::services::processor::{ProcessEnvelopeState, SessionGroup, MINIMUM_CLOCK_DRIFT};
+use crate::services::projects::project::ProjectInfo;
 use crate::statsd::RelayTimers;
 use crate::utils::ItemAction;
 
@@ -22,9 +23,13 @@ use crate::utils::ItemAction;
 ///
 /// Both are removed from the envelope if they contain invalid JSON or if their timestamps
 /// are out of range after clock drift correction.
-pub fn process(state: &mut ProcessEnvelopeState<SessionGroup>, config: &Config) {
+pub fn process(
+    state: &mut ProcessEnvelopeState<SessionGroup>,
+    project_info: Arc<ProjectInfo>,
+    config: &Config,
+) {
     let received = state.managed_envelope.received_at();
-    let metrics_config = state.project_info.config().session_metrics;
+    let metrics_config = project_info.config().session_metrics;
     let envelope = state.managed_envelope.envelope_mut();
     let client = envelope.meta().client().map(|x| x.to_owned());
     let client_addr = envelope.meta().client_addr();

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -1,5 +1,9 @@
 //! Contains the sessions related processor code.
 
+use std::error::Error;
+use std::net;
+use std::sync::Arc;
+
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use relay_config::Config;
 use relay_dynamic_config::SessionMetricsConfig;
@@ -9,9 +13,6 @@ use relay_event_schema::protocol::{
 };
 use relay_metrics::Bucket;
 use relay_statsd::metric;
-use std::error::Error;
-use std::net;
-use std::sync::Arc;
 
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::services::processor::{ProcessEnvelopeState, SessionGroup, MINIMUM_CLOCK_DRIFT};

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -1,5 +1,7 @@
 //! Processor code related to standalone spans.
 
+use std::sync::Arc;
+
 use prost::Message;
 use relay_dynamic_config::Feature;
 use relay_event_normalization::span::tag_extraction;
@@ -7,7 +9,6 @@ use relay_event_schema::protocol::{Event, Span};
 use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 use relay_spans::otel_trace::TracesData;
-use std::sync::Arc;
 
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::services::outcome::{DiscardReason, Outcome};

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -1,5 +1,8 @@
 //! Contains the processing-only functionality.
 
+use std::error::Error;
+use std::sync::Arc;
+
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::metrics_extraction::{event, generic};
 use crate::services::outcome::{DiscardReason, Outcome};
@@ -35,8 +38,6 @@ use relay_protocol::{Annotated, Empty, Value};
 use relay_quotas::DataCategory;
 use relay_sampling::evaluation::ReservoirEvaluator;
 use relay_spans::otel_trace::Span as OtelSpan;
-use std::error::Error;
-use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -12,6 +12,7 @@ use crate::services::processor::{
 use crate::utils::{sample, ItemAction, ManagedEnvelope};
 use chrono::{DateTime, Utc};
 use relay_base_schema::events::EventType;
+use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_dynamic_config::{
     CombinedMetricExtractionConfig, ErrorBoundary, Feature, GlobalConfig, ProjectConfig,
@@ -43,6 +44,7 @@ struct ValidationError(#[from] anyhow::Error);
 
 pub fn process(
     state: &mut ProcessEnvelopeState<SpanGroup>,
+    project_id: ProjectId,
     global_config: &GlobalConfig,
     geo_lookup: Option<&GeoIpLookup>,
     reservoir_counters: &ReservoirEvaluator,
@@ -148,7 +150,7 @@ pub fn process(
                     transaction,
                     1,
                     sampling_decision,
-                    state.project_id,
+                    project_id,
                 );
                 state
                     .extracted_metrics
@@ -794,7 +796,6 @@ mod tests {
 
     use bytes::Bytes;
     use once_cell::sync::Lazy;
-    use relay_base_schema::project::ProjectId;
     use relay_event_schema::protocol::{
         Context, ContextInner, EventId, SpanId, Timestamp, TraceContext, TraceId,
     };
@@ -861,7 +862,6 @@ mod tests {
             project_info,
             rate_limits: Arc::new(RateLimits::default()),
             sampling_project_info: None,
-            project_id: ProjectId::new(42),
             managed_envelope: managed_envelope.try_into().unwrap(),
             event_metrics_extracted: false,
             spans_extracted: false,


### PR DESCRIPTION
This PR removes the `project_info` and `sampling_project_info` from the state. This refactoring is part of a bigger effort to improve the processor and create independent processing for each processing group.

#skip-changelog