### PR TITLE
build(deps): update opentelemetry-proto to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1177,7 +1177,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1683,7 +1683,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1706,7 +1706,7 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -2468,7 +2468,7 @@ dependencies = [
  "procfs-core",
  "range-map",
  "scroll",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing",
  "uuid",
@@ -2806,24 +2806,25 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.7.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
+ "base64 0.22.1",
  "hex",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2834,20 +2835,18 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2939,7 +2938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -3450,7 +3449,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -3508,7 +3507,7 @@ dependencies = [
  "relay-statsd",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -3550,7 +3549,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "uuid",
 ]
@@ -3625,7 +3624,7 @@ dependencies = [
  "similar-asserts",
  "smallvec",
  "sqlparser",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "uuid",
 ]
@@ -3648,7 +3647,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "uuid",
 ]
@@ -3701,7 +3700,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3746,7 +3745,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "unescaper",
 ]
@@ -3759,7 +3758,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -3820,7 +3819,7 @@ dependencies = [
  "sha1",
  "similar-asserts",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "utf16string",
 ]
 
@@ -3843,7 +3842,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "uuid",
 ]
@@ -3889,7 +3888,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -3902,7 +3901,7 @@ dependencies = [
  "relay-log",
  "serde",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4025,7 +4024,7 @@ dependencies = [
  "symbolic-unreal",
  "sysinfo",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tower 0.5.2",
@@ -4497,7 +4496,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -4559,7 +4558,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
  "uuid",
@@ -4887,7 +4886,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4967,7 +4966,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
@@ -5005,7 +5004,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
@@ -5116,7 +5115,7 @@ dependencies = [
  "regex",
  "scroll",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -5215,7 +5214,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -5223,6 +5231,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5639,7 +5658,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ multer = "3.1.0"
 num-traits = "0.2.19"
 num_cpus = "1.13.1"
 once_cell = "1.13.1"
-opentelemetry-proto = { version = "0.7.0", default-features = false }
+opentelemetry-proto = { version = "0.28.0", default-features = false }
 papaya = "0.1.6"
 parking_lot = "0.12.3"
 path-slash = "0.2.1"

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -544,50 +544,48 @@ mod tests {
                         "arrayValue": {
                             "values": [
                                 {
-                                    "value": {
-                                        "kvlistValue": {
-                                            "values": [
-                                                {
-                                                    "key": "min",
-                                                    "value": {
-                                                        "doubleValue": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "key": "max",
-                                                    "value": {
-                                                        "doubleValue": 2.0
-                                                    }
-                                                },
-                                                {
-                                                    "key": "sum",
-                                                    "value": {
-                                                        "doubleValue": 3.0
-                                                    }
-                                                },
-                                                {
-                                                    "key": "count",
-                                                    "value": {
-                                                        "intValue": "2"
-                                                    }
-                                                },
-                                                {
-                                                    "key": "tags",
-                                                    "value": {
-                                                        "kvlistValue": {
-                                                            "values": [
-                                                                {
-                                                                    "key": "environment",
-                                                                    "value": {
-                                                                        "stringValue": "test"
-                                                                    }
+                                    "kvlistValue": {
+                                        "values": [
+                                            {
+                                                "key": "min",
+                                                "value": {
+                                                    "doubleValue": 1.0
+                                                }
+                                            },
+                                            {
+                                                "key": "max",
+                                                "value": {
+                                                    "doubleValue": 2.0
+                                                }
+                                            },
+                                            {
+                                                "key": "sum",
+                                                "value": {
+                                                    "doubleValue": 3.0
+                                                }
+                                            },
+                                            {
+                                                "key": "count",
+                                                "value": {
+                                                    "intValue": "2"
+                                                }
+                                            },
+                                            {
+                                                "key": "tags",
+                                                "value": {
+                                                    "kvlistValue": {
+                                                        "values": [
+                                                            {
+                                                                "key": "environment",
+                                                                "value": {
+                                                                    "stringValue": "test"
                                                                 }
-                                                            ]
-                                                        }
+                                                            }
+                                                        ]
                                                     }
                                                 }
-                                            ]
-                                        }
+                                            }
+                                        ]
                                     }
                                 }
                             ]


### PR DESCRIPTION
As I discovered when trying to store incoming OTLP span links, v0.7.0 of `opentelemetry-proto` can't deserialize the `traceId` or `spanId` properties of span links in OTLP JSON (See upstream issue: https://github.com/open-telemetry/opentelemetry-rust/issues/2065).

Updating to the latest `opentelemetry-proto` (0.28.0) fixes the issue, allowing us to deserialize incoming span links sent as JSON to the OTLP endpoint as well as in tests.

It looks like the JSON serialization for array attributes also changed slightly with this update, affecting a test. Since no one is actually using this endpoint yet it should be safe to update.

#skip-changelog