### PR TITLE
feat(cogs): Track categories in COGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,6 +3513,9 @@ dependencies = [
 [[package]]
 name = "relay-cogs"
 version = "25.1.0"
+dependencies = [
+ "insta",
+]
 
 [[package]]
 name = "relay-common"

--- a/relay-cogs/Cargo.toml
+++ b/relay-cogs/Cargo.toml
@@ -12,3 +12,6 @@ autobenches = false
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/relay-cogs/src/cogs.rs
+++ b/relay-cogs/src/cogs.rs
@@ -1,10 +1,10 @@
-use core::fmt;
+use crate::time::Instant;
 use std::collections::BTreeMap;
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::Instant;
 
-use crate::{AppFeature, ResourceId};
+use crate::{AppFeature, Measurements, ResourceId};
 use crate::{CogsMeasurement, CogsRecorder, Value};
 
 /// COGS measurements collector.
@@ -64,8 +64,8 @@ impl Cogs {
         Token {
             resource,
             features: weights.into(),
-            start: Instant::now(),
-            recorder: Arc::clone(&self.recorder),
+            measurements: Measurements::start(),
+            recorder: Some(Arc::clone(&self.recorder)),
         }
     }
 }
@@ -77,15 +77,41 @@ impl Cogs {
 pub struct Token {
     resource: ResourceId,
     features: FeatureWeights,
-    start: Instant,
-    recorder: Arc<dyn CogsRecorder>,
+    measurements: Measurements,
+    recorder: Option<Arc<dyn CogsRecorder>>,
 }
 
 impl Token {
+    /// Creates a new no-op token, which records nothing.
+    ///
+    /// This is primarily useful for testing.
+    pub fn noop() -> Self {
+        Self {
+            resource: ResourceId::Relay,
+            features: FeatureWeights::none(),
+            measurements: Measurements::start(),
+            recorder: None,
+        }
+    }
+
     /// Cancels the COGS measurement.
     pub fn cancel(&mut self) {
         // No features -> nothing gets attributed.
         self.update(FeatureWeights::none());
+    }
+
+    /// Starts a categorized measurement.
+    ///
+    /// The measurement is finalized when the returned [`CategoryToken`] is dropped.
+    ///
+    /// Instead of manually starting a categorized measurement, the [`crate::with`]
+    /// macro can be used.
+    pub fn start_category(&mut self, category: impl Category) -> CategoryToken<'_> {
+        CategoryToken {
+            parent: self,
+            start: Instant::now(),
+            category: category.name(),
+        }
     }
 
     /// Updates the app features to which the active measurement is attributed to.
@@ -115,15 +141,22 @@ impl Token {
 
 impl Drop for Token {
     fn drop(&mut self) {
-        let elapsed = self.start.elapsed();
+        let Some(recorder) = self.recorder.as_mut() else {
+            return;
+        };
 
-        for (feature, ratio) in self.features.weights() {
-            let time = elapsed.mul_f32(ratio);
-            self.recorder.record(CogsMeasurement {
-                resource: self.resource,
-                feature,
-                value: Value::Time(time),
-            });
+        let measurements = self.measurements.finish();
+
+        for measurement in measurements {
+            for (feature, ratio) in self.features.weights() {
+                let time = measurement.duration.mul_f32(ratio);
+                recorder.record(CogsMeasurement {
+                    resource: self.resource,
+                    feature,
+                    category: measurement.category,
+                    value: Value::Time(time),
+                });
+            }
         }
     }
 }
@@ -133,6 +166,46 @@ impl fmt::Debug for Token {
         f.debug_struct("CogsToken")
             .field("resource", &self.resource)
             .field("features", &self.features)
+            .finish()
+    }
+}
+
+/// A COGS category.
+pub trait Category {
+    /// String representation of the category.
+    fn name(&self) -> &'static str;
+}
+
+impl Category for &'static str {
+    fn name(&self) -> &'static str {
+        self
+    }
+}
+
+/// A categorized COGS measurement.
+///
+/// Must be started with [`Token::start_category`].
+#[must_use]
+pub struct CategoryToken<'a> {
+    parent: &'a mut Token,
+    start: Instant,
+    category: &'static str,
+}
+
+impl Drop for CategoryToken<'_> {
+    fn drop(&mut self) {
+        self.parent
+            .measurements
+            .add(self.start.elapsed(), self.category);
+    }
+}
+
+impl fmt::Debug for CategoryToken<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CategoryToken")
+            .field("resource", &self.parent.resource)
+            .field("features", &self.parent.features)
+            .field("category", &self.category)
             .finish()
     }
 }
