### PR TITLE
ci(release): Build linux binary in ubuntu 20 container

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release/**
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,17 +14,29 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
 
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git ca-certificates gcc libc6-dev curl make zip
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      - name: Add git safe directory exception
+        run: git config --global --add safe.directory "$(pwd)"
+
       - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain stable -y
 
       - name: Build binary
         run: |
+          . "$HOME/.cargo/env"
           make build-linux-release
         env:
           RELAY_FEATURES:
@@ -42,111 +55,111 @@ jobs:
           # since this artifact will be merged, compression is not necessary
           compression-level: '0'
 
-  linux-aarch64:
-    name: Linux Aarch64
-    runs-on: ubuntu-22.04-arm
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
-
-      - name: Build binary
-        run: |
-          make build-linux-release
-        env:
-          RELAY_FEATURES:
-
-      - name: Bundle Debug File
-        run: |
-          cd target/release/
-          zip relay-Linux-aarch64-debug.zip relay.debug
-          mv relay relay-Linux-aarch64
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: artifact-linux-aarch64
-          path: target/release/relay-Linux-aarch64*
-          if-no-files-found: 'error'
-          # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
-
-  macos:
-    name: macOS
-    runs-on: macos-14
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
-
-      - name: Run Cargo Build
-        run: cargo build --manifest-path=relay/Cargo.toml --release
-        env:
-          CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
-
-      - name: Bundle dSYM
-        run: |
-          cd target/release
-          mv relay relay-Darwin-x86_64
-          zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: artifact-macos
-          path: target/release/relay-Darwin-x86_64*
-          if-no-files-found: 'error'
-          # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
-
-  windows:
-    name: Windows
-    runs-on: windows-2019
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
-
-      - name: Run Cargo Build
-        run: cargo build --manifest-path=relay/Cargo.toml --release
-
-      - name: Bundle PDB
-        run: |
-          Install-Module 7Zip4PowerShell -Force -Verbose
-          cd target/release
-          7z a relay-Windows-x86_64-pdb.zip relay.pdb
-          mv relay.exe relay-Windows-x86_64.exe
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: artifact-windows
-          path: target/release/relay-Windows-x86_64*
-          if-no-files-found: 'error'
-          # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
-
-  merge:
-    name: Create Release Artifact
-    runs-on: ubuntu-latest
-    needs: [linux, linux-aarch64, macos, windows]
-    steps:
-      # Note: due to the immutability of artifacts in upload-artifact v4,
-      # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.
-      # However in this case it is fine because this only runs on release/** branches,
-      # and the other runs on release-library/** branches.
-      - uses: actions/upload-artifact/merge@v4
-        with:
-          # Craft expects release assets to be a single artifact named after the sha.
-          name: ${{ github.sha }}
-          pattern: artifact-*
-          delete-merged: true
+  # linux-aarch64:
+  #   name: Linux Aarch64
+  #   runs-on: ubuntu-22.04-arm
+  #
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #
+  #     - name: Install Rust Toolchain
+  #       run: rustup toolchain install stable --profile minimal --no-self-update
+  #
+  #     - name: Build binary
+  #       run: |
+  #         make build-linux-release
+  #       env:
+  #         RELAY_FEATURES:
+  #
+  #     - name: Bundle Debug File
+  #       run: |
+  #         cd target/release/
+  #         zip relay-Linux-aarch64-debug.zip relay.debug
+  #         mv relay relay-Linux-aarch64
+  #
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: artifact-linux-aarch64
+  #         path: target/release/relay-Linux-aarch64*
+  #         if-no-files-found: 'error'
+  #         # since this artifact will be merged, compression is not necessary
+  #         compression-level: '0'
+  #
+  # macos:
+  #   name: macOS
+  #   runs-on: macos-14
+  #
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #
+  #     - name: Install Rust Toolchain
+  #       run: rustup toolchain install stable --profile minimal --no-self-update
+  #
+  #     - name: Run Cargo Build
+  #       run: cargo build --manifest-path=relay/Cargo.toml --release
+  #       env:
+  #         CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
+  #
+  #     - name: Bundle dSYM
+  #       run: |
+  #         cd target/release
+  #         mv relay relay-Darwin-x86_64
+  #         zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
+  #
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: artifact-macos
+  #         path: target/release/relay-Darwin-x86_64*
+  #         if-no-files-found: 'error'
+  #         # since this artifact will be merged, compression is not necessary
+  #         compression-level: '0'
+  #
+  # windows:
+  #   name: Windows
+  #   runs-on: windows-2019
+  #
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #
+  #     - name: Install Rust Toolchain
+  #       run: rustup toolchain install stable --profile minimal --no-self-update
+  #
+  #     - name: Run Cargo Build
+  #       run: cargo build --manifest-path=relay/Cargo.toml --release
+  #
+  #     - name: Bundle PDB
+  #       run: |
+  #         Install-Module 7Zip4PowerShell -Force -Verbose
+  #         cd target/release
+  #         7z a relay-Windows-x86_64-pdb.zip relay.pdb
+  #         mv relay.exe relay-Windows-x86_64.exe
+  #
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: artifact-windows
+  #         path: target/release/relay-Windows-x86_64*
+  #         if-no-files-found: 'error'
+  #         # since this artifact will be merged, compression is not necessary
+  #         compression-level: '0'
+  #
+  # merge:
+  #   name: Create Release Artifact
+  #   runs-on: ubuntu-latest
+  #   needs: [linux, linux-aarch64, macos, windows]
+  #   steps:
+  #     # Note: due to the immutability of artifacts in upload-artifact v4,
+  #     # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.
+  #     # However in this case it is fine because this only runs on release/** branches,
+  #     # and the other runs on release-library/** branches.
+  #     - uses: actions/upload-artifact/merge@v4
+  #       with:
+  #         # Craft expects release assets to be a single artifact named after the sha.
+  #         name: ${{ github.sha }}
+  #         pattern: artifact-*
+  #         delete-merged: true

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - release/**
-  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,8 +12,9 @@ env:
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
+      # Use an older docker container to build the binary to guarantee glibc compatibility.
       image: ubuntu:20.04
 
     steps:
@@ -55,111 +55,111 @@ jobs:
           # since this artifact will be merged, compression is not necessary
           compression-level: '0'
 
-  # linux-aarch64:
-  #   name: Linux Aarch64
-  #   runs-on: ubuntu-22.04-arm
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #
-  #     - name: Install Rust Toolchain
-  #       run: rustup toolchain install stable --profile minimal --no-self-update
-  #
-  #     - name: Build binary
-  #       run: |
-  #         make build-linux-release
-  #       env:
-  #         RELAY_FEATURES:
-  #
-  #     - name: Bundle Debug File
-  #       run: |
-  #         cd target/release/
-  #         zip relay-Linux-aarch64-debug.zip relay.debug
-  #         mv relay relay-Linux-aarch64
-  #
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: artifact-linux-aarch64
-  #         path: target/release/relay-Linux-aarch64*
-  #         if-no-files-found: 'error'
-  #         # since this artifact will be merged, compression is not necessary
-  #         compression-level: '0'
-  #
-  # macos:
-  #   name: macOS
-  #   runs-on: macos-14
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #
-  #     - name: Install Rust Toolchain
-  #       run: rustup toolchain install stable --profile minimal --no-self-update
-  #
-  #     - name: Run Cargo Build
-  #       run: cargo build --manifest-path=relay/Cargo.toml --release
-  #       env:
-  #         CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
-  #
-  #     - name: Bundle dSYM
-  #       run: |
-  #         cd target/release
-  #         mv relay relay-Darwin-x86_64
-  #         zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
-  #
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: artifact-macos
-  #         path: target/release/relay-Darwin-x86_64*
-  #         if-no-files-found: 'error'
-  #         # since this artifact will be merged, compression is not necessary
-  #         compression-level: '0'
-  #
-  # windows:
-  #   name: Windows
-  #   runs-on: windows-2019
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #
-  #     - name: Install Rust Toolchain
-  #       run: rustup toolchain install stable --profile minimal --no-self-update
-  #
-  #     - name: Run Cargo Build
-  #       run: cargo build --manifest-path=relay/Cargo.toml --release
-  #
-  #     - name: Bundle PDB
-  #       run: |
-  #         Install-Module 7Zip4PowerShell -Force -Verbose
-  #         cd target/release
-  #         7z a relay-Windows-x86_64-pdb.zip relay.pdb
-  #         mv relay.exe relay-Windows-x86_64.exe
-  #
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: artifact-windows
-  #         path: target/release/relay-Windows-x86_64*
-  #         if-no-files-found: 'error'
-  #         # since this artifact will be merged, compression is not necessary
-  #         compression-level: '0'
-  #
-  # merge:
-  #   name: Create Release Artifact
-  #   runs-on: ubuntu-latest
-  #   needs: [linux, linux-aarch64, macos, windows]
-  #   steps:
-  #     # Note: due to the immutability of artifacts in upload-artifact v4,
-  #     # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.
-  #     # However in this case it is fine because this only runs on release/** branches,
-  #     # and the other runs on release-library/** branches.
-  #     - uses: actions/upload-artifact/merge@v4
-  #       with:
-  #         # Craft expects release assets to be a single artifact named after the sha.
-  #         name: ${{ github.sha }}
-  #         pattern: artifact-*
-  #         delete-merged: true
+  linux-aarch64:
+    name: Linux Aarch64
+    runs-on: ubuntu-22.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Build binary
+        run: |
+          make build-linux-release
+        env:
+          RELAY_FEATURES:
+
+      - name: Bundle Debug File
+        run: |
+          cd target/release/
+          zip relay-Linux-aarch64-debug.zip relay.debug
+          mv relay relay-Linux-aarch64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-linux-aarch64
+          path: target/release/relay-Linux-aarch64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  macos:
+    name: macOS
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Run Cargo Build
+        run: cargo build --manifest-path=relay/Cargo.toml --release
+        env:
+          CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
+
+      - name: Bundle dSYM
+        run: |
+          cd target/release
+          mv relay relay-Darwin-x86_64
+          zip -r relay-Darwin-x86_64-dsym.zip relay.dSYM
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-macos
+          path: target/release/relay-Darwin-x86_64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  windows:
+    name: Windows
+    runs-on: windows-2019
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Run Cargo Build
+        run: cargo build --manifest-path=relay/Cargo.toml --release
+
+      - name: Bundle PDB
+        run: |
+          Install-Module 7Zip4PowerShell -Force -Verbose
+          cd target/release
+          7z a relay-Windows-x86_64-pdb.zip relay.pdb
+          mv relay.exe relay-Windows-x86_64.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-windows
+          path: target/release/relay-Windows-x86_64*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  merge:
+    name: Create Release Artifact
+    runs-on: ubuntu-latest
+    needs: [linux, linux-aarch64, macos, windows]
+    steps:
+      # Note: due to the immutability of artifacts in upload-artifact v4,
+      # there cannot be mutliple upload-artifacts with the same name, in a sha's workflow runs.
+      # However in this case it is fine because this only runs on release/** branches,
+      # and the other runs on release-library/** branches.
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          # Craft expects release assets to be a single artifact named after the sha.
+          name: ${{ github.sha }}
+          pattern: artifact-*
+          delete-merged: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-**Breaking Changes**:
-
-- With the EOL coming up for Ubuntu 20.04 LTS, all binaries are now built on Ubuntu 22.04 LTS. This increases the minimum required glibc version from 2.31 to 2.35. ([#4545](https://github.com/getsentry/relay/pull/4545))
-
-
 **Features**:
 
 - Tag images with release version. ([#4532](https://github.com/getsentry/relay/pull/4532))


### PR DESCRIPTION
Build the binary in a 20.04 docker container, there is no longer a breaking change.

A successful build is here: https://github.com/getsentry/relay/actions/runs/13674742283

#skip-changelog