### PR TITLE
ref(store): Partition spans by trace_id in the Kafka producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add option to drop transaction attachments. ([#4466](https://github.com/getsentry/relay/pull/4466))
 - Add endpoint that exposes internally collected relay metrics. ([#4497](https://github.com/getsentry/relay/pull/4497))
 - Add sub-millisecond precision to internal timer metrics. ([#4495](https://github.com/getsentry/relay/pull/4495))
+- Partition spans by `trace_id` on the Kafka topic. ([#4503](https://github.com/getsentry/relay/pull/4503))
 
 ## 25.1.0
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1495,6 +1495,7 @@ impl Message for KafkaMessage<'_> {
             Self::AttachmentChunk(message) => message.event_id.0,
             Self::UserReport(message) => message.event_id.0,
             Self::ReplayEvent(message) => message.replay_id.0,
+            Self::Span { message, .. } => message.trace_id.0,
 
             // Monitor check-ins use the hinted UUID passed through from the Envelope.
             //
@@ -1504,13 +1505,10 @@ impl Message for KafkaMessage<'_> {
 
             // Random partitioning
             Self::Profile(_)
-            | Self::Span { .. }
             | Self::Log { .. }
             | Self::ReplayRecordingNotChunked(_)
-            | Self::ProfileChunk(_) => Uuid::nil(),
-
-            // TODO(ja): Determine a partitioning key
-            Self::Metric { .. } => Uuid::nil(),
+            | Self::ProfileChunk(_)
+            | Self::Metric { .. } => Uuid::nil(),
         };
 
         if uuid.is_nil() {


### PR DESCRIPTION
Partitions the spans kafka stream by `trace_id` to achieve higher locality and
no drift between spans. This especially applies to spans within the same segment
as those are usually produced together in batches.
