### PR TITLE
feat(ci): Use public arm64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
     runs-on: |-
       ${{fromJson('{
         "x86_64-unknown-linux-gnu": "ubuntu-20.04",
-        "aarch64-unknown-linux-gnu": "ubuntu-22.04-arm64-relay"
+        "aarch64-unknown-linux-gnu": "ubuntu-22.04-arm"
       }')[matrix.target] }}
 
     if: "!startsWith(github.ref, 'refs/heads/release-library/')"


### PR DESCRIPTION
GitHub [introduced](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) free arm64 runners for public repositories, so I decided to change our CI workflow to run on them.

#skip-changelog