@@ -278,7 +351,7 @@ impl FeatureWeightsBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, time::Duration};
+    use std::collections::HashMap;
 
     use super::*;
     use crate::test::TestRecorder;
@@ -291,9 +364,18 @@ mod tests {
         drop(cogs.timed(ResourceId::Relay, AppFeature::Spans));
 
         let measurements = recorder.measurements();
-        assert_eq!(measurements.len(), 1);
-        assert_eq!(measurements[0].resource, ResourceId::Relay);
-        assert_eq!(measurements[0].feature, AppFeature::Spans);
+        insta::assert_debug_snapshot!(measurements, @r###"
+        [
+            CogsMeasurement {
+                resource: Relay,
+                feature: Spans,
+                category: None,
+                value: Time(
+                    100ns,
+                ),
+            },
+        ]
+        "###);
     }
 
     #[test]
@@ -301,7 +383,6 @@ mod tests {
         let recorder = TestRecorder::default();
         let cogs = Cogs::new(recorder.clone());
 
-        let start = Instant::now();
         let f = FeatureWeights::builder()
             .weight(AppFeature::Spans, 1)
             .weight(AppFeature::Transactions, 1)
@@ -311,20 +392,114 @@ mod tests {
             .build();
         {
             let _token = cogs.timed(ResourceId::Relay, f);
-            std::thread::sleep(Duration::from_millis(50));
+            crate::time::advance_millis(50);
         }
-        let elapsed = start.elapsed();
 
         let measurements = recorder.measurements();
-        assert_eq!(measurements.len(), 2);
-        assert_eq!(measurements[0].resource, ResourceId::Relay);
-        assert_eq!(measurements[0].feature, AppFeature::Spans);
-        assert_eq!(measurements[1].resource, ResourceId::Relay);
-        assert_eq!(measurements[1].feature, AppFeature::MetricsSpans);
-        assert_eq!(measurements[0].value, measurements[1].value);
-        let Value::Time(time) = measurements[0].value;
-        assert!(time >= Duration::from_millis(25), "{time:?}");
-        assert!(time <= elapsed.div_f32(1.99), "{time:?}");
+        insta::assert_debug_snapshot!(measurements, @r###"
+        [
+            CogsMeasurement {
+                resource: Relay,
+                feature: Spans,
+                category: None,
+                value: Time(
+                    25ms,
+                ),
+            },
+            CogsMeasurement {
+                resource: Relay,
+                feature: MetricsSpans,
+                category: None,
+                value: Time(
+                    25ms,
+                ),
+            },
+        ]
+        "###);
+    }
+
+    #[test]
+    fn test_cogs_categorized() {
+        let recorder = TestRecorder::default();
+        let cogs = Cogs::new(recorder.clone());
+
+        let features = FeatureWeights::builder()
+            .weight(AppFeature::Spans, 1)
+            .weight(AppFeature::Errors, 1)
+            .build();
+
+        {
+            let mut token = cogs.timed(ResourceId::Relay, features);
+            crate::time::advance_millis(10);
+            crate::with!(token, "s1", {
+                crate::time::advance_millis(6);
+            });
+            crate::time::advance_millis(20);
+            let _category = token.start_category("s2");
+            crate::time::advance_millis(12);
+        }
+
+        let measurements = recorder.measurements();
+        insta::assert_debug_snapshot!(measurements, @r###"
+        [
+            CogsMeasurement {
+                resource: Relay,
+                feature: Errors,
+                category: None,
+                value: Time(
+                    15ms,
+                ),
+            },
+            CogsMeasurement {
+                resource: Relay,
+                feature: Spans,
+                category: None,
+                value: Time(
+                    15ms,
+                ),
+            },
+            CogsMeasurement {
+                resource: Relay,
+                feature: Errors,
+                category: Some(
+                    "s1",
+                ),
+                value: Time(
+                    3ms,
+                ),
+            },
+            CogsMeasurement {
+                resource: Relay,
+                feature: Spans,
+                category: Some(
+                    "s1",
+                ),
+                value: Time(
+                    3ms,
+                ),
+            },
+            CogsMeasurement {
+                resource: Relay,
+                feature: Errors,
+                category: Some(
+                    "s2",
+                ),
+                value: Time(
+                    6ms,
+                ),
+            },
+            CogsMeasurement {
+                resource: Relay,
+                feature: Spans,
+                category: Some(
+                    "s2",
+                ),
+                value: Time(
+                    6ms,
+                ),
+            },
+        ]
+        "###);
     }
 
     #[test]

--- a/relay-cogs/src/measurement.rs
+++ b/relay-cogs/src/measurement.rs
@@ -1,0 +1,53 @@
+use crate::time::{Duration, Instant};
+
+/// Simple collection of individual measurements.
+///
+/// Tracks the total time from starting the measurements as well as
+/// individual categorized measurements.
+pub struct Measurements {
+    start: Instant,
+    categorized: Vec<Measurement>,
+}
+
+impl Measurements {
+    /// Starts recording the first measurement.
+    pub fn start() -> Self {
+        Measurements {
+            start: Instant::now(),
+            categorized: Vec::new(),
+        }
+    }
+
+    /// Adds an individual categorized measurement.
+    pub fn add(&mut self, duration: Duration, category: &'static str) {
+        self.categorized.push(Measurement {
+            duration,
+            category: Some(category),
+        });
+    }
+
+    /// Finishes the current measurements and returns all individual
+    /// categorized measurements.
+    pub fn finish(&self) -> impl Iterator<Item = Measurement> + '_ {
+        let mut duration = self.start.elapsed();
+        for c in &self.categorized {
+            duration = duration.saturating_sub(c.duration);
+        }
+
+        std::iter::once(Measurement {
+            duration,
+            category: None,
+        })
+        .chain(self.categorized.iter().copied())
+        .filter(|m| !m.duration.is_zero())
+    }
+}
+
+/// A single, optionally, categorized measurement.
+#[derive(Copy, Clone)]
+pub struct Measurement {
+    /// Length of the measurement.
+    pub duration: Duration,
+    /// Optional category, if the measurement was categorized.
+    pub category: Option<&'static str>,
+}

--- a/relay-cogs/src/time.rs
+++ b/relay-cogs/src/time.rs
@@ -1,0 +1,44 @@
+pub use std::time::Duration;
+
+#[cfg(not(test))]
+pub use self::real::*;
+#[cfg(test)]
+pub use self::test::*;
+
+#[cfg(not(test))]
+mod real {
+    pub use std::time::Instant;
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    std::thread_local! {
+        static NOW: AtomicU64 = const { AtomicU64::new(0) };
+    }
+
+    fn now() -> u64 {
+        NOW.with(|now| now.load(Ordering::Relaxed))
+    }
+
+    pub fn advance_millis(time: u64) {
+        NOW.with(|now| now.fetch_add(time, Ordering::Relaxed));
+    }
+
+    pub struct Instant(u64);
+
+    impl Instant {
+        pub fn now() -> Self {
+            Self(now())
+        }
+
+        pub fn elapsed(&self) -> Duration {
+            match now() - self.0 {
+                0 => Duration::from_nanos(100),
+                v => Duration::from_millis(v),
+            }
+        }
+    }
+}

--- a/relay-server/src/services/cogs.rs
+++ b/relay-server/src/services/cogs.rs
@@ -46,7 +46,8 @@ impl CogsService {
         relay_statsd::metric!(
             counter(RelayCounters::CogsUsage) += amount,
             resource_id = resource_id,
-            app_feature = measurement.feature.as_str()
+            app_feature = measurement.feature.as_str(),
+            category = measurement.category.unwrap_or("default"),
         );
     }
 }
@@ -119,6 +120,7 @@ mod tests {
                 resource: ResourceId::Relay,
                 feature: relay_cogs::AppFeature::Spans,
                 value: relay_cogs::Value::Time(Duration::from_secs(1)),
+                category: None,
             });
         }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1632,6 +1632,7 @@ impl EnvelopeProcessorService {
     fn process_transactions(
         &self,
         managed_envelope: &mut TypedEnvelope<TransactionGroup>,
+        cogs: &mut Token,
         config: Arc<Config>,
         project_id: ProjectId,
         project_info: Arc<ProjectInfo>,
@@ -1649,13 +1650,15 @@ impl EnvelopeProcessorService {
 
         transaction::drop_invalid_items(managed_envelope, &global_config);
 
-        // We extract the main event from the envelope.
-        let extraction_result = event::extract(
-            managed_envelope,
-            &mut metrics,
-            event_fully_normalized,
-            &self.inner.config,
-        )?;
+        relay_cogs::with!(cogs, "event_extract", {
+            // We extract the main event from the envelope.
+            let extraction_result = event::extract(
+                managed_envelope,
+                &mut metrics,
+                event_fully_normalized,
+                &self.inner.config,
+            )?;
+        });
 
         // If metrics were extracted we mark that.
         if let Some(inner_event_metrics_extracted) = extraction_result.event_metrics_extracted {
@@ -1668,42 +1671,53 @@ impl EnvelopeProcessorService {
         // We take the main event out of the result.
         let mut event = extraction_result.event;
 
-        let profile_id = profile::filter(
-            managed_envelope,
-            &event,
-            config.clone(),
-            project_id,
-            project_info.clone(),
-        );
-        profile::transfer_id(&mut event, profile_id);
+        relay_cogs::with!(cogs, "profile_filter", {
+            let profile_id = profile::filter(
+                managed_envelope,
+                &event,
+                config.clone(),
+                project_id,
+                project_info.clone(),
+            );
+            profile::transfer_id(&mut event, profile_id);
+        });
 
-        event::finalize(
-            managed_envelope,
-            &mut event,
-            &mut metrics,
-            &self.inner.config,
-        )?;
-        event_fully_normalized = self.normalize_event(
-            managed_envelope,
-            &mut event,
-            project_id,
-            project_info.clone(),
-            event_fully_normalized,
-        )?;
+        relay_cogs::with!(cogs, "event_finalize", {
+            event::finalize(
+                managed_envelope,
+                &mut event,
+                &mut metrics,
+                &self.inner.config,
+            )?;
+        });
 
-        sampling_project_info = dynamic_sampling::validate_and_set_dsc(
-            managed_envelope,
-            &mut event,
-            project_info.clone(),
-            sampling_project_info.clone(),
-        );
+        relay_cogs::with!(cogs, "event_normalize", {
+            event_fully_normalized = self.normalize_event(
+                managed_envelope,
+                &mut event,
+                project_id,
+                project_info.clone(),
+                event_fully_normalized,
+            )?;
+        });
 
-        let filter_run = event::filter(
-            managed_envelope,
-            &mut event,
-            project_info.clone(),
-            &self.inner.global_config.current(),
-        )?;
+        relay_cogs::with!(cogs, "dynamic_sampling_dsc", {
+            sampling_project_info = dynamic_sampling::validate_and_set_dsc(
+                managed_envelope,
+                &mut event,
+                project_info.clone(),
+                sampling_project_info.clone(),
+            );
+        });
+
+        relay_cogs::with!(cogs, "filter", {
+            let filter_run = event::filter(
+                managed_envelope,
+                &mut event,
+                project_info.clone(),
+                &self.inner.global_config.current(),
+            )?;
+        });
 
         // Always run dynamic sampling on processing Relays,
         // but delay decision until inbound filters have been fully processed.
@@ -1715,17 +1729,19 @@ impl EnvelopeProcessorService {
             reservoir_counters,
         );
 
-        let sampling_result = match run_dynamic_sampling {
-            true => dynamic_sampling::run(
-                managed_envelope,
-                &mut event,
-                config.clone(),
-                project_info.clone(),
-                sampling_project_info,
-                &reservoir,
-            ),
-            false => SamplingResult::Pending,
-        };
+        relay_cogs::with!(cogs, "dynamic_sampling_run", {
+            let sampling_result = match run_dynamic_sampling {
+                true => dynamic_sampling::run(
+                    managed_envelope,
+                    &mut event,
+                    config.clone(),
+                    project_info.clone(),
+                    sampling_project_info,
+                    &reservoir,
+                ),
+                false => SamplingResult::Pending,
+            };
+        });
 
         #[cfg(feature = "processing")]
         let server_sample_rate = match sampling_result {
@@ -1773,6 +1789,8 @@ impl EnvelopeProcessorService {
 
             return Ok(Some(extracted_metrics));
         }
+
+        let _post_ds = cogs.start_category("post_ds");
 
         // Need to scrub the transaction before extracting spans.
         //
@@ -2104,8 +2122,10 @@ impl EnvelopeProcessorService {
         Ok(Some(extracted_metrics))
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn process_envelope(
         &self,
+        cogs: &mut Token,
         mut managed_envelope: ManagedEnvelope,
         project_id: ProjectId,
         project_info: Arc<ProjectInfo>,
@@ -2174,6 +2194,7 @@ impl EnvelopeProcessorService {
             ProcessingGroup::Transaction => {
                 run!(
                     process_transactions,
+                    cogs,
                     self.inner.config.clone(),
                     project_id,
                     project_info,
@@ -2257,6 +2278,7 @@ impl EnvelopeProcessorService {
 
     fn process(
         &self,
+        cogs: &mut Token,
         message: ProcessEnvelope,
     ) -> Result<ProcessEnvelopeResponse, ProcessingError> {
         let ProcessEnvelope {
@@ -2308,6 +2330,7 @@ impl EnvelopeProcessorService {
             },
             || {
                 match self.process_envelope(
+                    cogs,
                     managed_envelope,
                     project_id,
                     project_info,
@@ -2354,14 +2377,14 @@ impl EnvelopeProcessorService {
         )
     }
 
-    fn handle_process_envelope(&self, message: ProcessEnvelope) {
+    fn handle_process_envelope(&self, cogs: &mut Token, message: ProcessEnvelope) {
         let project_key = message.envelope.envelope().meta().public_key();
         let wait_time = message.envelope.age();
         metric!(timer(RelayTimers::EnvelopeWaitTime) = wait_time);
 
         let group = message.envelope.group().variant();
         let result = metric!(timer(RelayTimers::EnvelopeProcessingTime), group = group, {
-            self.process(message)
+            self.process(cogs, message)
         });
         match result {
             Ok(response) => {
@@ -3062,7 +3085,9 @@ impl EnvelopeProcessorService {
             let mut cogs = self.inner.cogs.timed(ResourceId::Relay, feature_weights);
 
             match message {
-                EnvelopeProcessor::ProcessEnvelope(m) => self.handle_process_envelope(*m),
+                EnvelopeProcessor::ProcessEnvelope(m) => {
+                    self.handle_process_envelope(&mut cogs, *m)
+                }
                 EnvelopeProcessor::ProcessProjectMetrics(m) => {
                     self.handle_process_metrics(&mut cogs, *m)
                 }
@@ -3797,7 +3822,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let new_envelope = envelope_response.envelope.unwrap();
         let new_envelope = new_envelope.envelope();
 
@@ -3869,7 +3894,9 @@ mod tests {
         .unwrap();
 
         let processor = create_test_processor(config).await;
-        let response = processor.process(process_message).unwrap();
+        let response = processor
+            .process(&mut Token::noop(), process_message)
+            .unwrap();
         let envelope = response.envelope.as_ref().unwrap().envelope();
         let event = envelope
             .get_item_by(|item| item.ty() == &ItemType::Event)

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -249,6 +249,7 @@ mod tests {
     use bytes::Bytes;
     use relay_base_schema::events::EventType;
     use relay_base_schema::project::ProjectKey;
+    use relay_cogs::Token;
     use relay_dynamic_config::{MetricExtractionConfig, TransactionMetricsConfig};
     use relay_event_schema::protocol::{EventId, LenientString};
     use relay_protocol::RuleCondition;
@@ -313,7 +314,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         ctx.envelope().clone()
     }

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -182,6 +182,7 @@ mod tests {
 
     #[cfg(feature = "processing")]
     use insta::assert_debug_snapshot;
+    use relay_cogs::Token;
     #[cfg(not(feature = "processing"))]
     use relay_dynamic_config::Feature;
     use relay_event_schema::protocol::EventId;
@@ -303,7 +304,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         let new_envelope = ctx.envelope();
 
@@ -434,7 +435,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         let new_envelope = ctx.envelope();
 
@@ -504,7 +505,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         assert!(envelope_response.envelope.is_none());
     }
 
@@ -576,7 +577,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         let new_envelope = ctx.envelope();
 

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -270,6 +270,7 @@ mod tests {
 
     use std::sync::Arc;
 
+    use relay_cogs::Token;
     use relay_config::Config;
     use relay_event_schema::protocol::EventId;
     use relay_sampling::evaluation::ReservoirCounters;
@@ -334,7 +335,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         assert!(envelope_response.envelope.is_none());
     }
 
@@ -389,7 +390,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         let item = ctx.envelope().items().next().unwrap();
         assert_eq!(item.ty(), &ItemType::ClientReport);
@@ -452,7 +453,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         assert!(envelope_response.envelope.is_none());
     }
 
@@ -493,7 +494,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         let new_envelope = ctx.envelope();
 
@@ -542,7 +543,7 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor.process(message).unwrap();
+        let envelope_response = processor.process(&mut Token::noop(), message).unwrap();
         let ctx = envelope_response.envelope.unwrap();
         let new_envelope = ctx.envelope();
 


### PR DESCRIPTION
Makes it possible to split a COGS measurement into multiple categories.

Also instruments the transaction processing with more categories. The initial plan was to instrument normalization in multiple smaller categories, I decided against that in this PR because that requires an API change with huge effects in tests. If we realize normalization takes up a significant amount, we can revisit this.

Ref: https://github.com/getsentry/team-ingest/issues/637

#skip-changelog