### PR TITLE
feat(pool): Remove heap allocation when sending task

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1080,7 +1080,7 @@ impl FromMessage<SubmitClientReports> for EnvelopeProcessor {
 }
 
 /// The asynchronous thread pool used for scheduling processing tasks in the processor.
-pub type EnvelopeProcessorServicePool = AsyncPool<HandleMessageFuture>;
+pub type EnvelopeProcessorServicePool = AsyncPool<EnvelopeProcessorTask>;
 
 /// Service implementing the [`EnvelopeProcessor`] interface.
 ///
@@ -3171,7 +3171,7 @@ impl Service for EnvelopeProcessorService {
             let service = self.clone();
             self.inner
                 .pool
-                .spawn_async(HandleMessageFuture {
+                .spawn_async(EnvelopeProcessorTask {
                     service,
                     message: Some(message),
                 })
@@ -3180,12 +3180,13 @@ impl Service for EnvelopeProcessorService {
     }
 }
 
-pub struct HandleMessageFuture {
+/// Task that wraps the `handle_message` method of the [`EnvelopeBufferService`] as a future.
+pub struct EnvelopeProcessorTask {
     service: EnvelopeProcessorService,
     message: Option<EnvelopeProcessor>,
 }
 
-impl Future for HandleMessageFuture {
+impl Future for EnvelopeProcessorTask {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -15,8 +15,6 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
-use futures::future::BoxFuture;
-use futures::FutureExt;
 use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_cogs::{AppFeature, Cogs, FeatureWeights, ResourceId, Token};
 use relay_common::time::UnixTimestamp;
@@ -3182,7 +3180,7 @@ impl Service for EnvelopeProcessorService {
     }
 }
 
-struct HandleMessageFuture {
+pub struct HandleMessageFuture {
     service: EnvelopeProcessorService,
     message: Option<EnvelopeProcessor>,
 }
@@ -3190,7 +3188,7 @@ struct HandleMessageFuture {
 impl Future for HandleMessageFuture {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         // This future will not do anything if it were to be polled by the runtime again.
         if let Some(message) = self.message.take() {
             self.service.handle_message(message);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3180,7 +3180,7 @@ impl Service for EnvelopeProcessorService {
     }
 }
 
-/// Task that wraps the `handle_message` method of the [`EnvelopeBufferService`] as a future.
+/// Task that wraps the `handle_message` method of the [`EnvelopeProcessorService`] as a future.
 pub struct EnvelopeProcessorTask {
     service: EnvelopeProcessorService,
     message: Option<EnvelopeProcessor>,


### PR DESCRIPTION
This PR implements a future to avoid heap allocation to understand why the new pool caused a performance regression.

#skip-changelog