### PR TITLE
build(relay): Fix linter warnings when building on Windows

### DIFF
--- a/relay-server/src/services/server/acceptor.rs
+++ b/relay-server/src/services/server/acceptor.rs
@@ -37,6 +37,8 @@ impl RelayAcceptor {
         {
             keepalive = keepalive.with_interval(timeout);
         }
+
+        let _retries = retries;
         #[cfg(not(any(
             target_os = "openbsd",
             target_os = "redox",
@@ -44,7 +46,7 @@ impl RelayAcceptor {
             target_os = "windows"
         )))]
         {
-            keepalive = keepalive.with_retries(retries);
+            keepalive = keepalive.with_retries(_retries);
         }
         self.tcp_keepalive = Some(keepalive);
 


### PR DESCRIPTION
```
warning: unused variable: `dequeue1`
   --> relay-server\src\services\buffer\mod.rs:539:13
    |
539 |         let dequeue1 = dequeue.clone();
    |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dequeue1`
    |
    = note: `#[warn(unused_variables)]` on by default
warning: unused variable: `retries`
  --> relay-server\src\services\server\acceptor.rs:29:55
   |
29 |     pub fn tcp_keepalive(mut self, timeout: Duration, retries: u32) -> Self {
   |                                                       ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_retries`
warning: `relay-server` (lib) generated 2 warnings
```

#skip-changelog