### PR TITLE
Revert "fix(replays): Use different enforcement category for replay video"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,6 @@
 
 ## 25.1.0
 
-**Features**:
-
-- Use a separate rate-limit enforcement category for replay-video envelope items. ([#4459](https://github.com/getsentry/relay/pull/4459))
-
 **Internal**:
 
 - Updates performance score calculation on spans and events to also store cdf values as measurements. ([#4438](https://github.com/getsentry/relay/pull/4438))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Support span `category` inference from span attributes. ([#4509](https://github.com/getsentry/relay/pull/4509))
 - Add option to control ourlogs ingestion. ([#4518](https://github.com/getsentry/relay/pull/4518))
 - Update Apple device model classes ([#4529](https://github.com/getsentry/relay/pull/4529))
+- Remove separate quota and rate limit counting for replay videos ([#4554](https://github.com/getsentry/relay/pull/4554))
 
 **Internal**:
 
@@ -52,6 +53,10 @@
 - Partition spans by `trace_id` on the Kafka topic. ([#4503](https://github.com/getsentry/relay/pull/4503))
 
 ## 25.1.0
+
+**Features**:
+
+- Use a separate rate-limit enforcement category for replay-video envelope items. ([#4459](https://github.com/getsentry/relay/pull/4459))
 
 **Internal**:
 

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -712,10 +712,9 @@ impl Item {
             ItemType::UserReport => smallvec![],
             ItemType::UserReportV2 => smallvec![(DataCategory::UserReportV2, 1)],
             ItemType::Profile => smallvec![(DataCategory::Profile, 1)],
-            ItemType::ReplayEvent | ItemType::ReplayRecording => {
+            ItemType::ReplayEvent | ItemType::ReplayRecording | ItemType::ReplayVideo => {
                 smallvec![(DataCategory::Replay, 1)]
             }
-            ItemType::ReplayVideo => smallvec![(DataCategory::ReplayVideo, 1)],
             ItemType::ClientReport => smallvec![],
             ItemType::CheckIn => smallvec![(DataCategory::Monitor, 1)],
             ItemType::Span | ItemType::OtelSpan => smallvec![(DataCategory::Span, 1)],

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -163,9 +163,6 @@ pub struct EnvelopeSummary {
     /// The number of replays.
     pub replay_quantity: usize,
 
-    /// The number of replay videos.
-    pub replay_video_quantity: usize,
-
     /// The number of monitor check-ins.
     pub monitor_quantity: usize,
 
@@ -248,7 +245,7 @@ impl EnvelopeSummary {
             DataCategory::Session => &mut self.session_quantity,
             DataCategory::Profile => &mut self.profile_quantity,
             DataCategory::Replay => &mut self.replay_quantity,
-            DataCategory::ReplayVideo => &mut self.replay_video_quantity,
+            DataCategory::ReplayVideo => &mut self.replay_quantity,
             DataCategory::Monitor => &mut self.monitor_quantity,
             DataCategory::Span => &mut self.span_quantity,
             DataCategory::LogItem => &mut self.log_item_quantity,
@@ -356,8 +353,6 @@ pub struct Enforcement {
     pub profiles_indexed: CategoryLimit,
     /// The combined replay item rate limit.
     pub replays: CategoryLimit,
-    /// The combined replay video item rate limit.
-    pub replay_videos: CategoryLimit,
     /// The combined check-in item rate limit.
     pub check_ins: CategoryLimit,
     /// The combined logs (our product logs) rate limit.
@@ -404,7 +399,6 @@ impl Enforcement {
             profiles,
             profiles_indexed,
             replays,
-            replay_videos,
             check_ins,
             log_items,
             log_bytes,
@@ -422,7 +416,6 @@ impl Enforcement {
             profiles,
             profiles_indexed,
             replays,
-            replay_videos,
             check_ins,
             log_items,
             log_bytes,
@@ -511,7 +504,7 @@ impl Enforcement {
             ItemType::Session => !self.sessions.is_active(),
             ItemType::Profile => !self.profiles_indexed.is_active(),
             ItemType::ReplayEvent => !self.replays.is_active(),
-            ItemType::ReplayVideo => !self.replay_videos.is_active(),
+            ItemType::ReplayVideo => !self.replays.is_active(),
             ItemType::ReplayRecording => !self.replays.is_active(),
             ItemType::CheckIn => !self.check_ins.is_active(),
             ItemType::OtelLog | ItemType::Log => {
@@ -803,21 +796,6 @@ where
             enforcement.replays = CategoryLimit::new(
                 DataCategory::Replay,
                 summary.replay_quantity,
-                replay_limits.longest(),
-            );
-            rate_limits.merge(replay_limits);
-        }
-
-        // Handle replay video.
-        // Remove: 2025-04-06
-        if summary.replay_video_quantity > 0 {
-            let item_scoping = scoping.item(DataCategory::ReplayVideo);
-            let replay_limits = self
-                .check
-                .apply(item_scoping, summary.replay_video_quantity)?;
-            enforcement.replay_videos = CategoryLimit::new(
-                DataCategory::ReplayVideo,
-                summary.replay_video_quantity,
                 replay_limits.longest(),
             );
             rate_limits.merge(replay_limits);
@@ -1336,34 +1314,16 @@ mod tests {
     /// Limit replays.
     #[test]
     fn test_enforce_limit_replays() {
-        let mut envelope = envelope![ReplayEvent, ReplayRecording];
+        let mut envelope = envelope![ReplayEvent, ReplayRecording, ReplayVideo];
 
         let mut mock = MockLimiter::default().deny(DataCategory::Replay);
         let (enforcement, limits) = enforce_and_apply(&mut mock, &mut envelope, None);
 
         assert!(limits.is_limited());
         assert_eq!(envelope.envelope().len(), 0);
-        mock.assert_call(DataCategory::Replay, 2);
+        mock.assert_call(DataCategory::Replay, 3);
 
-        assert_eq!(get_outcomes(enforcement), vec![(DataCategory::Replay, 2),]);
-    }
-
-    /// Limit replays.
-    #[test]
-    fn test_enforce_limit_replay_video() {
-        let mut envelope = envelope![ReplayVideo];
-
-        let mut mock = MockLimiter::default().deny(DataCategory::ReplayVideo);
-        let (enforcement, limits) = enforce_and_apply(&mut mock, &mut envelope, None);
-
-        assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 0);
-        mock.assert_call(DataCategory::ReplayVideo, 1);
-
-        assert_eq!(
-            get_outcomes(enforcement),
-            vec![(DataCategory::ReplayVideo, 1),]
-        );
+        assert_eq!(get_outcomes(enforcement), vec![(DataCategory::Replay, 3),]);
     }
 
     /// Limit monitor checkins.


### PR DESCRIPTION
Replay videos are billed as of March 6th.  This does not need to be merged immediately.  This is cleaning up unnecessary distinction between events.

Reverts getsentry/relay#4459