### PR TITLE
ref: fix lints for Rust v1.85.0

### DIFF
--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -157,7 +157,7 @@ impl Processor for TransactionsProcessor<'_> {
         // name is given, similar to how Sentry gives an "<unlabeled event>" title to error events.
         // SDKs should avoid sending empty transaction names, setting a more contextual default
         // value when possible.
-        if event.transaction.value().map_or(true, |s| s.is_empty()) {
+        if event.transaction.value().is_none_or(|s| s.is_empty()) {
             event
                 .transaction
                 .set_value(Some("<unlabeled transaction>".to_owned()))

--- a/relay-filter/src/generic.rs
+++ b/relay-filter/src/generic.rs
@@ -20,7 +20,7 @@ pub fn are_generic_filters_supported(
     global_filters_version: Option<u16>,
     project_filters_version: u16,
 ) -> bool {
-    global_filters_version.map_or(true, |v| v <= MAX_SUPPORTED_VERSION)
+    global_filters_version.is_none_or(|v| v <= MAX_SUPPORTED_VERSION)
         && project_filters_version <= MAX_SUPPORTED_VERSION
 }
 
@@ -82,7 +82,7 @@ fn merge_generic_filters<'a>(
     let max_supported_version = MAX_SUPPORTED_VERSION;
 
     let is_supported = project.version <= max_supported_version
-        && global.map_or(true, |gf| gf.version <= max_supported_version);
+        && global.is_none_or(|gf| gf.version <= max_supported_version);
 
     is_supported
         .then(|| {

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -205,7 +205,7 @@ impl Processor for PiiProcessor<'_> {
         _meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        let ip_was_valid = user.ip_address.value().map_or(true, IpAddr::is_valid);
+        let ip_was_valid = user.ip_address.value().is_none_or(IpAddr::is_valid);
 
         // Recurse into the user and does PII processing on fields.
         user.process_child_values(self, state)?;
@@ -214,7 +214,7 @@ impl Processor for PiiProcessor<'_> {
             || user.username.value().is_some()
             || user.email.value().is_some();
 
-        let ip_is_still_valid = user.ip_address.value().map_or(true, IpAddr::is_valid);
+        let ip_is_still_valid = user.ip_address.value().is_none_or(IpAddr::is_valid);
 
         // If the IP address has become invalid as part of PII processing, we move it into the user
         // ID. That ensures people can do IP hashing and still have a correct users-affected count.

--- a/relay-profiling/src/utils.rs
+++ b/relay-profiling/src/utils.rs
@@ -47,7 +47,7 @@ where
 }
 
 pub fn string_is_null_or_empty(s: &Option<String>) -> bool {
-    s.as_deref().map_or(true, |s| s.is_empty())
+    s.as_deref().is_none_or(|s| s.is_empty())
 }
 
 pub fn default_client_sdk(platform: &str) -> Option<ClientSdk> {

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -235,8 +235,8 @@ where
         match behavior {
             SkipSerialization::Never => false,
             SkipSerialization::Null(_) => self.value().is_none(),
-            SkipSerialization::Empty(false) => self.value().map_or(true, Empty::is_empty),
-            SkipSerialization::Empty(true) => self.value().map_or(true, Empty::is_deep_empty),
+            SkipSerialization::Empty(false) => self.value().is_none_or(Empty::is_empty),
+            SkipSerialization::Empty(true) => self.value().is_none_or(Empty::is_deep_empty),
         }
     }
 }

--- a/relay-protocol/src/impls.rs
+++ b/relay-protocol/src/impls.rs
@@ -161,12 +161,12 @@ where
 {
     #[inline]
     fn is_empty(&self) -> bool {
-        self.as_ref().map_or(true, Empty::is_empty)
+        self.as_ref().is_none_or(Empty::is_empty)
     }
 
     #[inline]
     fn is_deep_empty(&self) -> bool {
-        self.as_ref().map_or(true, Empty::is_deep_empty)
+        self.as_ref().is_none_or(Empty::is_deep_empty)
     }
 }
 

--- a/relay-protocol/src/meta.rs
+++ b/relay-protocol/src/meta.rs
@@ -583,7 +583,7 @@ impl Meta {
 
     /// Indicates whether this field has meta data attached.
     pub fn is_empty(&self) -> bool {
-        self.0.as_ref().map_or(true, |x| x.is_empty())
+        self.0.as_ref().is_none_or(|x| x.is_empty())
     }
 
     /// Merges this meta with another one.

--- a/relay-sampling/src/config.rs
+++ b/relay-sampling/src/config.rs
@@ -223,7 +223,7 @@ impl TimeRange {
     /// If one of the limits isn't provided, the range is considered open in
     /// that limit. A time range open on both sides matches with any given time.
     pub fn contains(&self, time: DateTime<Utc>) -> bool {
-        self.start.map_or(true, |s| s <= time) && self.end.map_or(true, |e| time < e)
+        self.start.is_none_or(|s| s <= time) && self.end.is_none_or(|e| time < e)
     }
 }
 

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -122,7 +122,7 @@ impl TryFrom<DatabaseEnvelope> for Box<Envelope> {
         debug_assert_eq!(envelope.meta().public_key(), own_key);
         debug_assert!(envelope
             .sampling_key()
-            .map_or(true, |key| key == sampling_key));
+            .is_none_or(|key| key == sampling_key));
 
         envelope.set_received_at(received_at);
 

--- a/relay-server/src/services/global_config.rs
+++ b/relay-server/src/services/global_config.rs
@@ -287,7 +287,7 @@ impl GlobalConfigService {
                 let mut success = false;
                 // Older relays won't send a global status, in that case, we will pretend like the
                 // default global config is an up to date one, because that was the old behaviour.
-                let is_ready = response.global_status.map_or(true, |stat| stat.is_ready());
+                let is_ready = response.global_status.is_none_or(|stat| stat.is_ready());
 
                 match response.global {
                     Some(mut global_config) if is_ready => {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -585,7 +585,7 @@ fn normalize(
     // for spans we derive it by default:
     if let Some(client_ip) = client_ip.as_ref() {
         let ip = span.data.value().and_then(|d| d.client_address.value());
-        if ip.map_or(true, |ip| ip.is_auto()) {
+        if ip.is_none_or(|ip| ip.is_auto()) {
             span.data
                 .get_or_insert_with(Default::default)
                 .client_address = Annotated::new(client_ip.clone());

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -222,7 +222,7 @@ fn merge_unreal_context(event: &mut Event, context: Unreal4Context) {
     if let Some(login_id) = &runtime_props.login_id {
         let id = event.user.get_or_insert_with(User::default).id.value_mut();
 
-        if id.as_ref().map_or(true, |s| s.is_empty()) {
+        if id.as_ref().is_none_or(|s| s.is_empty()) {
             *id = Some(login_id.clone().into());
         }
     }


### PR DESCRIPTION
v1.85 introduced `is_none_or` and clippy started flagging places where we should use it. Fixed with `cargo +stable clippy --workspace --all-targets --all-features --no-deps --fix` and `make format`.

#skip-changelog