### PR TITLE
feat(pool): Add finished_tasks metric

### DIFF
--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -196,7 +196,7 @@ impl RelayStats {
             pool = async_pool.name()
         );
         metric!(
-            gauge(RelayCounters::AsyncPoolFinishedTasks) = metrics.finished_tasks(),
+            counter(RelayCounters::AsyncPoolFinishedTasks) += metrics.finished_tasks(),
             pool = async_pool.name()
         );
     }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -12,7 +12,7 @@ use crate::services::processor::EnvelopeProcessorServicePool;
 #[cfg(feature = "processing")]
 use crate::services::store::StoreServicePool;
 use crate::services::upstream::{IsNetworkOutage, UpstreamRelay};
-use crate::statsd::{RelayGauges, RuntimeCounters, RuntimeGauges};
+use crate::statsd::{RelayCounters, RelayGauges, RuntimeCounters, RuntimeGauges};
 
 /// Relay Stats Service.
 ///
@@ -196,7 +196,7 @@ impl RelayStats {
             pool = async_pool.name()
         );
         metric!(
-            gauge(RelayGauges::AsyncPoolFinishedTasks) = metrics.finished_tasks() as f64,
+            gauge(RelayCounters::AsyncPoolFinishedTasks) = metrics.finished_tasks() as f64,
             pool = async_pool.name()
         );
     }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -196,7 +196,7 @@ impl RelayStats {
             pool = async_pool.name()
         );
         metric!(
-            gauge(RelayCounters::AsyncPoolFinishedTasks) = metrics.finished_tasks() as f64,
+            gauge(RelayCounters::AsyncPoolFinishedTasks) = metrics.finished_tasks(),
             pool = async_pool.name()
         );
     }

--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -195,6 +195,10 @@ impl RelayStats {
             gauge(RelayGauges::AsyncPoolUtilization) = metrics.utilization() as f64,
             pool = async_pool.name()
         );
