### PR TITLE
fix(insights): strip sql comments without trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 **Bug Fixes**:
 
 - Fix a bug where parsing large unsigned integers would fail incorrectly. ([#4472](https://github.com/getsentry/relay/pull/4472))
-- Set size limit for UserReport attachments so it gets properly reported as too large. ([#4482](https://github.com/getsentry/relay/pull/4482)) 
+- Set size limit for UserReport attachments so it gets properly reported as too large. ([#4482](https://github.com/getsentry/relay/pull/4482))
+- Improve stripping of SQL comments during Insights query normalization. ([#4493](https://github.com/getsentry/relay/pull/4493))
 
 **Internal**:
 

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -10,7 +10,7 @@ use parser::normalize_parsed_queries;
 use regex::Regex;
 
 /// Removes SQL comments starting with "--" or "#".
-static COMMENTS: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:--|#).*(?P<newline>\n)").unwrap());
+static COMMENTS: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:--|#).*(?P<newline>\n|$)").unwrap());
 
 /// Removes MySQL inline comments.
 static INLINE_COMMENTS: Lazy<Regex> = Lazy::new(|| Regex::new(r"/\*(?:.|\n)*?\*/").unwrap());
@@ -699,6 +699,12 @@ mod tests {
             inner join foo on foo.id = foo_id
         ",
         "SELECT .. FROM (SELECT * FROM (SELECT .. FROM x WHERE foo = %s) AS srpe WHERE x = %s) AS srpe JOIN foo ON id = foo_id"
+    );
+
+    scrub_sql_test!(
+        comment_after_named_param_without_ending_line_break,
+        "SELECT * FROM comments LIMIT %(param_1)s -- comment",
+        "SELECT * FROM comments LIMIT %s"
     );
 
     scrub_sql_test!(


### PR DESCRIPTION
Found this case when investigating projects emitting high cardinality metrics. SQL comments that did not end in a newline aren't being stripped correctly. Updated the comment-matching regex to additionally match comments up to the end of the haystack.

Note that there's an interesting interaction with the regexes that meant that the test
```rust
    scrub_sql_test!(
        comment_without_ending_line_break,
        "SELECT * FROM comments LIMIT 1 -- comment", // note the explicit limit
        "SELECT * FROM comments LIMIT %s"
    );
```
already passed without these changes, while the version with the named limit param (`LIMIT %(param_1)s`) did not. 