### PR TITLE
feat(eap): Allow to ingest spans per project

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -97,11 +97,16 @@ pub enum Feature {
     /// Serialized as `organizations:indexed-spans-extraction`.
     #[serde(rename = "organizations:indexed-spans-extraction")]
     ExtractSpansFromEvent,
-    /// Indicate if the EAP consumers should ingest a span.
+    /// Indicate if the EAP consumers should ingest a span for a given organization.
     ///
     /// Serialized as `organizations:ingest-spans-in-eap`
     #[serde(rename = "organizations:ingest-spans-in-eap")]
-    IngestSpansInEap,
+    IngestSpansInEapForOrganization,
+    /// Indicate if the EAP consumers should ingest a span for a given project.
+    ///
+    /// Serialized as `projects:ingest-spans-in-eap`
+    #[serde(rename = "projects:ingest-spans-in-eap")]
+    IngestSpansInEapForProject,
     /// Enable log ingestion for our log product (this is not internal logging).
     ///
     /// Serialized as `organizations:ourlogs-ingestion`.

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -231,8 +231,16 @@ pub fn process(
         };
         new_item.set_payload(ContentType::Json, payload);
         new_item.set_metrics_extracted(item.metrics_extracted());
-        new_item
-            .set_ingest_span_in_eap(project_info.config.features.has(Feature::IngestSpansInEap));
+        new_item.set_ingest_span_in_eap(
+            project_info
+                .config
+                .features
+                .has(Feature::IngestSpansInEapForOrganization)
+                || project_info
+                    .config
+                    .features
+                    .has(Feature::IngestSpansInEapForProject),
+        );
 
         *item = new_item;
 
@@ -298,7 +306,14 @@ pub fn extract_from_event(
         .envelope()
         .dsc()
         .and_then(|ctx| ctx.sample_rate);
-    let ingest_in_eap = project_info.config.features.has(Feature::IngestSpansInEap);
+    let ingest_in_eap = project_info
+        .config
+        .features
+        .has(Feature::IngestSpansInEapForOrganization)
+        || project_info
+            .config
+            .features
+            .has(Feature::IngestSpansInEapForProject);
 
     let mut add_span = |mut span: Span| {
         add_sample_rate(

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1876,7 +1876,7 @@ def test_dynamic_sampling(
 
 
 @pytest.mark.parametrize("ingest_in_eap", [True, False])
-def test_ingest_in_eap(
+def test_ingest_in_eap_for_organization(
     mini_sentry,
     relay_with_processing,
     spans_consumer,
@@ -1893,6 +1893,52 @@ def test_ingest_in_eap(
 
     if ingest_in_eap:
         project_config["config"]["features"] += ["organizations:ingest-spans-in-eap"]
+
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    end = datetime.now(timezone.utc) - timedelta(seconds=1)
+    duration = timedelta(milliseconds=500)
+    start = end - duration
+    event["spans"] = [
+        {
+            "description": "GET /api/0/organizations/?member=1",
+            "op": "http",
+            "origin": "manual",
+            "parent_span_id": "aaaaaaaaaaaaaaaa",
+            "span_id": "bbbbbbbbbbbbbbbb",
+            "start_timestamp": start.isoformat(),
+            "status": "success",
+            "timestamp": end.isoformat(),
+            "trace_id": "ff62a8b040f340bda5d830223def1d81",
+        },
+    ]
+
+    relay.send_event(project_id, event)
+
+    if ingest_in_eap:
+        spans_consumer.get_span()
+        spans_consumer.get_span()
+
+    spans_consumer.assert_empty()
+
+
+@pytest.mark.parametrize("ingest_in_eap", [True, False])
+def test_ingest_in_eap_for_project(
+    mini_sentry,
+    relay_with_processing,
+    spans_consumer,
+    ingest_in_eap,
+):
+    spans_consumer = spans_consumer()
+
+    relay = relay_with_processing(options=TEST_CONFIG)
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:indexed-spans-extraction",
+    ]
+
+    if ingest_in_eap:
+        project_config["config"]["features"] += ["projects:ingest-spans-in-eap"]
 
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
     end = datetime.now(timezone.utc) - timedelta(seconds=1)


### PR DESCRIPTION
For Laravel Insights, we want to enable the ingestion of spans in the EAP per project.

Needed to be able to use this flag: https://github.com/getsentry/sentry-options-automator/pull/3321

#skip-changelog