### PR TITLE
feat(pool): Add metrics to the async pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Expose additional metrics through the internal relay metric endpoint. ([#4511](https://github.com/getsentry/relay/pull/4511))
 - Write resource and instrumentation scope attributes as span attributes during OTLP ingestion. ([#4533](https://github.com/getsentry/relay/pull/4533))
 - Adopt new `AsyncPool` for the `EnvelopeProcessorService` and `StoreService`. ([#4520](https://github.com/getsentry/relay/pull/4520))
+- Expose metrics for the `AsyncPool`. ([#4538](https://github.com/getsentry/relay/pull/4538))
 
 ## 25.2.0
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -227,19 +227,14 @@ impl ServiceState {
 
         let metric_outcomes = MetricOutcomes::new(metric_stats, outcome_aggregator.clone());
 
-        // We create a vector containing all the pools that we want to track metrics of.
-        let mut async_pools_metrics = Vec::with_capacity(2);
-
         #[cfg(feature = "processing")]
         let store_pool = create_store_pool(&config)?;
-        #[cfg(feature = "processing")]
-        async_pools_metrics.push(store_pool.metrics());
         #[cfg(feature = "processing")]
         let store = config
             .processing_enabled()
             .then(|| {
                 StoreService::create(
-                    store_pool,
+                    store_pool.clone(),
                     config.clone(),
                     global_config_handle.clone(),
                     outcome_aggregator.clone(),
@@ -253,10 +248,9 @@ impl ServiceState {
         let cogs = Cogs::new(CogsServiceRecorder::new(&config, services.start(cogs)));
 
         let processor_pool = create_processor_pool(&config)?;
-        async_pools_metrics.push(processor_pool.metrics());
         services.start_with(
             EnvelopeProcessorService::new(
-                processor_pool,
+                processor_pool.clone(),
                 config.clone(),
                 global_config_handle,
                 project_cache_handle.clone(),
@@ -307,7 +301,9 @@ impl ServiceState {
             upstream_relay.clone(),
             #[cfg(feature = "processing")]
             redis_pools.clone(),
-            async_pools_metrics,
+            processor_pool,
+            #[cfg(feature = "processing")]
+            store_pool,
         ));
 
         let relay_cache = services.start(RelayCacheService::new(

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -188,7 +188,7 @@ impl RelayStats {
             pool_name = async_pool_metrics.pool_name()
         );
         metric!(
-            gauge(RelayGauges::AsyncPoolUtilization) = async_pool_metrics.utilization(),
+            gauge(RelayGauges::AsyncPoolUtilization) = async_pool_metrics.utilization() as f64,
             pool = async_pool_metrics.pool_name()
         );
     }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -1,18 +1,18 @@
 use std::sync::Arc;
 
-use crate::services::processor::EnvelopeProcessorServicePool;
-use crate::services::store::StoreServicePool;
-use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
-use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
 use relay_config::{Config, RelayMode};
 #[cfg(feature = "processing")]
-use relay_redis::AsyncRedisClient;
-#[cfg(feature = "processing")]
-use relay_redis::{RedisPool, RedisPools, Stats};
+use relay_redis::{AsyncRedisClient, RedisPool, RedisPools, Stats};
 use relay_statsd::metric;
 use relay_system::{Addr, Handle, RuntimeMetrics, Service};
 use relay_threading::AsyncPool;
 use tokio::time::interval;
+
+use crate::services::processor::EnvelopeProcessorServicePool;
+#[cfg(feature = "processing")]
+use crate::services::store::StoreServicePool;
+use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
+use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
 
 /// Relay Stats Service.
 ///
@@ -25,6 +25,7 @@ pub struct RelayStats {
     #[cfg(feature = "processing")]
     redis_pools: Option<RedisPools>,
     processor_pool: EnvelopeProcessorServicePool,
+    #[cfg(feature = "processing")]
     store_pool: StoreServicePool,
 }
 
@@ -45,6 +46,7 @@ impl RelayStats {
             #[cfg(feature = "processing")]
             redis_pools,
             processor_pool,
+            #[cfg(feature = "processing")]
             store_pool,
         }
     }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -195,7 +195,7 @@ impl RelayStats {
 
     async fn async_pools_metrics(&self) {
         for async_pool_metrics in self.async_pools_metrics.iter() {
-            Self::emit_async_pool_metrics(&async_pool_metrics);
+            Self::emit_async_pool_metrics(async_pool_metrics);
         }
     }
 }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -184,12 +184,12 @@ impl RelayStats {
 
     fn emit_async_pool_metrics(async_pool_metrics: &AsyncPoolMetrics) {
         metric!(
-            gauge(RelayGauges::AsyncPoolQueueSize) = async_pool_metrics.queue_size(),
-            pool_name = async_pool_metrics.pool_name()
+            gauge(RelayGauges::AsyncPoolQueueSize) = async_pool_metrics.queue_size,
+            pool_name = async_pool_metrics.pool_name
         );
         metric!(
-            gauge(RelayGauges::AsyncPoolUtilization) = async_pool_metrics.utilization() as f64,
-            pool = async_pool_metrics.pool_name()
+            gauge(RelayGauges::AsyncPoolUtilization) = async_pool_metrics.utilization as f64,
+            pool = async_pool_metrics.pool_name
         );
     }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -4,6 +4,15 @@ use relay_system::RuntimeMetrics;
 
 /// Gauge metrics used by Relay
 pub enum RelayGauges {
+    /// Tracks the number of futures waiting to be executed in the pool's queue.
+    ///
+    /// Useful for understanding the backlog of work and identifying potential bottlenecks.
+    AsyncPoolQueueSize,
+    /// Tracks the utilization of the async pool.
+    ///
+    /// The utilization is a value between 0.0 and 1.0 which determines how busy is the pool
+    /// w.r.t. to its provisioned capacity.
+    AsyncPoolUtilization,
     /// The state of Relay with respect to the upstream connection.
     /// Possible values are `0` for normal operations and `1` for a network outage.
     NetworkOutage,
@@ -53,6 +62,8 @@ pub enum RelayGauges {
 impl GaugeMetric for RelayGauges {
     fn name(&self) -> &'static str {
         match self {
+            RelayGauges::AsyncPoolQueueSize => "async_pool.queue_size",
+            RelayGauges::AsyncPoolUtilization => "async_pool.utilization",
             RelayGauges::NetworkOutage => "upstream.network_outage",
             RelayGauges::BufferStackCount => "buffer.stack_count",
             RelayGauges::BufferDiskUsed => "buffer.disk_used",

--- a/relay-threading/src/lib.rs
+++ b/relay-threading/src/lib.rs
@@ -55,4 +55,5 @@ mod multiplexing;
 mod pool;
 
 pub use self::builder::*;
+pub use self::metrics::*;
 pub use self::pool::*;

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -39,7 +39,7 @@ impl Clone for ThreadMetrics {
     }
 }
 
-/// Metrics for an asynchronous pool.
+/// Metrics for the asynchronous pool.
 #[derive(Debug)]
 pub struct AsyncPoolMetrics<'a> {
     max_expected_futures: u64,
@@ -48,6 +48,7 @@ pub struct AsyncPoolMetrics<'a> {
 }
 
 impl<'a> AsyncPoolMetrics<'a> {
+    /// Creates a new instance of [`AsyncPoolMetrics`].
     pub(crate) fn new(
         max_expected_futures: u64,
         queue_size: u64,

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -14,7 +14,7 @@ pub(crate) struct ThreadMetrics {
 /// Metrics for the asynchronous pool.
 #[derive(Debug)]
 pub struct AsyncPoolMetrics<'a> {
-    pub(crate) max_expected_futures: u64,
+    pub(crate) max_tasks: u64,
     pub(crate) queue_size: u64,
     pub(crate) threads_metrics: &'a [Arc<ThreadMetrics>],
 }
@@ -33,6 +33,6 @@ impl AsyncPoolMetrics<'_> {
             .map(|m| m.active_tasks.load(Ordering::Relaxed))
             .sum();
 
-        (total_polled_futures as f32 / self.max_expected_futures as f32).clamp(0.0, 1.0)
+        (total_polled_futures as f32 / self.max_tasks as f32).clamp(0.0, 1.0)
     }
 }

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -1,4 +1,3 @@
-use relay_statsd::GaugeMetric;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -6,61 +6,20 @@ use std::sync::Arc;
 /// This struct provides a way to track and query metrics specific to an individual thread, such as
 /// the number of futures it has polled. It is designed for safe concurrent access across threads.
 #[derive(Debug, Default)]
-pub struct ThreadMetrics {
+pub(crate) struct ThreadMetrics {
     /// Number of futures that are currently being polled concurrently by the thread in the pool.
-    polled_futures: AtomicU64,
-}
-
-impl ThreadMetrics {
-    /// Creates a new instance of [`ThreadMetrics`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns the number of futures polled by the thread.
-    ///
-    /// This method provides a snapshot of the total futures processed by the thread at the time of
-    /// the call. It is useful for monitoring thread activity and workload distribution.
-    pub fn polled_futures(&self) -> u64 {
-        self.polled_futures.load(Ordering::SeqCst)
-    }
-
-    /// Updates the `polled_futures` value.
-    pub(crate) fn update_polled_futures(&self, polled_futures: u64) {
-        self.polled_futures.store(polled_futures, Ordering::SeqCst);
-    }
-}
-
-impl Clone for ThreadMetrics {
-    fn clone(&self) -> Self {
-        Self {
-            polled_futures: AtomicU64::new(self.polled_futures.load(Ordering::SeqCst)),
-        }
-    }
+    pub(crate) active_tasks: AtomicU64,
 }
 
 /// Metrics for the asynchronous pool.
 #[derive(Debug)]
 pub struct AsyncPoolMetrics<'a> {
-    max_expected_futures: u64,
-    queue_size: u64,
-    threads_metrics: &'a Vec<Arc<ThreadMetrics>>,
+    pub(crate) max_expected_futures: u64,
+    pub(crate) queue_size: u64,
+    pub(crate) threads_metrics: &'a [Arc<ThreadMetrics>],
 }
 
-impl<'a> AsyncPoolMetrics<'a> {
-    /// Creates a new instance of [`AsyncPoolMetrics`].
-    pub(crate) fn new(
-        max_expected_futures: u64,
-        queue_size: u64,
-        threads_metrics: &'a Vec<Arc<ThreadMetrics>>,
-    ) -> Self {
-        Self {
-            max_expected_futures,
-            queue_size,
-            threads_metrics,
-        }
-    }
-
+impl AsyncPoolMetrics<'_> {
     /// Returns the amount of futures in the pool's queue.
     pub fn queue_size(&self) -> u64 {
         self.queue_size
@@ -71,7 +30,7 @@ impl<'a> AsyncPoolMetrics<'a> {
         let total_polled_futures: u64 = self
             .threads_metrics
             .iter()
-            .map(|m| m.polled_futures())
+            .map(|m| m.active_tasks.load(Ordering::Relaxed))
             .sum();
 
         (total_polled_futures as f32 / self.max_expected_futures as f32).clamp(0.0, 1.0)

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -20,7 +20,7 @@ pub struct AsyncPoolMetrics<'a> {
 }
 
 impl AsyncPoolMetrics<'_> {
-    /// Returns the amount of futures in the pool's queue.
+    /// Returns the amount of tasks in the pool's queue.
     pub fn queue_size(&self) -> u64 {
         self.queue_size
     }

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -1,5 +1,4 @@
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
 
 /// Metrics for a single thread in an asynchronous pool.
 ///
@@ -12,6 +11,11 @@ pub struct ThreadMetrics {
 }
 
 impl ThreadMetrics {
+    /// Creates a new instance of [`ThreadMetrics`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Returns the number of futures polled by the thread.
     ///
     /// This method provides a snapshot of the total futures processed by the thread at the time of
@@ -34,85 +38,9 @@ impl Clone for ThreadMetrics {
     }
 }
 
-/// Inner state of asynchronous pool metrics.
-///
-/// This struct is not intended for direct use by end users. It is wrapped by [`AsyncPoolMetrics`]
-/// to provide a safe, ergonomic interface for tracking pool performance.
-#[derive(Debug)]
-struct Inner {
-    /// The name of the pool from which the metrics originate.
-    pool_name: &'static str,
-    /// The maximum number of futures that are expected to run concurrently at any point in time.
-    max_expected_futures: u64,
-    /// Number of futures waiting to be executed by one of the threads of the pool.
-    queue_size: AtomicU64,
-    /// Vector containing all the metrics collected individually in each thread.
-    thread_metrics: Vec<ThreadMetrics>,
-}
-
 /// Metrics for an asynchronous pool.
-///
-/// This struct provides a high-level interface for monitoring the performance and utilization of
-/// an asynchronous pool. It tracks queued futures, per-thread activity, and overall utilization.
-///
-/// The metrics are stored in a thread-safe manner, allowing safe access from multiple threads.
-///
-/// Cloning this struct is inexpensive and shares the underlying data.
-#[derive(Debug, Clone)]
-pub struct AsyncPoolMetrics(Arc<Inner>);
-
-impl AsyncPoolMetrics {
-    /// Create a new instance [`AsyncPoolMetrics`].
-    pub(crate) fn new(pool_name: &'static str, num_threads: usize, max_concurrency: usize) -> Self {
-        let inner = Inner {
-            pool_name,
-            max_expected_futures: (num_threads * max_concurrency) as u64,
-            queue_size: AtomicU64::new(0),
-            thread_metrics: vec![ThreadMetrics::default(); num_threads],
-        };
-
-        Self(Arc::new(inner))
-    }
-
-    /// Returns the name of the pool that emits the metrics captured by the [`AsyncPoolMetrics`].
-    pub fn pool_name(&self) -> &'static str {
-        self.0.pool_name
-    }
-
-    /// Returns the number of futures currently queued for execution.
-    ///
-    /// This method provides a snapshot of the pool's backlog, which can help identify whether the
-    /// pool is overloaded or underutilized. A high value may indicate that the pool needs more
-    /// threads or higher concurrency limits.
-    pub fn queue_size(&self) -> u64 {
-        self.0.queue_size.load(Ordering::SeqCst)
-    }
-
-    /// Returns the utilization of the pool as a fraction between 0.0 and 1.0.
-    ///
-    /// Utilization represents how close the pool is to its maximum capacity, based on the number
-    /// of futures being polled across all threads compared to the expected maximum. A value near
-    /// 1.0 indicates full utilization, while a value near 0.0 suggests idle resources.
-    pub fn utilization(&self) -> f32 {
-        let total_polled_futures: u64 = self
-            .0
-            .thread_metrics
-            .iter()
-            .map(|m| m.polled_futures())
-            .sum();
-
-        (total_polled_futures as f32 / self.0.max_expected_futures as f32).clamp(0.0, 1.0)
-    }
-
-    /// Updates the `queued_futures` value.
-    pub(crate) fn update_queued_futures(&self, queued_futures: u64) {
-        self.0.queue_size.store(queued_futures, Ordering::SeqCst);
-    }
-
-    /// Returns the [`ThreadMetrics`] of the given thread, identified by thread id.
-    ///
-    /// If no thread exists with that id, `None` will be returned.
-    pub(crate) fn thread_metrics(&self, thread_id: usize) -> Option<&ThreadMetrics> {
-        self.0.thread_metrics.get(thread_id)
-    }
+#[derive(Debug)]
+pub struct AsyncPoolMetrics {
+    pub queue_size: u64,
+    pub utilization: f32,
 }

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -1,4 +1,6 @@
 use relay_statsd::GaugeMetric;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 /// Gauge metrics emitted by the asynchronous pool.
 pub enum AsyncPoolGauges {
@@ -14,5 +16,78 @@ impl GaugeMetric for AsyncPoolGauges {
             Self::AsyncPoolQueueSize => "async_pool.queue_size",
             Self::AsyncPoolFuturesPerThread => "async_pool.futures_per_thread",
         }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ThreadMetrics {
+    polled_futures: AtomicU64,
+}
+
+impl ThreadMetrics {
+    pub fn polled_futures(&self) -> u64 {
+        self.polled_futures.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn update_polled_futures(&self, polled_futures: u64) {
+        self.polled_futures.store(polled_futures, Ordering::SeqCst);
+    }
+}
+
+impl Clone for ThreadMetrics {
+    fn clone(&self) -> Self {
+        Self {
+            polled_futures: AtomicU64::new(self.polled_futures.load(Ordering::SeqCst)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Inner {
+    /// The number of futures we can poll within each thread times the number of threads.
+    ///
+    /// This value is used to compute the utilization metric, which should be as close as possible
+    /// to 100%, meaning all threads are busy to their maximum.
+    max_expected_futures: u64,
+    queued_futures: AtomicU64,
+    thread_metrics: Vec<ThreadMetrics>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsyncPoolMetrics(Arc<Inner>);
+
+impl AsyncPoolMetrics {
+    pub(crate) fn new(num_threads: usize, max_concurrency: usize) -> Self {
+        let inner = Inner {
+            max_expected_futures: (num_threads * max_concurrency) as u64,
+            queued_futures: AtomicU64::new(0),
+            thread_metrics: vec![ThreadMetrics::default(); num_threads],
+        };
+
+        Self(Arc::new(inner))
+    }
+
+    pub fn queued_futures(&self) -> u64 {
+        self.0.queued_futures.load(Ordering::SeqCst)
+    }
+
+    pub fn utilization(&self) -> f32 {
+        let total_polled_futures: u64 = self
+            .0
+            .thread_metrics
+            .iter()
+            .map(|m| m.polled_futures())
+            .sum();
+        total_polled_futures as f32 / self.0.max_expected_futures as f32
+    }
+
+    pub(crate) fn update_queued_futures(&self, queued_futures: u64) {
+        self.0
+            .queued_futures
+            .store(queued_futures, Ordering::SeqCst);
+    }
+
+    pub(crate) fn thread_metrics(&self, thread_id: usize) -> Option<&ThreadMetrics> {
+        self.0.thread_metrics.get(thread_id)
     }
 }

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -39,7 +39,7 @@ impl Clone for ThreadMetrics {
 /// This struct is not intended for direct use by end users. It is wrapped by [`AsyncPoolMetrics`]
 /// to provide a safe, ergonomic interface for tracking pool performance.
 #[derive(Debug)]
-pub struct Inner {
+struct Inner {
     /// The name of the pool from which the metrics originate.
     pool_name: &'static str,
     /// The maximum number of futures that are expected to run concurrently at any point in time.

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -41,6 +41,7 @@ impl Clone for ThreadMetrics {
 /// Metrics for an asynchronous pool.
 #[derive(Debug)]
 pub struct AsyncPoolMetrics {
+    pub pool_name: &'static str,
     pub queue_size: u64,
     pub utilization: f32,
 }

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -102,7 +102,6 @@ pin_project! {
     ///
     /// This multiplexer is primarily used by the [`AsyncPool`] to manage task execution on worker threads.
     pub struct Multiplexed<S, F> {
-        thread_id: usize,
         pool_name: &'static str,
         max_concurrency: usize,
         #[pin]
@@ -122,7 +121,6 @@ where
     /// Tasks from the stream will be scheduled for execution concurrently, and an optional panic handler
     /// can be provided to manage errors during task execution.
     pub fn new(
-        thread_id: usize,
         pool_name: &'static str,
         max_concurrency: usize,
         rx: S,
@@ -130,7 +128,6 @@ where
         metrics: Arc<ThreadMetrics>,
     ) -> Self {
         Self {
-            thread_id,
             pool_name,
             max_concurrency,
             rx,
@@ -218,7 +215,6 @@ mod tests {
     fn test_multiplexer_with_no_futures() {
         let (_, rx) = flume::bounded::<BoxFuture<'static, _>>(10);
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             1,
             rx.into_stream(),
@@ -247,7 +243,6 @@ mod tests {
             panic_handler_called_clone.store(true, Ordering::SeqCst);
         };
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             1,
             rx.into_stream(),
@@ -276,7 +271,6 @@ mod tests {
 
         let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
             futures::executor::block_on(Multiplexed::new(
-                0,
                 "my_pool",
                 1,
                 rx.into_stream(),
@@ -304,7 +298,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             1,
             rx.into_stream(),
@@ -332,7 +325,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             1,
             rx.into_stream(),
@@ -358,7 +350,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             5,
             rx.into_stream(),
@@ -386,7 +377,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             5,
             rx.into_stream(),
@@ -417,7 +407,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             5,
             rx.into_stream(),
@@ -454,7 +443,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             5,
             rx.into_stream(),
@@ -498,7 +486,6 @@ mod tests {
         drop(tx);
 
         futures::executor::block_on(Multiplexed::new(
-            0,
             "my_pool",
             1,
             rx.into_stream(),

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -24,8 +24,8 @@ pub struct AsyncPool<F> {
     name: &'static str,
     /// Transmission containing all futures.
     tx: flume::Sender<F>,
-    /// The maximum number of futures that are expected to run concurrently at any point in time.
-    max_expected_futures: u64,
+    /// The maximum number of tasks that are expected to run concurrently at any point in time.
+    max_tasks: u64,
     /// Vector containing all the metrics collected individually in each thread.
     threads_metrics: Arc<Vec<Arc<ThreadMetrics>>>,
 }
@@ -39,7 +39,7 @@ impl<F> AsyncPool<F> {
     /// Returns the [`AsyncPoolMetrics`] that are updated by the pool.
     pub fn metrics(&self) -> AsyncPoolMetrics {
         AsyncPoolMetrics {
-            max_expected_futures: self.max_expected_futures,
+            max_tasks: self.max_tasks,
             queue_size: self.tx.len() as u64,
             threads_metrics: &self.threads_metrics,
         }
@@ -91,7 +91,7 @@ where
         Ok(Self {
             name: pool_name,
             tx,
-            max_expected_futures: (builder.num_threads * builder.max_concurrency) as u64,
+            max_tasks: (builder.num_threads * builder.max_concurrency) as u64,
             threads_metrics: Arc::new(threads_metrics),
         })
     }
@@ -132,7 +132,7 @@ impl<F> Clone for AsyncPool<F> {
         Self {
             name: self.name,
             tx: self.tx.clone(),
-            max_expected_futures: self.max_expected_futures,
+            max_tasks: self.max_tasks,
             threads_metrics: self.threads_metrics.clone(),
         }
     }

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -38,11 +38,11 @@ impl<F> AsyncPool<F> {
 
     /// Returns the [`AsyncPoolMetrics`] that are updated by the pool.
     pub fn metrics(&self) -> AsyncPoolMetrics {
-        AsyncPoolMetrics::new(
-            self.max_expected_futures,
-            self.tx.len() as u64,
-            &self.threads_metrics,
-        )
+        AsyncPoolMetrics {
+            max_expected_futures: self.max_expected_futures,
+            queue_size: self.tx.len() as u64,
+            threads_metrics: &self.threads_metrics,
+        }
     }
 }
 
@@ -66,7 +66,7 @@ where
             let rx = rx.clone();
             let thread_name: Option<String> = builder.thread_name.as_mut().map(|f| f(thread_id));
 
-            let metrics = Arc::new(ThreadMetrics::new());
+            let metrics = Arc::new(ThreadMetrics::default());
             let thread = Thread {
                 id: thread_id,
                 max_concurrency: builder.max_concurrency,

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -22,7 +22,7 @@ const DEFAULT_POOL_NAME: &str = "unnamed";
 pub struct AsyncPool<F> {
     /// Name of the pool.
     name: &'static str,
-    /// Transmission containing all futures.
+    /// Transmission containing all tasks.
     tx: flume::Sender<F>,
     /// The maximum number of tasks that are expected to run concurrently at any point in time.
     max_tasks: u64,

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -127,6 +127,7 @@ where
     /// Returns the [`AsyncPoolMetrics`] that are updated by the pool.
     pub fn metrics(&self) -> AsyncPoolMetrics {
         AsyncPoolMetrics {
+            pool_name: self.name,
             queue_size: self.queue_size.load(Ordering::SeqCst),
             utilization: self.utilization(),
         }

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -61,7 +61,6 @@ where
                 runtime: builder.runtime.clone(),
                 panic_handler: builder.thread_panic_handler.clone(),
                 task: Multiplexed::new(
-                    thread_id,
                     pool_name,
                     builder.max_concurrency,
                     rx.into_stream(),

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -7,7 +7,7 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 
 use crate::builder::AsyncPoolBuilder;
-use crate::metrics::{AsyncPoolGauges, AsyncPoolMetrics};
+use crate::metrics::AsyncPoolMetrics;
 use crate::multiplexing::Multiplexed;
 use crate::PanicHandler;
 
@@ -40,7 +40,8 @@ where
         let pool_name = builder.pool_name.unwrap_or(DEFAULT_POOL_NAME);
         let (tx, rx) = flume::bounded(builder.num_threads * 2);
 
-        let metrics = AsyncPoolMetrics::new(builder.num_threads, builder.max_concurrency);
+        let metrics =
+            AsyncPoolMetrics::new(pool_name, builder.num_threads, builder.max_concurrency);
 
         for thread_id in 0..builder.num_threads {
             let rx = rx.clone();
@@ -71,6 +72,11 @@ where
             tx,
             metrics,
         })
+    }
+
+    /// Returns the `name` of the [`AsyncPool`].
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// Schedules a future for execution within the [`AsyncPool`].


### PR DESCRIPTION
This PR adds the possibility to expose metrics collected by the `AsyncPool`.

Closes: https://github.com/getsentry/team-ingest/issues/647