### PR TITLE
chore(devservices): Bump devservices to 1.0.16

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 black==24.3.0
 blinker==1.8.2
 click==8.1.7
-devservices==1.0.14
+devservices==1.0.16
 flake8==7.0.0
 confluent-kafka==2.1.1
 flask==3.0.3


### PR DESCRIPTION
Picks up a few small tweaks: https://github.com/getsentry/devservices/releases/tag/1.0.16

#skip-changelog