### PR TITLE
feat(devservices): Add devservices config validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,24 +74,23 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
-
-files-changed:
-  name: detect what files changed
-  runs-on: ubuntu-24.04
-  timeout-minutes: 3
-  outputs:
-    devservices-files-changed: ${{ steps.changes.outputs.devservices-files-changed }}
-  steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-      name: Check for file changes
-      id: changes
-      with:
-        token: ${{ github.token }}
-        filters: |
-          devservices-files-changed:
-            - 'devservices/**'
-            - '.github/workflows/ci.yml'
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    outputs:
+      devservices-files-changed: ${{ steps.changes.outputs.devservices-files-changed }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        name: Check for file changes
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: |
+            devservices-files-changed:
+              - 'devservices/**'
+              - '.github/workflows/ci.yml'
 
   test:
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
   validate-devservices-config:
       runs-on: ubuntu-24.04
       needs: files-changed
-      if: ${{ needs.files-changed.outputs.devservices_files_changed == 'true' }}
+      if: ${{ needs.files-changed.outputs.devservices-files-changed == 'true' }}
       steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
-  files-changed:
+  devservices-files-changed:
     name: detect what files changed
     runs-on: ubuntu-24.04
     timeout-minutes: 3
@@ -648,8 +648,8 @@ jobs:
 
   validate-devservices-config:
       runs-on: ubuntu-24.04
-      needs: files-changed
-      if: ${{ needs.files-changed.outputs.devservices-files-changed == 'true' }}
+      needs: devservices-files-changed
+      if: ${{ needs.devservices-files-changed.outputs.devservices-files-changed == 'true' }}
       steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,23 +75,23 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
-  files-changed:
-    name: detect what files changed
-    runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    outputs:
-      devservices-files-changed: ${{ steps.changes.outputs.devservices-files-changed }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        name: Check for file changes
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: |
-            devservices-files-changed:
-              - 'devservices/**'
-              - '.github/workflows/ci.yml'
+files-changed:
+  name: detect what files changed
+  runs-on: ubuntu-24.04
+  timeout-minutes: 3
+  outputs:
+    devservices-files-changed: ${{ steps.changes.outputs.devservices-files-changed }}
+  steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      name: Check for file changes
+      id: changes
+      with:
+        token: ${{ github.token }}
+        filters: |
+          devservices-files-changed:
+            - 'devservices/**'
+            - '.github/workflows/ci.yml'
 
   test:
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,24 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    outputs:
+      devservices-files-changed: ${{ steps.changes.outputs.devservices-files-changed }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        name: Check for file changes
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: |
+            devservices-files-changed:
+              - 'devservices/**'
+              - '.github/workflows/ci.yml'
+
   test:
     timeout-minutes: 20
     strategy:
@@ -627,3 +645,15 @@ jobs:
           image_url: ghcr.io/getsentry/relay:${{ github.event.pull_request.head.sha || github.sha }}
           docker_repo: getsentry/relay
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+
+  validate-devservices-config:
+      runs-on: ubuntu-24.04
+      needs: files-changed
+      if: ${{ needs.files-changed.outputs.devservices_changes == 'true' }}
+      steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        name: Checkout repository
+      - uses: getsentry/action-validate-devservices-config@6477ef1e9c96e456bfad726006e731f89fcd81db
+        name: Validate devservices config
+        with:
+          requirements-file-path: requirements-dev.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
+
   files-changed:
     name: detect what files changed
     runs-on: ubuntu-24.04
@@ -648,7 +649,7 @@ jobs:
   validate-devservices-config:
       runs-on: ubuntu-24.04
       needs: files-changed
-      if: ${{ needs.files-changed.outputs.devservices_changes == 'true' }}
+      if: ${{ needs.files-changed.outputs.devservices_files_changed == 'true' }}
       steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         name: Checkout repository


### PR DESCRIPTION
This validation job will only run if files are changed in the devservices/ directory or the .github/workflows/ci.yml has been changed. It will ensure that the config files that live in the relay devservices directory actually work, preventing potential breakages for devservices across repos that depend on snuba if invalid configs are merged.

Composite action used: https://github.com/getsentry/action-validate-devservices-config

#skip-changelog