### PR TITLE
feat(relay): expose service utilization metrics in autoscaling endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Track an utilization metric for internal services. ([#4501](https://github.com/getsentry/relay/pull/4501))
 - Add new `relay-threading` crate with asynchronous thread pool. ([#4500](https://github.com/getsentry/relay/pull/4500))
 - Expose additional metrics through the internal relay metric endpoint. ([#4511](https://github.com/getsentry/relay/pull/4511))
+- Expose service utilization metrics through the internal relay metric endpoint. ([#4543](https://github.com/getsentry/relay/pull/4543))
 
 ## 25.2.0
 

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -32,10 +32,7 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
     append_data_row(&mut result, "spool_item_count", data.item_count, &[]);
     append_data_row(&mut result, "spool_total_size", data.total_size, &[]);
     for utilization in &data.services_metrics {
-        // Service names contain the namespace they are declared in, e.g. foo::services::MyService.
-        // We are only interested in the actual service name.
-        // If it doesn't contain ':', we assume that a custom name has been defined.s
-        let service_name = utilization.0.split(":").last().unwrap_or(utilization.0);
+        let service_name = extract_service_name(utilization.0);
         append_data_row(
             &mut result,
             "utilization",

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -45,18 +45,18 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
 
 fn append_data_row(result: &mut String, label: &str, data: impl Display, tags: &[(&str, &str)]) {
     // Metrics are automatically prefixed with "relay_"
-    write!(result, "relay_{}", label).unwrap();
+    write!(result, "relay_{label}").unwrap();
     if !tags.is_empty() {
         result.push('{');
         for (idx, (key, value)) in tags.iter().enumerate() {
             if idx > 0 {
                 result.push_str(", ");
             }
-            write!(result, "{}=\"{}\"", key, value).unwrap();
+            write!(result, "{key}=\"{value}\"").unwrap();
         }
         result.push('}');
     }
-    writeln!(result, " {}", data).unwrap();
+    writeln!(result, " {data}").unwrap();
 }
 
 /// Extracts the concrete Service name from a string with a namespace,

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -2,7 +2,7 @@ use crate::http::StatusCode;
 use crate::service::ServiceState;
 use crate::services::autoscaling::{AutoscalingData, AutoscalingMessageKind};
 use std::fmt::Display;
-use std::fmt::Write as _;
+use std::fmt::Write;
 
 /// Returns internal metrics data for relay.
 pub async fn handle(state: ServiceState) -> (StatusCode, String) {
@@ -23,7 +23,7 @@ pub async fn handle(state: ServiceState) -> (StatusCode, String) {
     (StatusCode::OK, to_prometheus_string(&data))
 }
 
-/// Simple function to serialize a well-known format into a prometheus string.
+/// Serializes the autoscaling data into a prometheus string.
 fn to_prometheus_string(data: &AutoscalingData) -> String {
     let mut result = String::with_capacity(2048);
 
@@ -60,9 +60,10 @@ fn append_data_row(result: &mut String, label: &str, data: impl Display, tags: &
 }
 
 /// Extracts the concrete Service name from a string with a namespace,
-/// For example: `relay::services::MyService` -> `MyService`.
 /// In case there are no ':' because a custom name is used, then the full name is returned.
-/// For example: `aggregator_service` -> `aggregator_service`.
+/// For example:
+/// * `relay::services::MyService` -> `MyService`.
+/// * `aggregator_service` -> `aggregator_service`.
 fn extract_service_name(full_name: &str) -> &str {
     full_name
         .rsplit_once(':')

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -2,6 +2,7 @@ use crate::http::StatusCode;
 use crate::service::ServiceState;
 use crate::services::autoscaling::{AutoscalingData, AutoscalingMessageKind};
 use std::fmt::Display;
+use std::fmt::Write as _;
 
 /// Returns internal metrics data for relay.
 pub async fn handle(state: ServiceState) -> (StatusCode, String) {
@@ -24,27 +25,99 @@ pub async fn handle(state: ServiceState) -> (StatusCode, String) {
 
 /// Simple function to serialize a well-known format into a prometheus string.
 fn to_prometheus_string(data: &AutoscalingData) -> String {
-    let mut result = String::with_capacity(128);
+    let mut result = String::with_capacity(2048);
 
-    append_data_row(&mut result, "memory_usage", data.memory_usage);
-    append_data_row(&mut result, "up", data.up);
-    append_data_row(&mut result, "spool_item_count", data.item_count);
-    append_data_row(&mut result, "spool_total_size", data.total_size);
+    append_data_row(&mut result, "memory_usage", data.memory_usage, &[]);
+    append_data_row(&mut result, "up", data.up, &[]);
+    append_data_row(&mut result, "spool_item_count", data.item_count, &[]);
+    append_data_row(&mut result, "spool_total_size", data.total_size, &[]);
+    for utilization in &data.services_metrics {
+        // Service names contain the namespace they are declared in, e.g. foo::services::MyService.
+        // We are only interested in the actual service name.
+        // If it doesn't contain ':', we assume that a custom name has been defined.s
+        let service_name = utilization.0.split(":").last().unwrap_or(utilization.0);
+        append_data_row(
+            &mut result,
+            "utilization",
+            utilization.1,
+            &[("relay_service", service_name)],
+        );
+    }
     result
 }
 
-fn append_data_row(result: &mut String, label: &str, data: impl Display) {
+fn append_data_row(result: &mut String, label: &str, data: impl Display, tags: &[(&str, &str)]) {
     // Metrics are automatically prefixed with "relay_"
-    result.push_str("relay_");
-    result.push_str(label);
-    result.push(' ');
-    result.push_str(&data.to_string());
-    result.push('\n');
+    write!(result, "relay_{}", label).unwrap();
+    if !tags.is_empty() {
+        result.push('{');
+        for (idx, (key, value)) in tags.iter().enumerate() {
+            if idx > 0 {
+                result.push_str(", ");
+            }
+            write!(result, "{}=\"{}\"", key, value).unwrap();
+        }
+        result.push('}');
+    }
+    writeln!(result, " {}", data).unwrap();
+}
+
+/// Extracts the concrete Service name from a string with a namespace,
+/// For example: `relay::services::MyService` -> `MyService`.
+/// In case there are no ':' because a custom name is used, then the full name is returned.
+/// For example: `aggregator_service` -> `aggregator_service`.
+fn extract_service_name(full_name: &str) -> &str {
+    full_name
+        .rsplit_once(':')
+        .map(|(_, s)| s)
+        .unwrap_or(full_name)
 }
 
 #[cfg(test)]
 mod test {
-    use crate::services::autoscaling::AutoscalingData;
+    use crate::endpoints::autoscaling::{append_data_row, extract_service_name};
+    use crate::services::autoscaling::{AutoscalingData, ServiceUtilization};
+
+    #[test]
+    fn test_extract_service_with_namespace() {
+        let service_name = extract_service_name("relay::services::MyService");
+        assert_eq!(service_name, "MyService");
+    }
+
+    #[test]
+    fn test_extract_service_without_namespace() {
+        let service_name = extract_service_name("custom_service");
+        assert_eq!(service_name, "custom_service");
+    }
+
+    #[test]
+    fn test_append_no_labels() {
+        let mut result = String::new();
+        append_data_row(&mut result, "example", 200, &[]);
+        assert_eq!(result, "relay_example 200\n");
+    }
+
+    #[test]
+    fn test_append_single_label() {
+        let mut result = String::new();
+        append_data_row(&mut result, "example", 200, &[("key", "value")]);
+        assert_eq!(result, "relay_example{key=\"value\"} 200\n");
+    }
+
+    #[test]
+    fn test_append_multiple_labels() {
+        let mut result = String::new();
+        append_data_row(
+            &mut result,
+            "example",
+            200,
+            &[("first_key", "first_value"), ("second_key", "second_value")],
+        );
+        assert_eq!(
+            result,
+            "relay_example{first_key=\"first_value\", second_key=\"second_value\"} 200\n"
+        );
+    }
 
     #[test]
     fn test_prometheus_serialize() {
@@ -53,6 +126,10 @@ mod test {
             up: 1,
             item_count: 10,
             total_size: 30,
+            services_metrics: vec![
+                ServiceUtilization("test", 10),
+                ServiceUtilization("envelope", 50),
+            ],
         };
         let result = super::to_prometheus_string(&data);
         assert_eq!(
@@ -61,6 +138,8 @@ mod test {
 relay_up 1
 relay_spool_item_count 10
 relay_spool_total_size 30
+relay_utilization{relay_service="test"} 10
+relay_utilization{relay_service="envelope"} 50
 "#
         );
     }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -289,6 +289,7 @@ impl ServiceState {
         let autoscaling = services.start(AutoscalingMetricService::new(
             memory_stat.clone(),
             envelope_buffer.clone(),
+            handle.clone(),
         ));
 
         services.start(RelayStats::new(

--- a/relay-server/src/services/autoscaling.rs
+++ b/relay-server/src/services/autoscaling.rs
@@ -4,13 +4,13 @@ use relay_system::{AsyncResponse, Controller, FromMessage, Handle, Interface, Se
 
 /// Service that tracks internal relay metrics so that they can be exposed.
 pub struct AutoscalingMetricService {
-    /// For exposing internal memory usage or relay.
+    /// For exposing internal memory usage of relay.
     memory_stat: MemoryStat,
-    /// Reference to the spooler so query currently spooled items.
+    /// Reference to the spooler to get item count and total used size.
     envelope_buffer: PartitionedEnvelopeBuffer,
     /// Runtime handle to expose service utilization metrics.
     handle: Handle,
-    /// This will always report `1` unless the instance is in the process of being shutdown.
+    /// This will always report `1` unless the instance is shutting down.
     up: u8,
 }
 

--- a/relay-server/src/services/autoscaling.rs
+++ b/relay-server/src/services/autoscaling.rs
@@ -1,20 +1,29 @@
 use crate::services::buffer::PartitionedEnvelopeBuffer;
 use crate::MemoryStat;
-use relay_system::{AsyncResponse, Controller, FromMessage, Interface, Sender, Service};
-use serde::Serialize;
+use relay_system::{AsyncResponse, Controller, FromMessage, Handle, Interface, Sender, Service};
 
 /// Service that tracks internal relay metrics so that they can be exposed.
 pub struct AutoscalingMetricService {
+    /// For exposing internal memory usage or relay.
     memory_stat: MemoryStat,
+    /// Reference to the spooler so query currently spooled items.
     envelope_buffer: PartitionedEnvelopeBuffer,
+    /// Runtime handle to expose service utilization metrics.
+    handle: Handle,
+    /// This will always report `1` unless the instance is in the process of being shutdown.
     up: u8,
 }
 
 impl AutoscalingMetricService {
-    pub fn new(memory_stat: MemoryStat, envelope_buffer: PartitionedEnvelopeBuffer) -> Self {
+    pub fn new(
+        memory_stat: MemoryStat,
+        envelope_buffer: PartitionedEnvelopeBuffer,
+        handle: Handle,
+    ) -> Self {
         Self {
             memory_stat,
             envelope_buffer,
+            handle,
             up: 1,
         }
     }
@@ -34,11 +43,17 @@ impl Service for AutoscalingMetricService {
                     match message {
                         AutoscalingMetrics::Check(sender) => {
                             let memory_usage = self.memory_stat.memory();
+                            let metrics = self.handle
+                                .current_services_metrics()
+                                .iter()
+                                .map(|(id, metric)| ServiceUtilization(id.name(), metric.utilization))
+                                .collect();
                             sender.send(AutoscalingData {
                                 memory_usage: memory_usage.used_percent(),
                                 up: self.up,
                                 total_size: self.envelope_buffer.total_storage_size(),
-                                item_count: self.envelope_buffer.item_count()
+                                item_count: self.envelope_buffer.item_count(),
+                                services_metrics: metrics
                             });
                         }
                     }
@@ -72,10 +87,12 @@ impl FromMessage<AutoscalingMessageKind> for AutoscalingMetrics {
     }
 }
 
-#[derive(Debug, Serialize)]
 pub struct AutoscalingData {
     pub memory_usage: f32,
     pub up: u8,
     pub total_size: u64,
     pub item_count: u64,
+    pub services_metrics: Vec<ServiceUtilization>,
 }
+
+pub struct ServiceUtilization(pub &'static str, pub u8);

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -72,3 +72,16 @@ def test_memory_spooling_metrics(mini_sentry, relay):
     assert int(body["relay_spool_item_count"]) == 200
     assert int(body["relay_up"]) == 1
     assert int(body["relay_spool_total_size"]) == 0
+
+
+def test_service_utilization_metrics(mini_sentry, relay):
+    relay = relay(mini_sentry)
+
+    response = relay.get("/api/relay/autoscaling/")
+    parsed = parse_prometheus(response.text)
+    assert response.status_code == 200
+
+    assert int(parsed["relay_up"]) == 1
+    assert (
+        0 <= int(parsed['relay_utilization{relay_service="AggregatorService"}']) <= 100
+    )


### PR DESCRIPTION
This PR extends the autoscaling endpoint by adding service utilization metrics with the service name as the label.