### PR TITLE
feat(gocd): Add relay-pop-internal experimental pipeline

### DIFF
--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -72,6 +72,6 @@ pipelines:
                 - script: |
                     /devinfra/scripts/k8s/k8stunnel \
                     && /devinfra/scripts/k8s/k8s-deploy.py \
-                    --label-selector="service=relay-pop,deploy_if_canary=true" \
+                    --label-selector="service=relay-pop,env=canary" \
                     --image="us-central1-docker.pkg.dev/sentryio/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
                     --container-name="relay"

--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -11,7 +11,7 @@ pipelines:
       GKE_CLUSTER_ZONE: b
       GKE_BASTION_ZONE: b
 
-    group: relay
+    group: relay-pop
     lock_behavior: unlockWhenFinished
 
     materials:

--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -1,0 +1,77 @@
+# More information on gocd-flavor YAML can be found here:
+# - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
+# - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
+format_version: 10
+pipelines:
+  deploy-relay-experimental-us-internal:
+    environment_variables:
+      GCP_PROJECT: internal-sentry
+      GKE_CLUSTER: zdpwkxst
+      GKE_REGION: us-central1
+      GKE_CLUSTER_ZONE: b
+      GKE_BASTION_ZONE: b
+
+    group: relay
+    lock_behavior: unlockWhenFinished
+
+    materials:
+      relay_repo:
+        git: git@github.com:getsentry/relay.git
+        shallow_clone: true
+        branch: master
+        destination: relay
+
+    stages:
+      - checks:
+          approval:
+            type: manual
+          fetch_materials: true
+
+          jobs:
+            checks:
+              environment_variables:
+                # Required for checkruns.
+                GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
+              timeout: 1800
+              elastic_profile_id: relay-pop
+              tasks:
+                - script: |
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                    getsentry/relay \
+                    ${GO_REVISION_RELAY_REPO} \
+                    "Integration Tests" \
+                    "Test All Features (ubuntu-latest)" \
+                    "Publish Relay to GCR (relay)" \
+                    "Publish Relay to GCR (relay-pop)"
+
+      - deploy-experimental:
+          approval:
+            type: success
+            allow_only_on_success: true
+          fetch_materials: true
+
+          jobs:
+            create_sentry_release:
+              environment_variables:
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: relay-pop
+                SENTRY_URL: "https://sentry.my.sentry.io/"
+                # Temporary; self-service encrypted secrets aren't implemented yet.
+                # This should really be rotated to an internal integration token.
+                SENTRY_AUTH_TOKEN: "{{SECRET:[devinfra-temp][relay_sentry_auth_token]}}"
+              timeout: 1200
+              elastic_profile_id: relay-pop
+              tasks:
+                - script: |
+                    ./relay/scripts/create-sentry-release "${GO_REVISION_RELAY_REPO}" "relay"
+
+            deploy:
+              timeout: 1200
+              elastic_profile_id: relay-pop
+              tasks:
+                - script: |
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    --label-selector="service=relay-pop,deploy_if_canary=true" \
+                    --image="us-central1-docker.pkg.dev/sentryio/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
+                    --container-name="relay"


### PR DESCRIPTION
This PR adds a new pipeline for deploying an experimental version of pop-relay to the internal cluster.

Closes: https://github.com/getsentry/team-ingest/issues/565

#skip-changelog