### PR TITLE
feat(threading): Add new relay-threading module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
+
 ## 25.2.0
 
 - Allow log ingestion behind a flag, only for internal use currently. ([#4471](https://github.com/getsentry/relay/pull/4471))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -911,6 +912,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -1369,6 +1371,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "nanorand",
  "spin",
 ]
 
@@ -2528,6 +2531,15 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -4076,6 +4088,17 @@ version = "25.2.0"
 dependencies = [
  "relay-log",
  "relay-system",
+ "tokio",
+]
+
+[[package]]
+name = "relay-threading"
+version = "25.1.0"
+dependencies = [
+ "criterion",
+ "flume",
+ "futures",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "relay-threading"
-version = "25.1.0"
+version = "25.2.0"
 dependencies = [
  "criterion",
  "flume",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,6 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin",
 ]
 
@@ -2531,15 +2530,6 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ relay-server = { path = "relay-server" }
 relay-spans = { path = "relay-spans" }
 relay-statsd = { path = "relay-statsd" }
 relay-system = { path = "relay-system" }
+relay-threading = { path = "relay-threading" }
 relay-ua = { path = "relay-ua" }
 relay-test = { path = "relay-test" }
 relay-protocol-derive = { path = "relay-protocol-derive" }
@@ -98,6 +99,7 @@ enumset = "1.0.13"
 flate2 = "1.0.35"
 fnv = "1.0.7"
 futures = { version = "0.3", default-features = false, features = ["std"] }
+flume = "0.11.1"
 globset = "0.4.15"
 hash32 = "0.3.1"
 hashbrown = "0.14.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ enumset = "1.0.13"
 flate2 = "1.0.35"
 fnv = "1.0.7"
 futures = { version = "0.3", default-features = false, features = ["std"] }
-flume = "0.11.1"
+flume = { version = "0.11.1", default-features = false }
 globset = "0.4.15"
 hash32 = "0.3.1"
 hashbrown = "0.14.5"

--- a/relay-threading/Cargo.toml
+++ b/relay-threading/Cargo.toml
@@ -10,14 +10,14 @@ license-file = "../LICENSE.md"
 publish = false
 
 [dependencies]
-flume = { workspace = true, default-features = false }
-futures = { workspace = true, default-features = false }
+flume = { workspace = true }
+futures = { workspace = true }
 tokio = { workspace = true }
 pin-project-lite = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
-futures = { workspace = true, default-features = false, features = ["executor"] }
+futures = { workspace = true, features = ["executor"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "sync", "macros"] }
 
 [[bench]]

--- a/relay-threading/Cargo.toml
+++ b/relay-threading/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "relay-threading"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Threading code that is used by Relay"
+homepage = "https://getsentry.github.io/relay/"
+repository = "https://github.com/getsentry/relay"
+version = "25.1.0"
+edition = "2021"
+license-file = "../LICENSE.md"
+publish = false
+
+[dependencies]
+flume = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "sync", "macros"] }
+pin-project-lite = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["async_tokio"] }
+
+[[bench]]
+name = "pool"
+harness = false

--- a/relay-threading/Cargo.toml
+++ b/relay-threading/Cargo.toml
@@ -4,19 +4,21 @@ authors = ["Sentry <oss@sentry.io>"]
 description = "Threading code that is used by Relay"
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"
-version = "25.1.0"
+version = "25.2.0"
 edition = "2021"
 license-file = "../LICENSE.md"
 publish = false
 
 [dependencies]
-flume = { workspace = true }
-futures = { workspace = true, features = ["executor"] }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "sync", "macros"] }
+flume = { workspace = true, default-features = false }
+futures = { workspace = true, default-features = false }
+tokio = { workspace = true }
 pin-project-lite = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+futures = { workspace = true, default-features = false, features = ["executor"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "sync", "macros"] }
 
 [[bench]]
 name = "pool"

