### PR TITLE
instr(server): Log transactions with attachments

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -416,12 +416,35 @@ fn emit_envelope_metrics(envelope: &Envelope) {
         );
     }
 
+    // BEGIN temporary
     if has_transaction && has_attachment {
         metric!(
             counter(RelayCounters::TransactionsWithAttachments) += 1,
             sdk = client_name.name(),
-        )
+        );
+        relay_log::with_scope(
+            |scope| {
+                // Set the organization as user so we can figure out who uses this.
+                scope.set_user(Some(relay_log::sentry::User {
+                    id: Some(
+                        envelope
+                            .meta()
+                            .get_partial_scoping()
+                            .organization_id
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                }));
+            },
+            || {
+                relay_log::sentry::capture_message(
+                    "transaction with attachment",
+                    relay_log::sentry::Level::Info,
+                );
+            },
+        );
     }
+    // END temporary
 }
 
 #[derive(Debug)]

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -308,7 +308,7 @@ def mini_sentry(request):  # noqa
         if (
             event is not None
             and sentry.fail_on_relay_error
-            and event.level in ("error", "warning")
+            and event.get("level") != "info"
         ):
             error = AssertionError("Relay sent us event: " + get_error_message(event))
             sentry.test_failures.put(("/api/666/envelope/", error))

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -305,7 +305,11 @@ def mini_sentry(request):  # noqa
         envelope = Envelope.deserialize(flask_request.data)
         event = envelope.get_event()
 
-        if event is not None and sentry.fail_on_relay_error:
+        if (
+            event is not None
+            and sentry.fail_on_relay_error
+            and event.level in ("error", "warning")
+        ):
             error = AssertionError("Relay sent us event: " + get_error_message(event))
             sentry.test_failures.put(("/api/666/envelope/", error))
 


### PR DESCRIPTION
Get a list of distinct org IDs for transactions with attachments.

ref: https://github.com/getsentry/team-ingest/issues/607

#skip-changelog