### PR TITLE
feat(release): Tag images with release version.

### DIFF
--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,11 +1,23 @@
 name: Release GHCR Versioned Image
 
 on:
+  # https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published
+  # https://github.com/orgs/community/discussions/26281
+  # Not sure how one manages to get a [prereleased, released] working :confused:
   release:
     types: [prereleased, released]
+  # Add manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      test_version:
+        description: "Test version tag (e.g., v1.2.3)"
+        required: true
+        type: string
 
 jobs:
+  # Original job that runs on release
   release-ghcr-version-tag:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry
@@ -19,4 +31,22 @@ jobs:
         run: |
           docker buildx imagetools create --tag \
            ghcr.io/getsentry/relay:${{ github.ref_name }} \
+           ghcr.io/getsentry/relay:${{ github.sha }}
+
+  # Test job that runs on manual trigger
+  test-release-ghcr-version-tag:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/relay:${{ inputs.test_version }} \
            ghcr.io/getsentry/relay:${{ github.sha }}

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,0 +1,28 @@
+name: Release GHCR Versioned Image
+
+on:
+  release:
+    types: [prereleased, released]
+  workflow_dispatch: # Should add a manual trigger to see if this works.
+    inputs:
+      version_tag:
+        description: "Version tag to use (defaults to sha if empty)"
+        required: false
+        type: string
+
+jobs:
+  release-ghcr-version-tag:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker pull ghcr.io/getsentry/sentry-cli:${{ github.sha }}
+          docker tag ghcr.io/getsentry/sentry-cli:${{ github.sha }} ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}
+        #   docker push ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -4,15 +4,11 @@ on:
   # https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published
   # https://github.com/orgs/community/discussions/26281
   # Not sure how one manages to get a [prereleased, released] working :confused:
+  #  If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased. - https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
   release:
     types: [prereleased, released]
-  # Add manual trigger for testing
-  workflow_dispatch:
-    inputs:
-      test_version:
-        description: "Test version tag (e.g., v1.2.3)"
-        required: true
-        type: string
+  # Trigger for testing
+  pull_request:
 
 jobs:
   # Original job that runs on release
@@ -33,9 +29,9 @@ jobs:
            ghcr.io/getsentry/relay:${{ github.ref_name }} \
            ghcr.io/getsentry/relay:${{ github.sha }}
 
-  # Test job that runs on manual trigger
+  # Test job that runs on PR
   test-release-ghcr-version-tag:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry
@@ -48,5 +44,5 @@ jobs:
       - name: Tag release version
         run: |
           docker buildx imagetools create --tag \
-           ghcr.io/getsentry/relay:${{ inputs.test_version }} \
-           ghcr.io/getsentry/relay:${{ github.sha }}
+           ghcr.io/getsentry/relay:25.2.0 \
+           ghcr.io/getsentry/relay:3a0d4fa7ee106589b8ac98f54865e449f5ba5d4e

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -3,16 +3,10 @@ name: Release GHCR Versioned Image
 on:
   release:
     types: [prereleased, released]
-  workflow_dispatch: # Should add a manual trigger to see if this works.
-    inputs:
-      version_tag:
-        description: "Version tag to use (defaults to sha if empty)"
-        required: false
-        type: string
 
 jobs:
   release-ghcr-version-tag:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -23,6 +17,6 @@ jobs:
 
       - name: Tag release version
         run: |
-          docker pull ghcr.io/getsentry/sentry-cli:${{ github.sha }}
-          docker tag ghcr.io/getsentry/sentry-cli:${{ github.sha }} ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}
-        #   docker push ghcr.io/getsentry/sentry-cli:${{ github.ref_name }}
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/relay:${{ github.ref_name }} \
+           ghcr.io/getsentry/relay:${{ github.sha }}

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,19 +1,11 @@
 name: Release GHCR Versioned Image
 
 on:
-  # https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published
-  # https://github.com/orgs/community/discussions/26281
-  # Not sure how one manages to get a [prereleased, released] working :confused:
-  #  If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased. - https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
   release:
     types: [prereleased, released]
-  # Trigger for testing
-  pull_request:
 
 jobs:
-  # Original job that runs on release
   release-ghcr-version-tag:
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry
@@ -28,21 +20,3 @@ jobs:
           docker buildx imagetools create --tag \
            ghcr.io/getsentry/relay:${{ github.ref_name }} \
            ghcr.io/getsentry/relay:${{ github.sha }}
-
-  # Test job that runs on PR
-  test-release-ghcr-version-tag:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag release version
-        run: |
-          docker buildx imagetools create --tag \
-           ghcr.io/getsentry/relay:25.2.0 \
-           ghcr.io/getsentry/relay:3a0d4fa7ee106589b8ac98f54865e449f5ba5d4e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Tag images with release version. ([#4532](https://github.com/getsentry/relay/pull/4532))
 - Update release to include an aarch64 binary. ([#4514](https://github.com/getsentry/relay/pull/4514))
 - Support span `category` inference from span attributes. ([#4509](https://github.com/getsentry/relay/pull/4509))
 - Add option to control ourlogs ingestion. ([#4518](https://github.com/getsentry/relay/pull/4518))


### PR DESCRIPTION
Our images are currently only tagged with the sha of their release, it would be nice to also have some tagged with the version, this PR tries to duplicate the logic found in sentry-cli for this and adapt it to our multi-arch builds.

---
Still need to check during the next release on the 15th that the release triggers work correctly, but the internal logic works 
![image](https://github.com/user-attachments/assets/a81e9d9a-1ce4-42df-b347-5bfc353e4756)

Fixes: https://github.com/getsentry/relay/issues/4517