### PR TITLE
fix(pii): Fix attachment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Increase stacktrace function and symbol length limits to 512 chars. ([#4436](https://github.com/getsentry/relay/pull/4436))
-- Scrub non-minidump attachments if there are explicit `$attachment` rules. ([#4415](https://github.com/getsentry/relay/pull/4415))
+- Scrub non-minidump attachments if there are explicit `$attachment` rules. ([#4415](https://github.com/getsentry/relay/pull/4415), [#4441](https://github.com/getsentry/relay/pull/4441))
 - Include blocked domain in CSP reports as a tag. ([#4435](https://github.com/getsentry/relay/pull/4435))
 
 **Internal**:

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use relay_pii::{PiiAttachmentsProcessor, SelectorPathItem, SelectorSpec};
 use relay_statsd::metric;
 
-use crate::envelope::{AttachmentType, ContentType};
+use crate::envelope::{AttachmentType, ContentType, ItemType};
 use crate::statsd::RelayTimers;
 
 use crate::services::projects::project::ProjectInfo;
@@ -72,7 +72,7 @@ pub fn scrub<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: A
             // After we have assessed the impact on performance we can relax this condition.
             for item in envelope
                 .items_mut()
-                .filter(|item| item.attachment_type().is_some())
+                .filter(|item| item.ty() == &ItemType::Attachment)
             {
                 scrub_attachment(item, config);
             }

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -178,8 +178,6 @@ def test_attachments_pii(mini_sentry, relay):
 
 
 def test_attachments_pii_logfile(mini_sentry, relay):
-    event_id = "515539018c9b4260a6f999572f1661ee"
-
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["piiConfig"] = {
@@ -191,10 +189,7 @@ def test_attachments_pii_logfile(mini_sentry, relay):
     }
     relay = relay(mini_sentry)
 
-    attachment = (
-        "att_1",
-        "logfile.txt",
-        rb"""Alice Johnson
+    attachment = r"""Alice Johnson
 alice.johnson@example.com
 +1234567890
 4111 1111 1111 1111
@@ -202,10 +197,13 @@ Bob Smith bob.smith@example.net +9876543210 5500 0000 0000 0004
 Charlie Brown charlie.brown@example.org +1928374650 3782 822463 10005
 Dana White dana.white@example.co.uk +1029384756 6011 0009 9013 9424
 path=c:\Users\yan\mylogfile.txt
-password=mysupersecretpassword123""",
-    )
+password=mysupersecretpassword123"""
 
-    relay.send_attachments(project_id, event_id, [attachment])
+    envelope = Envelope()
+    item = Item(payload=attachment, type="attachment")
+    envelope.add_item(item)
+
+    relay.send_envelope(project_id, envelope)
 
     scrubbed_payload = mini_sentry.captured_events.get().items[0].payload.bytes
 

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -200,7 +200,9 @@ path=c:\Users\yan\mylogfile.txt
 password=mysupersecretpassword123"""
 
     envelope = Envelope()
-    item = Item(payload=attachment, type="attachment")
+    item = Item(
+        payload=attachment, type="attachment", headers={"filename": "logfile.txt"}
+    )
     envelope.add_item(item)
 
     relay.send_envelope(project_id, envelope)


### PR DESCRIPTION
Attachments items are not guaranteed to have an "attachment_type".

Fixes https://github.com/getsentry/relay/issues/4368.