### PR TITLE
fix(ci): Fix rust toolchain installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Rust Toolchain
         run: |
-          rustup install stable --profile minimal --no-self-update
+          rustup toolchain install stable --profile minimal --no-self-update
           rustup component add clippy rustfmt rust-docs --toolchain stable
 
       - uses: swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --component clippy rustfmt rust-docs --no-self-update
+        run: |
+          rustup install stable --profile minimal --no-self-update
+          rustup component add clippy rustfmt rust-docs --toolchain stable
 
       - uses: swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
This PR fixes the following CI issue:
```
Run rustup toolchain install stable --profile minimal --component clippy rustfmt rust-docs --no-self-update
  rustup toolchain install stable --profile minimal --component clippy rustfmt rust-docs --no-self-update
  shell: /usr/bin/bash -e {0}
  env:
    CARGO_TERM_COLOR: always
    RELAY_CARGO_ARGS: --locked
    pythonLocation: /opt/hostedtoolcache/Python/3.11.11/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.11/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.11/x64
    Python[2](https://github.com/getsentry/relay/actions/runs/13812937316/job/38640611254#step:5:2)_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.11/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.11/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/[3](https://github.com/getsentry/relay/actions/runs/13812937316/job/38640611254#step:5:3).11.11/x64/lib
error: invalid value 'rustfmt' for '[TOOLCHAIN]...': invalid toolchain name: 'rustfmt'
```

#skip-changelog