### PR TITLE
feat(server): Add option to drop transaction attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Internal**:
 
 - Add data categories for LogItem and LogByte. ([#4455](https://github.com/getsentry/relay/pull/4455))
+- Add option to drop transaction attachments. ([#4466](https://github.com/getsentry/relay/pull/4466))
 
 ## 25.1.0
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -184,6 +184,14 @@ pub struct Options {
     )]
     pub http_span_allowed_hosts: Vec<String>,
 
+    /// Whether or not relay should drop attachments submitted with transactions.
+    #[serde(
+        rename = "relay.processing.drop-transaction-attachments",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub drop_transaction_attachments: bool,
+
     /// Deprecated, still forwarded for older downstream Relays.
     #[doc(hidden)]
     #[serde(

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -186,7 +186,7 @@ pub struct Options {
 
     /// Whether or not relay should drop attachments submitted with transactions.
     #[serde(
-        rename = "relay.processing.drop-transaction-attachments",
+        rename = "relay.drop-transaction-attachments",
         deserialize_with = "default_on_error",
         skip_serializing_if = "is_default"
     )]

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -460,6 +460,9 @@ pub enum DiscardReason {
 
     /// (Relay) A required feature is not enabled.
     FeatureDisabled(Feature),
+
+    /// An attachment was submitted with a transaction.
+    TransactionAttachment,
 }
 
 impl DiscardReason {
@@ -506,6 +509,7 @@ impl DiscardReason {
             DiscardReason::Profiling(reason) => reason,
             DiscardReason::InvalidSpan => "invalid_span",
             DiscardReason::FeatureDisabled(_) => "feature_disabled",
+            DiscardReason::TransactionAttachment => "transaction_attachment",
         }
     }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1761,6 +1761,9 @@ impl EnvelopeProcessorService {
         // Unconditionally scrub to make sure PII is removed as early as possible.
         event::scrub(&mut event, project_info.clone())?;
 
+        // TODO: remove once `relay.drop-transaction-attachments` has graduated.
+        attachment::scrub(managed_envelope, project_info.clone());
+
         if_processing!(self.inner.config, {
             // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
             let profile_id = profile::process(

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1762,13 +1762,6 @@ impl EnvelopeProcessorService {
         event::scrub(&mut event, project_info.clone())?;
 
         if_processing!(self.inner.config, {
-            managed_envelope.retain_items(|item| match item.ty() {
-                &ItemType::Attachment => {
-                    ItemAction::Drop(Outcome::Invalid(DiscardReason::TransactionAttachment))
-                }
-                _ => ItemAction::Keep,
-            });
-
             // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
             let profile_id = profile::process(
                 managed_envelope,

--- a/relay-server/src/services/processor/transaction.rs
+++ b/relay-server/src/services/processor/transaction.rs
@@ -1,0 +1,10 @@
+//! Processing logic specific to transaction envelopes.
+
+use relay_dynamic_config::GlobalConfig;
+
+/// Drops attachments in transaction envelopes.
+pub fn drop_invalid_items(envelope: &mut ManagedEnvelope, global_config: &GlobalConfig) {
+    if global_config.options.drop_transaction_attachments {
+        envelope.retain_items(|item| item.ty() != &ItemType::Attachment);
+    }
+}

--- a/relay-server/src/services/processor/transaction.rs
+++ b/relay-server/src/services/processor/transaction.rs
@@ -2,9 +2,18 @@
 
 use relay_dynamic_config::GlobalConfig;
 
+use crate::envelope::ItemType;
+use crate::services::outcome::{DiscardReason, Outcome};
+use crate::utils::{ItemAction, ManagedEnvelope};
+
 /// Drops attachments in transaction envelopes.
 pub fn drop_invalid_items(envelope: &mut ManagedEnvelope, global_config: &GlobalConfig) {
-    if global_config.options.drop_transaction_attachments {
-        envelope.retain_items(|item| item.ty() != &ItemType::Attachment);
+    if dbg!(global_config.options.drop_transaction_attachments) {
+        envelope.retain_items(|item| match item.ty() {
+            &ItemType::Attachment => {
+                ItemAction::Drop(Outcome::Invalid(DiscardReason::TransactionAttachment))
+            }
+            _ => ItemAction::Keep,
+        });
     }
 }

--- a/relay-server/src/services/processor/transaction.rs
+++ b/relay-server/src/services/processor/transaction.rs
@@ -8,7 +8,7 @@ use crate::utils::{ItemAction, ManagedEnvelope};
 
 /// Drops attachments in transaction envelopes.
 pub fn drop_invalid_items(envelope: &mut ManagedEnvelope, global_config: &GlobalConfig) {
-    if dbg!(global_config.options.drop_transaction_attachments) {
+    if global_config.options.drop_transaction_attachments {
         envelope.retain_items(|item| match item.ty() {
             &ItemType::Attachment => {
                 ItemAction::Drop(Outcome::Invalid(DiscardReason::TransactionAttachment))

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -211,7 +211,7 @@ impl StoreService {
             KafkaTopic::Events
         };
 
-        let send_individual_attachments = matches!(event_type, None | Some(&ItemType::Transaction));
+        let send_individual_attachments = event_type.is_none();
 
         let mut attachments = Vec::new();
         let mut replay_event = None;
@@ -583,7 +583,7 @@ impl StoreService {
         // When sending individual attachments, and we have a single chunk, we want to send the
         // `data` inline in the `attachment` message.
         // This avoids a needless roundtrip through the attachments cache on the Sentry side.
-        let data = if send_individual_attachments && size < max_chunk_size {
+        let inlined_data = if send_individual_attachments && size < max_chunk_size {
             (size > 0).then_some(payload)
         } else {
             let mut offset = 0;
@@ -623,7 +623,7 @@ impl StoreService {
                 .map(|content_type| content_type.as_str().to_owned()),
             attachment_type: item.attachment_type().cloned().unwrap_or_default(),
             chunks: chunk_index,
-            data,
+            data: inlined_data,
             size: Some(size),
             rate_limited: Some(item.rate_limited()),
         };

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -438,17 +438,30 @@ def test_event_with_attachment(
         "rate_limited": False,
     }
 
-    attachment = attachments_consumer.get_individual_attachment()
-    assert attachment["attachment"].pop("id")
-    assert attachment == {
-        "type": "attachment",
-        "attachment": expected_attachment,
-        "event_id": event_id,
-        "project_id": project_id,
-    }
+    attachments_consumer.assert_empty()
 
-    _, event = attachments_consumer.get_event()
-    assert event["event_id"] == event_id
+    assert outcomes_consumer.get_outcomes() == [
+        {
+            "timestamp": "2025-01-21T12:23:27.000000Z",
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 3,
+            "reason": "transaction_attachment",
+            "category": 4,
+            "quantity": 22,
+        },
+        {
+            "timestamp": "2025-01-21T12:23:27.000000Z",
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 3,
+            "reason": "transaction_attachment",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_form_data_is_rejected(


### PR DESCRIPTION
To prepare the simplification of Kafka consumers, stop ingesting attachments that come with transactions.

ref: https://github.com/getsentry/team-ingest/issues/607