### PR TITLE
chore(filter): Filter another browser extension exception

### DIFF
--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -52,7 +52,7 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
         # Usually caused by extensions that do stuff that isn't allowed
         Permission\sdenied\sto\saccess\sproperty\s|
-        # NextJS related
+        # Error from Google Search App https://issuetracker.google.com/issues/396043331
         Can't\sfind\svariable:\sgmo
     "#,
     )

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -51,7 +51,9 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         undefined\sis\snot\san\sobject\s\(evaluating\s'a.L'\)|
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
         # Usually caused by extensions that do stuff that isn't allowed
-        Permission\sdenied\sto\saccess\sproperty\s
+        Permission\sdenied\sto\saccess\sproperty\s|
+        # NextJS related
+        Can't\sfind\svariable:\sgmo
     "#,
     )
     .expect("Invalid browser extensions filter (Exec Vals) Regex")
@@ -274,6 +276,7 @@ mod tests {
             "undefined is not an object (evaluating 'a.L')",
             "Permission denied to access property \"correspondingUseElement\"",
             "Permission denied to access property \"document\"",
+            "Can't find variable: gmo",
         ];
 
         for exc_value in &exceptions {


### PR DESCRIPTION
Extend the browser extensions exception filtering  with `ReferenceError Can't find variable: gmo`

related: https://github.com/getsentry/sentry-javascript/issues/15389

#skip-changelog