### PR TITLE
fix(buffer): Do not unwrap

### DIFF
--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -363,7 +363,7 @@ where
             return Ok(None);
         };
         let project_key_pair = *key;
-        let envelope = stack.pop().await.unwrap().expect("found an empty stack");
+        let envelope = stack.pop().await?.expect("found an empty stack");
 
         let last_received_at = stack.peek().await?;
 


### PR DESCRIPTION
We apparently missed this, should have a linter for it.

#skip-changelog