### PR TITLE
ref(autoscaling): expose different metric name

### DIFF
--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -33,13 +33,22 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
     append_data_row(&mut result, "spool_total_size", data.total_size, &[]);
     for utilization in &data.services_metrics {
         let service_name = extract_service_name(utilization.0);
+        // Expose both names temporarily so we can phase out `utilization` in favor
+        // of `service_utilization`
         append_data_row(
             &mut result,
             "utilization",
             utilization.1,
             &[("relay_service", service_name)],
         );
+        append_data_row(
+            &mut result,
+            "service_utilization",
+            utilization.1,
+            &[("relay_service", service_name)],
+        );
     }
+
     append_data_row(
         &mut result,
         "worker_pool_utilization",
@@ -151,7 +160,9 @@ relay_up 1
 relay_spool_item_count 10
 relay_spool_total_size 30
 relay_utilization{relay_service="test"} 10
+relay_service_utilization{relay_service="test"} 10
 relay_utilization{relay_service="envelope"} 50
+relay_service_utilization{relay_service="envelope"} 50
 relay_worker_pool_utilization 61
 relay_runtime_utilization 41
 "#

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -7,6 +7,8 @@ import signal
 import tempfile
 from time import sleep
 
+import pytest
+
 
 def parse_prometheus(input_string):
     result = {}
@@ -74,34 +76,20 @@ def test_memory_spooling_metrics(mini_sentry, relay):
     assert int(body["relay_spool_total_size"]) == 0
 
 
-def test_service_utilization_metrics(mini_sentry, relay):
+@pytest.mark.parametrize(
+    "metric_name",
+    (
+        'relay_utilization{relay_service="AggregatorService"}',
+        'relay_service_utilization{relay_service="AggregatorService"}',
+        "relay_worker_pool_utilization",
+        "relay_runtime_utilization",
+    ),
+)
+def test_service_utilization_metrics(mini_sentry, relay, metric_name):
     relay = relay(mini_sentry)
 
     response = relay.get("/api/relay/autoscaling/")
     parsed = parse_prometheus(response.text)
     assert response.status_code == 200
 
-    assert int(parsed["relay_up"]) == 1
-    assert (
-        0 <= int(parsed['relay_utilization{relay_service="AggregatorService"}']) <= 100
-    )
-
-
-def test_pool_utilization(mini_sentry, relay):
-    relay = relay(mini_sentry)
-
-    response = relay.get("/api/relay/autoscaling/")
-    parsed = parse_prometheus(response.text)
-    assert response.status_code == 200
-
-    assert 0 <= int(parsed["relay_worker_pool_utilization"]) <= 100
-
-
-def test_runtime_utilization(mini_sentry, relay):
-    relay = relay(mini_sentry)
-
-    response = relay.get("/api/relay/autoscaling/")
-    parsed = parse_prometheus(response.text)
-    assert response.status_code == 200
-
-    assert 0 <= int(parsed["relay_runtime_utilization"]) <= 100
+    assert 0 <= int(parsed[metric_name]) <= 100


### PR DESCRIPTION
This PR exposes the same values as `relay_utilization` using the key `relay_service_utilization`.

With the addition of new `relay_..._utilization` metrics, the service related metric `relay_utilization` is not very descriptive and can lead to confusion.
To enable a smooth transition away from the generic name, we will
1. expose the new metric name
2. change everything that relies on the old name to the new name
3. remove the exposure of the old name

#skip-changelog