### PR TITLE
feat(release): Release aarch64 / arm64 binary

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -33,5 +33,7 @@ requireNames:
   - /^relay-Darwin-x86_64-dsym.zip$/
   - /^relay-Linux-x86_64$/
   - /^relay-Linux-x86_64-debug.zip$/
+  - /^relay-Linux-aarch64$/
+  - /^relay-Linux-aarch64-debug.zip$/
   - /^relay-Windows-x86_64-pdb.zip$/
   - /^relay-Windows-x86_64\.exe$/

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -138,7 +138,7 @@ jobs:
   merge:
     name: Create Release Artifact
     runs-on: ubuntu-latest
-    needs: [linux, macos, windows]
+    needs: [linux, linux-aarch64, macos, windows]
     steps:
       # Note: due to the immutability of artifacts in upload-artifact v4,
       # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - release/**
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - release/**
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,6 +40,38 @@ jobs:
         with:
           name: artifact-linux
           path: target/release/relay-Linux-x86_64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  linux-aarch64:
+    name: Linux Aarch64
+    runs-on: ubuntu-22.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Build binary
+        run: |
+          make build-linux-release
+        env:
+          RELAY_FEATURES:
+
+      - name: Bundle Debug File
+        run: |
+          cd target/release/
+          zip relay-Linux-aarch64-debug.zip relay.debug
+          mv relay relay-Linux-aarch64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-linux-aarch64
+          path: target/release/relay-Linux-aarch64*
           if-no-files-found: 'error'
           # since this artifact will be merged, compression is not necessary
           compression-level: '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 **Features**:
 
-- Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
+- Update release to include an aarch64 binary. ([#4514](https://github.com/getsentry/relay/pull/4514))
 - Support span `category` inference from span attributes. ([#4509](https://github.com/getsentry/relay/pull/4509))
 
 **Internal**:
 
 - Track an utilization metric for internal services. ([#4501](https://github.com/getsentry/relay/pull/4501))
+- Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
 
 ## 25.2.0
 


### PR DESCRIPTION
Closes: #3497

[Successful build](https://github.com/getsentry/relay/actions/runs/13454041412).

Test of the binary:

```
iridium :: /tmp » chmod +x relay-Linux-aarch64  
iridium :: /tmp » ./relay-Linux-aarch64 
error: 'relay-Linux-aarch64' requires a subcommand but one was not provided
  [subcommands: run, credentials, config, generate-completions]

Usage: relay-Linux-aarch64 [OPTIONS] <COMMAND>

For more information, try '--help'.
iridium :: /tmp » uname -a
Linux iridium 6.8.0-1015-oracle #15~22.04.1-Ubuntu SMP Wed Oct  9 16:01:35 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
```