### PR TITLE
fix(relay): Remove `parent_span_id` from SpanLink struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 **Features**:
 
 - Add experimental playstation endpoint. ([#4555](https://github.com/getsentry/relay/pull/4555))
-- Remove `parent_span_link` from `SpanLink` struct. ([#4594](https://github.com/getsentry/relay/pull/4594))
 
 **Internal**:
 
 - Add ui chunk profiling data category. ([#4593](https://github.com/getsentry/relay/pull/4593))
+- Remove `parent_span_link` from `SpanLink` struct. ([#4594](https://github.com/getsentry/relay/pull/4594))
 - Switch global rate limiter to a service. ([#4581](https://github.com/getsentry/relay/pull/4581))
 
 ## 25.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 **Internal**:
 
 - Add ui chunk profiling data category. ([#4593](https://github.com/getsentry/relay/pull/4593))
-- Remove `parent_span_link` from `SpanLink` struct. ([#4594](https://github.com/getsentry/relay/pull/4594))
 - Switch global rate limiter to a service. ([#4581](https://github.com/getsentry/relay/pull/4581))
+- Remove `parent_span_link` from `SpanLink` struct. ([#4594](https://github.com/getsentry/relay/pull/4594))
 
 ## 25.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add experimental playstation endpoint. ([#4555](https://github.com/getsentry/relay/pull/4555))
+- Remove `parent_span_link` from `SpanLink` struct. ([#4594](https://github.com/getsentry/relay/pull/4594))
 
 **Internal**:
 

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -208,7 +208,6 @@ mod tests {
     {
       "trace_id": "3c79f60c11214eb38604f4ae0781bfb2",
       "span_id": "ea90fdead5f74052",
-      "parent_span_id": "ea90fdead5f74053",
       "sampled": true,
       "attributes": {
         "sentry.link.type": "previous_trace"
@@ -252,7 +251,6 @@ mod tests {
             links: Annotated::new(Array::from(vec![Annotated::new(SpanLink {
                 trace_id: Annotated::new(TraceId("3c79f60c11214eb38604f4ae0781bfb2".into())),
                 span_id: Annotated::new(SpanId("ea90fdead5f74052".into())),
-                parent_span_id: Annotated::new(SpanId("ea90fdead5f74053".into())),
                 sampled: Annotated::new(true),
                 attributes: Annotated::new({
                     let mut map: std::collections::BTreeMap<String, Annotated<Value>> =

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -753,10 +753,6 @@ pub struct SpanLink {
     #[metastructure(required = true, trim = false)]
     pub span_id: Annotated<SpanId>,
 
-    /// The parent span id of the linked span
-    #[metastructure(trim = false)]
-    pub parent_span_id: Annotated<SpanId>,
-
     /// Whether the linked span was positively/negatively sampled
     #[metastructure(trim = false)]
     pub sampled: Annotated<bool>,
@@ -860,7 +856,6 @@ mod tests {
     {
       "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
       "span_id": "fa90fdead5f74052",
-      "parent_span_id": "fa90fdead5f74052",
       "sampled": true,
       "attributes": {
         "boolAttr": true,
@@ -888,7 +883,6 @@ mod tests {
         let links = Annotated::new(vec![Annotated::new(SpanLink {
             trace_id: Annotated::new(TraceId("4c79f60c11214eb38604f4ae0781bfb2".into())),
             span_id: Annotated::new(SpanId("fa90fdead5f74052".into())),
-            parent_span_id: Annotated::new(SpanId("fa90fdead5f74052".into())),
             sampled: Annotated::new(true),
             attributes: Annotated::new({
                 let mut map: std::collections::BTreeMap<String, Annotated<Value>> = Object::new();
@@ -1210,7 +1204,6 @@ mod tests {
                 {
                     "trace_id": "5c79f60c11214eb38604f4ae0781bfb2",
                     "span_id": "ab90fdead5f74052",
-                    "parent_span_id": "eb90fdead5f74052",
                     "sampled": true,
                     "attributes": {
                         "sentry.link.type": "previous_trace"
@@ -1219,7 +1212,6 @@ mod tests {
                 {
                     "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
                     "span_id": "fa90fdead5f74052",
-                    "parent_span_id": "fa90fdead5f74052",
                     "sampled": true,
                     "attributes": {
                         "sentry.link.type": "next_trace"
@@ -1231,7 +1223,7 @@ mod tests {
         let span: Annotated<Span> = Annotated::from_json(span).unwrap();
         assert_eq!(
             span.to_json().unwrap(),
-            r#"{"links":[{"trace_id":"5c79f60c11214eb38604f4ae0781bfb2","span_id":"ab90fdead5f74052","parent_span_id":"eb90fdead5f74052","sampled":true,"attributes":{"sentry.link.type":"previous_trace"}},{"trace_id":"4c79f60c11214eb38604f4ae0781bfb2","span_id":"fa90fdead5f74052","parent_span_id":"fa90fdead5f74052","sampled":true,"attributes":{"sentry.link.type":"next_trace"}}]}"#
+            r#"{"links":[{"trace_id":"5c79f60c11214eb38604f4ae0781bfb2","span_id":"ab90fdead5f74052","sampled":true,"attributes":{"sentry.link.type":"previous_trace"}},{"trace_id":"4c79f60c11214eb38604f4ae0781bfb2","span_id":"fa90fdead5f74052","sampled":true,"attributes":{"sentry.link.type":"next_trace"}}]}"#
         );
     }
 }

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -110,7 +110,6 @@ mod tests {
                             {
                                 "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
                                 "span_id": "fa90fdead5f74052",
-                                "parent_span_id": "fa90fdead5f74053",
                                 "sampled": true,
                                 "attributes": {
                                     "sentry.link.type": "previous_trace"
@@ -244,9 +243,6 @@ mod tests {
                     ),
                     span_id: SpanId(
                         "fa90fdead5f74052",
-                    ),
-                    parent_span_id: SpanId(
-                        "fa90fdead5f74053",
                     ),
                     sampled: true,
                     attributes: {

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -234,8 +234,6 @@ fn otel_to_sentry_link(otel_link: OtelLink) -> SpanLink {
         span_id: SpanId(hex::encode(otel_link.span_id)).into(),
         sampled: (otel_link.flags & W3C_TRACE_CONTEXT_SAMPLED != 0).into(),
         attributes,
-        // The parent span ID is not available over OTLP.
-        parent_span_id: Annotated::empty(),
         other: Default::default(),
     }
 }


### PR DESCRIPTION
In #4486 I accidentally defined a `parent_span_id` field on the `SpanLink` struct. This is unnecessary because span links emitted by Otel SDKs OTLP as well as the JS SDK (as the only Sentry SDK implementing span links so far) never contain a parent span id. This PR therefore removes the field again. 