### PR TITLE
ref(spooler): Remove busy metric

### DIFF
--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -640,13 +640,6 @@ pub enum RelayCounters {
     /// Number of times one or more projects of an envelope were pending when trying to pop
     /// their envelope.
     BufferProjectPending,
-    /// Timing in nanoseconds for the time the buffer service spends handling input.
-    ///
-    /// This metric is tagged with:
-    /// - `input`: The type of input that the service is handling.
-    /// - `partition_id`: The ID of the buffer shard (0, 1, 2, ...)
-    BufferBusy,
-    ///
     /// Number of outcomes and reasons for rejected Envelopes.
     ///
     /// This metric is tagged with:
@@ -853,7 +846,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::BufferUnspooledEnvelopes => "buffer.unspooled_envelopes",
             RelayCounters::BufferProjectChangedEvent => "buffer.project_changed_event",
             RelayCounters::BufferProjectPending => "buffer.project_pending",
-            RelayCounters::BufferBusy => "buffer.busy",
             RelayCounters::Outcomes => "events.outcomes",
             RelayCounters::ProjectStateRequest => "project_state.request",
             #[cfg(feature = "processing")]


### PR DESCRIPTION
This PR removes the busy metric from the spooler since a new generic metric was introduced for all services.

#skip-changelog