### PR TITLE
ref(autoscaling): add prefix to autoscaling metrics

### DIFF
--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -34,9 +34,9 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
 }
 
 fn append_data_row(result: &mut String, label: &str, data: impl Display) {
+    // Metrics are automatically prefixed with "relay_"
+    result.push_str("relay_");
     result.push_str(label);
-    // Add tag to all metrics so that we can give the query more context
-    result.push_str(r#"{service="autoscaling"}"#);
     result.push(' ');
     result.push_str(&data.to_string());
     result.push('\n');
@@ -57,10 +57,10 @@ mod test {
         let result = super::to_prometheus_string(&data);
         assert_eq!(
             result,
-            r#"memory_usage{service="autoscaling"} 0.75
-up{service="autoscaling"} 1
-item_count{service="autoscaling"} 10
-total_size{service="autoscaling"} 30
+            r#"relay_memory_usage 0.75
+relay_up 1
+relay_item_count 10
+relay_total_size 30
 "#
         );
     }

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -28,8 +28,8 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
 
     append_data_row(&mut result, "memory_usage", data.memory_usage);
     append_data_row(&mut result, "up", data.up);
-    append_data_row(&mut result, "item_count", data.item_count);
-    append_data_row(&mut result, "total_size", data.total_size);
+    append_data_row(&mut result, "spool_item_count", data.item_count);
+    append_data_row(&mut result, "spool_total_size", data.total_size);
     result
 }
 
@@ -59,8 +59,8 @@ mod test {
             result,
             r#"relay_memory_usage 0.75
 relay_up 1
-relay_item_count 10
-relay_total_size 30
+relay_spool_item_count 10
+relay_spool_total_size 30
 "#
         );
     }

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -35,6 +35,8 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
 
 fn append_data_row(result: &mut String, label: &str, data: impl Display) {
     result.push_str(label);
+    // Add tag to all metrics so that we can give the query more context
+    result.push_str(r#"{service="autoscaling"}"#);
     result.push(' ');
     result.push_str(&data.to_string());
     result.push('\n');
@@ -55,7 +57,11 @@ mod test {
         let result = super::to_prometheus_string(&data);
         assert_eq!(
             result,
-            "memory_usage 0.75\nup 1\nitem_count 10\ntotal_size 30\n"
+            r#"memory_usage{service="autoscaling"} 0.75
+up{service="autoscaling"} 1
+item_count{service="autoscaling"} 10
+total_size{service="autoscaling"} 30
+"#
         );
     }
 }

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -905,7 +905,7 @@ mod tests {
             addr.addr().send(EnvelopeBuffer::Push(envelope.clone()));
         }
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         assert_eq!(addr.metrics.item_count.load(Ordering::Relaxed), 10);
     }

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -21,7 +21,7 @@ def test_basic_autoscaling_endpoint(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     parsed = parse_prometheus(response.text)
     assert response.status_code == 200
-    assert int(parsed['up{service="autoscaling"}']) == 1
+    assert int(parsed["relay_up"]) == 1
 
 
 def test_sqlite_spooling_metrics(mini_sentry, relay):
@@ -50,9 +50,9 @@ def test_sqlite_spooling_metrics(mini_sentry, relay):
     assert response.status_code == 200
     body = parse_prometheus(response.text)
     print(body)
-    assert int(body['item_count{service="autoscaling"}']) == 200
-    assert int(body['up{service="autoscaling"}']) == 1
-    assert int(body['total_size{service="autoscaling"}']) > 30000
+    assert int(body["relay_item_count"]) == 200
+    assert int(body["relay_up"]) == 1
+    assert int(body["relay_total_size"]) > 30000
 
 
 def test_memory_spooling_metrics(mini_sentry, relay):
@@ -70,6 +70,6 @@ def test_memory_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    assert int(body['item_count{service="autoscaling"}']) == 200
-    assert int(body['up{service="autoscaling"}']) == 1
-    assert int(body['total_size{service="autoscaling"}']) == 0
+    assert int(body["relay_item_count"]) == 200
+    assert int(body["relay_up"]) == 1
+    assert int(body["relay_total_size"]) == 0

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -21,7 +21,7 @@ def test_basic_autoscaling_endpoint(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     parsed = parse_prometheus(response.text)
     assert response.status_code == 200
-    assert int(parsed["up"]) == 1
+    assert int(parsed['up{service="autoscaling"}']) == 1
 
 
 def test_sqlite_spooling_metrics(mini_sentry, relay):
@@ -49,9 +49,10 @@ def test_sqlite_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    assert int(body["item_count"]) == 200
-    assert int(body["up"]) == 1
-    assert int(body["total_size"]) > 30000
+    print(body)
+    assert int(body['item_count{service="autoscaling"}']) == 200
+    assert int(body['up{service="autoscaling"}']) == 1
+    assert int(body['total_size{service="autoscaling"}']) > 30000
 
 
 def test_memory_spooling_metrics(mini_sentry, relay):
@@ -69,6 +70,6 @@ def test_memory_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    assert int(body["item_count"]) == 200
-    assert int(body["up"]) == 1
-    assert int(body["total_size"]) == 0
+    assert int(body['item_count{service="autoscaling"}']) == 200
+    assert int(body['up{service="autoscaling"}']) == 1
+    assert int(body['total_size{service="autoscaling"}']) == 0

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -49,9 +49,9 @@ def test_sqlite_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    assert int(body["relay_item_count"]) == 200
+    assert int(body["relay_spool_item_count"]) == 200
     assert int(body["relay_up"]) == 1
-    assert int(body["relay_total_size"]) > 30000
+    assert int(body["relay_spool_total_size"]) > 30000
 
 
 def test_memory_spooling_metrics(mini_sentry, relay):
@@ -69,6 +69,6 @@ def test_memory_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    assert int(body["relay_item_count"]) == 200
+    assert int(body["relay_spool_item_count"]) == 200
     assert int(body["relay_up"]) == 1
-    assert int(body["relay_total_size"]) == 0
+    assert int(body["relay_spool_total_size"]) == 0

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -49,7 +49,6 @@ def test_sqlite_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    print(body)
     assert int(body["relay_item_count"]) == 200
     assert int(body["relay_up"]) == 1
     assert int(body["relay_total_size"]) > 30000


### PR DESCRIPTION
This PR adds the `relay_` prefix to all produced metrics so they can be specifically queried. The metrics names are quite generic and with the prefix they are easier to find and use

#skip-changelog