### PR TITLE
feat(otlp): duplicate resource and instrumentation attrs into spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Track an utilization metric for internal services. ([#4501](https://github.com/getsentry/relay/pull/4501))
 - Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
 - Expose additional metrics through the internal relay metric endpoint. ([#4511](https://github.com/getsentry/relay/pull/4511))
+- Write resource and instrumentation scope attributes as span attributes during OTLP ingestion. ([#4533](https://github.com/getsentry/relay/pull/4533))
 
 ## 25.2.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3974,6 +3974,7 @@ dependencies = [
  "minidump",
  "multer",
  "once_cell",
+ "opentelemetry-proto",
  "papaya",
  "pin-project-lite",
  "priority-queue",

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -56,6 +56,7 @@ mime = { workspace = true }
 minidump = { workspace = true, optional = true }
 multer = { workspace = true }
 once_cell = { workspace = true }
+opentelemetry-proto = { workspace = true }
 papaya = { workspace = true }
 pin-project-lite = { workspace = true }
 priority-queue = { workspace = true }


### PR DESCRIPTION
OTLP trace payloads contain a nested structure wherein resources contain instrumentation scopes, and instrumentation scopes contain spans. The attributes set on the resource or instrumentation scope apply to all contained spans, and are useful to query and aggregate on at the span level. (For example, resource attributes conventionally contain the service name and version of the service emitting spans).

When converting incoming OTLP traces into individual `OtelSpan` items, denormalize these incoming extra attributes onto each span. This will make the data available in Sentry for viewing, searching, and aggregation. Prefix each attribute name with a prefix indicating its source so that attributes with the same name from different sources don't clobber each other.

(We might change our mind on whether these attributes should be prefixed or not - that's fine as no one is using the OTLP endpoint or `OtlpSpan` envelope item type yet).

In addition to an `attributes` dictionary, instrumentation scopes also have `name` and `version` string properties. Copy those to spans too.