### PR TITLE
feat(ourlogs): Add rate to control log ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update release to include an aarch64 binary. ([#4514](https://github.com/getsentry/relay/pull/4514))
 - Support span `category` inference from span attributes. ([#4509](https://github.com/getsentry/relay/pull/4509))
+- Add option to control ourlogs ingestion. ([#4518](https://github.com/getsentry/relay/pull/4518))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -174,6 +174,21 @@ pub struct Options {
     )]
     pub span_extraction_sample_rate: Option<f32>,
 
+    /// Sample rate at which to ingest logs.
+    ///
+    /// This number represents the fraction of received logs that are processed. It only applies if
+    /// [`crate::Feature::OurLogsIngestion`] is enabled.
+    ///
+    /// `None` is the default and interpreted as a value of 1.0 (ingest everything).
+    ///
+    /// Note: Any value below 1.0 will cause the product to not show all the users data, so use with caution.
+    #[serde(
+        rename = "relay.ourlogs-ingestion.sample-rate",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub ourlogs_ingestion_sample_rate: Option<f32>,
+
     /// List of values on span description that are allowed to be sent to Sentry without being scrubbed.
     ///
     /// At this point, it doesn't accept IP addresses in CIDR format.. yet.

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2056,6 +2056,7 @@ impl EnvelopeProcessorService {
             managed_envelope,
             self.inner.config.clone(),
             project_info.clone(),
+            &self.inner.global_config.current(),
         );
         if_processing!(self.inner.config, {
             self.enforce_quotas(

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -15,7 +15,8 @@ use {
     crate::envelope::{Item, ItemType},
     crate::services::outcome::{DiscardReason, Outcome},
     crate::services::processor::ProcessingError,
-    relay_dynamic_config::ProjectConfig,
+    crate::utils::sample,
+    relay_dynamic_config::{GlobalConfig, ProjectConfig},
     relay_event_schema::processor::{process_value, ProcessingState},
     relay_event_schema::protocol::OurLog,
     relay_ourlogs::OtelLog,
@@ -28,10 +29,17 @@ pub fn filter(
     managed_envelope: &mut TypedEnvelope<LogGroup>,
     config: Arc<Config>,
     project_info: Arc<ProjectInfo>,
+    global_config: &GlobalConfig,
 ) {
     let logging_disabled = should_filter(&config, &project_info, Feature::OurLogsIngestion);
+    let logs_sampled = global_config
+        .options
+        .ourlogs_ingestion_sample_rate
+        .map(sample)
+        .unwrap_or(true);
+
     managed_envelope.retain_items(|_| {
-        if logging_disabled {
+        if logging_disabled || !logs_sampled {
             ItemAction::DropSilently
         } else {
             ItemAction::Keep
@@ -102,4 +110,98 @@ fn scrub(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Envelope;
+    use crate::services::processor::ProcessingGroup;
+    use crate::utils::ManagedEnvelope;
+    use bytes::Bytes;
+    use relay_dynamic_config::GlobalConfig;
+    use relay_system::Addr;
+
+    fn params() -> (TypedEnvelope<LogGroup>, Arc<ProjectInfo>) {
+        let bytes = Bytes::from(
+            r#"{"dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}
+{"type":"otel_log"}
+{}
+"#,
+        );
+
+        let dummy_envelope = Envelope::parse_bytes(bytes).unwrap();
+        let mut project_info = ProjectInfo::default();
+        project_info
+            .config
+            .features
+            .0
+            .insert(Feature::OurLogsIngestion);
+        let project_info = Arc::new(project_info);
+
+        let managed_envelope = ManagedEnvelope::new(
+            dummy_envelope,
+            Addr::dummy(),
+            Addr::dummy(),
+            ProcessingGroup::Log,
+        );
+
+        let managed_envelope = managed_envelope.try_into().unwrap();
+
+        (managed_envelope, project_info)
+    }
+
+    #[test]
+    fn test_logs_sampled_default() {
+        let global_config = GlobalConfig::default();
+        let config = Arc::new(Config::default());
+        assert!(global_config
+            .options
+            .ourlogs_ingestion_sample_rate
+            .is_none());
+        let (mut managed_envelope, project_info) = params();
+        filter(&mut managed_envelope, config, project_info, &global_config);
+        assert!(
+            managed_envelope
+                .envelope()
+                .items()
+                .any(|item| item.ty() == &ItemType::OtelLog),
+            "{:?}",
+            managed_envelope.envelope()
+        );
+    }
+
+    #[test]
+    fn test_logs_sampled_explicit() {
+        let mut global_config = GlobalConfig::default();
+        global_config.options.ourlogs_ingestion_sample_rate = Some(1.0);
+        let config = Arc::new(Config::default());
+        let (mut managed_envelope, project_info) = params();
+        filter(&mut managed_envelope, config, project_info, &global_config);
+        assert!(
+            managed_envelope
+                .envelope()
+                .items()
+                .any(|item| item.ty() == &ItemType::OtelLog),
+            "{:?}",
+            managed_envelope.envelope()
+        );
+    }
+
+    #[test]
+    fn test_logs_sampled_dropped() {
+        let mut global_config = GlobalConfig::default();
+        global_config.options.ourlogs_ingestion_sample_rate = Some(0.0);
+        let config = Arc::new(Config::default());
+        let (mut managed_envelope, project_info) = params();
+        filter(&mut managed_envelope, config, project_info, &global_config);
+        assert!(
+            !managed_envelope
+                .envelope()
+                .items()
+                .any(|item| item.ty() == &ItemType::OtelLog),
+            "{:?}",
+            managed_envelope.envelope()
+        );
+    }
 }

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -120,9 +120,9 @@ mod tests {
     use crate::utils::ManagedEnvelope;
     use bytes::Bytes;
     use relay_dynamic_config::GlobalConfig;
+
     use relay_system::Addr;
 
-    #[test]
     fn params() -> (TypedEnvelope<LogGroup>, Arc<ProjectInfo>) {
         let bytes = Bytes::from(
             r#"{"dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -115,13 +115,14 @@ fn scrub(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::envelope::Envelope;
+    use crate::envelope::{Envelope, ItemType};
     use crate::services::processor::ProcessingGroup;
     use crate::utils::ManagedEnvelope;
     use bytes::Bytes;
     use relay_dynamic_config::GlobalConfig;
     use relay_system::Addr;
 
+    #[test]
     fn params() -> (TypedEnvelope<LogGroup>, Arc<ProjectInfo>) {
         let bytes = Bytes::from(
             r#"{"dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 
 use crate::services::processor::LogGroup;
 use relay_config::Config;
-use relay_dynamic_config::Feature;
+use relay_dynamic_config::{Feature, GlobalConfig};
 
 use crate::services::processor::should_filter;
 use crate::services::projects::project::ProjectInfo;
+use crate::utils::sample;
 use crate::utils::{ItemAction, TypedEnvelope};
 
 #[cfg(feature = "processing")]
@@ -15,8 +16,7 @@ use {
     crate::envelope::{Item, ItemType},
     crate::services::outcome::{DiscardReason, Outcome},
     crate::services::processor::ProcessingError,
-    crate::utils::sample,
-    relay_dynamic_config::{GlobalConfig, ProjectConfig},
+    relay_dynamic_config::ProjectConfig,
     relay_event_schema::processor::{process_value, ProcessingState},
     relay_event_schema::protocol::OurLog,
     relay_ourlogs::OtelLog,


### PR DESCRIPTION
### Summary
We're moving to sharing the EAP cluster for logs. In order to safely roll out logs onto the existing cluster, we want to be able to control processing into the kafka topics, consumers and storage, one project at a time in production.

Needs: https://github.com/getsentry/sentry/pull/85684