### PR TITLE
ref(processor): Implement a new structure for the processor

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2004,10 +2004,6 @@ impl EnvelopeProcessorService {
         sampling_project_info: Option<Arc<ProjectInfo>>,
         reservoir_counters: ReservoirCounters,
     ) -> Result<ProcessingResult, ProcessingError> {
-        // Get the group from the managed envelope context, and if it's not set, try to guess it
-        // from the contents of the envelope.
-        let group = managed_envelope.group();
-
         // Pre-process the envelope headers.
         if let Some(sampling_state) = sampling_project_info.as_ref() {
             // Both transactions and standalone span envelopes need a normalized DSC header
@@ -2031,6 +2027,10 @@ impl EnvelopeProcessorService {
             .envelope_mut()
             .meta_mut()
             .set_project_id(project_id);
+
+        // Get the group from the managed envelope context, and if it's not set, try to guess it
+        // from the contents of the envelope.
+        let group = managed_envelope.group();
 
         // If the group is supported by the new processing logic, we will use the new logic.
         if supports_new_processing(&group) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -52,9 +52,7 @@ use crate::services::global_config::GlobalConfigHandle;
 use crate::services::metrics::{Aggregator, FlushBuckets, MergeBuckets, ProjectBuckets};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::event::FiltersStatus;
-use crate::services::processor::groups::{
-    Group, GroupParams, GroupPayload, ProcessCheckIn, ProcessGroup,
-};
+use crate::services::processor::groups::{GroupParams, ProcessCheckIn, ProcessGroup};
 use crate::services::projects::cache::ProjectCacheHandle;
 use crate::services::projects::project::{ProjectInfo, ProjectState};
 use crate::services::test_store::{Capture, TestStore};
@@ -69,6 +67,7 @@ use crate::utils::{
 use relay_base_schema::organization::OrganizationId;
 #[cfg(feature = "processing")]
 use {
+    crate::services::processor::groups::{Group, GroupPayload},
     crate::services::store::{Store, StoreEnvelope},
     crate::utils::{CheckLimits, Enforcement, EnvelopeLimiter},
     itertools::Itertools,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -137,7 +137,7 @@ pub fn drop_unsampled_items(
     }
 
     // All items have been dropped, now make sure the event is also handled and dropped.
-    if let Some(category) = event_category(&event) {
+    if let Some(category) = event_category(event.value()) {
         let category = category.index_category().unwrap_or(category);
         managed_envelope.track_outcome(outcome, category, 1)
     }

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -266,7 +266,7 @@ pub fn finalize<Group: EventProcessing>(
     if let Some(timestamp) = event.value().and_then(|e| e.timestamp.value()) {
         let event_delay = managed_envelope.received_at() - timestamp.into_inner();
         if event_delay > SignedDuration::minutes(1) {
-            let category = event_category(event).unwrap_or(DataCategory::Unknown);
+            let category = event_category(event.value()).unwrap_or(DataCategory::Unknown);
             metric!(
                 timer(RelayTimers::TimestampDelay) = event_delay.to_std().unwrap(),
                 category = category.name(),
@@ -387,7 +387,7 @@ pub fn serialize<Group: EventProcessing>(
         event.to_json().map_err(ProcessingError::SerializeFailed)?
     });
 
-    let event_type = event_type(event).unwrap_or_default();
+    let event_type = event_type(event.value()).unwrap_or_default();
     let mut event_item = Item::new(ItemType::from_event_type(event_type));
     event_item.set_payload(ContentType::Json, data);
 

--- a/relay-server/src/services/processor/groups/base.rs
+++ b/relay-server/src/services/processor/groups/base.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+
+use relay_base_schema::project::ProjectId;
+use relay_event_schema::protocol::Event;
+use relay_quotas::RateLimits;
+
+use crate::services::processor::{InnerProcessor, ProcessingError, ProcessingExtractedMetrics};
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::{ManagedEnvelope, TypedEnvelope};
+
+/// A macro that creates a new processing group type and implements necessary traits.
+/// This macro reduces boilerplate code for creating new processing group types by automatically
+/// implementing the group trait and conversion traits to/from processing group.
+#[macro_export]
+macro_rules! group {
+    ($variant:ident, $ty:ident) => {
+        #[derive(Clone, Copy, Debug)]
+        pub struct $ty;
+
+        impl Group for $ty {}
+
+        impl From<$ty> for ProcessingGroup {
+            fn from(_: $ty) -> Self {
+                ProcessingGroup::$variant
+            }
+        }
+
+        impl TryFrom<ProcessingGroup> for $ty {
+            type Error = GroupTypeError;
+
+            fn try_from(value: ProcessingGroup) -> Result<Self, Self::Error> {
+                if matches!(value, ProcessingGroup::$variant) {
+                    return Ok($ty);
+                }
+                return Err(GroupTypeError);
+            }
+        }
+    };
+}
+
+/// A macro that creates a function to process specific group types.
+/// Takes pairs of (processing group, process group) identifiers and generates match arms for
+/// each.
+#[macro_export]
+macro_rules! build_process_group {
+    ($(($group:ident, $process_group:ident)),*) => {
+        pub fn supports_new_processing(group: &ProcessingGroup) -> bool {
+            $(matches!(group, ProcessingGroup::$group) ||)* false
+        }
+
+        pub fn process_group(
+            group: ProcessingGroup,
+            managed_envelope: ManagedEnvelope,
+            processor: Arc<InnerProcessor>,
+            project_info: Arc<ProjectInfo>,
+            project_id: ProjectId,
+            rate_limits: Arc<RateLimits>,
+        ) -> Result<ProcessingResult, ProcessingError> {
+                match group {
+                    $(
+                        ProcessingGroup::$group => {
+                            let mut managed_envelope = managed_envelope.try_into()?;
+                            let params = GroupParams {
+                                managed_envelope: &mut managed_envelope,
+                                processor: processor.clone(),
+                                rate_limits: rate_limits.clone(),
+                                project_info: project_info.clone(),
+                                project_id,
+                            };
+
+                            let group = $process_group::create(params);
+                            match group.process() {
+                                Ok(extracted_metrics) => Ok(ProcessingResult {
+                                    managed_envelope: managed_envelope.into_processed(),
+                                    extracted_metrics: extracted_metrics
+                                        .map_or(ProcessingExtractedMetrics::new(), |e| e),
+                                }),
+                                Err(error) => {
+                                    if let Some(outcome) = error.to_outcome() {
+                                        managed_envelope.reject(outcome);
+                                    }
+
+                                    return Err(error);
+                                }
+                            }
+                    }
+                )*
+                _ => {
+                    relay_log::error!("unknown processing group");
+
+                    Ok(ProcessingResult::no_metrics(
+                        managed_envelope.into_processed(),
+                    ))
+                }
+            }
+        }
+    };
+}
+
+/// A marker trait that identifies types which can be processed as groups.
+/// Types implementing this trait represent different categories of data that can be
+/// processed by Relay.
+pub trait Group {}
+
+/// Configuration parameters required to instantiate an instance of [`ProcessGroup`].
+/// Contains all necessary context and resources for processing group data.
+pub struct GroupParams<'a, G: Group> {
+    pub managed_envelope: &'a mut TypedEnvelope<G>,
+    pub processor: Arc<InnerProcessor>,
+    pub rate_limits: Arc<RateLimits>,
+    pub project_info: Arc<ProjectInfo>,
+    pub project_id: ProjectId,
+}
+
+/// Represents the payload data associated with a [`ProcessGroup`].
+/// Provides access to the managed envelope being processed and optional event data.
+/// This trait defines the core data structure that processing groups operate on.
+pub trait GroupPayload<'a, G: Group> {
+    /// Gets a mutable reference to the [`ManagedEnvelope`] being processed.
+    #[allow(dead_code)]
+    fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope;
+
+    /// Gets a reference to the [`ManagedEnvelope`] being processed.
+    #[allow(dead_code)]
+    fn managed_envelope(&self) -> &ManagedEnvelope;
+
+    /// Gets a reference to the [`Event`] data if it exists.
+    #[allow(dead_code)]
+    fn event(&self) -> Option<&Event>;
+
+    /// Removes the [`Event`] data from the payload.
+    #[allow(dead_code)]
+    fn remove_event(&mut self);
+}
+
+/// Defines the processing behavior for a specific group type.
+/// Types implementing this trait represent the actual processing logic for different
+/// kinds of data that flow through Relay.
+pub trait ProcessGroup<'a> {
+    /// The group of this processing group.
+    /// Must implement [`Group`].
+    type Group: Group;
+
+    /// The payload type associated with this processing group.
+    /// Must implement [`GroupPayload`].
+    type Payload: GroupPayload<'a, Self::Group>;
+
+    /// Creates a new instance of the processing group with the given [`GroupParams`].
+    fn create(params: GroupParams<'a, Self::Group>) -> Self;
+
+    /// Processes the group data and returns extracted metrics if any.
+    ///
+    /// Returns a [`Result`] containing optional [`ProcessingExtractedMetrics`] or a
+    /// [`ProcessingError`].
+    fn process(self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError>;
+}

--- a/relay-server/src/services/processor/groups/check_in.rs
+++ b/relay-server/src/services/processor/groups/check_in.rs
@@ -61,10 +61,13 @@ impl ProcessCheckIn<'_> {
     }
 }
 
-impl<'a> ProcessGroup<'a, CheckIn> for ProcessCheckIn<'a> {
-    type Payload = BasePayload<'a, CheckIn>;
+impl<'a> ProcessGroup<'a> for ProcessCheckIn<'a> {
+    
+    type Group = CheckIn;
+    
+    type Payload = BasePayload<'a, Self::Group>;
 
-    fn create(params: GroupParams<'a, CheckIn>) -> Self {
+    fn create(params: GroupParams<'a, Self::Group>) -> Self {
         Self {
             payload: Self::Payload::no_event(params.managed_envelope),
             processor: params.processor,

--- a/relay-server/src/services/processor/groups/check_in.rs
+++ b/relay-server/src/services/processor/groups/check_in.rs
@@ -1,27 +1,35 @@
-use crate::envelope::{ContentType, ItemType};
-#[cfg(feature = "processing")]
-use crate::services::processor::enforce_quotas;
+use std::sync::Arc;
+
+use relay_base_schema::project::ProjectId;
+use relay_quotas::RateLimits;
+
 use crate::services::processor::groups::payload::BasePayload;
-use crate::services::processor::groups::{Group, GroupParams, GroupPayload, ProcessGroup};
+use crate::services::processor::groups::{Group, GroupParams, ProcessGroup};
 use crate::services::processor::GroupTypeError;
 use crate::services::processor::{
     InnerProcessor, ProcessingError, ProcessingExtractedMetrics, ProcessingGroup,
 };
 use crate::services::projects::project::ProjectInfo;
-use crate::utils::ItemAction;
 use crate::{group, if_processing};
-use relay_base_schema::project::ProjectId;
-use relay_quotas::RateLimits;
-use std::error::Error;
-use std::sync::Arc;
+#[cfg(feature = "processing")]
+use {
+    crate::envelope::ContentType, crate::envelope::ItemType,
+    crate::services::processor::enforce_quotas, crate::services::processor::groups::GroupPayload,
+    crate::utils::ItemAction, std::error::Error,
+};
 
 group!(CheckIn, CheckIn);
 
 pub struct ProcessCheckIn<'a> {
+    #[allow(dead_code)]
     payload: BasePayload<'a, CheckIn>,
+    #[allow(dead_code)]
     processor: Arc<InnerProcessor>,
+    #[allow(dead_code)]
     rate_limits: Arc<RateLimits>,
+    #[allow(dead_code)]
     project_info: Arc<ProjectInfo>,
+    #[allow(dead_code)]
     project_id: ProjectId,
 }
 
@@ -66,7 +74,9 @@ impl<'a> ProcessGroup<'a, CheckIn> for ProcessCheckIn<'a> {
         }
     }
 
-    fn process(mut self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
+    fn process(
+        #[allow(unused_mut)] mut self,
+    ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         #[allow(unused_mut)]
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 

--- a/relay-server/src/services/processor/groups/check_in.rs
+++ b/relay-server/src/services/processor/groups/check_in.rs
@@ -18,11 +18,11 @@ use {
     crate::utils::ItemAction, std::error::Error,
 };
 
-group!(CheckIn, CheckIn);
+group!(CheckIn, CheckInGroup);
 
 pub struct ProcessCheckIn<'a> {
     #[allow(dead_code)]
-    payload: BasePayload<'a, CheckIn>,
+    payload: BasePayload<'a, CheckInGroup>,
     #[allow(dead_code)]
     processor: Arc<InnerProcessor>,
     #[allow(dead_code)]
@@ -62,7 +62,7 @@ impl ProcessCheckIn<'_> {
 }
 
 impl<'a> ProcessGroup<'a> for ProcessCheckIn<'a> {
-    type Group = CheckIn;
+    type Group = CheckInGroup;
 
     type Payload = BasePayload<'a, Self::Group>;
 

--- a/relay-server/src/services/processor/groups/check_in.rs
+++ b/relay-server/src/services/processor/groups/check_in.rs
@@ -1,0 +1,83 @@
+use crate::envelope::{ContentType, ItemType};
+use crate::if_processing;
+#[cfg(feature = "processing")]
+use crate::services::processor::enforce_quotas;
+use crate::services::processor::groups::payload::DefaultPayload;
+use crate::services::processor::groups::{Group, GroupParams, GroupPayload};
+use crate::services::processor::{InnerProcessor, ProcessingError, ProcessingExtractedMetrics};
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::ItemAction;
+use relay_base_schema::project::ProjectId;
+use relay_quotas::RateLimits;
+use std::error::Error;
+use std::sync::Arc;
+
+pub struct CheckInGroup<'a> {
+    payload: DefaultPayload<'a>,
+    processor: Arc<InnerProcessor>,
+    rate_limits: Arc<RateLimits>,
+    project_info: Arc<ProjectInfo>,
+    project_id: ProjectId,
+}
+
+impl<'a> CheckInGroup<'a> {
+    /// Normalize monitor check-ins and remove invalid ones.
+    #[cfg(feature = "processing")]
+    fn normalize_check_ins(&mut self) {
+        self.payload.managed_envelope_mut().retain_items(|item| {
+            if item.ty() != &ItemType::CheckIn {
+                return ItemAction::Keep;
+            }
+
+            match relay_monitors::process_check_in(&item.payload(), self.project_id) {
+                Ok(result) => {
+                    item.set_routing_hint(result.routing_hint);
+                    item.set_payload(ContentType::Json, result.payload);
+                    ItemAction::Keep
+                }
+                Err(error) => {
+                    // TODO: Track an outcome.
+                    relay_log::debug!(
+                        error = &error as &dyn Error,
+                        "dropped invalid monitor check-in"
+                    );
+                    ItemAction::DropSilently
+                }
+            }
+        })
+    }
+}
+
+impl<'a> Group<'a> for CheckInGroup<'a> {
+    type Payload = DefaultPayload<'a>;
+
+    fn create(params: GroupParams<'a>) -> Self {
+        Self {
+            payload: Self::Payload::no_event(params.managed_envelope),
+            processor: params.processor,
+            rate_limits: params.rate_limits,
+            project_info: params.project_info,
+            project_id: params.project_id,
+        }
+    }
+
+    fn process(mut self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
+        #[allow(unused_mut)]
+        let mut extracted_metrics = ProcessingExtractedMetrics::new();
+
+        if_processing!(self.processor.config, {
+            enforce_quotas::<Self>(
+                &mut self.payload,
+                &mut extracted_metrics,
+                self.processor.global_config.current().as_ref(),
+                self.processor.rate_limiter.as_ref(),
+                self.rate_limits.as_ref(),
+                &self.processor.project_cache,
+                self.project_info.as_ref(),
+            )?;
+            self.normalize_check_ins();
+        });
+
+        Ok(Some(extracted_metrics))
+    }
+}

--- a/relay-server/src/services/processor/groups/check_in.rs
+++ b/relay-server/src/services/processor/groups/check_in.rs
@@ -62,9 +62,8 @@ impl ProcessCheckIn<'_> {
 }
 
 impl<'a> ProcessGroup<'a> for ProcessCheckIn<'a> {
-    
     type Group = CheckIn;
-    
+
     type Payload = BasePayload<'a, Self::Group>;
 
     fn create(params: GroupParams<'a, Self::Group>) -> Self {

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -83,11 +83,10 @@ pub trait GroupPayload<'a, G: Group> {
 /// Types implementing this trait represent the actual processing logic for different
 /// kinds of data that flow through Relay.
 pub trait ProcessGroup<'a> {
-    
     /// The group of this processing group.
     /// Must implement [`Group`].
     type Group: Group;
-    
+
     /// The payload type associated with this processing group.
     /// Must implement [`GroupPayload`].
     type Payload: GroupPayload<'a, Self::Group>;

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -1,17 +1,21 @@
-use crate::services::processor::{InnerProcessor, ProcessingError, ProcessingExtractedMetrics};
-use crate::services::projects::project::ProjectInfo;
-use crate::utils::{ManagedEnvelope, TypedEnvelope};
+use std::sync::Arc;
+
 use relay_base_schema::project::ProjectId;
 use relay_event_schema::protocol::Event;
 use relay_quotas::RateLimits;
-use std::sync::Arc;
+
+use crate::services::processor::{InnerProcessor, ProcessingError, ProcessingExtractedMetrics};
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::{ManagedEnvelope, TypedEnvelope};
 
 mod check_in;
 mod payload;
 
 pub use check_in::ProcessCheckIn;
 
-/// Creates a group that can be bound to a [`ProcessGroup`].
+/// A macro that creates a new processing group type and implements necessary traits.
+/// This macro reduces boilerplate code for creating new processing group types by automatically
+/// implementing the group trait and conversion traits to/from processing group.
 #[macro_export]
 macro_rules! group {
     ($ty:ident, $variant:ident) => {
@@ -39,8 +43,13 @@ macro_rules! group {
     };
 }
 
+/// A marker trait that identifies types which can be processed as groups.
+/// Types implementing this trait represent different categories of data that can be
+/// processed by Relay.
 pub trait Group {}
 
+/// Configuration parameters required to instantiate an instance of [`ProcessGroup`].
+/// Contains all necessary context and resources for processing group data.
 pub struct GroupParams<'a, G: Group> {
     pub managed_envelope: &'a mut TypedEnvelope<G>,
     pub processor: Arc<InnerProcessor>,
@@ -49,20 +58,41 @@ pub struct GroupParams<'a, G: Group> {
     pub project_id: ProjectId,
 }
 
-pub trait GroupPayload<'a, Group> {
+/// Represents the payload data associated with a [`ProcessGroup`].
+/// Provides access to the managed envelope being processed and optional event data.
+/// This trait defines the core data structure that processing groups operate on.
+pub trait GroupPayload<'a, G: Group> {
+    /// Gets a mutable reference to the [`ManagedEnvelope`] being processed.
+    #[allow(dead_code)]
     fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope;
 
+    /// Gets a reference to the [`ManagedEnvelope`] being processed.
+    #[allow(dead_code)]
     fn managed_envelope(&self) -> &ManagedEnvelope;
 
+    /// Gets a reference to the [`Event`] data if it exists.
+    #[allow(dead_code)]
     fn event(&self) -> Option<&Event>;
 
+    /// Removes the [`Event`] data from the payload.
+    #[allow(dead_code)]
     fn remove_event(&mut self);
 }
 
+/// Defines the processing behavior for a specific group type.
+/// Types implementing this trait represent the actual processing logic for different
+/// kinds of data that flow through Relay.
 pub trait ProcessGroup<'a, G: Group> {
+    /// The payload type associated with this processing group.
+    /// Must implement [`GroupPayload`].
     type Payload: GroupPayload<'a, G>;
 
+    /// Creates a new instance of the processing group with the given [`GroupParams`].
     fn create(params: GroupParams<'a, G>) -> Self;
 
+    /// Processes the group data and returns extracted metrics if any.
+    ///
+    /// Returns a [`Result`] containing optional [`ProcessingExtractedMetrics`] or a
+    /// [`ProcessingError`].
     fn process(self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError>;
 }

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -82,13 +82,18 @@ pub trait GroupPayload<'a, G: Group> {
 /// Defines the processing behavior for a specific group type.
 /// Types implementing this trait represent the actual processing logic for different
 /// kinds of data that flow through Relay.
-pub trait ProcessGroup<'a, G: Group> {
+pub trait ProcessGroup<'a> {
+    
+    /// The group of this processing group.
+    /// Must implement [`Group`].
+    type Group: Group;
+    
     /// The payload type associated with this processing group.
     /// Must implement [`GroupPayload`].
-    type Payload: GroupPayload<'a, G>;
+    type Payload: GroupPayload<'a, Self::Group>;
 
     /// Creates a new instance of the processing group with the given [`GroupParams`].
-    fn create(params: GroupParams<'a, G>) -> Self;
+    fn create(params: GroupParams<'a, Self::Group>) -> Self;
 
     /// Processes the group data and returns extracted metrics if any.
     ///

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -1,6 +1,6 @@
 use crate::services::processor::{InnerProcessor, ProcessingError, ProcessingExtractedMetrics};
 use crate::services::projects::project::ProjectInfo;
-use crate::utils::ManagedEnvelope;
+use crate::utils::{ManagedEnvelope, TypedEnvelope};
 use relay_base_schema::project::ProjectId;
 use relay_event_schema::protocol::Event;
 use relay_quotas::RateLimits;
@@ -9,33 +9,60 @@ use std::sync::Arc;
 mod check_in;
 mod payload;
 
-pub use check_in::CheckInGroup;
-pub use payload::DefaultPayload;
+pub use check_in::ProcessCheckIn;
 
-pub struct GroupParams<'a> {
-    pub managed_envelope: &'a mut ManagedEnvelope,
+/// Creates a group that can be bound to a [`ProcessGroup`].
+#[macro_export]
+macro_rules! group {
+    ($ty:ident, $variant:ident) => {
+        #[derive(Clone, Copy, Debug)]
+        pub struct $ty;
+
+        impl Group for $ty {}
+
+        impl From<$ty> for ProcessingGroup {
+            fn from(_: $ty) -> Self {
+                ProcessingGroup::$variant
+            }
+        }
+
+        impl TryFrom<ProcessingGroup> for $ty {
+            type Error = GroupTypeError;
+
+            fn try_from(value: ProcessingGroup) -> Result<Self, Self::Error> {
+                if matches!(value, ProcessingGroup::$variant) {
+                    return Ok($ty);
+                }
+                return Err(GroupTypeError);
+            }
+        }
+    };
+}
+
+pub trait Group {}
+
+pub struct GroupParams<'a, G: Group> {
+    pub managed_envelope: &'a mut TypedEnvelope<G>,
     pub processor: Arc<InnerProcessor>,
     pub rate_limits: Arc<RateLimits>,
     pub project_info: Arc<ProjectInfo>,
     pub project_id: ProjectId,
 }
 
-pub trait GroupPayload<'a> {
+pub trait GroupPayload<'a, Group> {
     fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope;
 
     fn managed_envelope(&self) -> &ManagedEnvelope;
-
-    fn event_mut(&mut self) -> Option<&mut Event>;
 
     fn event(&self) -> Option<&Event>;
 
     fn remove_event(&mut self);
 }
 
-pub trait Group<'a>: Sized {
-    type Payload: GroupPayload<'a>;
+pub trait ProcessGroup<'a, G: Group> {
+    type Payload: GroupPayload<'a, G>;
 
-    fn create(params: GroupParams<'a>) -> Self;
+    fn create(params: GroupParams<'a, G>) -> Self;
 
     fn process(self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError>;
 }

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -20,7 +20,7 @@ pub use check_in::ProcessCheckIn;
 /// implementing the group trait and conversion traits to/from processing group.
 #[macro_export]
 macro_rules! group {
-    ($ty:ident, $variant:ident) => {
+    ($variant:ident, $ty:ident) => {
         #[derive(Clone, Copy, Debug)]
         pub struct $ty;
 

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -1,0 +1,41 @@
+use crate::services::processor::{InnerProcessor, ProcessingError, ProcessingExtractedMetrics};
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::ManagedEnvelope;
+use relay_base_schema::project::ProjectId;
+use relay_event_schema::protocol::Event;
+use relay_quotas::RateLimits;
+use std::sync::Arc;
+
+mod check_in;
+mod payload;
+
+pub use check_in::CheckInGroup;
+pub use payload::DefaultPayload;
+
+pub struct GroupParams<'a> {
+    pub managed_envelope: &'a mut ManagedEnvelope,
+    pub processor: Arc<InnerProcessor>,
+    pub rate_limits: Arc<RateLimits>,
+    pub project_info: Arc<ProjectInfo>,
+    pub project_id: ProjectId,
+}
+
+pub trait GroupPayload<'a> {
+    fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope;
+
+    fn managed_envelope(&self) -> &ManagedEnvelope;
+
+    fn event_mut(&mut self) -> Option<&mut Event>;
+
+    fn event(&self) -> Option<&Event>;
+
+    fn remove_event(&mut self);
+}
+
+pub trait Group<'a>: Sized {
+    type Payload: GroupPayload<'a>;
+
+    fn create(params: GroupParams<'a>) -> Self;
+
+    fn process(self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError>;
+}

--- a/relay-server/src/services/processor/groups/mod.rs
+++ b/relay-server/src/services/processor/groups/mod.rs
@@ -1,166 +1,84 @@
+//! How to create a new processing group:
+//!
+//! 1. Create a new module file for your group (e.g., `my_group.rs`)
+//!
+//! 2. Define your group type and implement necessary traits:
+//!    ```text
+//!    use crate::group;
+//!
+//!    // This creates MyGroup struct and implements required traits
+//!    group!(MyGroup, MyGroupType);
+//!    ```
+//!
+//! 3. Create a processing implementation:
+//!    ```text
+//!    pub struct ProcessMyGroup<'a> {
+//!        payload: BasePayload<'a, MyGroupType>,
+//!        processor: Arc<InnerProcessor>,
+//!        rate_limits: Arc<RateLimits>,
+//!        project_info: Arc<ProjectInfo>,
+//!        project_id: ProjectId,
+//!    }
+//!
+//!    impl<'a> ProcessGroup<'a> for ProcessMyGroup<'a> {
+//!        type Group = MyGroupType;
+//!        type Payload = BasePayload<'a, Self::Group>;
+//!
+//!        fn create(params: GroupParams<'a, Self::Group>) -> Self {
+//!            Self {
+//!                payload: Self::Payload::no_event(params.managed_envelope),
+//!                processor: params.processor,
+//!                rate_limits: params.rate_limits,
+//!                project_info: params.project_info,
+//!                project_id: params.project_id,
+//!            }
+//!        }
+//!
+//!        fn process(self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
+//!            // Implement your processing logic here
+//!        }
+//!    }
+//!    ```
+//!
+//! 4. Add your group to ProcessingGroup enum in processor.rs:
+//!    ```text
+//!    pub enum ProcessingGroup {
+//!        MyGroup,
+//!        // ... other variants
+//!    }
+//!    ```
+//!
+//! 5. Register your group in this macro call:
+//!    ```text
+//!    build_process_group!((MyGroup, ProcessMyGroup));
+//!    ```
+//!
+//! The macro will automatically:
+//! - Create a function to check if the group supports new processing
+//! - Generate the processing logic to handle your group type
+//! - Wire up error handling and metrics extraction
+
 use std::sync::Arc;
 
 use relay_base_schema::project::ProjectId;
-use relay_event_schema::protocol::Event;
 use relay_quotas::RateLimits;
 
+use crate::build_process_group;
+use crate::services::processor::groups::check_in::ProcessCheckIn;
+use crate::services::processor::InnerProcessor;
 use crate::services::processor::{
-    InnerProcessor, ProcessingError, ProcessingExtractedMetrics, ProcessingGroup, ProcessingResult,
+    ProcessingError, ProcessingExtractedMetrics, ProcessingGroup, ProcessingResult,
 };
 use crate::services::projects::project::ProjectInfo;
-use crate::utils::{ManagedEnvelope, TypedEnvelope};
+use crate::utils::ManagedEnvelope;
 
+mod base;
 mod check_in;
 mod payload;
 
-pub use check_in::ProcessCheckIn;
+pub use base::*;
 
-/// A macro that creates a new processing group type and implements necessary traits.
-/// This macro reduces boilerplate code for creating new processing group types by automatically
-/// implementing the group trait and conversion traits to/from processing group.
-#[macro_export]
-macro_rules! group {
-    ($variant:ident, $ty:ident) => {
-        #[derive(Clone, Copy, Debug)]
-        pub struct $ty;
-
-        impl Group for $ty {}
-
-        impl From<$ty> for ProcessingGroup {
-            fn from(_: $ty) -> Self {
-                ProcessingGroup::$variant
-            }
-        }
-
-        impl TryFrom<ProcessingGroup> for $ty {
-            type Error = GroupTypeError;
-
-            fn try_from(value: ProcessingGroup) -> Result<Self, Self::Error> {
-                if matches!(value, ProcessingGroup::$variant) {
-                    return Ok($ty);
-                }
-                return Err(GroupTypeError);
-            }
-        }
-    };
-}
-
-/// A macro that creates a function to process specific group types.
-/// Takes pairs of ([`ProcessingGroup`], [`ProcessGroup`]) identifiers and generates match arms for
-/// each.
-macro_rules! build_process_group {
-    ($(($group:ident, $process_group:ident)),* $(,)?) => {
-        pub fn supports_new_processing(group: &ProcessingGroup) -> bool {
-            $(matches!(group, ProcessingGroup::$group) ||)* false
-        }
-
-        pub fn process_group(
-            group: ProcessingGroup,
-            managed_envelope: ManagedEnvelope,
-            processor: Arc<InnerProcessor>,
-            project_info: Arc<ProjectInfo>,
-            project_id: ProjectId,
-            rate_limits: Arc<RateLimits>,
-        ) -> Result<ProcessingResult, ProcessingError> {
-                match group {
-                    $(
-                        ProcessingGroup::$group => {
-                            let mut managed_envelope = managed_envelope.try_into()?;
-                            let params = GroupParams {
-                                managed_envelope: &mut managed_envelope,
-                                processor: processor.clone(),
-                                rate_limits: rate_limits.clone(),
-                                project_info: project_info.clone(),
-                                project_id,
-                            };
-
-                            let group = $process_group::create(params);
-                            match group.process() {
-                                Ok(extracted_metrics) => Ok(ProcessingResult {
-                                    managed_envelope: managed_envelope.into_processed(),
-                                    extracted_metrics: extracted_metrics
-                                        .map_or(ProcessingExtractedMetrics::new(), |e| e),
-                                }),
-                                Err(error) => {
-                                    if let Some(outcome) = error.to_outcome() {
-                                        managed_envelope.reject(outcome);
-                                    }
-
-                                    return Err(error);
-                                }
-                            }
-                    }
-                )*
-                _ => {
-                    relay_log::error!("unknown processing group");
-
-                    Ok(ProcessingResult::no_metrics(
-                        managed_envelope.into_processed(),
-                    ))
-                }
-            }
-        }
-    };
-}
-
-/// A marker trait that identifies types which can be processed as groups.
-/// Types implementing this trait represent different categories of data that can be
-/// processed by Relay.
-pub trait Group {}
-
-/// Configuration parameters required to instantiate an instance of [`ProcessGroup`].
-/// Contains all necessary context and resources for processing group data.
-pub struct GroupParams<'a, G: Group> {
-    pub managed_envelope: &'a mut TypedEnvelope<G>,
-    pub processor: Arc<InnerProcessor>,
-    pub rate_limits: Arc<RateLimits>,
-    pub project_info: Arc<ProjectInfo>,
-    pub project_id: ProjectId,
-}
-
-/// Represents the payload data associated with a [`ProcessGroup`].
-/// Provides access to the managed envelope being processed and optional event data.
-/// This trait defines the core data structure that processing groups operate on.
-pub trait GroupPayload<'a, G: Group> {
-    /// Gets a mutable reference to the [`ManagedEnvelope`] being processed.
-    #[allow(dead_code)]
-    fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope;
-
-    /// Gets a reference to the [`ManagedEnvelope`] being processed.
-    #[allow(dead_code)]
-    fn managed_envelope(&self) -> &ManagedEnvelope;
-
-    /// Gets a reference to the [`Event`] data if it exists.
-    #[allow(dead_code)]
-    fn event(&self) -> Option<&Event>;
-
-    /// Removes the [`Event`] data from the payload.
-    #[allow(dead_code)]
-    fn remove_event(&mut self);
-}
-
-/// Defines the processing behavior for a specific group type.
-/// Types implementing this trait represent the actual processing logic for different
-/// kinds of data that flow through Relay.
-pub trait ProcessGroup<'a> {
-    /// The group of this processing group.
-    /// Must implement [`Group`].
-    type Group: Group;
-
-    /// The payload type associated with this processing group.
-    /// Must implement [`GroupPayload`].
-    type Payload: GroupPayload<'a, Self::Group>;
-
-    /// Creates a new instance of the processing group with the given [`GroupParams`].
-    fn create(params: GroupParams<'a, Self::Group>) -> Self;
-
-    /// Processes the group data and returns extracted metrics if any.
-    ///
-    /// Returns a [`Result`] containing optional [`ProcessingExtractedMetrics`] or a
-    /// [`ProcessingError`].
-    fn process(self) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError>;
-}
-
-// Invocation of the macro which generates the code for statically dispatching the processing to
-// the respective processing functions.
+// Macro invocation for the function that wires up processing.
+//
+// Add here any (ProcessingGroup -> ProcessGroup) mappings.
 build_process_group!((CheckIn, ProcessCheckIn));

--- a/relay-server/src/services/processor/groups/payload.rs
+++ b/relay-server/src/services/processor/groups/payload.rs
@@ -1,43 +1,29 @@
-use crate::services::processor::groups::GroupPayload;
-use crate::utils::ManagedEnvelope;
+use crate::services::processor::groups::{Group, GroupPayload};
+use crate::utils::{ManagedEnvelope, TypedEnvelope};
 use relay_event_schema::protocol::Event;
 use relay_protocol::Annotated;
 
-pub struct DefaultPayload<'a> {
-    managed_envelope: &'a mut ManagedEnvelope,
+pub struct BasePayload<'a, G: Group> {
+    managed_envelope: &'a mut TypedEnvelope<G>,
     event: Option<&'a mut Annotated<Event>>,
 }
 
-impl<'a> DefaultPayload<'a> {
-    pub fn no_event(managed_envelope: &'a mut ManagedEnvelope) -> Self {
+impl<'a, G: Group> BasePayload<'a, G> {
+    pub fn no_event(managed_envelope: &'a mut TypedEnvelope<G>) -> Self {
         Self {
             managed_envelope,
             event: None,
         }
     }
-
-    pub fn with_event(
-        managed_envelope: &'a mut ManagedEnvelope,
-        event: &'a mut Annotated<Event>,
-    ) -> Self {
-        Self {
-            managed_envelope,
-            event: Some(event),
-        }
-    }
 }
 
-impl<'a> GroupPayload<'a> for DefaultPayload<'a> {
+impl<'a, G: Group> GroupPayload<'a, G> for BasePayload<'a, G> {
     fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope {
         self.managed_envelope
     }
 
     fn managed_envelope(&self) -> &ManagedEnvelope {
         self.managed_envelope
-    }
-
-    fn event_mut(&mut self) -> Option<&mut Event> {
-        self.event.as_mut().and_then(|e| e.value_mut().as_mut())
     }
 
     fn event(&self) -> Option<&Event> {

--- a/relay-server/src/services/processor/groups/payload.rs
+++ b/relay-server/src/services/processor/groups/payload.rs
@@ -3,12 +3,19 @@ use crate::utils::{ManagedEnvelope, TypedEnvelope};
 use relay_event_schema::protocol::Event;
 use relay_protocol::Annotated;
 
+/// A base implementation of a payload that can be processed by a group processor.
+///
+/// This struct holds a reference to a typed envelope and an optional event. It provides
+/// the basic functionality required by the [`GroupPayload`] trait.
 pub struct BasePayload<'a, G: Group> {
     managed_envelope: &'a mut TypedEnvelope<G>,
     event: Option<&'a mut Annotated<Event>>,
 }
 
 impl<'a, G: Group> BasePayload<'a, G> {
+    /// Creates a new [`BasePayload`] without an event.
+    ///
+    /// This is useful when processing envelopes that don't contain event data.
     pub fn no_event(managed_envelope: &'a mut TypedEnvelope<G>) -> Self {
         Self {
             managed_envelope,

--- a/relay-server/src/services/processor/groups/payload.rs
+++ b/relay-server/src/services/processor/groups/payload.rs
@@ -1,0 +1,50 @@
+use crate::services::processor::groups::GroupPayload;
+use crate::utils::ManagedEnvelope;
+use relay_event_schema::protocol::Event;
+use relay_protocol::Annotated;
+
+pub struct DefaultPayload<'a> {
+    managed_envelope: &'a mut ManagedEnvelope,
+    event: Option<&'a mut Annotated<Event>>,
+}
+
+impl<'a> DefaultPayload<'a> {
+    pub fn no_event(managed_envelope: &'a mut ManagedEnvelope) -> Self {
+        Self {
+            managed_envelope,
+            event: None,
+        }
+    }
+
+    pub fn with_event(
+        managed_envelope: &'a mut ManagedEnvelope,
+        event: &'a mut Annotated<Event>,
+    ) -> Self {
+        Self {
+            managed_envelope,
+            event: Some(event),
+        }
+    }
+}
+
+impl<'a> GroupPayload<'a> for DefaultPayload<'a> {
+    fn managed_envelope_mut(&mut self) -> &mut ManagedEnvelope {
+        self.managed_envelope
+    }
+
+    fn managed_envelope(&self) -> &ManagedEnvelope {
+        self.managed_envelope
+    }
+
+    fn event_mut(&mut self) -> Option<&mut Event> {
+        self.event.as_mut().and_then(|e| e.value_mut().as_mut())
+    }
+
+    fn event(&self) -> Option<&Event> {
+        self.event.as_ref().and_then(|e| e.value())
+    }
+
+    fn remove_event(&mut self) {
+        self.event = None;
+    }
+}

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -28,7 +28,7 @@ pub fn filter<Group>(
     project_info: Arc<ProjectInfo>,
 ) -> Option<ProfileId> {
     let profiling_disabled = should_filter(&config, &project_info, Feature::Profiling);
-    let has_transaction = event_type(event) == Some(EventType::Transaction);
+    let has_transaction = event_type(event.value()) == Some(EventType::Transaction);
     let keep_unsampled_profiles = true;
 
     let mut profile_id = None;

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -280,7 +280,7 @@ pub fn extract_from_event(
     spans_extracted: SpansExtracted,
 ) -> SpansExtracted {
     // Only extract spans from transactions (not errors).
-    if event_type(event) != Some(EventType::Transaction) {
+    if event_type(event.value()) != Some(EventType::Transaction) {
         return spans_extracted;
     };
 
@@ -403,7 +403,7 @@ pub fn maybe_discard_transaction(
     event: Annotated<Event>,
     project_info: Arc<ProjectInfo>,
 ) -> Annotated<Event> {
-    if event_type(&event) == Some(EventType::Transaction)
+    if event_type(event.value()) == Some(EventType::Transaction)
         && project_info.has_feature(Feature::DiscardTransaction)
     {
         managed_envelope.update();

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -81,9 +81,9 @@ impl Display for InvalidProcessingGroupType {
 impl std::error::Error for InvalidProcessingGroupType {}
 
 /// A wrapper for [`ManagedEnvelope`] with assigned processing group type.
-pub struct TypedEnvelope<G>(ManagedEnvelope, PhantomData<G>);
+pub struct TypedEnvelope<Group>(ManagedEnvelope, PhantomData<Group>);
 
-impl<G> TypedEnvelope<G> {
+impl<Group> TypedEnvelope<Group> {
     /// Changes the typed of the current envelope to processed.
     ///
     /// Once it's marked processed it can be submitted to upstream.
@@ -104,8 +104,8 @@ impl<G> TypedEnvelope<G> {
     ///
     /// Note: this method is private to make sure that only `TryFrom` implementation is used, which
     /// requires the check for the error if conversion is failing.
-    fn new(managed_envelope: ManagedEnvelope, _ty: G) -> Self {
-        Self(managed_envelope, PhantomData::<G> {})
+    pub fn new(managed_envelope: ManagedEnvelope, _ty: Group) -> Self {
+        Self(managed_envelope, PhantomData::<Group> {})
     }
 }
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -81,9 +81,9 @@ impl Display for InvalidProcessingGroupType {
 impl std::error::Error for InvalidProcessingGroupType {}
 
 /// A wrapper for [`ManagedEnvelope`] with assigned processing group type.
-pub struct TypedEnvelope<Group>(ManagedEnvelope, PhantomData<Group>);
+pub struct TypedEnvelope<G>(ManagedEnvelope, PhantomData<G>);
 
-impl<Group> TypedEnvelope<Group> {
+impl<G> TypedEnvelope<G> {
     /// Changes the typed of the current envelope to processed.
     ///
     /// Once it's marked processed it can be submitted to upstream.
@@ -104,8 +104,8 @@ impl<Group> TypedEnvelope<Group> {
     ///
     /// Note: this method is private to make sure that only `TryFrom` implementation is used, which
     /// requires the check for the error if conversion is failing.
-    fn new(managed_envelope: ManagedEnvelope, _ty: Group) -> Self {
-        Self(managed_envelope, PhantomData::<Group> {})
+    fn new(managed_envelope: ManagedEnvelope, _ty: G) -> Self {
+        Self(managed_envelope, PhantomData::<G> {})
     }
 }
 

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -104,7 +104,7 @@ impl<Group> TypedEnvelope<Group> {
     ///
     /// Note: this method is private to make sure that only `TryFrom` implementation is used, which
     /// requires the check for the error if conversion is failing.
-    pub fn new(managed_envelope: ManagedEnvelope, _ty: Group) -> Self {
+    fn new(managed_envelope: ManagedEnvelope, _ty: Group) -> Self {
         Self(managed_envelope, PhantomData::<Group> {})
     }
 }


### PR DESCRIPTION
This PR introduces a new processor structure, currently implemented for check-ins only.

The new structure has the following goals:
* Each processing group is defined in its own file. The file should contain the processing logic and all the methods specific to that group.
* Shared processing functions should be placed in the common folder inside groups.
* The state of each group is built from a common set of parameters, with the state clearly defined for each processing group. This makes it easy to understand the functionality of each group.
* All processing functions now use a `GroupPayload` abstraction, which abstracts away whether the function operates on the `ManagedEnvelope` and the `Event` or only the `ManagedEnvelope`.
* Dispatch of processing is done statically via a macro, which requires pairs of `ProcessingGroup` -> `ProcessGroup`.
* The processor will have less and less code that will be moved into each individual group.

Upcoming work:
* Continue porting processing groups to the new structure and move the group specific functions into their own group within `groups`.
* Move `ProcessingGroup` into the groups module in addition to other structs.
* Refine the abstractions further, if necessary.