### PR TITLE
fix(relay): set size limit for user report attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Bug Fixes**:
 
 - Fix a bug where parsing large unsigned integers would fail incorrectly. ([#4472](https://github.com/getsentry/relay/pull/4472))
+- Set size limit for UserReport attachments so it gets properly reported as too large. ([#4482](https://github.com/getsentry/relay/pull/4482)) 
 
 **Internal**:
 

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -43,7 +43,7 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> Resul
                 event_size += item.len();
                 NO_LIMIT
             }
-            ItemType::Attachment | ItemType::UnrealReport => {
+            ItemType::Attachment | ItemType::UnrealReport | ItemType::UserReport => {
                 attachments_size += item.len();
                 config.max_attachment_size()
             }
@@ -59,7 +59,6 @@ pub fn check_envelope_size_limits(config: &Config, envelope: &Envelope) -> Resul
             }
             ItemType::Profile => config.max_profile_size(),
             ItemType::CheckIn => config.max_check_in_size(),
-            ItemType::UserReport => NO_LIMIT,
             ItemType::Statsd => config.max_statsd_size(),
             ItemType::MetricBuckets => config.max_metric_buckets_size(),
             ItemType::Log => config.max_log_size(),


### PR DESCRIPTION
This PR introduces a limit for `UserReport` attachments. Without the limit, the user report will be dropped by the kafka consumer due to limits imposed on the topic.

Fixes [RELAY-2P0Z](https://sentry.my.sentry.io/organizations/sentry/issues/2204947/)