### PR TITLE
fix(processor): Fix async timers and sentry sdk scoping

### DIFF
--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -162,12 +162,11 @@ impl Limiter for RedisSetLimiter {
             let id = &state.id().to_string();
             let scopes = num_scopes_tag(&state);
             let results = metric!(
-                timer(CardinalityLimiterTimers::Redis),
+                async_timer(CardinalityLimiterTimers::Redis),
                 id = id,
                 scopes = scopes,
-                { self.check_limits(&mut connection, &mut state, timestamp) }
-            )
-            .await?;
+                { self.check_limits(&mut connection, &mut state, timestamp).await }
+            )?;
 
             for result in results {
                 reporter.report_cardinality(state.cardinality_limit(), result.to_report(timestamp));

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -162,7 +162,7 @@ impl Limiter for RedisSetLimiter {
             let id = &state.id().to_string();
             let scopes = num_scopes_tag(&state);
             let results = metric!(
-                async_timer(CardinalityLimiterTimers::Redis),
+                timer(CardinalityLimiterTimers::Redis),
                 id = id,
                 scopes = scopes,
                 {

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -165,7 +165,10 @@ impl Limiter for RedisSetLimiter {
                 async_timer(CardinalityLimiterTimers::Redis),
                 id = id,
                 scopes = scopes,
-                { self.check_limits(&mut connection, &mut state, timestamp).await }
+                {
+                    self.check_limits(&mut connection, &mut state, timestamp)
+                        .await
+                }
             )?;
 
             for result in results {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2412,9 +2412,11 @@ impl EnvelopeProcessorService {
         metric!(timer(RelayTimers::EnvelopeWaitTime) = wait_time);
 
         let group = message.envelope.group().variant();
-        let result = metric!(async_timer(RelayTimers::EnvelopeProcessingTime), group = group, {
-            self.process(cogs, message).await
-        });
+        let result = metric!(
+            async_timer(RelayTimers::EnvelopeProcessingTime),
+            group = group,
+            { self.process(cogs, message).await }
+        );
         match result {
             Ok(response) => {
                 if let Some(envelope) = response.envelope {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2431,11 +2431,9 @@ impl EnvelopeProcessorService {
         metric!(timer(RelayTimers::EnvelopeWaitTime) = wait_time);
 
         let group = message.envelope.group().variant();
-        let result = metric!(
-            async_timer(RelayTimers::EnvelopeProcessingTime),
-            group = group,
-            { self.process(cogs, message).await }
-        );
+        let result = metric!(timer(RelayTimers::EnvelopeProcessingTime), group = group, {
+            self.process(cogs, message).await
+        });
         match result {
             Ok(response) => {
                 if let Some(envelope) = response.envelope {
@@ -3314,7 +3312,7 @@ impl RateLimiter {
 
         let scoping = managed_envelope.scoping();
         let (enforcement, rate_limits) =
-            metric!(async_timer(RelayTimers::EventProcessingRateLimiting), {
+            metric!(timer(RelayTimers::EventProcessingRateLimiting), {
                 envelope_limiter
                     .compute(managed_envelope.envelope_mut(), &scoping)
                     .await

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2344,20 +2344,31 @@ impl EnvelopeProcessorService {
             }
         };
 
-        let _client = managed_envelope
+        let client = managed_envelope
             .envelope()
             .meta()
             .client()
             .map(str::to_owned);
 
-        let _user_agent = managed_envelope
+        let user_agent = managed_envelope
             .envelope()
             .meta()
             .user_agent()
             .map(str::to_owned);
 
-        // TODO: figure out how to add sentry context back in.
-        match self
+        // We set additional information on the scope, which will be removed after processing the
+        // envelope.
+        relay_log::configure_scope(|scope| {
+            scope.set_tag("project", project_id);
+            if let Some(client) = client {
+                scope.set_tag("sdk", client);
+            }
+            if let Some(user_agent) = user_agent {
+                scope.set_extra("user_agent", user_agent.into());
+            }
+        });
+
+        let result = match self
             .process_envelope(
                 cogs,
                 managed_envelope,
@@ -2403,7 +2414,15 @@ impl EnvelopeProcessorService {
                 })
             }
             Err(err) => Err(err),
-        }
+        };
+
+        relay_log::configure_scope(|scope| {
+            scope.remove_tag("project");
+            scope.remove_tag("sdk");
+            scope.remove_tag("user_agent");
+        });
+
+        result
     }
 
     async fn handle_process_envelope(&self, cogs: &mut Token, message: ProcessEnvelope) {

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -619,14 +619,6 @@ macro_rules! metric {
         $crate::metric!(timer($id) = now.elapsed() $(, $k = $v)*);
         rv
     }};
-
-    // timed async block
-    (async_timer($id:expr), $($k:ident = $v:expr,)* $block:block) => {{
-        let now = std::time::Instant::now();
-        let rv = async {$block}.await;
-        $crate::metric!(timer($id) = now.elapsed() $(, $k = $v)*);
-        rv
-    }};
 }
 
 #[cfg(test)]

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -619,6 +619,14 @@ macro_rules! metric {
         $crate::metric!(timer($id) = now.elapsed() $(, $k = $v)*);
         rv
     }};
+    
+    // timed async block
+    (async_timer($id:expr), $($k:ident = $v:expr,)* $block:block) => {{
+        let now = std::time::Instant::now();
+        let rv = async {$block}.await;
+        $crate::metric!(timer($id) = now.elapsed() $(, $k = $v)*);
+        rv
+    }};
 }
 
 #[cfg(test)]

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -619,7 +619,7 @@ macro_rules! metric {
         $crate::metric!(timer($id) = now.elapsed() $(, $k = $v)*);
         rv
     }};
-    
+
     // timed async block
     (async_timer($id:expr), $($k:ident = $v:expr,)* $block:block) => {{
         let now = std::time::Instant::now();


### PR DESCRIPTION
This PR provides two follow up fixes for (https://github.com/getsentry/relay/pull/4552):
* The awaiting of async blocks within timers had some issues which are now fixed.
* The scoping that was removed due to lack of `async` closure support, was added back with the use of `configure_scope`.

Closes: https://github.com/getsentry/team-ingest/issues/669, https://github.com/getsentry/team-ingest/issues/668

#skip-changelog