### PR TITLE
ref: use version of statsdproxy that can work with Duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,6 +1270,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1832,12 @@ name = "human-size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9994b79e8c1a39b3166c63ae7823bb2b00831e2a96a31399c50fe69df408eaeb"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -4664,6 +4693,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4997,14 +5036,18 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "statsdproxy"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1331025d2b2fd51955ddba105a3b66b558d5979c54fd690ec26f06f215abd2"
+source = "git+https://github.com/getsentry/statsdproxy?rev=50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f#50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f"
 dependencies = [
  "anyhow",
  "cadence",
+ "clap",
  "crc32fast",
+ "env_logger",
  "log",
  "rand",
+ "serde",
+ "serde_yaml",
+ "signal-hook",
  "thread_local",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,29 +1270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,12 +1809,6 @@ name = "human-size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9994b79e8c1a39b3166c63ae7823bb2b00831e2a96a31399c50fe69df408eaeb"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -4693,16 +4664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,14 +5001,9 @@ source = "git+https://github.com/getsentry/statsdproxy?rev=50155c5c5dc103fb1557e
 dependencies = [
  "anyhow",
  "cadence",
- "clap",
  "crc32fast",
- "env_logger",
  "log",
  "rand",
- "serde",
- "serde_yaml",
- "signal-hook",
  "thread_local",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,8 @@ smallvec = { version = "1.13.2", features = ["serde"] }
 socket2 = "0.5.8"
 sqlparser = "0.44.0"
 sqlx = { version = "0.8.2", default-features = false }
-statsdproxy = { git = "https://github.com/getsentry/statsdproxy", rev = "50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f"}
+# See statsdproxy PR: https://github.com/getsentry/statsdproxy/pull/55
+statsdproxy = { git = "https://github.com/getsentry/statsdproxy", rev = "50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f", default-features = false}
 symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }
 syn = { version = "2.0.90" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ smallvec = { version = "1.13.2", features = ["serde"] }
 socket2 = "0.5.8"
 sqlparser = "0.44.0"
 sqlx = { version = "0.8.2", default-features = false }
-statsdproxy = { version = "0.2.0", default-features = false }
+statsdproxy = { git = "https://github.com/getsentry/statsdproxy", rev = "50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f"}
 symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }
 syn = { version = "2.0.90" }

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -56,16 +56,16 @@
 //! ```
 //!
 //! [Metric Types]: https://github.com/statsd/statsd/blob/master/docs/metric_types.md
-use std::collections::BTreeMap;
-use std::net::ToSocketAddrs;
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
-
 use cadence::{Metric, MetricBuilder, StatsdClient};
 use parking_lot::RwLock;
 use rand::distributions::{Distribution, Uniform};
 use statsdproxy::cadence::StatsdProxyMetricSink;
 use statsdproxy::config::AggregateMetricsConfig;
+use std::collections::BTreeMap;
+use std::net::ToSocketAddrs;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::time::Duration;
 
 /// Maximum number of metric events that can be queued before we start dropping them
 const METRICS_MAX_QUEUE_SIZE: usize = 100_000;
@@ -253,7 +253,7 @@ pub fn init<A: ToSocketAddrs>(
                 AggregateMetricsConfig {
                     aggregate_gauges: true,
                     aggregate_counters: true,
-                    flush_interval: 1,
+                    flush_interval: Duration::from_millis(125),
                     flush_offset: 0,
                     max_map_size: None,
                 },


### PR DESCRIPTION
This PR uses a fixed commit for `statsdproxy` that takes a `Duration` instead of u64 seconds as `flush_interval` so we can see if reducing the `flush_interval` helps with the metrics problem.

This is meant as a proof of concept, if it works we will update the `statsdproxy` crate to support it regulary.

statsdproxy PR: https://github.com/getsentry/statsdproxy/pull/55

#skip-changelog