### PR TITLE
feat(config): Allow setting log format from envar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add configuration option to limit the amount of concurrent http connections. ([#4453](https://github.com/getsentry/relay/pull/4453))
 - Add flags context to event schema. ([#4458](https://github.com/getsentry/relay/pull/4458))
 - Add support for view hierarchy attachment scrubbing. ([#4452](https://github.com/getsentry/relay/pull/4452))
+- Allow configuration of Relay's log format via an environment variable. ([#4484](https://github.com/getsentry/relay/pull/4484))
 
 **Bug Fixes**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -226,6 +226,8 @@ pub struct OverridableConfig {
     pub instance: Option<String>,
     /// The log level of this relay.
     pub log_level: Option<String>,
+    /// The log format of this relay.
+    pub log_format: Option<String>,
     /// The upstream relay or sentry instance.
     pub upstream: Option<String>,
     /// Alternate upstream provided through a Sentry DSN. Key and project will be ignored.
@@ -1639,6 +1641,10 @@ impl Config {
 
         if let Some(log_level) = overrides.log_level {
             self.values.logging.level = log_level.parse()?;
+        }
+
+        if let Some(log_format) = overrides.log_format {
+            self.values.logging.format = log_format.parse()?;
         }
 
         if let Some(upstream) = overrides.upstream {

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -50,6 +50,39 @@ pub enum LogFormat {
     Json,
 }
 
+/// The logging format parse error.
+#[derive(Clone, Debug)]
+pub struct FormatParseError(String);
+
+impl Display for FormatParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"error parsing "{}" as format: expected one of "auto", "pretty", "simplified", "json""#,
+            self.0
+        )
+    }
+}
+
+impl FromStr for LogFormat {
+    type Err = FormatParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let result = match s {
+            "" => LogFormat::Auto,
+            s if s.eq_ignore_ascii_case("auto") => LogFormat::Auto,
+            s if s.eq_ignore_ascii_case("pretty") => LogFormat::Pretty,
+            s if s.eq_ignore_ascii_case("simplified") => LogFormat::Simplified,
+            s if s.eq_ignore_ascii_case("json") => LogFormat::Json,
+            s => return Err(FormatParseError(s.into())),
+        };
+
+        Ok(result)
+    }
+}
+
+impl std::error::Error for FormatParseError {}
+
 /// The logging level parse error.
 #[derive(Clone, Debug)]
 pub struct LevelParseError(String);

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -81,6 +81,7 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
     OverridableConfig {
         mode: matches.get_one("mode").cloned(),
         log_level: matches.get_one("log_level").cloned(),
+        log_format: matches.get_one("log_format").cloned(),
         upstream: matches.get_one("upstream").cloned(),
         upstream_dsn: matches.get_one("upstream_dsn").cloned(),
         host: matches.get_one("host").cloned(),
@@ -103,6 +104,7 @@ pub fn extract_config_env_vars() -> OverridableConfig {
     OverridableConfig {
         mode: env::var("RELAY_MODE").ok(),
         log_level: env::var("RELAY_LOG_LEVEL").ok(),
+        log_format: env::var("RELAY_LOG_FORMAT").ok(),
         upstream: env::var("RELAY_UPSTREAM_URL").ok(),
         upstream_dsn: env::var("RELAY_UPSTREAM_DSN").ok(),
         host: env::var("RELAY_HOST").ok(),

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -44,6 +44,12 @@ pub fn make_app() -> Command {
                         .value_parser(["info", "warn", "error", "debug", "trace"]),
                 )
                 .arg(
+                    Arg::new("log_format")
+                        .long("log-format")
+                        .help("The relay log format")
+                        .value_parser(["auto", "pretty", "simplified", "json"]),
+                )
+                .arg(
                     Arg::new("secret_key")
                         .long("secret-key")
                         .short('s')


### PR DESCRIPTION
There is a large discontinuity between config values that can be set in environment variables. When running in containers the prefered config approach is through environment variables and not config files. This PR enables setting of the logging format through an environment variable

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
