### PR TITLE
ref(metrics): Remove custom metric blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
 - Expose additional metrics through the internal relay metric endpoint. ([#4511](https://github.com/getsentry/relay/pull/4511))
 - Write resource and instrumentation scope attributes as span attributes during OTLP ingestion. ([#4533](https://github.com/getsentry/relay/pull/4533))
+- Remove unused capability to block metric names and tags. ([#4536](https://github.com/getsentry/relay/pull/4536))
 - Adopt new `AsyncPool` for the `EnvelopeProcessorService` and `StoreService`. ([#4520](https://github.com/getsentry/relay/pull/4520))
 
 ## 25.2.0

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove unused capability to block metric names and tags. ([#4536](https://github.com/getsentry/relay/pull/4536))
+
 ## 0.9.6
 
 - Add a new data category for UI profiling. ([#4468](https://github.com/getsentry/relay/pull/4468))

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -22,22 +22,12 @@ pub struct Metrics {
     /// List of cardinality limits to enforce for this project.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cardinality_limits: Vec<CardinalityLimit>,
-    /// List of patterns for blocking metrics based on their name.
-    #[serde(skip_serializing_if = "Patterns::is_empty")]
-    pub denied_names: TypedPatterns,
-    /// Configuration for removing tags from a bucket.
-    ///
-    /// Note that removing tags does not drop the overall metric bucket.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub denied_tags: Vec<TagBlock>,
 }
 
 impl Metrics {
     /// Returns `true` if there are no changes to the metrics config.
     pub fn is_empty(&self) -> bool {
         self.cardinality_limits.is_empty()
-            && self.denied_names.is_empty()
-            && self.denied_tags.is_empty()
     }
 }
 
@@ -687,14 +677,6 @@ mod tests {
         let m: Metrics = serde_json::from_str("{}").unwrap();
         assert!(m.is_empty());
         assert_eq!(m, Metrics::default());
-    }
-
-    #[test]
-    fn test_serialize_metrics_config_denied_names() {
-        let input_str = r#"{"deniedNames":["foo","bar"]}"#;
-        let deny_list: Metrics = serde_json::from_str(input_str).unwrap();
-        let back_to_str = serde_json::to_string(&deny_list).unwrap();
-        assert_eq!(input_str, back_to_str);
     }
 
     #[test]

--- a/relay-server/src/services/processor/metrics.rs
+++ b/relay-server/src/services/processor/metrics.rs
@@ -1,4 +1,4 @@
-use relay_dynamic_config::{ErrorBoundary, Feature, Metrics};
+use relay_dynamic_config::Feature;
 use relay_filter::FilterStatKey;
 use relay_metrics::{Bucket, MetricNamespace};
 use relay_quotas::Scoping;
@@ -30,27 +30,16 @@ pub fn apply_project_info(
     project_info: &ProjectInfo,
     scoping: Scoping,
 ) -> Vec<Bucket> {
-    let mut denied_buckets = Vec::new();
     let mut disabled_namespace_buckets = Vec::new();
 
     buckets = buckets
         .into_iter()
-        .filter_map(|mut bucket| {
+        .filter_map(|bucket| {
             if !is_metric_namespace_valid(project_info, bucket.name.namespace()) {
                 relay_log::trace!(mri = &*bucket.name, "dropping metric in disabled namespace");
                 disabled_namespace_buckets.push(bucket);
                 return None;
             };
-
-            if let ErrorBoundary::Ok(ref metric_config) = project_info.config.metrics {
-                if metric_config.denied_names.is_match(&bucket.name) {
-                    relay_log::trace!(mri = &*bucket.name, "dropping metrics due to block list");
-                    denied_buckets.push(bucket);
-                    return None;
-                }
-
-                remove_matching_bucket_tags(metric_config, &mut bucket);
-            }
 
             Some(bucket)
         })
@@ -61,14 +50,6 @@ pub fn apply_project_info(
             scoping,
             &disabled_namespace_buckets,
             Outcome::Filtered(FilterStatKey::DisabledNamespace),
-        );
-    }
-
-    if !denied_buckets.is_empty() {
-        metric_outcomes.track(
-            scoping,
-            &denied_buckets,
-            Outcome::Filtered(FilterStatKey::DeniedName),
         );
     }
 
@@ -86,24 +67,10 @@ fn is_metric_namespace_valid(state: &ProjectInfo, namespace: MetricNamespace) ->
     }
 }
 
-/// Removes tags based on user configured deny list.
-fn remove_matching_bucket_tags(metric_config: &Metrics, bucket: &mut Bucket) {
-    for tag_block in &metric_config.denied_tags {
-        if tag_block.name.is_match(&bucket.name) {
-            bucket
-                .tags
-                .retain(|tag_key, _| !tag_block.tags.is_match(tag_key));
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use relay_base_schema::organization::OrganizationId;
     use relay_base_schema::project::{ProjectId, ProjectKey};
-    use relay_dynamic_config::TagBlock;
     use relay_metrics::{BucketValue, UnixTimestamp};
     use relay_system::Addr;
 
@@ -121,88 +88,6 @@ mod tests {
             width: 10,
             metadata: Default::default(),
         }
-    }
-
-    fn get_test_bucket(name: &str, tags: BTreeMap<String, String>) -> Bucket {
-        let json = serde_json::json!({
-            "timestamp": 1615889440,
-            "width": 10,
-            "name": name,
-            "type": "c",
-            "value": 4.0,
-            "tags": tags,
-        });
-
-        serde_json::from_value(json).unwrap()
-    }
-
-    #[test]
-    fn test_remove_tags() {
-        let mut tags = BTreeMap::default();
-        tags.insert("foobazbar".to_owned(), "val".to_owned());
-        tags.insert("foobaz".to_owned(), "val".to_owned());
-        tags.insert("bazbar".to_owned(), "val".to_owned());
-
-        let mut bucket = get_test_bucket("foobar", tags);
-
-        let tag_block_pattern = "foobaz*";
-
-        let metric_config = Metrics {
-            denied_tags: vec![TagBlock {
-                name: "foobar".to_owned().into(),
-                tags: tag_block_pattern.to_owned().into(),
-            }],
-            ..Default::default()
-        };
-
-        remove_matching_bucket_tags(&metric_config, &mut bucket);
-
-        // the tag_block_pattern should match on two of the tags.
-        assert_eq!(bucket.tags.len(), 1);
-    }
-
-    #[test]
-    fn test_apply_project_info() {
-        let (outcome_aggregator, _) = Addr::custom();
-        let (metric_stats, mut metric_stats_rx) = MetricStats::test();
-        let metric_outcomes = MetricOutcomes::new(metric_stats, outcome_aggregator);
-
-        let project_info = ProjectInfo {
-            config: serde_json::from_value(serde_json::json!({
-                "metrics": { "deniedNames": ["*cpu_time*"] },
-                "features": ["organizations:custom-metrics"]
-            }))
-            .unwrap(),
-            ..Default::default()
-        };
-
-        let b1 = create_custom_bucket_with_name("cpu_time".into());
-        let b2 = create_custom_bucket_with_name("memory_usage".into());
-        let buckets = vec![b1.clone(), b2.clone()];
-
-        let buckets = apply_project_info(
-            buckets,
-            &metric_outcomes,
-            &project_info,
-            Scoping {
-                organization_id: OrganizationId::new(42),
-                project_id: ProjectId::new(43),
-                project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
-                key_id: Some(44),
-            },
-        );
-
-        // We assert that one metric passes all the pre-processing.
-        assert_eq!(&*buckets, &[b2]);
-
-        // We assert that one metric is emitted by metric stats.
-        let value = metric_stats_rx.blocking_recv().unwrap();
-        let Aggregator::MergeBuckets(merge_buckets) = value;
-        assert_eq!(merge_buckets.buckets.len(), 1);
-        assert_eq!(
-            merge_buckets.buckets[0].tags.get("mri").unwrap().as_str(),
-            &*b1.name
-        );
     }
 
     #[test]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1912,42 +1912,6 @@ def test_missing_global_filters_enables_metric_extraction(
     assert metrics_consumer.get_metrics()
 
 
-def test_metrics_with_denied_names(
-    mini_sentry, relay_with_processing, metrics_consumer
-):
-    metrics_consumer = metrics_consumer()
-
-    mini_sentry.global_config["options"]["relay.metric-stats.rollout-rate"] = 1.0
-
-    project_id = 42
-    mini_sentry.add_full_project_config(project_id)
-    project_config = mini_sentry.project_configs[project_id]["config"]
-    project_config["features"] = ["organizations:custom-metrics"]
-    project_config["metrics"] = {
-        "deniedNames": ["d:custom/cpu_time*"],
-    }
-
-    relay = relay_with_processing(options=TEST_CONFIG)
-
-    relay.send_metrics(project_id, "custom/cpu_time@millisecond:10|d|#foo:bar")
-
-    metrics = metrics_by_name(metrics_consumer, 1)
-    volume_metric = metrics["c:metric_stats/volume@none"]
-    assert volume_metric["value"] == 1.0
-    assert volume_metric["tags"]["mri"] == "d:custom/cpu_time@millisecond"
-    assert volume_metric["tags"]["outcome.id"] == "1"
-    assert volume_metric["tags"]["outcome.reason"] == "denied-name"
-
-    relay.send_metrics(project_id, "custom/memory_usage@byte:10|d|#foo:bar")
-
-    metrics = metrics_by_name(metrics_consumer, 2)
-    volume_metric = metrics["c:metric_stats/volume@none"]
-    assert volume_metric["value"] == 1.0
-    assert volume_metric["tags"]["mri"] == "d:custom/memory_usage@byte"
-    assert volume_metric["tags"]["outcome.id"] == "0"
-    assert "d:custom/memory_usage@byte" in metrics
-
-
 @pytest.mark.parametrize("mode", ["default", "chain"])
 def test_metrics_received_at(
     mini_sentry, relay, relay_with_processing, relay_credentials, metrics_consumer, mode


### PR DESCRIPTION
Metric blocking was originally added for DDM, it is no longer necessary.

See also: https://github.com/getsentry/team-ingest/issues/653