### PR TITLE
feat(pool): Emit active tasks metric after every poll

### DIFF
--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -153,12 +153,12 @@ where
         let mut this = self.project();
 
         loop {
+            this.tasks.as_mut().poll_tasks_until_pending(cx);
+
             // We report how many tasks are being concurrently polled in this future.
             this.metrics
                 .active_tasks
                 .store(this.tasks.len() as u64, Ordering::Relaxed);
-
-            this.tasks.as_mut().poll_tasks_until_pending(cx);
 
             // If we can't get anymore tasks, and we don't have anything else to process, we report
             // ready. Otherwise, if we have something to process, we report pending.


### PR DESCRIPTION
This PR enhances the emission of the `active_tasks` metric by capturing it after each poll. This location is the best one I found to place it, though it’s not perfect. If we want to always emit the most up-to-date metric, we should do it at every state change, but I believe this is sufficient.

#skip-changelog