### PR TITLE
ref(relay): Bump sysinfo library version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Remove `parent_span_link` from `SpanLink` struct. ([#4594](https://github.com/getsentry/relay/pull/4594))
 - Extract transaction breakdowns into measurements. ([#4600](https://github.com/getsentry/relay/pull/4600))
 - Expose worker pool metrics in autoscaler endpoint ([#4605](https://github.com/getsentry/relay/pull/4605))
+- Bump the revision of `sysinfo` to the revision at `15b3be3273ba286740122fed7bb7dccd2a79dc8f`.  ([#4613](https://github.com/getsentry/relay/pull/4613))
 
 ## 25.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2727,6 +2727,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -5154,14 +5163,13 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
-source = "git+https://github.com/getsentry/sysinfo.git?rev=e2e5d530600f96bdd79652c856918da23e5dd938#e2e5d530600f96bdd79652c856918da23e5dd938"
+version = "0.33.1"
+source = "git+https://github.com/getsentry/sysinfo.git?rev=15b3be3273ba286740122fed7bb7dccd2a79dc8f#15b3be3273ba286740122fed7bb7dccd2a79dc8f"
 dependencies = [
- "bstr",
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
+ "objc2-core-foundation",
  "rayon",
  "windows 0.56.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,9 +183,15 @@ symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }
 syn = { version = "2.0.90" }
 synstructure = { version = "0.13.1" }
+<<<<<<< Updated upstream
 # This dependency was added through git since we are experimenting with a fork of sysinfo which adds additional
 # capabilities of reading cgroups memory stats. Such stats are used in Relay to correctly determine memory usage.
 sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "15b3be3273ba286740122fed7bb7dccd2a79dc8f" }
+=======
+# This dependency should be bumped to the next version once it's out. The next version must contain the commit with hash
+# `e2e5d530600f96bdd79652c856918da23e5dd938`.
+sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "e2e5d530600f96bdd79652c856918da23e5dd938" }
+>>>>>>> Stashed changes
 tempfile = "3.14.0"
 thiserror = "1.0.69"
 tikv-jemallocator = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,15 +183,9 @@ symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }
 syn = { version = "2.0.90" }
 synstructure = { version = "0.13.1" }
-<<<<<<< Updated upstream
-# This dependency was added through git since we are experimenting with a fork of sysinfo which adds additional
-# capabilities of reading cgroups memory stats. Such stats are used in Relay to correctly determine memory usage.
-sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "15b3be3273ba286740122fed7bb7dccd2a79dc8f" }
-=======
 # This dependency should be bumped to the next version once it's out. The next version must contain the commit with hash
-# `e2e5d530600f96bdd79652c856918da23e5dd938`.
-sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "e2e5d530600f96bdd79652c856918da23e5dd938" }
->>>>>>> Stashed changes
+# `e2e5d530600f96bdd79652c856918da23e5dd938`
+sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "15b3be3273ba286740122fed7bb7dccd2a79dc8f" }
 tempfile = "3.14.0"
 thiserror = "1.0.69"
 tikv-jemallocator = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ syn = { version = "2.0.90" }
 synstructure = { version = "0.13.1" }
 # This dependency was added through git since we are experimenting with a fork of sysinfo which adds additional
 # capabilities of reading cgroups memory stats. Such stats are used in Relay to correctly determine memory usage.
-sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "e2e5d530600f96bdd79652c856918da23e5dd938" }
+sysinfo = { git = "https://github.com/getsentry/sysinfo.git", rev = "15b3be3273ba286740122fed7bb7dccd2a79dc8f" }
 tempfile = "3.14.0"
 thiserror = "1.0.69"
 tikv-jemallocator = "0.6.0"

--- a/relay-server/src/utils/memory.rs
+++ b/relay-server/src/utils/memory.rs
@@ -85,7 +85,7 @@ impl MemoryStat {
 
     /// Refreshes the memory readings.
     fn refresh_memory(system: &mut System) -> Memory {
-        system.refresh_memory_specifics(MemoryRefreshKind::new().with_ram());
+        system.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
         let memory = match system.cgroup_limits() {
             Some(cgroup) => Memory {
                 used: cgroup.rss,


### PR DESCRIPTION
This PR bumps the `sysinfo` library version to the latest commit added by the PR (https://github.com/GuillaumeGomez/sysinfo/pull/1488).

We should not forget to update to a stable version once the changes made in the PR mentioned above are added to the release.

Closes: https://github.com/getsentry/relay/issues/4059