### PR TITLE
ref(processor): Remove metrics and spans extracted booleans from state

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1126,7 +1126,7 @@ struct InnerProcessor {
 
 /// New type representing the normalization state of the event.
 #[derive(Copy, Clone)]
-struct EventFullyNormalized(pub bool);
+struct EventFullyNormalized(bool);
 
 impl EventFullyNormalized {
     /// Returns `true` if the event is fully normalized, `false` otherwise.
@@ -1142,11 +1142,11 @@ impl EventFullyNormalized {
 
 /// New type representing whether metrics were extracted from transactions/spans.
 #[derive(Copy, Clone)]
-struct EventMetricsExtracted(pub bool);
+struct EventMetricsExtracted(bool);
 
 /// New type representing whether spans were extracted.
 #[derive(Copy, Clone)]
-struct SpansExtracted(pub bool);
+struct SpansExtracted(bool);
 
 impl EnvelopeProcessorService {
     /// Creates a multi-threaded envelope processor.

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1552,9 +1552,9 @@ impl EnvelopeProcessorService {
         });
 
         // When extracting the event when processing an error, we expect that the result of this
-        // function is unsued since we don't have error metrics and errors are not correlated to
+        // function is unused since we don't have error metrics and errors are not correlated to
         // extracted spans.
-        let _ = event::extract(state, event_fully_normalized, &self.inner.config)?;
+        event::extract(state, event_fully_normalized, &self.inner.config)?;
 
         if_processing!(self.inner.config, {
             if let Some(inner_event_fully_normalized) = unreal::process(state)? {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1615,6 +1615,7 @@ impl EnvelopeProcessorService {
     }
 
     /// Processes only transactions and transaction-related items.
+    #[allow(unused_assignments)]
     fn process_transactions(
         &self,
         state: &mut ProcessEnvelopeState<TransactionGroup>,
@@ -1734,11 +1735,13 @@ impl EnvelopeProcessorService {
             )?;
 
             if project_info.has_feature(Feature::ExtractSpansFromEvent) {
-                span::extract_from_event(
+                spans_extracted = span::extract_from_event(
                     state,
                     project_info.clone(),
                     &global_config,
                     server_sample_rate,
+                    event_metrics_extracted,
+                    spans_extracted,
                 );
             }
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -461,8 +461,6 @@ mod tests {
                 )
                 .try_into()
                 .unwrap(),
-                event_metrics_extracted: false,
-                spans_extracted: false,
             };
 
             (state, project_info)
@@ -721,8 +719,6 @@ mod tests {
         let envelope = Envelope::parse_bytes(bytes).unwrap();
         let mut state = ProcessEnvelopeState::<G> {
             event: Annotated::new(Event::default()),
-            event_metrics_extracted: false,
-            spans_extracted: false,
             metrics: Default::default(),
             extracted_metrics: ProcessingExtractedMetrics::new(),
             config: Arc::new(Config::default()),


### PR DESCRIPTION
This PR removes the `event_metrics_extracted` and `spans_extracted` fields from the state.

#skip-changelog