### PR TITLE
feat(server): Update multipart infer for `view-hierarchy.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add naver.me / Yeti spider on the crawler filter list. ([#4602](https://github.com/getsentry/relay/pull/4602))
 - Add the item type that made the envelope too large to invalid outcomes. ([#4558](https://github.com/getsentry/relay/pull/4558))
 - Filter out certain AI crawlers. ([#4608](https://github.com/getsentry/relay/pull/4608))
+- Infer the attachment type of view hierarchy items in multipart messages. ([#4624](https://github.com/getsentry/relay/pull/4624))
 
 **Bug Fixes**:
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -28,6 +28,11 @@ use crate::utils;
 /// Sentry requires
 const MINIDUMP_FIELD_NAME: &str = "upload_file_minidump";
 
+/// The field name of a view hierarchy file in the multipart form-data upload.
+/// It matches the expected file name of the view hierarchy, as outlined in RFC#33
+/// https://github.com/getsentry/rfcs/blob/main/text/0033-view-hierarchy.md
+const VIEW_HIERARCHY_FIELD_NAME: &str = "view-hierarchy.json";
+
 /// File name for a standalone minidump upload.
 ///
 /// In contrast to the field name, this is used when a standalone minidump is uploaded not in a
@@ -119,15 +124,13 @@ fn remove_container_extension(filename: &str) -> &str {
         .unwrap_or(filename)
 }
 
-fn infer_attachment_type(field_name: Option<&str>, file_name: &str) -> AttachmentType {
-    if file_name == "view-hierarchy.json" {
-        return AttachmentType::ViewHierarchy;
-    }
+fn infer_attachment_type(field_name: Option<&str>, _file_name: &str) -> AttachmentType {
     match field_name.unwrap_or("") {
         MINIDUMP_FIELD_NAME => AttachmentType::Minidump,
         ITEM_NAME_BREADCRUMBS1 => AttachmentType::Breadcrumbs,
         ITEM_NAME_BREADCRUMBS2 => AttachmentType::Breadcrumbs,
         ITEM_NAME_EVENT => AttachmentType::EventPayload,
+        VIEW_HIERARCHY_FIELD_NAME => AttachmentType::ViewHierarchy,
         _ => AttachmentType::Attachment,
     }
 }
@@ -377,7 +380,7 @@ mod tests {
             Content-Type: application/octet-stream\x0d\x0a\x0d\x0a\
             \x82\xa5level\xa5fatal\xa8platform\xa6native\x0d\x0a\
             -----MultipartBoundary-sQ95dYmFvVzJ2UcOSdGPBkqrW0syf0Uw---\x0d\x0a\
-            Content-Disposition: form-data; name=\"view-hierarchy\"; filename=\"view-hierarchy.json\"\x0d\x0a\
+            Content-Disposition: form-data; name=\"view-hierarchy.json\"; filename=\"view-hierarchy.json\"\x0d\x0a\
             Content-Type: application/json\x0d\x0a\x0d\x0a\
             {\"rendering_system\":\"android_view_system\",\"windows\":[{\"type\":\"com.android.internal.policy.DecorView\",\"width\":768.0,\"height\":1280.0,\"x\":0.0,\"y\":0.0,\"visibility\":\"visible\",\"alpha\":1.0}]}\x0d\x0a\
             -----MultipartBoundary-sQ95dYmFvVzJ2UcOSdGPBkqrW0syf0Uw-----\x0d\x0a";

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -30,7 +30,7 @@ const MINIDUMP_FIELD_NAME: &str = "upload_file_minidump";
 
 /// The field name of a view hierarchy file in the multipart form-data upload.
 /// It matches the expected file name of the view hierarchy, as outlined in RFC#33
-/// https://github.com/getsentry/rfcs/blob/main/text/0033-view-hierarchy.md
+/// <https://github.com/getsentry/rfcs/blob/main/text/0033-view-hierarchy.md>
 const VIEW_HIERARCHY_FIELD_NAME: &str = "view-hierarchy.json";
 
 /// File name for a standalone minidump upload.

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -120,12 +120,14 @@ fn remove_container_extension(filename: &str) -> &str {
 }
 
 fn infer_attachment_type(field_name: Option<&str>, file_name: &str) -> AttachmentType {
+    if file_name == "view-hierarchy.json" {
+        return AttachmentType::ViewHierarchy;
+    }
     match field_name.unwrap_or("") {
         MINIDUMP_FIELD_NAME => AttachmentType::Minidump,
         ITEM_NAME_BREADCRUMBS1 => AttachmentType::Breadcrumbs,
         ITEM_NAME_BREADCRUMBS2 => AttachmentType::Breadcrumbs,
         ITEM_NAME_EVENT => AttachmentType::EventPayload,
-        _ if file_name == "view-hierarchy.json" => AttachmentType::ViewHierarchy,
         _ => AttachmentType::Attachment,
     }
 }

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -119,12 +119,13 @@ fn remove_container_extension(filename: &str) -> &str {
         .unwrap_or(filename)
 }
 
-fn infer_attachment_type(field_name: Option<&str>, _file_name: &str) -> AttachmentType {
+fn infer_attachment_type(field_name: Option<&str>, file_name: &str) -> AttachmentType {
     match field_name.unwrap_or("") {
         MINIDUMP_FIELD_NAME => AttachmentType::Minidump,
         ITEM_NAME_BREADCRUMBS1 => AttachmentType::Breadcrumbs,
         ITEM_NAME_BREADCRUMBS2 => AttachmentType::Breadcrumbs,
         ITEM_NAME_EVENT => AttachmentType::EventPayload,
+        _ if file_name == "view-hierarchy.json" => AttachmentType::ViewHierarchy,
         _ => AttachmentType::Attachment,
     }
 }
@@ -373,6 +374,10 @@ mod tests {
             Content-Disposition: form-data; name=\"__sentry-event\"; filename=\"__sentry-event\"\x0d\x0a\
             Content-Type: application/octet-stream\x0d\x0a\x0d\x0a\
             \x82\xa5level\xa5fatal\xa8platform\xa6native\x0d\x0a\
+            -----MultipartBoundary-sQ95dYmFvVzJ2UcOSdGPBkqrW0syf0Uw---\x0d\x0a\
+            Content-Disposition: form-data; name=\"view-hierarchy\"; filename=\"view-hierarchy.json\"\x0d\x0a\
+            Content-Type: application/json\x0d\x0a\x0d\x0a\
+            {\"rendering_system\":\"android_view_system\",\"windows\":[{\"type\":\"com.android.internal.policy.DecorView\",\"width\":768.0,\"height\":1280.0,\"x\":0.0,\"y\":0.0,\"visibility\":\"visible\",\"alpha\":1.0}]}\x0d\x0a\
             -----MultipartBoundary-sQ95dYmFvVzJ2UcOSdGPBkqrW0syf0Uw-----\x0d\x0a";
 
         let request = Request::builder()
@@ -392,7 +397,8 @@ mod tests {
         // * two breadcrumb files
         // * one event file
         // * one form-data item
-        assert_eq!(5, items.len());
+        // * one view-hierarchy file
+        assert_eq!(6, items.len());
 
         // `config.json` has no content-type. MIME-detection in later processing will assign this.
         let item = &items[0];
@@ -435,8 +441,19 @@ mod tests {
         );
         assert_eq!(item.payload().len(), 29);
 
-        // the last item is the form-data if any and contains a `guid` from the `crashpad_handler`
+        // the next item is the view-hierarchy file
         let item = &items[4];
+        assert_eq!(item.filename().unwrap(), "view-hierarchy.json");
+        assert_eq!(item.content_type().unwrap(), &ContentType::Json);
+        assert_eq!(item.ty(), &ItemType::Attachment);
+        assert_eq!(
+            item.attachment_type().unwrap(),
+            &AttachmentType::ViewHierarchy
+        );
+        assert_eq!(item.payload().len(), 184);
+
+        // the last item is the form-data if any and contains a `guid` from the `crashpad_handler`
+        let item = &items[5];
         assert!(item.filename().is_none());
         assert_eq!(item.content_type().unwrap(), &ContentType::Text);
         assert_eq!(item.ty(), &ItemType::FormData);


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-native/pull/1191

We want to infer the AttachmentType of any incoming attachment that is called `view-hierarchy.json`. This follows the file naming convention specified in [RFC#33](https://github.com/getsentry/rfcs/blob/main/text/0033-view-hierarchy.md). We can still match on the `field_name` because it'll be the same as the `file_name`.