### PR TITLE
feat(spans): extract transaction breakdowns into measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add ui chunk profiling data category. ([#4593](https://github.com/getsentry/relay/pull/4593))
 - Switch global rate limiter to a service. ([#4581](https://github.com/getsentry/relay/pull/4581))
+- Extract transaction breakdowns into measurements. ([#4600](https://github.com/getsentry/relay/pull/4600))
 
 ## 25.3.0
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -400,6 +400,35 @@ fn extract_shared_tags(event: &Event) -> SharedTags {
 fn extract_segment_measurements(event: &Event) -> BTreeMap<String, Measurement> {
     let mut measurements = BTreeMap::new();
 
+    // Extract breakdowns into measurements, similar to /metrics_extraction/transacitons/mod.rs
+    if let Some(breakdowns) = event.breakdowns.value() {
+        for (breakdown, measurement_list) in breakdowns.iter() {
+            if let Some(measurement_list) = measurement_list.value() {
+                for (measurement_name, annotated) in measurement_list.iter() {
+                    if measurement_name == "total.time" {
+                        continue;
+                    }
+
+                    let Some(measurement) = annotated.value() else {
+                        continue;
+                    };
+
+                    let Some(value) = measurement.value.value().copied() else {
+                        continue;
+                    };
+
+                    measurements.insert(
+                        format!("{breakdown}.{measurement_name}"),
+                        Measurement {
+                            value: value.into(),
+                            unit: MetricUnit::Duration(DurationUnit::MilliSecond).into(),
+                        },
+                    );
+                }
+            }
+        }
+    }
+
     if let Some(trace_context) = event.context::<TraceContext>() {
         if let Some(op) = extract_transaction_op(trace_context) {
             if op == "queue.publish" || op == "queue.process" {
@@ -2303,6 +2332,81 @@ LIMIT 1
                 "messaging.message.retry.count": Measurement {
                     value: 3.0,
                     unit: None,
+                },
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_extract_breakdown_tags() {
+        let json = r#"
+                {
+                "type": "transaction",
+                "platform": "javascript",
+                "start_timestamp": "2021-04-26T07:59:01+0100",
+                "timestamp": "2021-04-26T08:00:00+0100",
+                "transaction": "foo",
+                "contexts": {
+                    "trace": {
+                        "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                        "span_id": "bd429c44b67a3eb4"
+                    }
+                },
+                "breakdowns": {
+                    "span_ops": {
+                        "ops.http": {
+                            "value": 1000,
+                            "unit": "millisecond"
+                        },
+                        "ops.resource": {
+                            "value": 420,
+                            "unit": "millisecond"
+                        },
+                        "ops.ui": {
+                            "value": 27000,
+                            "unit": "millisecond"
+                        },
+                        "total.time": {
+                            "value": 45000,
+                            "unit": "millisecond"
+                        }
+                    }
+                },
+                "spans": []
+            }
+        "#;
+
+        let event = Annotated::<Event>::from_json(json)
+            .unwrap()
+            .into_value()
+            .unwrap();
+
+        let mut spans = [Span::from(&event).into()];
+        extract_segment_span_tags(&event, &mut spans);
+        let segment_span: &Annotated<Span> = &spans[0];
+        let measurements = segment_span.value().unwrap().measurements.value().unwrap();
+
+        assert_debug_snapshot!(measurements, @r###"
+        Measurements(
+            {
+                "span_ops.ops.http": Measurement {
+                    value: 1000.0,
+                    unit: Duration(
+                        MilliSecond,
+                    ),
+                },
+                "span_ops.ops.resource": Measurement {
+                    value: 420.0,
+                    unit: Duration(
+                        MilliSecond,
+                    ),
+                },
+                "span_ops.ops.ui": Measurement {
+                    value: 27000.0,
+                    unit: Duration(
+                        MilliSecond,
+                    ),
                 },
             },
         )

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -409,13 +409,11 @@ fn extract_segment_measurements(event: &Event) -> BTreeMap<String, Measurement> 
                         continue;
                     }
 
-let Some(value) = annotated.value().and_then(|value| value.value.value()).copied() else {
-    continue;
-};
-                        continue;
-                    };
-
-                    let Some(value) = measurement.value.value().copied() else {
+                    let Some(value) = annotated
+                        .value()
+                        .and_then(|value| value.value.value())
+                        .copied()
+                    else {
                         continue;
                     };
 

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -409,7 +409,9 @@ fn extract_segment_measurements(event: &Event) -> BTreeMap<String, Measurement> 
                         continue;
                     }
 
-                    let Some(measurement) = annotated.value() else {
+let Some(value) = annotated.value().and_then(|value| value.value.value()).copied() else {
+    continue;
+};
                         continue;
                     };
 


### PR DESCRIPTION
closes https://github.com/getsentry/relay/issues/4598

More details found in the issue above. This PR extracts transaction breakdowns into measurements, so that they are automatically stored in the eap dataset. (Snuba does not look at breakdowns at all, but it automatically stores all measurements) We are moving the insights overview pages to eap, and the product relies on these breakdown values.