### PR TITLE
fix(pii): filter the IP address when setting is turned on

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1413,7 +1413,15 @@ impl EnvelopeProcessorService {
         };
 
         let request_meta = managed_envelope.envelope().meta();
-        let client_ipaddr = request_meta.client_addr().map(IpAddr::from);
+        let client_ipaddr = request_meta
+            .client_addr()
+            .filter(|_| {
+                !project_info
+                    .config
+                    .datascrubbing_settings
+                    .scrub_ip_addresses
+            })
+            .map(IpAddr::from);
 
         let transaction_aggregator_config = self
             .inner


### PR DESCRIPTION
This PR removes the `client_ip` from the normalization settings if the proper flag is set. This way it cannot be accidentally copied somewhere down the line before scrubbing happens.

#skip-changelog