### PR TITLE
instr(metrics): Fix small issues with delay metric

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -443,6 +443,9 @@ impl StoreService {
         }
 
         for (namespace, (total, count, max)) in delay_stats {
+            if count == 0 {
+                continue;
+            }
             metric!(
                 counter(RelayCounters::MetricDelaySum) += total,
                 namespace = namespace.as_str()

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -62,7 +62,7 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::ProjectCacheScheduledFetches => "project_cache.fetches.size",
             RelayGauges::ServerActiveConnections => "server.http.connections",
             #[cfg(feature = "processing")]
-            RelayGauges::MetricDelayMax => "metrics.buckets.delay.max",
+            RelayGauges::MetricDelayMax => "metrics.delay.max",
         }
     }
 }


### PR DESCRIPTION
- Only emit the metrics when there are actual values (needed for the gauge metric).
- Align the max metric with the count/sum metric names.

#skip-changelog