--- a/relay-threading/benches/pool.rs
+++ b/relay-threading/benches/pool.rs
@@ -1,0 +1,159 @@
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use futures::future::{BoxFuture, FutureExt};
+use relay_threading::AsyncPoolBuilder;
+use tokio::runtime::Runtime;
+use tokio::sync::Semaphore;
+
+struct BenchBarrier {
+    semaphore: Arc<Semaphore>,
+    count: usize,
+}
+
+impl BenchBarrier {
+    fn new(count: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(count)),
+            count,
+        }
+    }
+
+    async fn spawn<F, Fut>(&self, pool: &relay_threading::AsyncPool<BoxFuture<'static, ()>>, f: F)
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let semaphore = self.semaphore.clone();
+        let permit = semaphore.acquire_owned().await.unwrap();
+        pool.spawn_async(
+            async move {
+                f().await;
+                drop(permit);
+            }
+            .boxed(),
+        )
+        .await;
+    }
+
+    async fn wait(&self) {
+        let _ = self
+            .semaphore
+            .acquire_many(self.count as u32)
+            .await
+            .unwrap();
+    }
+}
+
+fn create_runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+async fn run_benchmark(pool: &relay_threading::AsyncPool<BoxFuture<'static, ()>>, count: usize) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let barrier = BenchBarrier::new(count);
+
+    // Spawn tasks
+    for _ in 0..count {
+        let counter = counter.clone();
+        barrier
+            .spawn(pool, move || async move {
+                // Simulate some work
+                tokio::time::sleep(Duration::from_micros(50)).await;
+                counter.fetch_add(1, Ordering::SeqCst);
+            })
+            .await;
+    }
+
+    // Wait for all tasks to complete
+    barrier.wait().await;
+    assert_eq!(counter.load(Ordering::SeqCst), count);
+}
+
+fn bench_pool_scaling(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("pool_scaling");
+    group.sampling_mode(criterion::SamplingMode::Flat);
+    group.measurement_time(Duration::from_secs(10));
+
+    // Test with different numbers of threads
+    for threads in [1, 2, 4, 8].iter() {
+        let pool = AsyncPoolBuilder::new(runtime.handle().clone())
+            .num_threads(*threads)
+            .max_concurrency(100)
+            .build()
+            .unwrap();
+
+        // Test with different task counts
+        for tasks in [100, 1000, 10000].iter() {
+            group.bench_with_input(
+                BenchmarkId::new(format!("threads_{}", threads), tasks),
+                tasks,
+                |b, &tasks| {
+                    b.to_async(&runtime).iter(|| run_benchmark(&pool, tasks));
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_multi_threaded_spawn(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("multi_threaded_spawn");
+    group.sampling_mode(criterion::SamplingMode::Flat);
+    group.measurement_time(Duration::from_secs(10));
+
+    // Test with different numbers of spawning threads
+    for spawn_threads in [2, 4, 8].iter() {
+        // Test with different task counts
+        for tasks in [1000, 10000].iter() {
+            group.bench_with_input(
+                BenchmarkId::new(format!("spawn_threads_{}", spawn_threads), tasks),
+                tasks,
+                |b, &tasks| {
+                    b.to_async(&runtime).iter(|| async {
+                        let pool = Arc::new(
+                            AsyncPoolBuilder::new(runtime.handle().clone())
+                                .num_threads(4) // Fixed number of worker threads
+                                .max_concurrency(100)
+                                .build()
+                                .unwrap(),
+                        );
+
+                        let tasks_per_thread = tasks / spawn_threads;
+                        let mut handles = Vec::new();
+
+                        // Spawn tasks from multiple threads
+                        for _ in 0..*spawn_threads {
+                            let runtime = runtime.handle().clone();
+                            let pool = pool.clone();
+                            let handle = std::thread::spawn(move || {
+                                runtime.block_on(run_benchmark(&pool, tasks_per_thread));
+                            });
+                            handles.push(handle);
+                        }
+
+                        // Wait for all spawning threads to complete
+                        for handle in handles {
+                            handle.join().unwrap();
+                        }
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_pool_scaling, bench_multi_threaded_spawn);
+criterion_main!(benches);

--- a/relay-threading/src/builder.rs
+++ b/relay-threading/src/builder.rs
@@ -13,7 +13,9 @@ use crate::pool::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 pub struct AsyncPoolBuilder<S = DefaultSpawn> {
     pub(crate) runtime: tokio::runtime::Handle,
     pub(crate) thread_name: Option<Box<dyn FnMut(usize) -> String>>,
+    #[allow(clippy::type_complexity)]
     pub(crate) thread_panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    #[allow(clippy::type_complexity)]
     pub(crate) task_panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
     pub(crate) spawn_handler: S,
     pub(crate) num_threads: usize,

--- a/relay-threading/src/builder.rs
+++ b/relay-threading/src/builder.rs
@@ -61,10 +61,6 @@ where
     ///
     /// If a thread panics, the provided handler will be invoked so that you can perform
     /// custom error handling or cleanup.
-    ///
-    /// # Panics
-    ///
-    /// In the absence of this handler, thread panics will propagate.
     pub fn thread_panic_handler<F>(mut self, panic_handler: F) -> Self
     where
         F: Fn(Box<dyn Any + Send>) + Send + Sync + 'static,
@@ -77,10 +73,6 @@ where
     ///
     /// This handler is used to manage panics that occur during task execution, allowing for graceful
     /// error handling.
-    ///
-    /// # Panics
-    ///
-    /// Without a handler, panics in tasks will propagate.
     pub fn task_panic_handler<F>(mut self, panic_handler: F) -> Self
     where
         F: Fn(Box<dyn Any + Send>) + Send + Sync + 'static,

--- a/relay-threading/src/builder.rs
+++ b/relay-threading/src/builder.rs
@@ -6,6 +6,9 @@ use std::sync::Arc;
 use crate::pool::{AsyncPool, Thread};
 use crate::pool::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 
+/// Type alias for a thread safe closure that is used for panic handling across the code.
+pub(crate) type PanicHandler = dyn Fn(Box<dyn Any + Send>) + Send + Sync;
+
 /// [`AsyncPoolBuilder`] provides a flexible way to configure and build an [`AsyncPool`] for executing
 /// asynchronous tasks concurrently on dedicated threads.
 ///
@@ -14,10 +17,8 @@ use crate::pool::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 pub struct AsyncPoolBuilder<S = DefaultSpawn> {
     pub(crate) runtime: tokio::runtime::Handle,
     pub(crate) thread_name: Option<Box<dyn FnMut(usize) -> String>>,
-    #[allow(clippy::type_complexity)]
-    pub(crate) thread_panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
-    #[allow(clippy::type_complexity)]
-    pub(crate) task_panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    pub(crate) thread_panic_handler: Option<Arc<PanicHandler>>,
+    pub(crate) task_panic_handler: Option<Arc<PanicHandler>>,
     pub(crate) spawn_handler: S,
     pub(crate) num_threads: usize,
     pub(crate) max_concurrency: usize,

--- a/relay-threading/src/builder.rs
+++ b/relay-threading/src/builder.rs
@@ -1,0 +1,115 @@
+use std::any::Any;
+use std::future::Future;
+use std::io;
+use std::sync::Arc;
+
+use crate::pool::{AsyncPool, Thread};
+use crate::pool::{CustomSpawn, DefaultSpawn, ThreadSpawn};
+
+/// A builder for constructing an [`AsyncPool`] with custom configurations.
+///
+/// Use this builder to fine-tune the performance and threading behavior of your asynchronous
+/// task pool.
+pub struct AsyncPoolBuilder<S = DefaultSpawn> {
+    pub(crate) runtime: tokio::runtime::Handle,
+    pub(crate) thread_name: Option<Box<dyn FnMut(usize) -> String>>,
+    pub(crate) thread_panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    pub(crate) task_panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    pub(crate) spawn_handler: S,
+    pub(crate) num_threads: usize,
+    pub(crate) max_concurrency: usize,
+}
+
+impl AsyncPoolBuilder<DefaultSpawn> {
+    /// Creates a new [`AsyncPoolBuilder`] with default settings.
+    pub fn new(runtime: tokio::runtime::Handle) -> AsyncPoolBuilder<DefaultSpawn> {
+        AsyncPoolBuilder {
+            runtime,
+            thread_name: None,
+            thread_panic_handler: None,
+            task_panic_handler: None,
+            spawn_handler: DefaultSpawn,
+            num_threads: 1,
+            max_concurrency: 1,
+        }
+    }
+}
+
+impl<S> AsyncPoolBuilder<S>
+where
+    S: ThreadSpawn,
+{
+    /// Specifies a custom hook to generate the thread name given the thread index within the
+    /// [`AsyncPool`].
+    pub fn thread_name<F>(mut self, thread_name: F) -> Self
+    where
+        F: FnMut(usize) -> String + 'static,
+    {
+        self.thread_name = Some(Box::new(thread_name));
+        self
+    }
+
+    /// Specifies a custom hook to handle the panic happening in one of the threads of the
+    /// [`AsyncPool`].
+    ///
+    /// The `panic_handler` is called once for each panicking thread with the error caught in the
+    /// panicking as argument.
+    pub fn thread_panic_handler<F>(mut self, panic_handler: F) -> Self
+    where
+        F: Fn(Box<dyn Any + Send>) + Send + Sync + 'static,
+    {
+        self.thread_panic_handler = Some(Arc::new(panic_handler));
+        self
+    }
+
+    /// Specifies a custom hook to handle the panic happening in one of the tasks of the
+    /// [`AsyncPool`].
+    ///
+    /// The `panic_handler` is called once for each panicking task with the error caught in the
+    /// panicking as argument.
+    pub fn task_panic_handler<F>(mut self, panic_handler: F) -> Self
+    where
+        F: Fn(Box<dyn Any + Send>) + Send + Sync + 'static,
+    {
+        self.task_panic_handler = Some(Arc::new(panic_handler));
+        self
+    }
+
+    /// Specifies a custom hook to dynamically adjust thread settings for the [`AsyncPool`].
+    pub fn spawn_handler<F>(self, spawn_handler: F) -> AsyncPoolBuilder<CustomSpawn<F>>
+    where
+        F: FnMut(Thread) -> io::Result<()>,
+    {
+        AsyncPoolBuilder {
+            runtime: self.runtime,
+            thread_name: self.thread_name,
+            thread_panic_handler: self.thread_panic_handler,
+            task_panic_handler: self.task_panic_handler,
+            spawn_handler: CustomSpawn::new(spawn_handler),
+            num_threads: self.num_threads,
+            max_concurrency: self.max_concurrency,
+        }
+    }
+
+    /// Sets the number of executor threads for running tasks in the [`AsyncPool`].
+    pub fn num_threads(mut self, num_threads: usize) -> Self {
+        self.num_threads = num_threads;
+        self
+    }
+
+    /// Adjusts the maximum number of concurrent tasks allowed per executor in the [`AsyncPool`].
+    ///
+    /// The max concurrency determines how many futures can be polled simultaneously.
+    pub fn max_concurrency(mut self, max_concurrency: usize) -> Self {
+        self.max_concurrency = max_concurrency;
+        self
+    }
+
+    /// Finalizes the configuration and constructs an operational [`AsyncPool`] for executing tasks.
+    pub fn build<F>(self) -> Result<AsyncPool<F>, io::Error>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        AsyncPool::new(self)
+    }
+}

--- a/relay-threading/src/lib.rs
+++ b/relay-threading/src/lib.rs
@@ -22,13 +22,6 @@
 //! backpressure - when workers are overwhelmed, task submission will block until capacity becomes
 //! available, preventing resource exhaustion.
 //!
-//! ## Modules
-//!
-//! - **builder**: Contains the [`AsyncPoolBuilder`] which configures and constructs an [`AsyncPool`].
-//! - **multiplexing**: Provides the [`Multiplexed`] future that manages and executes multiple asynchronous tasks concurrently.
-//! - **pool**: Implements the [`AsyncPool`] and related types, such as [`Thread`]. Together they encapsulate the logic
-//!   for scheduling tasks across multiple threads.
-//!
 //! ## Usage Example
 //!
 //! ```rust
@@ -55,11 +48,6 @@
 //!
 //! Both the async pool and its task multiplexer support custom panic handlers, allowing graceful
 //! recovery from panics in either thread execution or individual tasks.
-//!
-//! For more details on specific functionalities, refer to the documentation in the submodules:
-//! - [`builder`]
-//! - [`multiplexing`]
-//! - [`pool`]
 
 mod builder;
 mod multiplexing;

--- a/relay-threading/src/lib.rs
+++ b/relay-threading/src/lib.rs
@@ -1,0 +1,63 @@
+//! # Relay Threading
+//!
+//! This module provides threading abstractions for Relay, offering a set of utilities for managing
+//! asynchronous work. It includes a thread-based asynchronous task pool, a flexible builder for
+//! configuring pool parameters (thread naming, panic handling, concurrency limits), and mechanisms for
+//! multiplexing tasks across dedicated threads with built-in panic recovery.
+//!
+//! ## Features
+//!
+//! - **AsyncPool**: A thread-based asynchronous pool for executing futures concurrently on dedicated threads.
+//! - **AsyncPoolBuilder**: A configurable builder to construct an [`AsyncPool`] with custom settings,
+//!   including thread naming, panic handlers (for both threads and tasks), custom spawn handlers, and
+//!   concurrency limits.
+//! - **Multiplexed Execution**: A task multiplexer that drives a collection of asynchronous tasks while
+//!   respecting a specified concurrency limit. It handles panics gracefully via an optional panic callback.
+//! - **Custom Thread Spawning**: Supports customized thread creation, allowing usage of system defaults or
+//!   custom configurations through a provided spawn handler.
+//!
+//! ## Modules
+//!
+//! - **builder**: Contains the [`AsyncPoolBuilder`] which configures and constructs an [`AsyncPool`].
+//! - **multiplexing**: Provides the [`Multiplexed`] future that manages and executes multiple asynchronous tasks concurrently.
+//! - **pool**: Implements the [`AsyncPool`] and related types, such as [`Thread`]. Together they encapsulate the logic
+//!   for scheduling tasks across multiple threads.
+//!
+//! ## Usage Example
+//!
+//! ```rust
+//! use relay_threading::{AsyncPoolBuilder, AsyncPool};
+//! use tokio::runtime::Handle;
+//!
+//! // Create a runtime handle (for example purposes, using the current runtime)
+//! let runtime_handle = Handle::current();
+//!
+//! // Build an async pool with 4 threads and a max of 100 concurrent tasks per thread
+//! let pool: AsyncPool<_> = AsyncPoolBuilder::new(runtime_handle)
+//!     .num_threads(4)
+//!     .max_concurrency(100)
+//!     .build()
+//!     .expect("Failed to build async pool");
+//!
+//! // Schedule a task to be executed by the pool
+//! pool.spawn(async {
+//!     // Place your asynchronous task logic here
+//! });
+//! ```
+//!
+//! ## Error Handling
+//!
+//! Both the async pool and its task multiplexer support custom panic handlers, allowing graceful
+//! recovery from panics in either thread execution or individual tasks.
+//!
+//! For more details on specific functionalities, refer to the documentation in the submodules:
+//! - [`builder`]
+//! - [`multiplexing`]
+//! - [`pool`]
+
+mod builder;
+mod multiplexing;
+mod pool;
+
+pub use self::builder::*;
+pub use self::pool::*;

--- a/relay-threading/src/lib.rs
+++ b/relay-threading/src/lib.rs
@@ -1,20 +1,26 @@
 //! # Relay Threading
 //!
-//! This module provides threading abstractions for Relay, offering a set of utilities for managing
-//! asynchronous work. It includes a thread-based asynchronous task pool, a flexible builder for
-//! configuring pool parameters (thread naming, panic handling, concurrency limits), and mechanisms for
-//! multiplexing tasks across dedicated threads with built-in panic recovery.
+//! This module provides a robust threading framework for Relay, designed to efficiently manage and execute
+//! asynchronous workloads. At its core is a thread-based asynchronous task pool that offers:
 //!
-//! ## Features
+//! - **Flexible Configuration**: Fine-tune thread counts, naming patterns, panic handling strategies,
+//!   and concurrency limits through a builder pattern.
+//! - **Task Multiplexing**: Distribute tasks across dedicated worker threads.
+//! - **Panic Recovery**: Built-in mechanisms to gracefully handle and recover from panics, both at the
+//!   thread and individual task level
+//! - **Tokio Integration**: Seamlessly integrates with Tokio runtime for async task execution
 //!
-//! - **AsyncPool**: A thread-based asynchronous pool for executing futures concurrently on dedicated threads.
-//! - **AsyncPoolBuilder**: A configurable builder to construct an [`AsyncPool`] with custom settings,
-//!   including thread naming, panic handlers (for both threads and tasks), custom spawn handlers, and
-//!   concurrency limits.
-//! - **Multiplexed Execution**: A task multiplexer that drives a collection of asynchronous tasks while
-//!   respecting a specified concurrency limit. It handles panics gracefully via an optional panic callback.
-//! - **Custom Thread Spawning**: Supports customized thread creation, allowing usage of system defaults or
-//!   custom configurations through a provided spawn handler.
+//! ## Concurrency Model
+//!
+//! The pool maintains a set of dedicated worker threads, each capable of executing multiple async tasks
+//! concurrently up to a configurable limit. This architecture ensures efficient resource utilization
+//! while preventing any single thread from becoming overwhelmed.
+//!
+//! The pool maintains a bounded queue with a capacity of twice the number of worker threads. This
+//! design allows new tasks to be queued while existing ones are being processed, ensuring smooth
+//! task handoff between producers and consumers. The bounded nature of the queue provides natural
+//! backpressure - when workers are overwhelmed, task submission will block until capacity becomes
+//! available, preventing resource exhaustion.
 //!
 //! ## Modules
 //!

--- a/relay-threading/src/lib.rs
+++ b/relay-threading/src/lib.rs
@@ -26,13 +26,13 @@
 //!
 //! ```rust
 //! use relay_threading::{AsyncPoolBuilder, AsyncPool};
-//! use tokio::runtime::Handle;
+//! use tokio::runtime::Runtime;
 //!
-//! // Create a runtime handle (for example purposes, using the current runtime)
-//! let runtime_handle = Handle::current();
+//! // Create a runtime (for example purposes, create one inline)
+//! let runtime_handle = Runtime::new().unwrap();
 //!
 //! // Build an async pool with 4 threads and a max of 100 concurrent tasks per thread
-//! let pool: AsyncPool<_> = AsyncPoolBuilder::new(runtime_handle)
+//! let pool: AsyncPool<_> = AsyncPoolBuilder::new(runtime_handle.handle().clone())
 //!     .num_threads(4)
 //!     .max_concurrency(100)
 //!     .build()

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -59,6 +59,10 @@ where
     ///
     /// If a future panics and a panic handler is provided, the handler is invoked.
     /// Otherwise, the panic is propagated.
+    ///
+    /// # Panics
+    ///
+    /// Panics are either handled by the custom handler or propagated if no handler is specified.
     fn poll_tasks_until_pending(self: Pin<&mut Self>, cx: &mut Context<'_>) {
         let mut this = self.project();
 
@@ -96,10 +100,6 @@ pin_project! {
     /// the number of concurrently executing tasks does not exceed a specified limit.
     ///
     /// This multiplexer is primarily used by the [`AsyncPool`] to manage task execution on worker threads.
-    ///
-    /// # Panics
-    ///
-    /// If any task panics without a custom panic handler, the panic will propagate.
     pub struct Multiplexed<S, F> {
         max_concurrency: usize,
         #[pin]

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -27,6 +27,7 @@ impl<F> Tasks<F> {
     /// Initializes a new [`Tasks`] collection for managing asynchronous tasks.
     ///
     /// This collection is used internally by [`Multiplexed`] to schedule task execution.
+    #[allow(clippy::type_complexity)]
     fn new(panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>) -> Self {
         Self {
             futures: FuturesUnordered::new(),
@@ -119,6 +120,7 @@ where
     ///
     /// This multiplexer should be awaited until completion, at which point all submitted tasks
     /// will have been executed.
+    #[allow(clippy::type_complexity)]
     pub fn new(
         max_concurrency: usize,
         rx: S,

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -169,13 +169,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use futures::{future::BoxFuture, FutureExt};
     use std::sync::atomic::AtomicBool;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     };
+
+    use futures::{future::BoxFuture, FutureExt};
+
+    use super::*;
 
     fn future_with(block: impl FnOnce() + Send + 'static) -> BoxFuture<'static, ()> {
         let fut = async {

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -1,0 +1,380 @@
+use std::any::Any;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::future::CatchUnwind;
+use futures::stream::{FusedStream, FuturesUnordered, Stream};
+use futures::FutureExt;
+use pin_project_lite::pin_project;
+use tokio::task::Unconstrained;
+
+pin_project! {
+    /// Manages a collection of asynchronous tasks that are executed concurrently.
+    ///
+    /// This helper is designed for use within the [`Multiplexed`] executor to schedule and drive tasks
+    /// while respecting a set concurrency limit.
+    struct Tasks<F> {
+        #[pin]
+        futures: FuturesUnordered<Unconstrained<CatchUnwind<AssertUnwindSafe<F>>>>,
+        panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    }
+}
+
+impl<F> Tasks<F> {
+    /// Initializes a new [`Tasks`] collection for managing asynchronous tasks.
+    ///
+    /// This collection is used internally by [`Multiplexed`] to schedule task execution.
+    fn new(panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>) -> Self {
+        Self {
+            futures: FuturesUnordered::new(),
+            panic_handler,
+        }
+    }
+
+    /// Returns the number of tasks currently scheduled for execution.
+    fn len(&self) -> usize {
+        self.futures.len()
+    }
+
+    /// Returns whether there are no tasks scheduled.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<F> Tasks<F>
+where
+    F: Future<Output = ()>,
+{
+    /// Adds a new asynchronous task to the collection.
+    ///
+    /// Use this method to submit additional tasks for concurrent execution.
+    fn push(&mut self, future: F) {
+        let future = AssertUnwindSafe(future).catch_unwind();
+        self.futures.push(tokio::task::unconstrained(future));
+    }
+
+    /// Drives the scheduled tasks until one remains pending.
+    ///
+    /// This method advances the execution of managed tasks until it encounters a task
+    /// that is not immediately ready, ensuring that completed tasks are processed and the
+    /// multiplexer can schedule new ones.
+    ///
+    /// For any task that panics, the `panic_handler` callback will be called.
+    fn poll_tasks_until_pending(self: Pin<&mut Self>, cx: &mut Context<'_>) {
+        let mut this = self.project();
+
+        loop {
+            // If the unordered pool of futures is terminated, we stop polling.
+            if this.futures.is_terminated() {
+                return;
+            }
+
+            // If we don't get a Ready(Some(_)), it means we are now polling a pending future or the
+            // stream has ended, in that case we return.
+            let Poll::Ready(Some(result)) = this.futures.as_mut().poll_next(cx) else {
+                return;
+            };
+
+            // If there is an error, it means that the future has panicked, we want to notify this.
+            match (this.panic_handler.as_ref(), result) {
+                // Panic handler and error, we swallow the panic and invoke the callback.
+                (Some(panic_handler), Err(error)) => {
+                    panic_handler(error);
+                }
+                // No panic handler and error, we propagate the panic.
+                (None, Err(error)) => {
+                    std::panic::resume_unwind(error);
+                }
+                // Otherwise, we do nothing.
+                (_, Ok(())) => {}
+            }
+        }
+    }
+}
+
+pin_project! {
+    /// A task multiplexer that concurrently executes asynchronous tasks while limiting the maximum
+    /// number of tasks running simultaneously.
+    ///
+    /// The [`Multiplexed`] executor retrieves tasks from a stream and schedules them according to the
+    /// specified concurrency limit. The multiplexer completes once all tasks have been executed and
+    /// no further tasks are available.
+    pub struct Multiplexed<S, F> {
+        max_concurrency: usize,
+        #[pin]
+        rx: S,
+        #[pin]
+        tasks: Tasks<F>,
+    }
+}
+impl<S, F> Multiplexed<S, F>
+where
+    S: Stream<Item = F>,
+{
+    /// Constructs a new [`Multiplexed`] executor with a concurrency limit and a stream of tasks.
+    ///
+    /// This multiplexer should be awaited until completion, at which point all submitted tasks
+    /// will have been executed.
+    pub fn new(
+        max_concurrency: usize,
+        rx: S,
+        panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    ) -> Self {
+        Self {
+            max_concurrency,
+            rx,
+            tasks: Tasks::new(panic_handler),
+        }
+    }
+}
+
+impl<S, F> Future for Multiplexed<S, F>
+where
+    S: FusedStream<Item = F>,
+    F: Future<Output = ()>,
+{
+    type Output = ();
+
+    /// Drives the execution of the multiplexer by advancing scheduled tasks and fetching new ones.
+    ///
+    /// This method polls the collection of tasks and retrieves additional tasks from the stream until
+    /// the concurrency limit is reached or no more tasks are available. It yields `Poll::Pending` when
+    /// there is ongoing work and returns `Poll::Ready(())` only once the task stream is exhausted
+    /// and no active tasks remain.
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            this.tasks.as_mut().poll_tasks_until_pending(cx);
+
+            if this.tasks.len() >= *this.max_concurrency {
+                return Poll::Pending;
+            }
+
+            match this.rx.as_mut().poll_next(cx) {
+                Poll::Ready(Some(task)) => this.tasks.push(task),
+                // The stream is exhausted and there are no remaining tasks.
+                Poll::Ready(None) if this.tasks.is_empty() => return Poll::Ready(()),
+                // The stream is exhausted but tasks remain active.
+                Poll::Ready(None) => return Poll::Pending,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{future::BoxFuture, FutureExt};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    };
+
+    fn future_with(block: impl FnOnce() + Send + 'static) -> BoxFuture<'static, ()> {
+        let fut = async {
+            // Yield to allow a pending state during polling.
+            tokio::task::yield_now().await;
+            block();
+        };
+
+        fut.boxed()
+    }
+
+    #[test]
+    fn test_multiplexer_with_no_futures() {
+        let (_, rx) = flume::bounded::<BoxFuture<'static, _>>(10);
+        futures::executor::block_on(Multiplexed::new(1, rx.into_stream(), None));
+    }
+
+    #[test]
+    fn test_multiplexer_with_panic_handler_panicking_future() {
+        let panic_handler_called = Arc::new(AtomicBool::new(false));
+        let count = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = flume::bounded(10);
+
+        let count_clone = count.clone();
+        tx.send(future_with(move || {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+            panic!("panicked");
+        }))
+        .unwrap();
+
+        drop(tx);
+
+        let panic_handler_called_clone = panic_handler_called.clone();
+        let panic_handler = move |_| {
+            panic_handler_called_clone.store(true, Ordering::SeqCst);
+        };
+        futures::executor::block_on(Multiplexed::new(
+            1,
+            rx.into_stream(),
+            Some(Arc::new(panic_handler)),
+        ));
+
+        // The count is expected to have been incremented and the handler called.
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        assert!(panic_handler_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_multiplexer_with_no_panic_handler_panicking_future() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = flume::bounded(10);
+
+        let count_clone = count.clone();
+        tx.send(future_with(move || {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+            panic!("panicked");
+        }))
+        .unwrap();
+
+        drop(tx);
+
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            futures::executor::block_on(Multiplexed::new(1, rx.into_stream(), None))
+        }));
+
+        // The count is expected to have been incremented and the handler called.
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multiplexer_with_one_concurrency_and_one_future() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = flume::bounded(10);
+
+        let count_clone = count.clone();
+        tx.send(future_with(move || {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+        }))
+        .unwrap();
+
+        drop(tx);
+
+        futures::executor::block_on(Multiplexed::new(1, rx.into_stream(), None));
+
+        // The count is expected to have been incremented.
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_multiplexer_with_one_concurrency_and_multiple_futures() {
+        let entries = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = flume::bounded(10);
+
+        for i in 0..5 {
+            let entries_clone = entries.clone();
+            tx.send(future_with(move || {
+                entries_clone.lock().unwrap().push(i);
+            }))
+            .unwrap();
+        }
+
+        drop(tx);
+
+        futures::executor::block_on(Multiplexed::new(1, rx.into_stream(), None));
+
+        // The order of completion is expected to match the order of submission.
+        assert_eq!(*entries.lock().unwrap(), (0..5).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_multiplexer_with_multiple_concurrency_and_one_future() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = flume::bounded(10);
+
+        let count_clone = count.clone();
+        tx.send(future_with(move || {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+        }))
+        .unwrap();
+
+        drop(tx);
+
+        futures::executor::block_on(Multiplexed::new(5, rx.into_stream(), None));
+
+        // The count is expected to have been incremented.
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_multiplexer_with_multiple_concurrency_and_multiple_futures() {
+        let entries = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = flume::bounded(10);
+
+        for i in 0..5 {
+            let entries_clone = entries.clone();
+            tx.send(future_with(move || {
+                entries_clone.lock().unwrap().push(i);
+            }))
+            .unwrap();
+        }
+
+        drop(tx);
+
+        futures::executor::block_on(Multiplexed::new(5, rx.into_stream(), None));
+
+        // The order of completion is expected to be the same as the order of submission.
+        assert_eq!(*entries.lock().unwrap(), (0..5).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_multiplexer_with_multiple_concurrency_and_multiple_futures_from_multiple_threads() {
+        let entries = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = flume::bounded(10);
+
+        let mut handles = vec![];
+        for i in 0..5 {
+            let entries_clone = entries.clone();
+            let tx_clone = tx.clone();
+            handles.push(std::thread::spawn(move || {
+                tx_clone
+                    .send(future_with(move || {
+                        entries_clone.lock().unwrap().push(i);
+                    }))
+                    .unwrap();
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        drop(tx);
+
+        futures::executor::block_on(Multiplexed::new(5, rx.into_stream(), None));
+
+        // The order of completion may vary; verify that all expected elements are present.
+        let mut entries = entries.lock().unwrap();
+        entries.sort();
+        assert_eq!(*entries, (0..5).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_catch_unwind_future_handles_panics() {
+        let future = AssertUnwindSafe(async {
+            panic!("panicked");
+        })
+        .catch_unwind();
+
+        // The future should complete without propagating the panic but propagating the error.
+        assert!(futures::executor::block_on(future).is_err());
+
+        // Verify that non-panicking tasks complete normally.
+        let future = AssertUnwindSafe(async {
+            // A normal future that completes.
+        })
+        .catch_unwind();
+
+        // The future should successfully complete.
+        assert!(futures::executor::block_on(future).is_ok());
+    }
+}

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -117,7 +117,6 @@ where
     ///
     /// Tasks from the stream will be scheduled for execution concurrently, and an optional panic handler
     /// can be provided to manage errors during task execution.
-
     pub fn new(max_concurrency: usize, rx: S, panic_handler: Option<Arc<PanicHandler>>) -> Self {
         Self {
             max_concurrency,

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -192,10 +192,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::AsyncPoolBuilder;
-    use crate::{AsyncPool, Thread};
-    use futures::future::BoxFuture;
-    use futures::FutureExt;
     use std::future::Future;
     use std::sync::atomic::AtomicBool;
     use std::sync::{
@@ -203,9 +199,15 @@ mod tests {
         Arc,
     };
     use std::time::{Duration, Instant};
+
+    use futures::future::BoxFuture;
+    use futures::FutureExt;
     use tokio::runtime::Runtime;
     use tokio::sync::Semaphore;
     use tokio::{runtime::Handle, time::sleep};
+
+    use crate::builder::AsyncPoolBuilder;
+    use crate::{AsyncPool, Thread};
 
     struct TestBarrier {
         semaphore: Arc<Semaphore>,

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -89,6 +89,7 @@ pub struct Thread {
     max_concurrency: usize,
     name: Option<String>,
     runtime: tokio::runtime::Handle,
+    #[allow(clippy::type_complexity)]
     panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
     task: BoxFuture<'static, ()>,
 }
@@ -353,6 +354,6 @@ mod tests {
         }
         .run();
 
-        assert_eq!(has_panicked.load(Ordering::SeqCst), true);
+        assert!(has_panicked.load(Ordering::SeqCst));
     }
 }

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -1,0 +1,356 @@
+use std::any::Any;
+use std::future::Future;
+use std::io;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+
+use crate::builder::AsyncPoolBuilder;
+use crate::multiplexing::Multiplexed;
+
+/// A thread-based asynchronous pool for executing futures concurrently.
+///
+/// [`AsyncPool`] enables scheduling asynchronous tasks that are executed across a set of dedicated threads.
+/// Each thread runs its own asynchronous executor executing tasks concurrently up to a configurable limit.
+/// This design isolates task execution to dedicated threads while remaining safe for scheduling from multiple threads.
+#[derive(Debug)]
+pub struct AsyncPool<F> {
+    tx: flume::Sender<F>,
+}
+
+impl<F> AsyncPool<F>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    /// Constructs a new [`AsyncPool`] using the configuration specified by [`AsyncPoolBuilder`].
+    ///
+    /// This method creates the thread pool with the appropriate number of threads and configures each executor,
+    /// thus enabling efficient processing of asynchronous tasks.
+    pub fn new<S>(mut builder: AsyncPoolBuilder<S>) -> io::Result<Self>
+    where
+        S: ThreadSpawn,
+    {
+        let (tx, rx) = flume::bounded(builder.num_threads * 2);
+
+        for index in 0..builder.num_threads {
+            let rx = rx.clone();
+
+            let thread = Thread {
+                index,
+                max_concurrency: builder.max_concurrency,
+                name: builder.thread_name.as_mut().map(|f| f(index)),
+                runtime: builder.runtime.clone(),
+                panic_handler: builder.thread_panic_handler.clone(),
+                task: Multiplexed::new(
+                    builder.max_concurrency,
+                    rx.into_stream(),
+                    builder.task_panic_handler.clone(),
+                )
+                .boxed(),
+            };
+
+            builder.spawn_handler.spawn(thread)?;
+        }
+
+        Ok(Self { tx })
+    }
+}
+
+impl<F> AsyncPool<F>
+where
+    F: Future<Output = ()>,
+{
+    /// Schedules a future for asynchronous execution within the pool.
+    ///
+    /// This method adds the given future to the pool's task queue where it will be executed by an available thread.
+    pub fn spawn(&self, future: F) {
+        assert!(
+            self.tx.send(future).is_ok(),
+            "receiver never exits before sender"
+        );
+    }
+
+    /// Schedules a future for asynchronous execution, awaiting until it is enqueued.
+    ///
+    /// Use this asynchronous method when you need assurance that the task has been successfully queued.
+    pub async fn spawn_async(&self, future: F) {
+        assert!(
+            self.tx.send_async(future).await.is_ok(),
+            "receiver never exits before sender"
+        );
+    }
+}
+
+/// Represents a dedicated thread running asynchronous tasks within an [`AsyncPool`].
+pub struct Thread {
+    index: usize,
+    max_concurrency: usize,
+    name: Option<String>,
+    runtime: tokio::runtime::Handle,
+    panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
+    task: BoxFuture<'static, ()>,
+}
+
+impl Thread {
+    /// Returns the identifier assigned to this thread.
+    ///
+    /// The identifier is useful for debugging or tracing task execution across threads.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Returns the maximum concurrency for this thread.
+    ///
+    /// The maximum concurrency determines how many futures will be polled concurrently by the
+    /// thread.
+    pub fn max_concurrency(&self) -> usize {
+        self.max_concurrency
+    }
+
+    /// Returns the name of this thread, if one was provided.
+    ///
+    /// Thread names can aid in logging and debugging by providing a human-readable identifier.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+}
+
+impl Thread {
+    /// Runs the [`Multiplexed`] future associated with this thread that executes incoming futures.
+    ///
+    /// If there is a panic during execution, the `panic_handler` will be called.
+    pub fn run(self) {
+        let result =
+            std::panic::catch_unwind(AssertUnwindSafe(|| self.runtime.block_on(self.task)));
+
+        match (self.panic_handler, result) {
+            // Panic handler and error, we swallow the panic and invoke the callback.
+            (Some(panic_handler), Err(error)) => {
+                panic_handler(error);
+            }
+            // No panic handler and error, we propagate the panic.
+            (None, Err(error)) => {
+                std::panic::resume_unwind(error);
+            }
+            // Otherwise, we do nothing.
+            (_, Ok(())) => {}
+        }
+    }
+}
+
+/// A trait for customizing the spawning of threads in an [`AsyncPool`].
+///
+/// Implement [`ThreadSpawn`] to modify thread settings—such as the thread name or stack size—prior to creation,
+/// allowing the thread to be tailored for the requirements of your application.
+pub trait ThreadSpawn {
+    /// Spawns a new thread using the provided configuration.
+    fn spawn(&mut self, thread: Thread) -> io::Result<()>;
+}
+
+/// A default implementation of [`ThreadSpawn`] that uses system defaults.
+///
+/// [`DefaultSpawn`] does not alter thread settings and relies on the standard behavior of the operating system.
+#[derive(Clone)]
+pub struct DefaultSpawn;
+
+impl ThreadSpawn for DefaultSpawn {
+    fn spawn(&mut self, thread: Thread) -> io::Result<()> {
+        let mut b = std::thread::Builder::new();
+        if let Some(name) = thread.name() {
+            b = b.name(name.to_owned());
+        }
+        b.spawn(|| thread.run())?;
+
+        Ok(())
+    }
+}
+
+/// A flexible [`ThreadSpawn`] implementation that uses a closure for dynamic thread configuration.
+///
+/// Use [`CustomSpawn`] to provide custom settings for thread creation via a user-supplied closure.
+#[derive(Clone)]
+pub struct CustomSpawn<B>(B);
+
+impl<B> CustomSpawn<B> {
+    /// Creates a new instance of [`CustomSpawn`] with the provided configuration closure.
+    pub fn new(spawn_handler: B) -> Self {
+        CustomSpawn(spawn_handler)
+    }
+}
+
+impl<B> ThreadSpawn for CustomSpawn<B>
+where
+    B: FnMut(Thread) -> io::Result<()>,
+{
+    /// Applies the custom configuration closure when spawning a new thread.
+    fn spawn(&mut self, thread: Thread) -> io::Result<()> {
+        self.0(thread)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::builder::AsyncPoolBuilder;
+    use crate::{AsyncPool, Thread};
+    use futures::future::BoxFuture;
+    use futures::FutureExt;
+    use std::future::Future;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::{Duration, Instant};
+    use tokio::runtime::Runtime;
+    use tokio::sync::Semaphore;
+    use tokio::{runtime::Handle, time::sleep};
+
+    struct TestBarrier {
+        semaphore: Arc<Semaphore>,
+        count: u32,
+    }
+
+    impl TestBarrier {
+        async fn new(count: u32) -> Self {
+            Self {
+                semaphore: Arc::new(Semaphore::new(count as usize)),
+                count,
+            }
+        }
+
+        async fn spawn<F, Fut>(&self, pool: &AsyncPool<BoxFuture<'static, ()>>, f: F)
+        where
+            F: FnOnce() -> Fut + Send + 'static,
+            Fut: Future<Output = ()> + Send + 'static,
+        {
+            let semaphore = self.semaphore.clone();
+            let permit = semaphore.acquire_owned().await.unwrap();
+            pool.spawn_async(
+                async move {
+                    f().await;
+                    drop(permit);
+                }
+                .boxed(),
+            )
+            .await;
+        }
+
+        async fn wait(&self) {
+            let _ = self.semaphore.acquire_many(self.count).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_pool_executes_all_tasks() {
+        let pool = AsyncPoolBuilder::new(Handle::current())
+            .num_threads(1)
+            .max_concurrency(2)
+            .build()
+            .unwrap();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let barrier = TestBarrier::new(20).await;
+
+        // Spawn 20 tasks that wait briefly and then update the counter.
+        for _ in 0..20 {
+            let counter_clone = counter.clone();
+            barrier
+                .spawn(&pool, move || async move {
+                    sleep(Duration::from_millis(50)).await;
+                    counter_clone.fetch_add(1, Ordering::SeqCst);
+                })
+                .await;
+        }
+
+        barrier.wait().await;
+        assert_eq!(counter.load(Ordering::SeqCst), 20);
+    }
+
+    #[tokio::test]
+    async fn test_async_pool_executes_all_tasks_concurrently_with_single_thread() {
+        let pool = AsyncPoolBuilder::new(Handle::current())
+            .num_threads(1)
+            .max_concurrency(2)
+            .build()
+            .unwrap();
+
+        let start = Instant::now();
+        let barrier = TestBarrier::new(2).await;
+
+        // Spawn 2 tasks that each sleep for 200ms.
+        for _ in 0..2 {
+            barrier
+                .spawn(&pool, || async {
+                    sleep(Duration::from_millis(200)).await;
+                })
+                .await;
+        }
+
+        barrier.wait().await;
+
+        let elapsed = start.elapsed();
+        // If running concurrently, the overall time should be near 200ms (with some allowance).
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "Elapsed time was too high: {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_async_pool_executes_all_tasks_concurrently_with_multiple_threads() {
+        let pool = AsyncPoolBuilder::new(Handle::current())
+            .num_threads(2)
+            .max_concurrency(1)
+            .build()
+            .unwrap();
+
+        let start = Instant::now();
+        let barrier = TestBarrier::new(2).await;
+
+        // Spawn 2 tasks that each sleep for 200ms.
+        for _ in 0..2 {
+            barrier
+                .spawn(&pool, || async {
+                    sleep(Duration::from_millis(200)).await;
+                })
+                .await;
+        }
+
+        barrier.wait().await;
+
+        let elapsed = start.elapsed();
+        // If running concurrently, the overall time should be near 200ms (with some allowance).
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "Elapsed time was too high: {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn test_thread_panic_handling() {
+        let runtime = Runtime::new().unwrap();
+        let has_panicked = Arc::new(AtomicBool::new(false));
+        let has_panicked_clone = has_panicked.clone();
+        let panic_handler = move |_| {
+            has_panicked_clone.store(true, Ordering::SeqCst);
+        };
+
+        Thread {
+            index: 0,
+            max_concurrency: 1,
+            name: Some("test-thread".to_owned()),
+            runtime: runtime.handle().clone(),
+            panic_handler: Some(Arc::new(panic_handler)),
+            task: async move {
+                panic!("panicked");
+            }
+            .boxed(),
+        }
+        .run();
+
+        assert_eq!(has_panicked.load(Ordering::SeqCst), true);
+    }
+}

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -63,6 +63,7 @@
 //!  - [`relay-statsd`]: High-level StatsD metric client for internal measurements.
 //!  - [`relay-system`]: Foundational system components for Relay's services.
 //!  - [`relay-test`]: Helpers for testing the web server and services.
+//!  - [`relay-threading`]: Threading code that is used by Relay.
 //!  - [`relay-ua`]: User agent parser with built-in rules.
 //!
 //! # Tools


### PR DESCRIPTION
This PR a new `relay-threading` package that provides a thread-based task execution framework for managing concurrent workloads in Relay.

## Key Features

* **Async Task Pool**: Thread-based pool for executing async tasks with configurable concurrency limits
* **Builder Pattern**: Flexible configuration of thread counts, naming, and panic handling through `AsyncPoolBuilder`
* **Backpressure Control**: Bounded task queue prevents resource exhaustion
* **Panic Recovery**: Built-in handling for both thread and task-level panics
* **Tokio Integration**: Seamless integration with Tokio runtime for async execution

## Example Usage

```rust
let pool = AsyncPoolBuilder::new(runtime_handle)
    .num_threads(4)
    .max_concurrency(100)
    .build()
    .unwrap();

// Schedule a task
pool.spawn(async {
    // Task logic here
});
```

## Testing

The package includes comprehensive tests covering:
* Single and multi-threaded execution
* Concurrent task handling
* Panic recovery
* Performance benchmarks for various thread/task