### PR TITLE
feat(derive): Implement flattened values

### DIFF
--- a/relay-protocol-derive/src/lib.rs
+++ b/relay-protocol-derive/src/lib.rs
@@ -564,7 +564,7 @@ fn derive_metastructure(mut s: synstructure::Structure<'_>, t: Trait) -> syn::Re
                 }
             };
 
-            s.gen_impl(quote! {
+            let into_value = s.gen_impl(quote! {
                 #[automatically_derived]
                 gen impl ::relay_protocol::IntoValue for @Self {
                     fn into_value(self) -> ::relay_protocol::Value {
@@ -590,7 +590,9 @@ fn derive_metastructure(mut s: synstructure::Structure<'_>, t: Trait) -> syn::Re
                         __child_meta
                     }
                 }
+            });
 
+            let into_object_ref = (!is_tuple_struct).then(|| s.gen_impl(quote! {
                 #[automatically_derived]
                 gen impl ::relay_protocol::IntoObjectRef for @Self {
                     fn into_object_ref(self, __map: &mut ::relay_protocol::Object<::relay_protocol::Value>) {
@@ -598,7 +600,12 @@ fn derive_metastructure(mut s: synstructure::Structure<'_>, t: Trait) -> syn::Re
                         #to_value_body;
                     }
                 }
-            })
+            }));
+
+            quote! {
+                #into_value
+                #into_object_ref
+            }
         }
     })
 }

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use crate::annotated::{Annotated, MetaMap, MetaTree};
-use crate::value::{Val, Value};
+use crate::value::{Object, Val, Value};
 
 /// A value that can be empty.
 pub trait Empty {
@@ -86,6 +86,18 @@ pub trait FromValue: Debug {
         Self: Sized;
 }
 
+/// Implemented for all meta structures which can be created from key value pairs.
+///
+/// Only meta structures which implement [`FromObjectRef`] can be flattened.
+pub trait FromObjectRef: FromValue {
+    /// Creates a meta structure from key value pairs.
+    ///
+    /// The implementation is supposed remove used fields from the passed `value`.
+    fn from_object_ref(value: &mut Object<Value>) -> Self
+    where
+        Self: Sized;
+}
+
 /// Implemented for all meta structures.
 pub trait IntoValue: Debug + Empty {
     /// Boxes the meta structure back into a value.
@@ -123,6 +135,14 @@ pub trait IntoValue: Debug + Empty {
             },
         }
     }