+        metric!(
+            gauge(RelayGauges::AsyncPoolFinishedTasks) = metrics.finished_tasks() as f64,
+            pool = async_pool.name()
+        );
     }
 
     async fn async_pools_metrics(&self) {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -19,11 +19,6 @@ pub enum RelayGauges {
     /// This metric is tagged with:
     /// - `pool`: the name of the pool.
     AsyncPoolUtilization,
-    /// Tracks the number of tasks driven to completion by the async pool.
-    ///
-    /// This metric is tagged with:
-    /// - `pool`: the name of the pool.
-    AsyncPoolFinishedTasks,
     /// The state of Relay with respect to the upstream connection.
     /// Possible values are `0` for normal operations and `1` for a network outage.
     NetworkOutage,
@@ -75,7 +70,6 @@ impl GaugeMetric for RelayGauges {
         match self {
             RelayGauges::AsyncPoolQueueSize => "async_pool.queue_size",
             RelayGauges::AsyncPoolUtilization => "async_pool.utilization",
-            RelayGauges::AsyncPoolFinishedTasks => "async_pool.finished_tasks",
             RelayGauges::NetworkOutage => "upstream.network_outage",
             RelayGauges::BufferStackCount => "buffer.stack_count",
             RelayGauges::BufferDiskUsed => "buffer.disk_used",
@@ -623,6 +617,11 @@ impl TimerMetric for RelayTimers {
 
 /// Counter metrics used by Relay
 pub enum RelayCounters {
+    /// Tracks the number of tasks driven to completion by the async pool.
+    ///
+    /// This metric is tagged with:
+    /// - `pool`: the name of the pool.
+    AsyncPoolFinishedTasks,
     /// Number of Events that had corrupted (unprintable) event attributes.
     ///
     /// This currently checks for `environment` and `release`, for which we know that
@@ -859,6 +858,7 @@ pub enum RelayCounters {
 impl CounterMetric for RelayCounters {
     fn name(&self) -> &'static str {
         match self {
+            RelayCounters::AsyncPoolFinishedTasks => "async_pool.finished_tasks",
             RelayCounters::EventCorrupted => "event.corrupted",
             RelayCounters::EnvelopeAccepted => "event.accepted",
             RelayCounters::EnvelopeRejected => "event.rejected",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -19,6 +19,11 @@ pub enum RelayGauges {
     /// This metric is tagged with:
     /// - `pool`: the name of the pool.
     AsyncPoolUtilization,
+    /// Tracks the number of tasks driven to completion by the async pool.
+    ///
+    /// This metric is tagged with:
+    /// - `pool`: the name of the pool.
+    AsyncPoolFinishedTasks,
     /// The state of Relay with respect to the upstream connection.
     /// Possible values are `0` for normal operations and `1` for a network outage.
     NetworkOutage,
@@ -70,6 +75,7 @@ impl GaugeMetric for RelayGauges {
         match self {
             RelayGauges::AsyncPoolQueueSize => "async_pool.queue_size",
             RelayGauges::AsyncPoolUtilization => "async_pool.utilization",
+            RelayGauges::AsyncPoolFinishedTasks => "async_pool.finished_tasks",
             RelayGauges::NetworkOutage => "upstream.network_outage",
             RelayGauges::BufferStackCount => "buffer.stack_count",
             RelayGauges::BufferDiskUsed => "buffer.disk_used",

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -9,6 +9,17 @@ use std::sync::Arc;
 pub(crate) struct ThreadMetrics {
     /// Number of futures that are currently being polled concurrently by the thread in the pool.
     pub(crate) active_tasks: AtomicU64,
+    /// Number of tasks that have been successfully driven to completion.
+    ///
+    /// This number will monotonically grow if not reset.
+    pub(crate) finished_tasks: AtomicU64,
+}
+
+impl ThreadMetrics {
+    /// Resets metrics that are monotonically increasing.
+    pub fn reset(&self) {
+        self.finished_tasks.store(0, Ordering::Relaxed);
+    }
 }
 
 /// Metrics for the asynchronous pool.
@@ -23,6 +34,22 @@ impl AsyncPoolMetrics<'_> {
     /// Returns the amount of tasks in the pool's queue.
     pub fn queue_size(&self) -> u64 {
         self.queue_size
+    }
+
+    /// Returns the total number of finished tasks since the last poll.
+    pub fn finished_tasks(&self) -> u64 {
+        let total_finished_tasks: u64 = self
+            .threads_metrics
+            .iter()
+            .map(|m| {
+                let finished_tasks = m.finished_tasks.load(Ordering::Relaxed);
+                m.reset();
+
+                finished_tasks
+            })
+            .sum();
+
+        total_finished_tasks
     }
 
     /// Returns the utilization metric for the pool.

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -173,7 +173,7 @@ where
             // We calculate how many tasks have been driven to completion.
             if let Some(finished_tasks) = before_len.checked_sub(after_len) {
                 this.metrics
-                    .active_tasks
+                    .finished_tasks
                     .store(finished_tasks, Ordering::Relaxed);
             }
 

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -156,17 +156,26 @@ where
             // We report before polling since we might have only blocking tasks meaning that the
             // measure after the `poll_tasks_until_pending` will return 0, since all futures will
             // be completed.
+            let before_len = this.tasks.len() as u64;
             this.metrics
                 .active_tasks
-                .store(this.tasks.len() as u64, Ordering::Relaxed);
+                .store(before_len, Ordering::Relaxed);
 
             this.tasks.as_mut().poll_tasks_until_pending(cx);
 
             // We also want to report after polling since we might have finished polling some futures
             // and some not.
+            let after_len = this.tasks.len() as u64;
             this.metrics
                 .active_tasks
-                .store(this.tasks.len() as u64, Ordering::Relaxed);
+                .store(after_len, Ordering::Relaxed);
+
+            // We calculate how many tasks have been driven to completion.
+            if let Some(finished_tasks) = before_len.checked_sub(after_len) {
+                this.metrics
+                    .active_tasks
+                    .store(finished_tasks, Ordering::Relaxed);
+            }
 
             // If we can't get anymore tasks, and we don't have anything else to process, we report
             // ready. Otherwise, if we have something to process, we report pending.

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -523,5 +523,7 @@ mod tests {
 
         // We expect that now we have 1 active task, the one that is indefinitely pending.
         assert_eq!(metrics.active_tasks.load(Ordering::Relaxed), 1);
+        // An indefinitely pending task is never finished.
+        assert_eq!(metrics.finished_tasks.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
This PR adds a new metric to track the number of finished tasks.

#skip-changelog