### PR TITLE
chore(grouping): Add `project_root` to `debug_meta` schema

### DIFF
--- a/relay-event-schema/src/protocol/debugmeta.rs
+++ b/relay-event-schema/src/protocol/debugmeta.rs
@@ -523,6 +523,11 @@ pub struct DebugMeta {
     #[metastructure(skip_serialization = "empty")]
     pub images: Annotated<Array<DebugImage>>,
 
+    /// Path to the root of the app generating the event.
+    #[metastructure(max_chars = 256, max_chars_allowance = 40)]
+    #[metastructure(skip_serialization = "empty", pii = "maybe")]
+    pub project_root: Annotated<String>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,

--- a/relay-event-schema/src/protocol/debugmeta.rs
+++ b/relay-event-schema/src/protocol/debugmeta.rs
@@ -528,7 +528,9 @@ pub struct DebugMeta {
     #[metastructure(skip_serialization = "empty", pii = "maybe")]
     pub project_root: Annotated<String>,
 
-    /// Additional arbitrary fields for forwards compatibility.
+    /// Additional arbitrary fields for forwards compatibility. Note that they may still get
+    /// normalized out of the event, depending on the value of `remove_other` passed to the
+    /// normalizer.
     #[metastructure(additional_properties)]
     pub other: Object<Value>,
 }


### PR DESCRIPTION
Draft until we decide if this is the right approach. (In other words, ignore the questions I asked below for now.)

------------------

As part of a larger [bug fix](https://github.com/getsentry/sentry/issues/83603), we are in the midst of trying to move `in_app` logic from the Python SDK to the sentry server. To do that, we need to [send the app's root path in the event](https://github.com/getsentry/sentry-python/pull/3941), which we are for now planning to include in `debug_meta`.

In my testing, I discovered that even though the `debug_meta` schema includes an `other` entry with the note `/// Additional arbitrary fields for forwards compatibility`, in order for the project root data to make it all the way to the grouping algorithm it has to survive the normalizer, and to do that, it has to be an explicitly listed. (Reviewers, please correct me if I'm wrong about this.) This PR does that, and adds a note explaining the requirement for any future additions.

Note to reviewers: I got the `metastructure` values from the `abs_path` entry, to which the `project_root` will get compared. Happy to change any of them if needed. I also didn't add or modify any tests related to this change. If that's needed, I would appreciate some guidance as I've never worked in rust before.