### PR TITLE
fix(processor): Fix client handling and number of active connections

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2425,6 +2425,7 @@ impl Config {
         Some(create_redis_pools(
             redis_configs,
             self.cpu_concurrency() as u32,
+            self.pool_concurrency() as u32,
         ))
     }
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -56,9 +56,9 @@ pub enum ServiceError {
     #[error("could not initialize kafka producer: {0}")]
     Kafka(String),
 
-    /// Initializing the Redis cluster client failed.
+    /// Initializing the Redis client failed.
     #[cfg(feature = "processing")]
-    #[error("could not initialize redis cluster client")]
+    #[error("could not initialize redis client during startup")]
     Redis,
 }
 


### PR DESCRIPTION
This PR fixes issues with the async processor in two ways:
- It no longer holds the Redis client across await points, which previously caused a massive slowdown because we had many futures holding the connection and never releasing it, resulting in new futures timing out while trying to get the connection. After acquiring the client, the system would wait for the global rate limits service to perform work, and during this wait, the connection remained held.
- It scales the number of active connections based on the maximum concurrency.

Related to: https://github.com/getsentry/team-ingest/issues/673

#skip-changelog