### PR TITLE
feat(ds): Use sample rate in trace context if missing from DSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add naver.me / Yeti spider on the crawler filter list. ([#4602](https://github.com/getsentry/relay/pull/4602))
 - Add the item type that made the envelope too large to invalid outcomes. ([#4558](https://github.com/getsentry/relay/pull/4558))
 - Filter out certain AI crawlers. ([#4608](https://github.com/getsentry/relay/pull/4608))
+- Respect client sample rates sent by older SDKs. ([#4620](https://github.com/getsentry/relay/pull/4620))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 - Add naver.me / Yeti spider on the crawler filter list. ([#4602](https://github.com/getsentry/relay/pull/4602))
 - Add the item type that made the envelope too large to invalid outcomes. ([#4558](https://github.com/getsentry/relay/pull/4558))
 - Filter out certain AI crawlers. ([#4608](https://github.com/getsentry/relay/pull/4608))
-- Respect client sample rates sent by older SDKs. ([#4620](https://github.com/getsentry/relay/pull/4620))
 
 **Bug Fixes**:
 
 - Separates profiles into backend and ui profiles. ([#4595](https://github.com/getsentry/relay/pull/4595))
+- Add a workaround for missing DSC sample rates from the Electron SDK. ([#4620](https://github.com/getsentry/relay/pull/4620))
 
 **Internal**:
 

--- a/relay-sampling/src/dsc.rs
+++ b/relay-sampling/src/dsc.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 /// Because SDKs need to funnel this data through the baggage header, this needs to be
 /// representable as `HashMap<String, String>`, meaning no nested dictionaries/objects, arrays or
 /// other non-string values.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamicSamplingContext {
     /// ID created by clients to represent the current call flow.
     pub trace_id: Uuid,
@@ -87,7 +87,7 @@ fn or_none(string: &impl AsRef<str>) -> Option<&str> {
 }
 
 /// User-related information in a [`DynamicSamplingContext`].
-#[derive(Debug, Clone, Serialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct TraceUserContext {
     /// The value of the `user.segment` property.
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/relay-sampling/src/dsc.rs
+++ b/relay-sampling/src/dsc.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 /// Because SDKs need to funnel this data through the baggage header, this needs to be
 /// representable as `HashMap<String, String>`, meaning no nested dictionaries/objects, arrays or
 /// other non-string values.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DynamicSamplingContext {
     /// ID created by clients to represent the current call flow.
     pub trace_id: Uuid,
@@ -87,7 +87,7 @@ fn or_none(string: &impl AsRef<str>) -> Option<&str> {
 }
 
 /// User-related information in a [`DynamicSamplingContext`].
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, PartialEq)]
 pub struct TraceUserContext {
     /// The value of the `user.segment` property.
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -51,7 +51,7 @@ pub fn validate_and_set_dsc(
     sampling_project_info: Option<Arc<ProjectInfo>>,
 ) -> Option<Arc<ProjectInfo>> {
     if managed_envelope.envelope().dsc().is_some() && sampling_project_info.is_some() {
-        apply_legacy_sample_rate(managed_envelope, event);
+        maybe_apply_legacy_sample_rate(managed_envelope, event);
         return sampling_project_info;
     }
 
@@ -72,7 +72,7 @@ pub fn validate_and_set_dsc(
     sampling_project_info
 }
 
-fn apply_legacy_sample_rate(
+fn maybe_apply_legacy_sample_rate(
     managed_envelope: &mut TypedEnvelope<TransactionGroup>,
     event: &mut Annotated<Event>,
 ) {

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -859,7 +859,9 @@ mod tests {
                 "contexts": {{
                     "trace": {{
                         "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-                        "client_sample_rate": {}
+                        "data": {{
+                            "sentry.sample_rate": {}
+                        }}
                     }}
                 }}
             }}"#,

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -85,13 +85,12 @@ fn apply_legacy_sample_rate(
         return;
     }
 
-    let Some(event) = event.value() else {
-        return;
-    };
-    if let sample_rate @ Some(_) = utils::sample_rate_from_event(event) {
-        let mut new_dsc = dsc.clone();
-        new_dsc.sample_rate = sample_rate;
-        managed_envelope.envelope_mut().set_dsc(new_dsc);
+    if let Some(event) = event.value() {
+        if let sample_rate @ Some(_) = utils::sample_rate_from_event(event) {
+            let mut new_dsc = dsc.clone();
+            new_dsc.sample_rate = sample_rate;
+            managed_envelope.envelope_mut().set_dsc(new_dsc);
+        }
     }
 }
 

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -367,24 +367,29 @@ mod tests {
 
         let dsc = dsc_from_event(public_key, &event).expect("dsc should be extracted");
 
-        assert_eq!(
-            dsc,
-            DynamicSamplingContext {
-                trace_id: Uuid::parse_str("89143b0763095bd9c9955e8175d1fb23").unwrap(),
-                public_key,
-                sample_rate: None,
-                release: Some("v1.0".to_owned()),
-                environment: Some("staging".to_owned()),
-                transaction: Some("transaction_name".to_owned()),
-                user: TraceUserContext {
-                    user_segment: "segment".to_owned(),
-                    user_id: "id".to_owned()
-                },
-                replay_id: None,
-                sampled: None,
-                other: Default::default(),
-            }
-        )
+        insta::assert_debug_snapshot!(dsc, @r###"
+        DynamicSamplingContext {
+            trace_id: 89143b07-6309-5bd9-c995-5e8175d1fb23,
+            public_key: ProjectKey("e12d836b15bb49d7bbf99e64295d995b"),
+            release: Some(
+                "v1.0",
+            ),
+            environment: Some(
+                "staging",
+            ),
+            transaction: Some(
+                "transaction_name",
+            ),
+            sample_rate: None,
+            user: TraceUserContext {
+                user_segment: "segment",
+                user_id: "id",
+            },
+            replay_id: None,
+            sampled: None,
+            other: {},
+        }
+        "###);
     }
 
     #[test]

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -487,11 +487,10 @@ def test_buffer_envelopes_without_global_config(
         (True, 0.1, None, 0.1),
         # DSC sample rate overrides trace context
         (True, 0.1, {"data": {"sentry.sample_rate": 0.5}}, 0.1),
-        # If no DSC sample rate, do *not* take it from trace context
-        # (this is different behaviour than spans)
-        (True, None, {"data": {"sentry.sample_rate": 0.9}}, None),
-        (False, None, {"data": {"sentry.sample_rate": 0.9}}, None),
-        # Sent client sample rate is overriden with DSC sample rate
+        # If no DSC sample rate, take it from trace context
+        (True, None, {"data": {"sentry.sample_rate": 0.9}}, 0.9),
+        (False, None, {"data": {"sentry.sample_rate": 0.9}}, 0.9),
+        # Sent client sample rate is ignored
         (True, 0.1, {"client_sample_rate": 0.5}, 0.1),
         (True, None, {"client_sample_rate": 0.5}, None),
         (False, None, {"client_sample_rate": 0.5}, None),

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -491,6 +491,10 @@ def test_buffer_envelopes_without_global_config(
         # (this is different behaviour than spans)
         (True, None, {"data": {"sentry.sample_rate": 0.9}}, None),
         (False, None, {"data": {"sentry.sample_rate": 0.9}}, None),
+        # Sent client sample rate is overriden with DSC sample rate
+        (True, 0.1, {"client_sample_rate": 0.5}, 0.1),
+        (True, None, {"client_sample_rate": 0.5}, None),
+        (False, None, {"client_sample_rate": 0.5}, None),
         # No sample rate if none given in DSC or trace context
         (True, None, None, None),
         (False, None, None, None),

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -2125,6 +2125,10 @@ def test_scrubs_ip_addresses(
         # If no DSC sample rate, take it from trace context
         (True, None, {"data": {"sentry.sample_rate": 0.9}}, 0.9),
         (False, None, {"data": {"sentry.sample_rate": 0.9}}, 0.9),
+        # Setting client_sample_rate in trace context does nothing.
+        (True, 0.1, {"client_sample_rate": 0.5}, 0.1),
+        (True, None, {"client_sample_rate": 0.5}, None),
+        (False, None, {"client_sample_rate": 0.5}, None),
         # No sample rate if none given in DSC or trace context
         (True, None, None, None),
         (False, None, None, None),


### PR DESCRIPTION
Our Electron SDK is not populating the `sample_rate` field in DSC (see https://github.com/getsentry/sentry-electron/issues/1114). As a result, span metric extrapolation does not work as the client's sample rate is unknown.

Although we will also fix this in the SDK, it will take time for clients to upgrade. In the meantime, it would be nice if data sent by existing SDK versions could work too.

In the case of the Electron SDK, the client sample rate is being sent in the transaction event payload, inside the trace context:

```json
{
  "contexts": {
    "trace": {
      "data": {
        "sentry.sample_rate": 0.1
      }
    }
  }
}
```

This PR checks if we are missing a DSC sample rate (because that field is missing, or the entire DSC is missing), and if so, tries to find a client sample rate in the transaction event payload to use and copies it into the DSC. The first place we check is trace context's [documented](https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#trace-context) `client_sample_rate` field, falling back to the non-standard `sentry.sample_rate` in trace context's `data` being used by Electron.

---

I would like to add an integration test to this PR as well, but I'll get to that tomorrow if the concept and direction seem sound. Thanks!