+}
+
+/// Implemented for all meta structures which can be serialized into an object.
+///
+/// Only meta structures which implement [`IntoValueObject`] can be flattened.
+pub trait IntoValueObject: IntoValue {
+    /// Boxes the meta structure back into an object of values.
+    fn into_object_fields(self) -> Object<Value>;
 }
 
 /// A type-erased iterator over a collection of [`Getter`]s.

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -139,10 +139,13 @@ pub trait IntoValue: Debug + Empty {
 
 /// Implemented for all meta structures which can be serialized into an object.
 ///
-/// Only meta structures which implement [`IntoValueObject`] can be flattened.
-pub trait IntoValueObject: IntoValue {
+/// Only meta structures which implement [`IntoObjectRef`] can be flattened.
+pub trait IntoObjectRef: IntoValue {
     /// Boxes the meta structure back into an object of values.
-    fn into_object_fields(self) -> Object<Value>;
+    ///
+    /// All fields contained need to be added to the passed `obj`.
+    /// This is the inverse operation to [`FromObjectRef::from_object_ref`].
+    fn into_object_ref(self, obj: &mut Object<Value>);
 }
 
 /// A type-erased iterator over a collection of [`Getter`]s.

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -86,7 +86,7 @@ pub trait FromValue: Debug {
         Self: Sized;
 }
 
-/// Implemented for all meta structures which can be created from key value pairs.
+/// Implemented for all meta structures which can be created from an object.
 ///
 /// Only meta structures which implement [`FromObjectRef`] can be flattened.
 pub trait FromObjectRef: FromValue {
@@ -138,6 +138,11 @@ pub trait IntoValue: Debug + Empty {
 }
 
 /// Implemented for all meta structures which can be serialized into an object.
+///
+/// Instead of creating a new [`Value`] as done with [`IntoValue::into_value`],
+/// this trait assumes the underlying value is an object like (struct) and
+/// can be directly serialized into an object without creating an intermediate
+/// object first.
 ///
 /// Only meta structures which implement [`IntoObjectRef`] can be flattened.
 pub trait IntoObjectRef: IntoValue {

--- a/relay-protocol/tests/test_derive_flatten.rs
+++ b/relay-protocol/tests/test_derive_flatten.rs
@@ -1,0 +1,147 @@
+#![cfg(feature = "derive")]
+
+use relay_protocol::{
+    assert_annotated_snapshot, Annotated, Empty, FromValue, IntoValue, Object, Value,
+};
+
+#[test]
+fn test_from_value_flatten() {
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Outer {
+        id: Annotated<String>,
+
+        #[metastructure(flatten)]
+        inner: Inner,
+
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
+    }
+
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Inner {
+        #[metastructure(field = "foo")]
+        not_foo: Annotated<String>,
+        bar: Annotated<String>,
+    }
+
+    let outer = Annotated::<Outer>::from_json(
+        r#"
+        {
+            "id": "my id",
+            "foo": "foo_value",
+            "bar": "bar_value",
+            "future": "into"
+        }
+    "#,
+    )
+    .unwrap();
+
+    insta::assert_debug_snapshot!(outer, @r###"
+    Outer {
+        id: "my id",
+        inner: Inner {
+            not_foo: "foo_value",
+            bar: "bar_value",
+        },
+        other: {
+            "future": String(
+                "into",
+            ),
+        },
+    }
+    "###);
+
+    assert_annotated_snapshot!(outer, @r###"
+    {
+      "id": "my id",
+      "foo": "foo_value",
+      "bar": "bar_value",
+      "future": "into"
+    }
+    "###);
+}
+
+#[test]
+fn test_from_value_flatten_nested_additional_properties() {
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Outer {
+        #[metastructure(flatten)]
+        inner: Inner,
+
+        id: Annotated<String>,
+    }
+
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Inner {
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
+    }
+
+    let outer = Annotated::<Outer>::from_json(
+        r#"
+        {
+            "id": "my id",
+            "foo": "foo_value",
+            "bar": "bar_value",
+            "future": "into"
+        }
+    "#,
+    )
+    .unwrap();
+
+    insta::assert_debug_snapshot!(outer, @r###"
+    Outer {
+        inner: Inner {
+            other: {
+                "bar": String(
+                    "bar_value",
+                ),
+                "foo": String(
+                    "foo_value",
+                ),
+                "future": String(
+                    "into",
+                ),
+                "id": String(
+                    "my id",
+                ),
+            },
+        },
+        id: ~,
+    }
+    "###);
+
+    assert_annotated_snapshot!(outer, @r###"
+    {
+      "bar": "bar_value",
+      "foo": "foo_value",
+      "future": "into",
+      "id": "my id"
+    }
+    "###);
+}
+
+#[test]
+fn test_empty_flatten() {
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Outer {
+        #[metastructure(flatten)]
+        inner: Inner,
+
+        id: Annotated<String>,
+    }
+
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Inner {
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
+    }
+
+    let outer: Annotated<Outer> = Annotated::empty();
+    assert!(outer.is_empty());
+    assert!(outer.is_deep_empty());
+
+    let inner: Annotated<Inner> = Annotated::empty();
+    assert!(inner.is_empty());
+    assert!(inner.is_deep_empty());
+}


### PR DESCRIPTION
Adds `metastructure(flatten)` support to our derive macros. In preparation to supporting the following schema:

```json
{
    "type": "string",
    "value": T,
    "other": "..."
}
```

#skip-changelog