### PR TITLE
build: build binaries with Ubuntu 22.04

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
     name: Build Relay Binary
     runs-on: |-
       ${{fromJson('{
-        "x86_64-unknown-linux-gnu": "ubuntu-20.04",
+        "x86_64-unknown-linux-gnu": "ubuntu-22.04",
         "aarch64-unknown-linux-gnu": "ubuntu-22.04-arm"
       }')[matrix.target] }}
 
@@ -369,7 +369,7 @@ jobs:
   publish-to-dockerhub:
     needs: [build-setup, build-docker]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Publish Relay to DockerHub
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Breaking Changes**:
+
+- With the EOL coming up for Ubuntu 20.04 LTS, all binaries are now built on Ubuntu 22.04 LTS. This increases the minimum required glibc version from 2.31 to 2.35. ([#4545](https://github.com/getsentry/relay/pull/4545))
+
+
 **Features**:
 
 - Tag images with release version. ([#4532](https://github.com/getsentry/relay/pull/4532))


### PR DESCRIPTION
The Ubuntu 20.04 image is currently failing with the message

```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be
removed on 2025-04-01. For more details, see
https://github.com/actions/runner-images/issues/11101
```

Update CI to use the next LTS version instead (22.04).
