### PR TITLE
fix(filter): check client_ip for localhost filter if user not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Bug Fixes**:
 
 - Prevent partial trims in indexed and queryable span data. ([#4557](https://github.com/getsentry/relay/pull/4557))
+- Check `client_ip` for localhost filter if user has no ip address. ([#4570](https://github.com/getsentry/relay/pull/4570))
 
 **Internal**:
 

--- a/relay-filter/src/lib.rs
+++ b/relay-filter/src/lib.rs
@@ -61,7 +61,7 @@ pub fn should_filter<F: Filterable + Getter>(
     client_ips::should_filter(client_ip, &config.client_ips)?;
     releases::should_filter(item, &config.releases)?;
     error_messages::should_filter(item, &config.error_messages)?;
-    localhost::should_filter(item, &config.localhost)?;
+    localhost::should_filter(item, client_ip, &config.localhost)?;
     browser_extensions::should_filter(item, &config.browser_extensions)?;
     legacy_browsers::should_filter(item, &config.legacy_browsers)?;
     web_crawlers::should_filter(item, &config.web_crawlers)?;

--- a/relay-filter/src/localhost.rs
+++ b/relay-filter/src/localhost.rs
@@ -1,17 +1,25 @@
 //! Implements filtering for events originating from the localhost
 
 use crate::{FilterConfig, FilterStatKey, Filterable};
+use std::net::IpAddr;
 
 const LOCAL_IPS: &[&str] = &["127.0.0.1", "::1"];
 const LOCAL_DOMAINS: &[&str] = &["127.0.0.1", "localhost"];
 
 /// Check if the event originates from the local host.
-fn matches<F: Filterable>(item: &F) -> bool {
+///
+/// Some impls of [`Filterable`] will use the IP address that is stored in the user object.
+/// However, certain combinations of PII scrubbing rules will remove all user information and
+/// leave us with no IP to filter on.
+/// As a fallback mechanism, the optional `client_ip` will be checked as well to not break
+/// localhost filtering.
+///
+/// The fallback filter will only be evaluated if the ip_addr call from the [`Filterable`] did not
+/// return a value to prevent inconsistencies.
+fn matches<F: Filterable>(item: &F, client_ip: Option<IpAddr>) -> bool {
     if let Some(ip_addr) = item.ip_addr() {
-        for &local_ip in LOCAL_IPS {
-            if local_ip == ip_addr {
-                return true;
-            }
+        if LOCAL_IPS.iter().any(|ip| *ip == ip_addr) {
+            return true;
         }
     }
 
@@ -21,10 +29,20 @@ fn matches<F: Filterable>(item: &F) -> bool {
         }
 
         if let Some(host) = url.host_str() {
-            for &local_domain in LOCAL_DOMAINS {
-                if host_matches_or_is_subdomain_of(host, local_domain) {
-                    return true;
-                }
+            if LOCAL_DOMAINS
+                .iter()
+                .any(|local_domain| host_matches_or_is_subdomain_of(host, local_domain))
+            {
+                return true;
+            }
+        }
+    }
+
+    // Only check the fallback address if the item ip_address does not exist
+    if item.ip_addr().is_none() {
+        if let Some(ip_addr) = client_ip.map(|ip| ip.to_string()) {
+            if LOCAL_IPS.iter().any(|ip| *ip == ip_addr.as_str()) {
+                return true;
             }
         }
     }
@@ -38,11 +56,15 @@ fn host_matches_or_is_subdomain_of(host: &str, domain: &str) -> bool {
 }
 
 /// Filters events originating from the local host.
-pub fn should_filter<F: Filterable>(item: &F, config: &FilterConfig) -> Result<(), FilterStatKey> {
+pub fn should_filter<F: Filterable>(
+    item: &F,
+    client_ip: Option<IpAddr>,
+    config: &FilterConfig,
+) -> Result<(), FilterStatKey> {
     if !config.is_enabled {
         return Ok(());
     }
-    if matches(item) {
+    if matches(item, client_ip) {
         return Err(FilterStatKey::Localhost);
     }
     Ok(())
@@ -91,7 +113,7 @@ mod tests {
             get_event_with_ip_addr("127.0.0.1"),
             get_event_with_domain("localhost"),
         ] {
-            let filter_result = should_filter(event, &FilterConfig { is_enabled: false });
+            let filter_result = should_filter(event, None, &FilterConfig { is_enabled: false });
             assert_eq!(
                 filter_result,
                 Ok(()),
@@ -104,7 +126,7 @@ mod tests {
     fn test_filter_local_ip() {
         for ip_addr in &["127.0.0.1", "::1"] {
             let event = get_event_with_ip_addr(ip_addr);
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
             assert_ne!(
                 filter_result,
                 Ok(()),
@@ -117,7 +139,7 @@ mod tests {
     fn test_dont_filter_non_local_ip() {
         for ip_addr in &["133.12.12.1", "2001:db8:0:0:0:ff00:42:8329"] {
             let event = get_event_with_ip_addr(ip_addr);
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
             assert_eq!(
                 filter_result,
                 Ok(()),
@@ -129,7 +151,7 @@ mod tests {
     #[test]
     fn test_dont_filter_missing_ip_or_domains() {
         let event = Event::default();
-        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
         assert_eq!(
             filter_result,
             Ok(()),
@@ -146,7 +168,7 @@ mod tests {
             "foo.bar.baz.localhost",
         ] {
             let event = get_event_with_domain(domain);
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
             assert_ne!(filter_result, Ok(()), "Failed to filter domain '{domain}'");
         }
     }
@@ -162,7 +184,7 @@ mod tests {
             "alocalhostgoesintoabar",
         ] {
             let event = get_event_with_domain(domain);
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
             assert_eq!(
                 filter_result,
                 Ok(()),
@@ -175,7 +197,7 @@ mod tests {
     fn test_filter_file_urls() {
         let url = "file:///Users/Maisey/work/squirrelchasers/src/leaderboard.html";
         let event = get_event_with_url(url);
-        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
         assert_ne!(
             filter_result,
             Ok(()),
@@ -187,7 +209,25 @@ mod tests {
     fn test_dont_filter_non_file_urls() {
         let url = "http://www.squirrelchasers.com/leaderboard";
         let event = get_event_with_url(url);
-        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        let filter_result = should_filter(&event, None, &FilterConfig { is_enabled: true });
         assert_eq!(filter_result, Ok(()), "Filtered valid url '{url}'");
+    }
+
+    #[test]
+    fn test_filter_ip4_without_user() {
+        let event = Event::default();
+        let client_ip = core::net::IpAddr::from([127, 0, 0, 1]);
+        let filter_result =
+            should_filter(&event, Some(client_ip), &FilterConfig { is_enabled: true });
+        assert_eq!(filter_result, Err(FilterStatKey::Localhost));
+    }
+
+    #[test]
+    fn test_filter_ip6_without_user() {
+        let event = Event::default();
+        let client_ip = core::net::IpAddr::from([0, 0, 0, 0, 0, 0, 0, 1]);
+        let filter_result =
+            should_filter(&event, Some(client_ip), &FilterConfig { is_enabled: true });
+        assert_eq!(filter_result, Err(FilterStatKey::Localhost));
     }
 }


### PR DESCRIPTION
If PII scrubbing rules remove the user object entirely, we lose the possibility to filter on localhost ip addresses.
To circumvent this we will now perform a fallback check on the `client_ip`.
