### PR TITLE
fix(spans): Fix name of cache.hit and cache.key field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Fix serialized name of `cache.hit` and `cache.key` span tags. ([#4408](https://github.com/getsentry/relay/pull/4408))
+
 ## 24.12.0
 
 **Bug Fixes**:

--- a/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__cache_extraction.snap
+++ b/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__cache_extraction.snap
@@ -1,0 +1,126 @@
+---
+source: relay-event-normalization/src/normalize/span/tag_extraction.rs
+expression: event.to_json_pretty().unwrap()
+---
+{
+  "spans": [
+    {
+      "timestamp": 1694732408.3145,
+      "start_timestamp": 1694732407.8367,
+      "exclusive_time": 477.800131,
+      "op": "cache.get_item",
+      "span_id": "97c0ef9770a02f9d",
+      "parent_span_id": "9756d8d7b2b364ff",
+      "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+      "description": "get my_key",
+      "data": {
+        "cache.hit": true,
+        "cache.key": [
+          "my_key"
+        ],
+        "cache.item_size": 8,
+        "thread.name": "Thread-4 (process_request_thread)",
+        "thread.id": "6286962688"
+      },
+      "sentry_tags": {
+        "sdk.name": "unknown",
+        "sdk.version": "unknown",
+        "platform": "other",
+        "category": "cache",
+        "description": "GET *",
+        "group": "37e3d9fab1ae9162",
+        "op": "cache.get_item",
+        "cache.hit": "true",
+        "cache.key": "[\"my_key\"]",
+        "thread.name": "Thread-4 (process_request_thread)",
+        "thread.id": "6286962688"
+      },
+      "measurements": {
+        "cache.item_size": {
+          "value": 8.0,
+          "unit": "byte"
+        }
+      },
+      "hash": "e2fae740cccd3781"
+    },
+    {
+      "timestamp": 1694732409.3145,
+      "start_timestamp": 1694732408.8367,
+      "exclusive_time": 477.800131,
+      "op": "cache.get_item",
+      "span_id": "97c0ef9770a02f9d",
+      "parent_span_id": "9756d8d7b2b364ff",
+      "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+      "description": "mget my_key my_key_2",
+      "data": {
+        "cache.hit": false,
+        "cache.key": [
+          "my_key",
+          "my_key_2"
+        ],
+        "cache.item_size": 8,
+        "thread.name": "Thread-4 (process_request_thread)",
+        "thread.id": "6286962688"
+      },
+      "sentry_tags": {
+        "sdk.name": "unknown",
+        "sdk.version": "unknown",
+        "platform": "other",
+        "category": "cache",
+        "description": "MGET *",
+        "group": "8383eea37ec89fb1",
+        "op": "cache.get_item",
+        "cache.hit": "false",
+        "cache.key": "[\"my_key\",\"my_key_2\"]",
+        "thread.name": "Thread-4 (process_request_thread)",
+        "thread.id": "6286962688"
+      },
+      "measurements": {
+        "cache.item_size": {
+          "value": 8.0,
+          "unit": "byte"
+        }
+      },
+      "hash": "e2fae740cccd3781"
+    },
+    {
+      "timestamp": 1694732409.3145,
+      "start_timestamp": 1694732408.8367,
+      "exclusive_time": 477.800131,
+      "op": "cache.get",
+      "span_id": "97c0ef9770a02f9d",
+      "parent_span_id": "9756d8d7b2b364ff",
+      "trace_id": "77aeb1c16bb544a4a39b8d42944947a3",
+      "description": "get my_key_2",
+      "data": {
+        "cache.hit": false,
+        "cache.key": [
+          "my_key_2"
+        ],
+        "cache.item_size": 8,
+        "thread.name": "Thread-4 (process_request_thread)",
+        "thread.id": "6286962688"
+      },
+      "sentry_tags": {
+        "sdk.name": "unknown",
+        "sdk.version": "unknown",
+        "platform": "other",
+        "category": "cache",
+        "description": "GET *",
+        "group": "37e3d9fab1ae9162",
+        "op": "cache.get",
+        "cache.hit": "false",
+        "cache.key": "[\"my_key_2\"]",
+        "thread.name": "Thread-4 (process_request_thread)",
+        "thread.id": "6286962688"
+      },
+      "measurements": {
+        "cache.item_size": {
+          "value": 8.0,
+          "unit": "byte"
+        }
+      },
+      "hash": "e2fae740cccd3781"
+    }
+  ]
+}

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1813,58 +1813,9 @@ LIMIT 1
             }
         "#;
 
-        let mut event = Annotated::<Event>::from_json(json)
-            .unwrap()
-            .into_value()
-            .unwrap();
-
-        extract_span_tags_from_event(&mut event, 200, &[]);
-
-        let span_1 = &event.spans.value().unwrap()[0];
-        let span_2 = &event.spans.value().unwrap()[1];
-        let span_3 = &event.spans.value().unwrap()[2];
-
-        let tags_1 = get_value!(span_1.sentry_tags).unwrap();
-        let tags_2 = get_value!(span_2.sentry_tags).unwrap();
-        let tags_3 = get_value!(span_3.sentry_tags).unwrap();
-
-        let measurements_1 = span_1.value().unwrap().measurements.value().unwrap();
-
-        assert_eq!(tags_1.cache_hit.as_str(), Some("true"));
-        assert_eq!(tags_2.cache_hit.as_str(), Some("false"));
-        assert_eq!(tags_3.cache_hit.as_str(), Some("false"));
-
-        let keys_1 = Value::Array(vec![Annotated::new(Value::String("my_key".to_string()))]);
-        let keys_2 = Value::Array(vec![
-            Annotated::new(Value::String("my_key".to_string())),
-            Annotated::new(Value::String("my_key_2".to_string())),
-        ]);
-        let keys_3 = Value::Array(vec![Annotated::new(Value::String("my_key_2".to_string()))]);
-        assert_eq!(
-            tags_1.cache_key.as_str(),
-            serde_json::to_string(&keys_1).ok().as_deref()
-        );
-        assert_eq!(
-            tags_2.cache_key.as_str(),
-            serde_json::to_string(&keys_2).ok().as_deref()
-        );
-        assert_eq!(
-            tags_3.cache_key.as_str(),
-            serde_json::to_string(&keys_3).ok().as_deref()
-        );
-
-        assert_debug_snapshot!(measurements_1, @r###"
-        Measurements(
-            {
-                "cache.item_size": Measurement {
-                    value: 8.0,
-                    unit: Information(
-                        Byte,
-                    ),
-                },
-            },
-        )
-        "###);
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+        extract_span_tags_from_event(event.value_mut().as_mut().unwrap(), 200, &[]);
+        insta::assert_snapshot!(event.to_json_pretty().unwrap());
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -244,7 +244,9 @@ pub struct SentryTags {
     /// The start type of the application when the span occurred(String).
     pub app_start_type: Annotated<String>,
     pub replay_id: Annotated<String>,
+    #[metastructure(field = "cache.hit")]
     pub cache_hit: Annotated<String>,
+    #[metastructure(field = "cache.key")]
     pub cache_key: Annotated<String>,
     #[metastructure(field = "trace.status")]
     pub trace_status: Annotated<String>,


### PR DESCRIPTION
Since https://github.com/getsentry/relay/pull/4364, `cache.hit` and `cache.key` did not serialize into the correct field name.