### PR TITLE
instr(config): Log error on suspicious quota

### DIFF
--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -103,6 +103,21 @@ impl ProjectConfig {
         for flag in GRADUATED_FEATURE_FLAGS {
             self.features.0.insert(*flag);
         }
+
+        // Check if indexed and non-indexed are double-counting towards the same ID.
+        // This is probably not intended behavior.
+        for quota in &self.quotas {
+            for category in &quota.categories {
+                if let Some(indexed) = category.index_category() {
+                    if quota.categories.contains(&indexed) {
+                        relay_log::error!(
+                            id = ?quota.id,
+                            "Categories {category} and {indexed} share the same quota ID. This will double-count items.",
+                        );
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Log an error during project config sanitation when a total and indexed category count toward the same quota.

ref: https://github.com/getsentry/relay/issues/4259

#skip-changelog