### PR TITLE
chore: add debug profile + instructions to readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,12 @@ resolver = "2"
 # target folder, but we don't require stack traces in most cases.
 debug = false
 
+[profile.dev-debug]
+# A version of the dev profile with debug information enabled, for e.g. local
+# debugging.
+inherits = "dev"
+debug = true
+
 [profile.release]
 # In release, however, we do want full debug information to report
 # panic and error stack traces to Sentry.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ make format
 make lint
 ```
 
+### Debugging
+
+Developer builds do not include debug information by default. Before attaching a
+debugger to your local relay, first change `debug` to `true` under
+`[profile.dev]` in Cargo.toml.
+
 ### Python and C-ABI
 
 Potentially, new functionality also needs to be added to the Python package.

--- a/README.md
+++ b/README.md
@@ -185,9 +185,16 @@ make lint
 
 ### Debugging
 
-Developer builds do not include debug information by default. Before attaching a
-debugger to your local Relay, first change `debug` to `true` under
-`[profile.dev]` in Cargo.toml and rebuild.
+Developer builds do not include debug information by default. If you want to attach a
+debugger to your local Relay, add a custom profile to your local `$HOME/.cargo/config.toml`:
+
+```toml
+[profile.mydebug]
+inherits = "dev"
+debug = true
+```
+
+and run `cargo run --all-features --profile mydebug`.
 
 ### Python and C-ABI
 

--- a/README.md
+++ b/README.md
@@ -185,16 +185,9 @@ make lint
 
 ### Debugging
 
-Developer builds do not include debug information by default. If you want to attach a
-debugger to your local Relay, add a custom profile to your local `$HOME/.cargo/config.toml`:
-
-```toml
-[profile.mydebug]
-inherits = "dev"
-debug = true
-```
-
-and run `cargo run --all-features --profile mydebug`.
+Developer builds do not include debug information by default. If you want to
+attach a debugger to your local Relay, you can use the provided `dev-debug`
+profile instead with `cargo run --all-features --profile dev-debug`.
 
 ### Python and C-ABI
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ make lint
 ### Debugging
 
 Developer builds do not include debug information by default. Before attaching a
-debugger to your local relay, first change `debug` to `true` under
+debugger to your local Relay, first change `debug` to `true` under
 `[profile.dev]` in Cargo.toml and rebuild.
 
 ### Python and C-ABI

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ make lint
 
 Developer builds do not include debug information by default. Before attaching a
 debugger to your local relay, first change `debug` to `true` under
-`[profile.dev]` in Cargo.toml.
+`[profile.dev]` in Cargo.toml and rebuild.
 
 ### Python and C-ABI
 


### PR DESCRIPTION
After troubleshooting my failure to debug Relay using VSCode, I found that we had `debug` set to `false` in the dev profile. Added a note to the readme about it in case anyone else runs into the same issue.

#skip-changelog