### PR TITLE
ref(spooler): Remove the spool command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Remove the `spool` command from Relay. ([#4423](https://github.com/getsentry/relay/pull/4423))
+
 ## 24.12.1
 
 **Bug Fixes**:

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -306,36 +306,4 @@ pub fn make_app() -> Command {
                         ),
                 ),
         )
-        .subcommand(
-            Command::new("spool")
-                .about("Manage the spool file")
-                .after_help(
-                    "This comand provides basic spool management. \
-                    It can be used for checking spooled data, cleaning up the spool file."
-                )
-                .subcommand_required(true)
-                .subcommand(
-                    Command::new("clear")
-                        .about("Remove the spooled data from the spool file")
-                        .after_help(
-                            "This deletes all the spooled on-disk data."
-                        )
-                        .arg(
-                            Arg::new("path")
-                            .short('p')
-                            .long("path")
-                            .help(
-                                "Path to the spool file. \
-                                This option overwrites the value from the config file."
-                            )
-                        )
-                        .arg(
-                            Arg::new("force")
-                            .short('f')
-                            .long("force")
-                            .help("Run without confirmation")
-                            .action(clap::ArgAction::SetTrue)
-                        )
-                )
-        )
 }


### PR DESCRIPTION
This PR removes the `spool` command which is not needed anymore since the introduction of spooler v2.