### PR TITLE
feat(relay): do not assume empty means {{auto}} for some sdks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Track an utilization metric for internal services. ([#4501](https://github.com/getsentry/relay/pull/4501))
 - Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
+- Do not convert empty ip address into `{{auto}}` for newer SDKs. ([#4519](https://github.com/getsentry/relay/pull/4519))
 
 ## 25.2.0
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -486,7 +486,7 @@ pub fn normalize_ip_addresses(
                         .0
                         .as_ref()
                         .and_then(|sdk| sdk.version.0.as_ref())
-                        .map(|s| SdkVersion::try_parse(s.as_str()))
+                        .map(|sdk_version| sdk_version.as_str().parse::<SdkVersion>())
                     {
                         match platform {
                             Some("javascript") => {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -38,7 +38,13 @@ use crate::{
     RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig,
 };
 
+/// This is the first Javascript SDK version that does explicitly send `{{auto}}` instead of
+/// empty string to signal that the user IP address should be inferred.
+/// https://github.com/getsentry/sentry-javascript/releases/tag/9.0.0
 const CUTOFF_JAVASCRIPT_VERSION: SdkVersion = SdkVersion::new(9, 0, 0);
+/// This is the first Cocoa SDK version that  explicitly send `{{auto}}` instead of
+/// empty string to signal that the user IP address should be inferred.
+/// https://github.com/getsentry/sentry-cocoa/releases/tag/6.2.0
 const CUTOFF_COCOA_VERSION: SdkVersion = SdkVersion::new(6, 2, 0);
 
 /// Configuration for [`normalize_event`].

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -480,7 +480,7 @@ pub fn normalize_ip_addresses(
                         .0
                         .as_ref()
                         .and_then(|sdk| sdk.version.0.as_ref())
-                        .map(|s| SdkVersion::from_str(s.as_str()))
+                        .map(|s| SdkVersion::try_parse(s.as_str()))
                     {
                         match platform {
                             Some("javascript") => {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -42,7 +42,7 @@ use crate::{
 /// empty string to signal that the user IP address should be inferred.
 /// See: <https://github.com/getsentry/sentry-javascript/releases/tag/9.0.0>
 const CUTOFF_JAVASCRIPT_VERSION: SdkVersion = SdkVersion::new(9, 0, 0);
-/// This is the first Cocoa SDK version that  explicitly send `{{auto}}` instead of
+/// This is the first Cocoa SDK version that explicitly send `{{auto}}` instead of
 /// empty string to signal that the user IP address should be inferred.
 /// See: <https://github.com/getsentry/sentry-cocoa/releases/tag/6.2.0>
 const CUTOFF_COCOA_VERSION: SdkVersion = SdkVersion::new(6, 2, 0);

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -40,11 +40,11 @@ use crate::{
 
 /// This is the first Javascript SDK version that does explicitly send `{{auto}}` instead of
 /// empty string to signal that the user IP address should be inferred.
-/// https://github.com/getsentry/sentry-javascript/releases/tag/9.0.0
+/// See: <https://github.com/getsentry/sentry-javascript/releases/tag/9.0.0>
 const CUTOFF_JAVASCRIPT_VERSION: SdkVersion = SdkVersion::new(9, 0, 0);
 /// This is the first Cocoa SDK version that  explicitly send `{{auto}}` instead of
 /// empty string to signal that the user IP address should be inferred.
-/// https://github.com/getsentry/sentry-cocoa/releases/tag/6.2.0
+/// See: <https://github.com/getsentry/sentry-cocoa/releases/tag/6.2.0>
 const CUTOFF_COCOA_VERSION: SdkVersion = SdkVersion::new(6, 2, 0);
 
 /// Configuration for [`normalize_event`].

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -488,11 +488,17 @@ pub fn normalize_ip_addresses(
                                     user.ip_address = Annotated::new(client_ip.to_owned());
                                 }
                             }
-                            Some("cocoa") | Some("objc") => {
+                            Some("cocoa") => {
                                 if sdk_version < CUTOFF_COCOA_VERSION {
                                     user.ip_address = Annotated::new(client_ip.to_owned());
                                 }
                             }
+                            // The obj-c SDK is deprecated in favour of cocoa so we keep the
+                            // old behavior of empty == {{auto}}.
+                            // With the `scrubbed_before` check we made sure that we only
+                            // derive empty as {{auto}} if the empty string comes from the SDK
+                            // directly and is not the result of scrubbing.
+                            Some("objc") => user.ip_address = Annotated::new(client_ip.to_owned()),
                             _ => {}
                         }
                     }

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -17,6 +17,7 @@ mod normalize;
 mod regexes;
 mod remove_other;
 mod schema;
+mod sdk_version;
 mod stacktrace;
 mod statsd;
 mod timestamp;
@@ -26,7 +27,6 @@ mod validation;
 
 pub use validation::{validate_event, validate_span, EventValidationConfig};
 pub mod replay;
-mod sdk_version;
 
 pub use event::{
     normalize_event, normalize_measurements, normalize_performance_score, NormalizationConfig,

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -26,6 +26,8 @@ mod validation;
 
 pub use validation::{validate_event, validate_span, EventValidationConfig};
 pub mod replay;
+mod sdk_version;
+
 pub use event::{
     normalize_event, normalize_measurements, normalize_performance_score, NormalizationConfig,
 };

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -454,8 +454,10 @@ mod tests {
             },
         );
 
-        let ip_addr = get_value!(event.user.ip_address!);
-        assert_eq!(ip_addr, &IpAddr("2.125.160.216".to_string()));
+        assert_eq!(
+            Annotated::empty(),
+            event.0.unwrap().user.0.unwrap().ip_address
+        );
     }
 
     #[test]

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -128,6 +128,7 @@ fn normalize_ip_address(replay: &mut Replay, ip_address: Option<StdIpAddr>) {
         &mut replay.user,
         replay.platform.as_str(),
         ip_address.map(|ip| IpAddr(ip.to_string())).as_ref(),
+        &replay.sdk,
     );
 }
 

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -311,8 +311,10 @@ mod tests {
             None,
         );
 
-        let ipaddr = get_value!(replay.user!).ip_address.as_str();
-        assert_eq!(Some("127.0.0.1"), ipaddr);
+        assert_eq!(
+            Annotated::empty(),
+            replay.0.unwrap().user.0.unwrap().ip_address
+        );
     }
 
     #[test]

--- a/relay-event-normalization/src/sdk_version.rs
+++ b/relay-event-normalization/src/sdk_version.rs
@@ -54,9 +54,7 @@ impl FromStr for SdkVersion {
     /// 1.2 -> 1.2.0
     /// 1   -> 1.0.0
     ///
-    /// Also supports the release types `alpha` and `beta`.
-    /// **NOTE**: If there is a release type specified that is neither `alpha` nor `beta`, it will
-    /// default to `beta`.
+    /// Also supports the release types `alpha` and `beta` in the form `1.2.3-beta.1`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut split = s.split(".");
         let major = split

--- a/relay-event-normalization/src/sdk_version.rs
+++ b/relay-event-normalization/src/sdk_version.rs
@@ -106,6 +106,12 @@ mod test {
     }
 
     #[test]
+    fn test_version_defaults_to_zero() {
+        let only_major = SdkVersion::try_parse("9").unwrap();
+        assert_eq!(only_major, SdkVersion::new(9, 0, 0))
+    }
+
+    #[test]
     fn test_version_string_parse_failed() {
         assert!(SdkVersion::try_parse("amd64").is_err());
     }

--- a/relay-event-normalization/src/sdk_version.rs
+++ b/relay-event-normalization/src/sdk_version.rs
@@ -40,7 +40,7 @@ impl SdkVersion {
     /// For example:
     /// 1.2 -> 1.2.0
     /// 1   -> 1.0.0
-    pub fn from_str(input: &str) -> Result<Self, ParseIntError> {
+    pub fn try_parse(input: &str) -> Result<Self, ParseIntError> {
         let mut split = input.split(".");
         let major = split.next().map(str::parse).transpose()?.unwrap_or(0);
         let minor = split.next().map(str::parse).transpose()?.unwrap_or(0);
@@ -85,10 +85,10 @@ mod test {
 
     #[test]
     fn test_version_string_compare() {
-        let main_version = SdkVersion::from_str("1.2.3").unwrap();
-        let less = SdkVersion::from_str("1.2.1").unwrap();
-        let greater = SdkVersion::from_str("2.1.1").unwrap();
-        let equal = SdkVersion::from_str("1.2.3").unwrap();
+        let main_version = SdkVersion::try_parse("1.2.3").unwrap();
+        let less = SdkVersion::try_parse("1.2.1").unwrap();
+        let greater = SdkVersion::try_parse("2.1.1").unwrap();
+        let equal = SdkVersion::try_parse("1.2.3").unwrap();
         assert!(main_version > less);
         assert!(main_version < greater);
         assert_eq!(main_version, equal);
@@ -96,9 +96,9 @@ mod test {
 
     #[test]
     fn test_release_type() {
-        let alpha = SdkVersion::from_str("9.0.0-alpha.2").unwrap();
-        let beta = SdkVersion::from_str("9.0.0-beta.2").unwrap();
-        let release = SdkVersion::from_str("9.0.0").unwrap();
+        let alpha = SdkVersion::try_parse("9.0.0-alpha.2").unwrap();
+        let beta = SdkVersion::try_parse("9.0.0-beta.2").unwrap();
+        let release = SdkVersion::try_parse("9.0.0").unwrap();
 
         assert!(alpha < beta);
         assert!(beta < release);
@@ -107,6 +107,6 @@ mod test {
 
     #[test]
     fn test_version_string_parse_failed() {
-        assert!(SdkVersion::from_str("amd64").is_err());
+        assert!(SdkVersion::try_parse("amd64").is_err());
     }
 }

--- a/relay-event-normalization/src/sdk_version.rs
+++ b/relay-event-normalization/src/sdk_version.rs
@@ -48,7 +48,7 @@ impl FromStr for SdkVersion {
     type Err = SdkVersionParseError;
 
     /// Attempts to parse a version string and returning a [`SdkVersionParseError`] if it contains any
-    /// non-numerical characters apart from dots.
+    /// non-numerical characters apart from dots or the release type.
     /// If a version part is not provided, 0 will be assumed.
     /// For example:
     /// 1.2 -> 1.2.0

--- a/relay-event-normalization/src/sdk_version.rs
+++ b/relay-event-normalization/src/sdk_version.rs
@@ -1,0 +1,112 @@
+use std::num::ParseIntError;
+
+/// Represents an SDK Version using the semvar versioning, meaning MAJOR.MINOR.PATCH.
+/// An optional release type can be specified, then it becomes
+/// MAJOR.MINOR.PATCH-(alpha|beta).RELEASE_VERSION
+#[derive(Debug, PartialOrd, Eq, PartialEq, Ord)]
+pub struct SdkVersion {
+    major: usize,
+    minor: usize,
+    patch: usize,
+    release_type: ReleaseType,
+}
+
+/// Represents the release type which might be present in a version string,
+/// for example: 9.0.0-alpha.0.
+/// Release types are also comparable to each other, using the rules:
+/// alpha < beta < release.
+/// **NOTE**: The discriminants are explicitly set to keep the comparison rules
+///           even if the order is changed.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum ReleaseType {
+    Alpha = 1,
+    Beta = 2,
+    Release = 3,
+}
+
+impl SdkVersion {
+    pub const fn new(major: usize, minor: usize, patch: usize) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            release_type: ReleaseType::Release,
+        }
+    }
+
+    /// Attempts to parse a version string and returning a [`ParseIntError`] if it contains any
+    /// non-numerical characters apart from dots.
+    /// If a version part is not provided, 0 will be assumed.
+    /// For example:
+    /// 1.2 -> 1.2.0
+    /// 1   -> 1.0.0
+    pub fn from_str(input: &str) -> Result<Self, ParseIntError> {
+        let mut split = input.split(".");
+        let major = split.next().map(str::parse).transpose()?.unwrap_or(0);
+        let minor = split.next().map(str::parse).transpose()?.unwrap_or(0);
+        let (patch, release_type) = if let Some(next) = split.next() {
+            match next.split_once("-") {
+                Some((patch, release_type)) => (
+                    patch.parse()?,
+                    if release_type.starts_with("alpha") {
+                        ReleaseType::Alpha
+                    } else {
+                        ReleaseType::Beta
+                    },
+                ),
+                None => (next.parse()?, ReleaseType::Release),
+            }
+        } else {
+            (0, ReleaseType::Release)
+        };
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            release_type,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::sdk_version::SdkVersion;
+
+    #[test]
+    fn test_version_compare() {
+        let main_version = SdkVersion::new(1, 2, 3);
+        let less = SdkVersion::new(1, 2, 1);
+        let greater = SdkVersion::new(2, 1, 1);
+        let equal = SdkVersion::new(1, 2, 3);
+        assert!(main_version > less);
+        assert!(main_version < greater);
+        assert_eq!(main_version, equal);
+    }
+
+    #[test]
+    fn test_version_string_compare() {
+        let main_version = SdkVersion::from_str("1.2.3").unwrap();
+        let less = SdkVersion::from_str("1.2.1").unwrap();
+        let greater = SdkVersion::from_str("2.1.1").unwrap();
+        let equal = SdkVersion::from_str("1.2.3").unwrap();
+        assert!(main_version > less);
+        assert!(main_version < greater);
+        assert_eq!(main_version, equal);
+    }
+
+    #[test]
+    fn test_release_type() {
+        let alpha = SdkVersion::from_str("9.0.0-alpha.2").unwrap();
+        let beta = SdkVersion::from_str("9.0.0-beta.2").unwrap();
+        let release = SdkVersion::from_str("9.0.0").unwrap();
+
+        assert!(alpha < beta);
+        assert!(beta < release);
+        assert!(alpha < release)
+    }
+
+    #[test]
+    fn test_version_string_parse_failed() {
+        assert!(SdkVersion::from_str("amd64").is_err());
+    }
+}

--- a/tests/fixtures/replay_missing_user_ip_address.json
+++ b/tests/fixtures/replay_missing_user_ip_address.json
@@ -30,7 +30,8 @@
     "user": {
         "id": "123",
         "username": "user",
-        "email": "user@site.com"
+        "email": "user@site.com",
+        "ip_address": "{{auto}}"
     },
     "request": {
         "url": null,

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -401,8 +401,17 @@ def test_ip_normalization_with_remove_remark(mini_sentry, relay_chain):
         ("cocoa", "6.1.4", "127.0.0.1"),
         ("cocoa", "6.2", None),
         ("objc", "6.1.4", "127.0.0.1"),
-        ("objc", "6.2", None),
+        ("objc", "6.2", "127.0.0.1"),
         ("random_sdk", None, None),
+    ],
+    ids=[
+        "Javascript SDK version before cut-off",
+        "Javascript SDK version same to cut-off",
+        "Cocoa SDK version before cut-off",
+        "Cocoa SDK version same to cut-off",
+        "Obj-C SDK any version",
+        "Obj-C SDK with other version",
+        "random SDK string without any version",
     ],
 )
 def test_empty_ip_not_auto(mini_sentry, relay, platform, version, expected):

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -398,10 +398,10 @@ def test_ip_normalization_with_remove_remark(mini_sentry, relay_chain):
     [
         ("javascript", "8.55", "127.0.0.1"),
         ("javascript", "9", None),
-        ("cocoa", "8.44", "127.0.0.1"),
-        ("cocoa", "8.45", None),
-        ("objc", "8.44", "127.0.0.1"),
-        ("objc", "8.45", None),
+        ("cocoa", "6.1.4", "127.0.0.1"),
+        ("cocoa", "6.2", None),
+        ("objc", "6.1.4", "127.0.0.1"),
+        ("objc", "6.2", None),
         ("random_sdk", None, None),
     ],
 )

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -426,6 +426,38 @@ def test_empty_ip_not_auto(mini_sentry, relay, platform, version, expected):
 
 
 @pytest.mark.parametrize(
+    "platform, version, expected",
+    [
+        ("javascript", "8.55", "89.128.74.91"),
+        ("javascript", "9", "89.128.74.91"),
+        ("cocoa", "6.1.4", "89.128.74.91"),
+        ("cocoa", "6.2", "89.128.74.91"),
+        ("objc", "6.1.4", "89.128.74.91"),
+        ("objc", "6.2", "89.128.74.91"),
+        ("random_sdk", None, "89.128.74.91"),
+    ],
+)
+def test_explicit_ip_version_cutoff(mini_sentry, relay, platform, version, expected):
+    project_id = 42
+    relay = relay(mini_sentry)
+
+    mini_sentry.add_basic_project_config(project_id)
+
+    relay.send_event(
+        project_id,
+        {
+            "platform": platform,
+            "sdk": {"version": version},
+            "user": {"ip_address": "89.128.74.91"},
+        },
+    )
+
+    envelope = mini_sentry.captured_events.get(timeout=1)
+    event = envelope.get_event()
+    assert event["user"]["ip_address"] == expected
+
+
+@pytest.mark.parametrize(
     "scrub_ip_addresses, expected", [(True, None), (False, "127.0.0.1")]
 )
 def test_ip_address_scrubbed(mini_sentry, relay, scrub_ip_addresses, expected):


### PR DESCRIPTION
This PR introduces a cut-off version after which an empty string will not be translated to `{{auto}}` for Javascript and Cocoa/Objc platforms.

Turning on the toggle in Sentry will inject rules to scrub IP addresses, so we don't have to touch the code that derives `{{auto}}` to the IP itself.
If we have concerns with the approach we can also check in the code that derives the IP.

Cocoa sends `{{auto}}` starting with [6.2.0](https://github.com/getsentry/sentry-cocoa/releases/tag/6.2.0).
Javascript sends `{{auto}}` starting with [9.0.0](https://github.com/getsentry/sentry-javascript/releases/tag/9.0.0).
Obj-C SDK is deprecated so we keep the old behaviour as there will never be a new version.