### PR TITLE
ref(processor): Remove event from state

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3132,7 +3132,6 @@ impl RateLimiter<'_> {
 
         if event_active {
             debug_assert!(managed_envelope.envelope().is_empty());
-            debug_assert!(event.value().is_none());
             return Ok(EnforcementResult::new(Annotated::empty(), rate_limits));
         }
 

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -30,6 +30,7 @@ use {
 pub fn create_placeholders(
     state: &mut ProcessEnvelopeState,
     managed_envelope: &mut TypedEnvelope<ErrorGroup>,
+    event: &mut Annotated<Event>,
 ) -> Option<EventFullyNormalized> {
     let envelope = managed_envelope.envelope();
     let minidump_attachment =
@@ -38,12 +39,12 @@ pub fn create_placeholders(
         .get_item_by(|item| item.attachment_type() == Some(&AttachmentType::AppleCrashReport));
 
     if let Some(item) = minidump_attachment {
-        let event = state.event.get_or_insert_with(Event::default);
+        let event = event.get_or_insert_with(Event::default);
         state.metrics.bytes_ingested_event_minidump = Annotated::new(item.len() as u64);
         utils::process_minidump(event, &item.payload());
         return Some(EventFullyNormalized(false));
     } else if let Some(item) = apple_crash_report_attachment {
-        let event = state.event.get_or_insert_with(Event::default);
+        let event = event.get_or_insert_with(Event::default);
         state.metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
         utils::process_apple_crash_report(event, &item.payload());
         return Some(EventFullyNormalized(false));

--- a/relay-server/src/services/processor/unreal.rs
+++ b/relay-server/src/services/processor/unreal.rs
@@ -2,14 +2,13 @@
 //!
 //! These functions are included only in the processing mode.
 
-use relay_config::Config;
-
 use crate::envelope::ItemType;
-use crate::services::processor::{
-    ErrorGroup, EventFullyNormalized, ProcessEnvelopeState, ProcessingError,
-};
+use crate::services::processor::{ErrorGroup, EventFullyNormalized, ProcessingError};
 use crate::utils;
 use crate::utils::TypedEnvelope;
+use relay_config::Config;
+use relay_event_schema::protocol::Event;
+use relay_protocol::Annotated;
 
 /// Expands Unreal 4 items inside an envelope.
 ///
@@ -41,10 +40,10 @@ pub fn expand(
 /// If the event does not contain an unreal context, this function does not perform any action.
 /// If there was no event payload prior to this function, it is created.
 pub fn process(
-    state: &mut ProcessEnvelopeState,
     managed_envelope: &mut TypedEnvelope<ErrorGroup>,
+    event: &mut Annotated<Event>,
 ) -> Result<Option<EventFullyNormalized>, ProcessingError> {
-    if utils::process_unreal_envelope(&mut state.event, managed_envelope.envelope_mut())
+    if utils::process_unreal_envelope(event, managed_envelope.envelope_mut())
         .map_err(ProcessingError::InvalidUnrealReport)?
     {
         return Ok(Some(EventFullyNormalized(false)));


### PR DESCRIPTION
This PR removes the `event` from the state of the processor.

#skip-changelog