### PR TITLE
ref(profiling): remove android chunk duration check

### DIFF
--- a/relay-profiling/src/android/chunk.rs
+++ b/relay-profiling/src/android/chunk.rs
@@ -18,7 +18,7 @@ use crate::debug_image::get_proguard_image;
 use crate::measurements::ChunkMeasurement;
 use crate::sample::v2::ProfileData;
 use crate::types::{ClientSdk, DebugMeta};
-use crate::{ProfileError, MAX_PROFILE_DURATION};
+use crate::ProfileError;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Metadata {
@@ -106,10 +106,6 @@ fn parse_chunk(payload: &[u8]) -> Result<Chunk, ProfileError> {
 
     if profile.profile.events.is_empty() {
         return Err(ProfileError::NotEnoughSamples);
-    }
-
-    if profile.profile.elapsed_time > MAX_PROFILE_DURATION {
-        return Err(ProfileError::DurationIsTooLong);
     }
 
     if profile.profile.elapsed_time.is_zero() {


### PR DESCRIPTION
We're temporarily removing max_duration checks to let profiles through and let us debug  some duration anomalies we've been noticing. Related PR: https://github.com/getsentry/sentry/pull/86789


Once we're done with that we'll re-introduce the duration check for android (updated to ~1 minute for continuous profile) and add it for the sample v2 which is currently missing with the following PR: https://github.com/getsentry/relay/pull/4571


#skip-changelog