### PR TITLE
instr(server): Use project_key instead of org_id

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -425,16 +425,10 @@ fn emit_envelope_metrics(envelope: &Envelope) {
         relay_log::with_scope(
             |scope| {
                 // Set the organization as user so we can figure out who uses this.
-                scope.set_user(Some(relay_log::sentry::User {
-                    id: Some(
-                        envelope
-                            .meta()
-                            .get_partial_scoping()
-                            .organization_id
-                            .to_string(),
-                    ),
-                    ..Default::default()
-                }));
+                scope.set_tag(
+                    "project_key",
+                    envelope.meta().get_partial_scoping().project_key,
+                );
             },
             || {
                 relay_log::sentry::capture_message(


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/4397: As I could have known, the organization ID is not available in the request handler:

https://github.com/getsentry/relay/blob/b28929ccb314e9a577ad16a025abb37be6a1f722/relay-server/src/extractors/request_meta.rs#L398-L400

#skip-changelog