### PR TITLE
fix(test): Increase timer for metric diff test

### DIFF
--- a/relay-system/src/runtime/metrics.rs
+++ b/relay-system/src/runtime/metrics.rs
@@ -254,7 +254,7 @@ mod tests {
             assert_eq!(tokio_metrics.worker_local_schedule_count(0), 0);
 
             // Increase local worker schedule count by awaiting a timer.
-            crate::spawn!(tokio::time::sleep(Duration::from_nanos(10)))
+            crate::spawn!(tokio::time::sleep(Duration::from_millis(1)))
                 .await
                 .unwrap();
 
@@ -262,7 +262,7 @@ mod tests {
             assert_eq!(tokio_metrics.worker_local_schedule_count(0), 1);
 
             // Increase it again.
-            crate::spawn!(tokio::time::sleep(Duration::from_nanos(10)))
+            crate::spawn!(tokio::time::sleep(Duration::from_millis(1)))
                 .await
                 .unwrap();
 


### PR DESCRIPTION
This PR fixes a flaky test that I assumed was flaking because the pending task was not active for enough time in the executor, leading to a difference of `0` being reported when calling `metrics.worker_local_schedule_count` since the newly scheduled task was the only one pending.

#skip-changelog