### PR TITLE
ref(profiling): add proper max_duration check for continuous profiles

### DIFF
--- a/relay-profiling/src/android/chunk.rs
+++ b/relay-profiling/src/android/chunk.rs
@@ -18,7 +18,7 @@ use crate::debug_image::get_proguard_image;
 use crate::measurements::ChunkMeasurement;
 use crate::sample::v2::ProfileData;
 use crate::types::{ClientSdk, DebugMeta};
-use crate::{ProfileError, MAX_PROFILE_DURATION};
+use crate::{ProfileError, MAX_PROFILE_CHUNK_DURATION};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Metadata {
@@ -108,7 +108,7 @@ fn parse_chunk(payload: &[u8]) -> Result<Chunk, ProfileError> {
         return Err(ProfileError::NotEnoughSamples);
     }
 
-    if profile.profile.elapsed_time > MAX_PROFILE_DURATION {
+    if profile.profile.elapsed_time > MAX_PROFILE_CHUNK_DURATION {
         return Err(ProfileError::DurationIsTooLong);
     }
 

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -69,6 +69,10 @@ mod types;
 mod utils;
 
 const MAX_PROFILE_DURATION: Duration = Duration::from_secs(30);
+/// For continuous profiles, each chunk can be at most 1 minute.
+/// In certain circumstances (e.g. high cpu load) the profiler
+/// the profiler may be stopped slightly after 60, hence here we
+/// give it a bit more room to handle such cases (66 instead of 60)
 const MAX_PROFILE_CHUNK_DURATION: Duration = Duration::from_secs(66);
 
 /// Unique identifier for a profile.

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -69,6 +69,7 @@ mod types;
 mod utils;
 
 const MAX_PROFILE_DURATION: Duration = Duration::from_secs(30);
+const MAX_PROFILE_CHUNK_DURATION: Duration = Duration::from_secs(66);
 
 /// Unique identifier for a profile.
 ///

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -225,4 +225,66 @@ mod tests {
             vec![FiniteF64::new(30.0).unwrap(), FiniteF64::new(60.0).unwrap(),]
         );
     }
+
+    #[test]
+    fn test_is_above_max_duration() {
+        struct TestStruct {
+            name: String,
+            profile: ProfileData,
+            want: bool,
+        }
+
+        let test_cases = [
+            TestStruct {
+                name: "not above max duration".to_string(),
+                profile: ProfileData {
+                    samples: vec![
+                        Sample {
+                            stack_id: 0,
+                            thread_id: "1".into(),
+                            timestamp: FiniteF64::new(30.0).unwrap(),
+                        },
+                        Sample {
+                            stack_id: 0,
+                            thread_id: "1".to_string(),
+                            timestamp: FiniteF64::new(60.0).unwrap(),
+                        },
+                    ],
+                    stacks: vec![vec![0]],
+                    frames: vec![Default::default()],
+                    ..Default::default()
+                },
+                want: false,
+            },
+            TestStruct {
+                name: "not above max duration".to_string(),
+                profile: ProfileData {
+                    samples: vec![
+                        Sample {
+                            stack_id: 0,
+                            thread_id: "1".into(),
+                            timestamp: FiniteF64::new(10.0).unwrap(),
+                        },
+                        Sample {
+                            stack_id: 0,
+                            thread_id: "1".to_string(),
+                            timestamp: FiniteF64::new(80.0).unwrap(),
+                        },
+                    ],
+                    stacks: vec![vec![0]],
+                    frames: vec![Default::default()],
+                    ..Default::default()
+                },
+                want: true,
+            },
+        ];
+        for test in &test_cases {
+            assert_eq!(
+                test.profile.is_above_max_duration(),
+                test.want,
+                "test <{}> failed",
+                test.name
+            )
+        }
+    }
 }

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -116,8 +116,8 @@ impl ProfileData {
             }
         }
 
-        let duration = max - min;
-        duration.is_some_and(|d| d.to_f64() > MAX_PROFILE_CHUNK_DURATION_SECS)
+        let duration = max.saturating_sub(min);
+        duration.to_f64() > MAX_PROFILE_CHUNK_DURATION_SECS
     }
     /// Ensures valid profile chunk or returns an error.
     ///


### PR DESCRIPTION
This add a safety check for continuous profiles.

Currently SDKs send chunks that are capped at 1 minute. 

Here we leave a bit of room (66 secs instead of 60) for cases where the profiler might be stopped slightly later.

#skip-changelog