### PR TITLE
test(metrics): Fix flaky test

### DIFF
--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1013,12 +1013,13 @@ def test_transaction_metrics_extraction_external_relays(
     }
     external.send_transaction(project_id, tx, item_headers, trace_info)
 
+    # Client reports.
+    envelope = mini_sentry.captured_events.get(timeout=3)
+    assert len(envelope.items) == 1
     envelope = mini_sentry.captured_events.get(timeout=3)
     assert len(envelope.items) == 1
 
     if expect_metrics_extraction:
-        metrics_envelope = mini_sentry.captured_events.get(timeout=3)
-        assert len(metrics_envelope.items) == 1
         metrics_envelope = mini_sentry.captured_events.get(timeout=3)
         assert len(metrics_envelope.items) == 1
 


### PR DESCRIPTION
When changing the span outcomes in #4569, I fixed this test incorrectly making it flaky. When the test runner is fast enough it would never fail (locally) but in CI this was noticed because the tests run slower.

This is the correct fix.

#skip-changelog