### PR TITLE
fix(replays): Deprecate ReplayVideo data category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add option to control ourlogs ingestion. ([#4518](https://github.com/getsentry/relay/pull/4518))
 - Update Apple device model classes ([#4529](https://github.com/getsentry/relay/pull/4529))
 - Remove separate quota and rate limit counting for replay videos ([#4554](https://github.com/getsentry/relay/pull/4554))
+- Fully remove ReplayVideo data category ([#4560](https://github.com/getsentry/relay/pull/4560))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add option to control ourlogs ingestion. ([#4518](https://github.com/getsentry/relay/pull/4518))
 - Update Apple device model classes ([#4529](https://github.com/getsentry/relay/pull/4529))
 - Remove separate quota and rate limit counting for replay videos ([#4554](https://github.com/getsentry/relay/pull/4554))
-- Fully remove ReplayVideo data category ([#4560](https://github.com/getsentry/relay/pull/4560))
+- Deprecate ReplayVideo data category ([#4560](https://github.com/getsentry/relay/pull/4560))
 
 **Internal**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove unused capability to block metric names and tags. ([#4536](https://github.com/getsentry/relay/pull/4536))
+- Fully remove ReplayVideo data category ([#4560](https://github.com/getsentry/relay/pull/4560))
 
 ## 0.9.6
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Remove unused capability to block metric names and tags. ([#4536](https://github.com/getsentry/relay/pull/4536))
-- Fully remove ReplayVideo data category ([#4560](https://github.com/getsentry/relay/pull/4560))
+- Deprecate ReplayVideo data category ([#4560](https://github.com/getsentry/relay/pull/4560))
 
 ## 0.9.6
 

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -29,7 +29,6 @@ class DataCategory(IntEnum):
     PROFILE_DURATION = 17
     PROFILE_CHUNK = 18
     METRIC_SECOND = 19
-    REPLAY_VIDEO = 20
     UPTIME = 21
     ATTACHMENT_ITEM = 22
     LOG_ITEM = 23

--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -29,6 +29,7 @@ class DataCategory(IntEnum):
     PROFILE_DURATION = 17
     PROFILE_CHUNK = 18
     METRIC_SECOND = 19
+    DO_NOT_USE_REPLAY_VIDEO = 20
     UPTIME = 21
     ATTACHMENT_ITEM = 22
     LOG_ITEM = 23

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -87,7 +87,6 @@ pub enum DataCategory {
     /// Replay Video
     ///
     /// This is the data category for Session Replays produced via a video recording.
-    #[deprecated]
     DoNotUseReplayVideo = 20,
     /// This is the data category for Uptime monitors.
     Uptime = 21,

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -87,7 +87,7 @@ pub enum DataCategory {
     /// Replay Video
     ///
     /// This is the data category for Session Replays produced via a video recording.
-    #[warn(deprecated)]
+    #[deprecated]
     DoNotUseReplayVideo = 20,
     /// This is the data category for Uptime monitors.
     Uptime = 21,
@@ -147,6 +147,7 @@ impl DataCategory {
             "profile_duration_ui" => Self::ProfileDurationUi,
             "profile_chunk" => Self::ProfileChunk,
             "metric_second" => Self::MetricSecond,
+            "replay_video" => Self::DoNotUseReplayVideo,
             "uptime" => Self::Uptime,
             "attachment_item" => Self::AttachmentItem,
             _ => Self::Unknown,
@@ -166,7 +167,7 @@ impl DataCategory {
             Self::Profile => "profile",
             Self::ProfileIndexed => "profile_indexed",
             Self::Replay => "replay",
-            Self::DoNotUseReplayVideo => "do_not_use_replay_video",
+            Self::DoNotUseReplayVideo => "replay_video",
             Self::TransactionProcessed => "transaction_processed",
             Self::TransactionIndexed => "transaction_indexed",
             Self::Monitor => "monitor",

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -84,10 +84,6 @@ pub enum DataCategory {
     /// and metric cardinality. Defined here so as not to clash with future
     /// categories.
     MetricSecond = 19,
-    /// Replay Video
-    ///
-    /// This is the data category for Session Replays produced via a video recording.
-    ReplayVideo = 20,
     /// This is the data category for Uptime monitors.
     Uptime = 21,
     /// Counts the number of individual attachments, as opposed to the number of bytes in an attachment.
@@ -146,7 +142,6 @@ impl DataCategory {
             "profile_duration_ui" => Self::ProfileDurationUi,
             "profile_chunk" => Self::ProfileChunk,
             "metric_second" => Self::MetricSecond,
-            "replay_video" => Self::ReplayVideo,
             "uptime" => Self::Uptime,
             "attachment_item" => Self::AttachmentItem,
             _ => Self::Unknown,
@@ -180,7 +175,6 @@ impl DataCategory {
             Self::ProfileDurationUi => "profile_duration_ui",
             Self::ProfileChunk => "profile_chunk",
             Self::MetricSecond => "metric_second",
-            Self::ReplayVideo => "replay_video",
             Self::Uptime => "uptime",
             Self::AttachmentItem => "attachment_item",
             Self::Unknown => "unknown",

--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -84,6 +84,11 @@ pub enum DataCategory {
     /// and metric cardinality. Defined here so as not to clash with future
     /// categories.
     MetricSecond = 19,
+    /// Replay Video
+    ///
+    /// This is the data category for Session Replays produced via a video recording.
+    #[warn(deprecated)]
+    DoNotUseReplayVideo = 20,
     /// This is the data category for Uptime monitors.
     Uptime = 21,
     /// Counts the number of individual attachments, as opposed to the number of bytes in an attachment.
@@ -161,6 +166,7 @@ impl DataCategory {
             Self::Profile => "profile",
             Self::ProfileIndexed => "profile_indexed",
             Self::Replay => "replay",
+            Self::DoNotUseReplayVideo => "do_not_use_replay_video",
             Self::TransactionProcessed => "transaction_processed",
             Self::TransactionIndexed => "transaction_indexed",
             Self::Monitor => "monitor",

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -129,12 +129,6 @@ enum RelayDataCategory {
    */
   RELAY_DATA_CATEGORY_METRIC_SECOND = 19,
   /**
-   * Replay Video
-   *
-   * This is the data category for Session Replays produced via a video recording.
-   */
-  RELAY_DATA_CATEGORY_REPLAY_VIDEO = 20,
-  /**
    * This is the data category for Uptime monitors.
    */
   RELAY_DATA_CATEGORY_UPTIME = 21,

--- a/relay-cabi/include/relay.h
+++ b/relay-cabi/include/relay.h
@@ -129,6 +129,12 @@ enum RelayDataCategory {
    */
   RELAY_DATA_CATEGORY_METRIC_SECOND = 19,
   /**
+   * Replay Video
+   *
+   * This is the data category for Session Replays produced via a video recording.
+   */
+  RELAY_DATA_CATEGORY_DO_NOT_USE_REPLAY_VIDEO = 20,
+  /**
    * This is the data category for Uptime monitors.
    */
   RELAY_DATA_CATEGORY_UPTIME = 21,

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -186,6 +186,7 @@ impl CategoryUnit {
             | DataCategory::Error
             | DataCategory::Transaction
             | DataCategory::Replay
+            | DataCategory::DoNotUseReplayVideo
             | DataCategory::Security
             | DataCategory::Profile
             | DataCategory::ProfileIndexed

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -186,7 +186,6 @@ impl CategoryUnit {
             | DataCategory::Error
             | DataCategory::Transaction
             | DataCategory::Replay
-            | DataCategory::ReplayVideo
             | DataCategory::Security
             | DataCategory::Profile
             | DataCategory::ProfileIndexed

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -245,7 +245,7 @@ impl EnvelopeSummary {
             DataCategory::Session => &mut self.session_quantity,
             DataCategory::Profile => &mut self.profile_quantity,
             DataCategory::Replay => &mut self.replay_quantity,
-            DataCategory::ReplayVideo => &mut self.replay_quantity,
+            DataCategory::DoNotUseReplayVideo => &mut self.replay_quantity,
             DataCategory::Monitor => &mut self.monitor_quantity,
             DataCategory::Span => &mut self.span_quantity,
             DataCategory::LogItem => &mut self.log_item_quantity,


### PR DESCRIPTION
There were some remaining entries relating to ReplayVideo.  It is fully deprecated and should never be used.