### PR TITLE
fix(server): Reorder DSC validation for correct client sample rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Bug Fixes**:
 
 - Separates profiles into backend and ui profiles. ([#4595](https://github.com/getsentry/relay/pull/4595))
+- Normalize trace context information before writing it into transaction and span data. This ensures the correct sampling rates are stored for extrapolation in Sentry. ([#4625](https://github.com/getsentry/relay/pull/4625))
 
 **Internal**:
 

--- a/relay-server/src/envelope.rs
+++ b/relay-server/src/envelope.rs
@@ -1363,6 +1363,11 @@ impl Envelope {
         self.headers.trace = Some(ErrorBoundary::Ok(dsc));
     }
 
+    /// Removes the dynamic sampling context from envelope headers.
+    pub fn remove_dsc(&mut self) {
+        self.headers.trace = None;
+    }
+
     /// Features required to process this envelope.
     pub fn required_features(&self) -> &[Feature] {
         &self.headers.required_features

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3983,6 +3983,8 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "processing")]
     async fn test_materialize_dsc() {
+        use crate::services::projects::project::PublicKeyConfig;
+
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
             .unwrap();
@@ -4008,11 +4010,18 @@ mod tests {
             ProcessingGroup::Error,
         );
 
+        let mut project_info = ProjectInfo::default();
+        project_info.public_keys.push(PublicKeyConfig {
+            public_key: ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
+            numeric_id: Some(1),
+        });
+        let project_info = Arc::new(project_info);
+
         let process_message = ProcessEnvelope {
             envelope: managed_envelope,
-            project_info: Arc::new(ProjectInfo::default()),
+            project_info: project_info.clone(),
             rate_limits: Default::default(),
-            sampling_project_info: None,
+            sampling_project_info: Some(project_info),
             reservoir_counters: ReservoirCounters::default(),
         };
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -44,31 +44,36 @@ use crate::utils::{self, SamplingResult, TypedEnvelope};
 /// The function will return the sampling project information of the root project for the event. If
 /// no sampling project information is specified, the project information of the event’s project
 /// will be returned.
-pub fn validate_and_set_dsc(
-    managed_envelope: &mut TypedEnvelope<TransactionGroup>,
+pub fn validate_and_set_dsc<T>(
+    managed_envelope: &mut TypedEnvelope<T>,
     event: &mut Annotated<Event>,
     project_info: Arc<ProjectInfo>,
     sampling_project_info: Option<Arc<ProjectInfo>>,
 ) -> Option<Arc<ProjectInfo>> {
-    if managed_envelope.envelope().dsc().is_some() && sampling_project_info.is_some() {
+    let original_dsc = managed_envelope.envelope().dsc();
+    if original_dsc.is_some() && sampling_project_info.is_some() {
         return sampling_project_info;
     }
 
     // The DSC can only be computed if there's a transaction event. Note that `dsc_from_event`
     // below already checks for the event type.
-    let Some(event) = event.value() else {
-        return sampling_project_info;
-    };
-    let Some(key_config) = project_info.get_public_key_config() else {
-        return sampling_project_info;
-    };
+    if let Some(event) = event.value() {
+        if let Some(key_config) = project_info.get_public_key_config() {
+            if let Some(mut dsc) = utils::dsc_from_event(key_config.public_key, event) {
+                // All other information in the DSC must be discarded, but the sample rate was
+                // actually applied by the client and is therefore correct.
+                let original_sample_rate = original_dsc.and_then(|dsc| dsc.sample_rate);
+                dsc.sample_rate = dsc.sample_rate.or(original_sample_rate);
 
-    if let Some(dsc) = utils::dsc_from_event(key_config.public_key, event) {
-        managed_envelope.envelope_mut().set_dsc(dsc);
-        return Some(project_info.clone());
+                managed_envelope.envelope_mut().set_dsc(dsc);
+                return Some(project_info.clone());
+            }
+        }
     }
 
-    sampling_project_info
+    // If we cannot compute a new DSC but the old one is incorrect, we need to remove it.
+    managed_envelope.envelope_mut().remove_dsc();
+    None
 }
 
 /// Computes the sampling decision on the incoming event

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -355,6 +355,8 @@ def send_transaction_with_dsc(mini_sentry, relay, project_id, sampling_project_k
         trace_info={
             "public_key": sampling_project_key,
             "trace_id": "1234F60C11214EB38604F4AE0781BFB2",
+            "release": "testapp@1.0",
+            "sample_rate": 0.5,
         },
     )
 
@@ -366,7 +368,7 @@ def test_root_project_disabled(mini_sentry, relay):
     mini_sentry.add_full_project_config(project_id)
     disabled_dsn = "00000000000000000000000000000000"
     txn = send_transaction_with_dsc(mini_sentry, relay, project_id, disabled_dsn)
-    assert txn
+    assert txn["contexts"]["trace"].get("client_sample_rate") == 0.5
 
 
 def test_root_project_same(mini_sentry, relay):
@@ -374,4 +376,4 @@ def test_root_project_same(mini_sentry, relay):
     mini_sentry.add_full_project_config(project_id)
     same_dsn = mini_sentry.get_dsn_public_key(project_id)
     txn = send_transaction_with_dsc(mini_sentry, relay, project_id, same_dsn)
-    assert txn
+    assert txn["contexts"]["trace"]["client_sample_rate"] == 0.5


### PR DESCRIPTION
This PR contains several fixes to the Envelope processor surrounding DSC
validation. Together, these fixes ensure that the `_dsc` metadata field
in the event payload contains the same values that were used during
sampling and normalization. It also fixes the `trace.client_sample_rate`
field in case a foreign DSC was reset.

### Background

Relay validates whether the DSC originates in a project of the same
organization. If this is not the case and we were to use this DSC for
dynamic sampling, we would be applying sampling rules and rates from a
different organization.

If the DSC is invalid, we try to compute a new one from the information
in the event payload: We take the trace ID, environment, release, and
project key from event data. This simplifies the sampling routines,
since they can afterwards use the DSC and do not have to access the
event payload.

### Fixes

1. If computing a fallback DSC from the event payload fails, remove the
   DSC from the event payload. Previously, we would leave the old DSC
   in.
2. Retain the client sampling rate from the original DSC. While the
   remaining DSC contents cannot be used, the sampling rate was actually
   applied and must be retained for extrapolation. Previously, we
   removed it along with the rest of the foreign DSC.
3. Validate the DSC before `finalize_event`, where it gets written into
   the event payload `_dsc` field. Since we validate the DSC both in
   PoPs and processing Relays, in practice the field always received the
   correct value. However, we now ensure correct order.
4. Validate the DSC before normalization, where we materialize the
   client sampling rate into the event's trace context. Previously,
   these two functions were switched and potentially wrong data was
   written.
5. Apply DSC validation in the errors pipeline so that the correct
   `_dsc` metadata is materialized there, too.