### PR TITLE
ref(pool): Remove rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,7 +3980,6 @@ dependencies = [
  "priority-queue",
  "prost",
  "rand",
- "rayon",
  "regex",
  "relay-auth",
  "relay-base-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,6 @@ quote = "1.0.37"
 r2d2 = "0.8.10"
 rand = "0.8.5"
 rand_pcg = "0.3.1"
-rayon = "1.10"
 rdkafka = "0.36.2"
 rdkafka-sys = "4.8.0"
 redis = { version = "0.27.6", default-features = false }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -62,7 +62,6 @@ pin-project-lite = { workspace = true }
 priority-queue = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
-rayon = { workspace = true }
 regex = { workspace = true }
 relay-auth = { workspace = true }
 relay-base-schema = { workspace = true }

--- a/relay-server/src/utils/thread_pool.rs
+++ b/relay-server/src/utils/thread_pool.rs
@@ -38,7 +38,7 @@ impl ThreadPoolBuilder {
         }
     }
 
-    /// Sets the number of threads to be used in the rayon thread-pool.
+    /// Sets the number of threads to be used in the pool.
     ///
     /// See also [`AsyncPoolBuilder::num_threads`].
     pub fn num_threads(mut self, num_threads: usize) -> Self {


### PR DESCRIPTION
This PR removes the `rayon` dependency since it's not used anymore.

Closes: https://github.com/getsentry/team-ingest/issues/654

#skip-changelog