### PR TITLE
feat(eap): Add AttributeValue data structure

### DIFF
--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -114,6 +114,10 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
                 quote! {
                     __state.enter_nothing(Some(::std::borrow::Cow::Borrowed(&#field_attrs_name)))
                 }
+            } else if field_attrs.flatten {
+                quote! {
+                    __state.enter_nothing(Some(::std::borrow::Cow::Borrowed(&#field_attrs_name)))
+                }
             } else if is_tuple_struct {
                 quote! {
                     __state.enter_index(
@@ -301,6 +305,7 @@ struct FieldAttrs {
     additional_properties: bool,
     omit_from_schema: bool,
     field_name: String,
+    flatten: bool,
     required: Option<bool>,
     nonempty: Option<bool>,
     trim_whitespace: Option<bool>,
@@ -463,6 +468,8 @@ fn parse_field_attributes(
             } else if ident == "field" {
                 let s = meta.value()?.parse::<LitStr>()?;
                 rv.field_name = s.value();
+            } else if ident == "flatten" {
+                rv.flatten = true;
             } else if ident == "required" {
                 let s = meta.value()?.parse::<LitBool>()?;
                 rv.required = Some(s.value());

--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -113,7 +113,10 @@ pub trait Processor: Sized {
     process_method!(process_trace_context, crate::protocol::TraceContext);
     process_method!(process_native_image_path, crate::protocol::NativeImagePath);
     process_method!(process_contexts, crate::protocol::Contexts);
-    process_method!(process_attribute_value, crate::protocol::AttributeValue);
+    process_method!(
+        process_attribute_value,
+        crate::protocol::OurlogAttributeValue
+    );
 
     fn process_other(
         &mut self,

--- a/relay-event-schema/src/protocol/attribute.rs
+++ b/relay-event-schema/src/protocol/attribute.rs
@@ -1,0 +1,608 @@
+use relay_protocol::{
+    Annotated, Empty, ErrorKind, FromObjectRef, FromValue, IntoValue, IntoValueObject, Object,
+    SkipSerialization, Value,
+};
+use serde::ser::SerializeMap;
+use std::fmt;
+
+#[derive(Debug, Empty, FromValue, IntoValue)]
+pub struct Attribute {
+    #[metastructure(flatten)]
+    pub value: AttributeValue,
+
+    /// Additional arbitrary fields for forwards compatibility.
+    #[metastructure(additional_properties)]
+    pub other: Object<Value>,
+}
+
+#[derive(Debug)]
+enum AttributeType {
+    Bool,
+    Int,
+    Float,
+    String,
+    Unknown(String),
+}
+
+impl AttributeType {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Bool => "bool",
+            Self::Int => "int",
+            Self::Float => "float",
+            Self::String => "string",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl fmt::Display for AttributeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<String> for AttributeType {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "bool" => Self::Bool,
+            "int" => Self::Int,
+            "float" => Self::Float,
+            "string" => Self::String,
+            _ => Self::Unknown(value),
+        }
+    }
+}
+
+impl Empty for AttributeType {
+    #[inline]
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl FromValue for AttributeType {
+    fn from_value(value: Annotated<Value>) -> Annotated<Self> {
+        match String::from_value(value) {
+            Annotated(Some(value), meta) => Annotated(Some(value.into()), meta),
+            Annotated(None, meta) => Annotated(None, meta),
+        }
+    }
+}
+
+impl IntoValue for AttributeType {
+    fn into_value(self) -> Value
+    where
+        Self: Sized,
+    {
+        Value::String(match self {
+            Self::Unknown(s) => s,
+            s => s.to_string(),
+        })
+    }
+
+    fn serialize_payload<S>(&self, s: S, _behavior: SkipSerialization) -> Result<S::Ok, S::Error>
+    where
+        Self: Sized,
+        S: serde::Serializer,
+    {
+        serde::ser::Serialize::serialize(self.as_str(), s)
+    }
+}
+
+#[derive(Debug)]
+pub enum AttributeValue {
+    /// A boolean value.
+    Bool(bool),
+    /// A signed integer value.
+    I64(i64),
+    /// An unsigned integer value.
+    U64(u64),
+    /// A floating point value.
+    F64(f64),
+    /// A string value.
+    String(String),
+    /// Any other unknown attribute value.
+    ///
+    /// This exists to ensure other attribute values such as array and object can be added in the future.
+    Other(AttributeValueRaw),
+}
+
+#[derive(Debug, Empty, FromValue, IntoValue)]
+pub struct AttributeValueRaw {
+    #[metastructure(field = "type")]
+    ty: Annotated<AttributeType>,
+    value: Annotated<Value>,
+}
+
+impl From<AttributeValueRaw> for AttributeValue {
+    fn from(value: AttributeValueRaw) -> Self {
+        match (value.ty, value.value) {
+            (Annotated(Some(ty), ty_meta), Annotated(Some(value), mut value_meta)) => {
+                match (ty, value) {
+                    (AttributeType::Bool, Value::Bool(v)) => Self::Bool(v),
+                    (AttributeType::Int, Value::I64(v)) => Self::I64(v),
+                    (AttributeType::Int, Value::U64(v)) => Self::U64(v),
+                    (AttributeType::Float, Value::F64(v)) => Self::F64(v),
+                    (AttributeType::Float, Value::I64(v)) => Self::F64(v as f64),
+                    (AttributeType::Float, Value::U64(v)) => Self::F64(v as f64),
+                    (AttributeType::String, Value::String(v)) => Self::String(v),
+                    (ty @ AttributeType::Unknown(_), value) => Self::Other(AttributeValueRaw {
+                        ty: Annotated(Some(ty), ty_meta),
+                        value: Annotated(Some(value), value_meta),
+                    }),
+                    (ty, value) => {
+                        value_meta.add_error(ErrorKind::InvalidData);
+                        value_meta.set_original_value(Some(value));
+                        Self::Other(AttributeValueRaw {
+                            ty: Annotated(Some(ty), ty_meta),
+                            value: Annotated(None, value_meta),
+                        })
+                    }
+                }
+            }
+            (mut ty, mut value) => {
+                if ty.is_empty() {
+                    ty.meta_mut().add_error(ErrorKind::MissingAttribute);
+                }
+                if value.is_empty() {
+                    value.meta_mut().add_error(ErrorKind::MissingAttribute);
+                }
+                Self::Other(AttributeValueRaw { ty, value })
+            }
+        }
+    }
+}
+
+impl From<AttributeValue> for AttributeValueRaw {
+    fn from(value: AttributeValue) -> Self {
+        match value {
+            AttributeValue::Bool(v) => Self {
+                ty: Annotated::new(AttributeType::Bool),
+                value: Annotated::new(v.into()),
+            },
+            AttributeValue::I64(v) => Self {
+                ty: Annotated::new(AttributeType::Int),
+                value: Annotated::new(v.into()),
+            },
+            AttributeValue::U64(v) => Self {
+                ty: Annotated::new(AttributeType::Int),
+                value: Annotated::new(v.into()),
+            },
+            AttributeValue::F64(v) => Self {
+                ty: Annotated::new(AttributeType::Float),
+                value: Annotated::new(v.into()),
+            },
+            AttributeValue::String(v) => Self {
+                ty: Annotated::new(AttributeType::String),
+                value: Annotated::new(v.into()),
+            },
+            AttributeValue::Other(v) => v,
+        }
+    }
+}
+
+impl Empty for AttributeValue {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Other(v) => v.is_empty(),
+            _ => false,
+        }
+    }
+}
+
+impl FromObjectRef for AttributeValue {
+    fn from_object_ref(value: &mut Object<Value>) -> Self
+    where
+        Self: Sized,
+    {
+        AttributeValueRaw::from_object_ref(value).into()
+    }
+}
+
+impl FromValue for AttributeValue {
+    fn from_value(value: Annotated<Value>) -> Annotated<Self>
+    where
+        Self: Sized,
+    {
+        AttributeValueRaw::from_value(value).map_value(Into::into)
+    }
+}
+
+impl IntoValue for AttributeValue {
+    fn into_value(self) -> Value
+    where
+        Self: Sized,
+    {
+        AttributeValueRaw::from(self).into_value()
+    }
+
+    fn serialize_payload<S>(
+        &self,
+        s: S,
+        behavior: relay_protocol::SkipSerialization,
+    ) -> Result<S::Ok, S::Error>
+    where
+        Self: Sized,
+        S: serde::Serializer,
+    {
+        macro_rules! ser {
+            ($ty:expr, $value:expr) => {{
+                let mut map_ser = s.serialize_map(Some(2))?;
+                map_ser.serialize_key("type")?;
+                map_ser.serialize_value($ty)?;
+                map_ser.serialize_key("value")?;
+                map_ser.serialize_value($value)?;
+                map_ser.end()
+            }};
+        }
+
+        match self {
+            Self::Bool(v) => ser!("bool", v),
+            Self::I64(v) => ser!("int", v),
+            Self::U64(v) => ser!("int", v),
+            Self::F64(v) => ser!("float", v),
+            Self::String(v) => ser!("string", v),
+            Self::Other(v) => v.serialize_payload(s, behavior),
+        }
+    }
+}
+
+impl IntoValueObject for AttributeValue {
+    fn into_object_fields(self) -> Object<Value> {
+        AttributeValueRaw::from(self).into_object_fields()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test {
+        ($name:ident, $json:literal, @$foo:literal) => {
+            test!($name, $json, @$foo, $json);
+        };
+        ($name:ident, $json:literal, @$foo:literal, $expected:literal) => {
+            #[test]
+            fn $name() {
+                let v = Annotated::<Attribute>::from_json($json).unwrap();
+                insta::assert_debug_snapshot!(v, @$foo);
+
+                let expected: serde_json::Value = serde_json::from_str($expected).unwrap();
+
+                let v_json = v.to_json().unwrap();
+                let v_json: serde_json::Value = serde_json::from_str(&v_json).unwrap();
+
+                assert_eq!(v_json, expected);
+            }
+        }
+    }
+
+    test!(test_valid_string,
+        r#"{
+            "type": "string",
+            "value": "My String",
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: String(
+            "My String",
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###);
+
+    test!(test_valid_i64,
+        r#"{
+            "type": "int",
+            "value": -1,
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: I64(
+            -1,
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###);
+    test!(test_valid_u64,
+        r#"{
+            "type": "int",
+            "value": 18446744073709551615,
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: U64(
+            18446744073709551615,
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###);
+    test!(test_valid_bool,
+        r#"{
+            "type": "bool",
+            "value": false,
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: Bool(
+            false,
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###);
+    test!(test_valid_f64,
+        r#"{
+            "type": "float",
+            "value": 1337.0,
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: F64(
+            1337.0,
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###);
+    test!(test_valid_f64_from_i64,
+        r#"{
+            "type": "float",
+            "value": -1,
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: F64(
+            -1.0,
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###,
+        r#"{
+            "type": "float",
+            "value": -1.0,
+            "other": "does not exist yet"
+        }"#
+    );
+    test!(test_valid_f64_from_u64,
+        r#"{
+            "type": "float",
+            "value": 18446744073709551615,
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: F64(
+            1.8446744073709552e19,
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###,
+        r#"{
+            "type": "float",
+            "value": 1.8446744073709552e19,
+            "other": "does not exist yet"
+        }"#
+    );
+    test!(test_valid_unknown,
+        r#"{
+            "type": "unknown",
+            "value": "foobar",
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: Other(
+            AttributeValueRaw {
+                ty: Unknown(
+                    "unknown",
+                ),
+                value: String(
+                    "foobar",
+                ),
+            },
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###
+    );
+
+    test!(test_invalid_type_mismatch,
+        r#"{
+            "type": "float",
+            "value": "not a float",
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: Other(
+            AttributeValueRaw {
+                ty: Float,
+                value: Meta {
+                    remarks: [],
+                    errors: [
+                        Error {
+                            kind: InvalidData,
+                            data: {},
+                        },
+                    ],
+                    original_length: None,
+                    original_value: Some(
+                        String(
+                            "not a float",
+                        ),
+                    ),
+                },
+            },
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###,
+        r#"{
+            "type": "float",
+            "value": null,
+            "other": "does not exist yet"
+        }"#
+    );
+
+    test!(test_invalid_type_missing,
+        r#"{
+            "value": "a string",
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: Other(
+            AttributeValueRaw {
+                ty: Meta {
+                    remarks: [],
+                    errors: [
+                        Error {
+                            kind: MissingAttribute,
+                            data: {},
+                        },
+                    ],
+                    original_length: None,
+                    original_value: None,
+                },
+                value: String(
+                    "a string",
+                ),
+            },
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###,
+        r#"{
+            "type": null,
+            "value": "a string",
+            "other": "does not exist yet"
+        }"#
+    );
+    test!(test_invalid_value_missing,
+        r#"{
+            "type": "float",
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: Other(
+            AttributeValueRaw {
+                ty: Float,
+                value: Meta {
+                    remarks: [],
+                    errors: [
+                        Error {
+                            kind: MissingAttribute,
+                            data: {},
+                        },
+                    ],
+                    original_length: None,
+                    original_value: None,
+                },
+            },
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###,
+        r#"{
+            "type": "float",
+            "value": null,
+            "other": "does not exist yet"
+        }"#
+    );
+    test!(test_invalid_type_value_missing,
+        r#"{
+            "other": "does not exist yet"
+        }"#,
+        @r###"
+    Attribute {
+        value: Other(
+            AttributeValueRaw {
+                ty: Meta {
+                    remarks: [],
+                    errors: [
+                        Error {
+                            kind: MissingAttribute,
+                            data: {},
+                        },
+                    ],
+                    original_length: None,
+                    original_value: None,
+                },
+                value: Meta {
+                    remarks: [],
+                    errors: [
+                        Error {
+                            kind: MissingAttribute,
+                            data: {},
+                        },
+                    ],
+                    original_length: None,
+                    original_value: None,
+                },
+            },
+        ),
+        other: {
+            "other": String(
+                "does not exist yet",
+            ),
+        },
+    }
+    "###,
+        r#"{
+            "type": null,
+            "value": null,
+            "other": "does not exist yet"
+        }"#
+    );
+}

--- a/relay-event-schema/src/protocol/mod.rs
+++ b/relay-event-schema/src/protocol/mod.rs
@@ -1,5 +1,6 @@
 //! Implements the sentry event protocol.
 
+mod attribute;
 mod base;
 mod breadcrumb;
 mod breakdowns;
@@ -38,6 +39,7 @@ mod utils;
 #[doc(inline)]
 pub use relay_base_schema::{events::*, spans::*};
 
+pub use self::attribute::*;
 pub use self::breadcrumb::*;
 pub use self::breakdowns::*;
 pub use self::client_report::*;

--- a/relay-event-schema/src/protocol/ourlog.rs
+++ b/relay-event-schema/src/protocol/ourlog.rs
@@ -44,7 +44,7 @@ pub struct OurLog {
 
     /// Arbitrary attributes on a log.
     #[metastructure(pii = "true", trim = false)]
-    pub attributes: Annotated<Object<AttributeValue>>,
+    pub attributes: Annotated<Object<OurlogAttributeValue>>,
 
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = true, pii = "maybe", trim = false)]
@@ -52,7 +52,7 @@ pub struct OurLog {
 }
 
 #[derive(Debug, Clone, PartialEq, ProcessValue)]
-pub enum AttributeValue {
+pub enum OurlogAttributeValue {
     #[metastructure(field = "string_value", pii = "true")]
     StringValue(String),
     #[metastructure(field = "int_value", pii = "true")]
@@ -67,23 +67,23 @@ pub enum AttributeValue {
     Unknown(String),
 }
 
-impl IntoValue for AttributeValue {
+impl IntoValue for OurlogAttributeValue {
     fn into_value(self) -> Value {
         let mut map = Object::new();
         match self {
-            AttributeValue::StringValue(v) => {
+            OurlogAttributeValue::StringValue(v) => {
                 map.insert("string_value".to_string(), Annotated::new(Value::String(v)));
             }
-            AttributeValue::IntValue(v) => {
+            OurlogAttributeValue::IntValue(v) => {
                 map.insert("int_value".to_string(), Annotated::new(Value::I64(v)));
             }
-            AttributeValue::DoubleValue(v) => {
+            OurlogAttributeValue::DoubleValue(v) => {
                 map.insert("double_value".to_string(), Annotated::new(Value::F64(v)));
             }
-            AttributeValue::BoolValue(v) => {
+            OurlogAttributeValue::BoolValue(v) => {
                 map.insert("bool_value".to_string(), Annotated::new(Value::Bool(v)));
             }
-            AttributeValue::Unknown(v) => {
+            OurlogAttributeValue::Unknown(v) => {
                 map.insert("unknown".to_string(), Annotated::new(Value::String(v)));
             }
         }
@@ -97,19 +97,19 @@ impl IntoValue for AttributeValue {
     {
         let mut map = s.serialize_map(None)?;
         match self {
-            AttributeValue::StringValue(v) => {
+            OurlogAttributeValue::StringValue(v) => {
                 map.serialize_entry("string_value", v)?;
             }
-            AttributeValue::IntValue(v) => {
+            OurlogAttributeValue::IntValue(v) => {
                 map.serialize_entry("int_value", v)?;
             }
-            AttributeValue::DoubleValue(v) => {
+            OurlogAttributeValue::DoubleValue(v) => {
                 map.serialize_entry("double_value", v)?;
             }
-            AttributeValue::BoolValue(v) => {
+            OurlogAttributeValue::BoolValue(v) => {
                 map.serialize_entry("bool_value", v)?;
             }
-            AttributeValue::Unknown(v) => {
+            OurlogAttributeValue::Unknown(v) => {
                 map.serialize_entry("unknown", v)?;
             }
         }
@@ -117,54 +117,54 @@ impl IntoValue for AttributeValue {
     }
 }
 
-impl AttributeValue {
+impl OurlogAttributeValue {
     pub fn string_value(&self) -> Option<&String> {
         match self {
-            AttributeValue::StringValue(s) => Some(s),
+            OurlogAttributeValue::StringValue(s) => Some(s),
             _ => None,
         }
     }
     pub fn int_value(&self) -> Option<i64> {
         match self {
-            AttributeValue::IntValue(i) => Some(*i),
+            OurlogAttributeValue::IntValue(i) => Some(*i),
             _ => None,
         }
     }
     pub fn double_value(&self) -> Option<f64> {
         match self {
-            AttributeValue::DoubleValue(d) => Some(*d),
+            OurlogAttributeValue::DoubleValue(d) => Some(*d),
             _ => None,
         }
     }
     pub fn bool_value(&self) -> Option<bool> {
         match self {
-            AttributeValue::BoolValue(b) => Some(*b),
+            OurlogAttributeValue::BoolValue(b) => Some(*b),
             _ => None,
         }
     }
 }
 
-impl Empty for AttributeValue {
+impl Empty for OurlogAttributeValue {
     #[inline]
     fn is_empty(&self) -> bool {
         matches!(self, Self::Unknown(_))
     }
 }
 
-impl FromValue for AttributeValue {
+impl FromValue for OurlogAttributeValue {
     fn from_value(value: Annotated<Value>) -> Annotated<Self> {
         match value {
             Annotated(Some(Value::String(value)), meta) => {
-                Annotated(Some(AttributeValue::StringValue(value)), meta)
+                Annotated(Some(OurlogAttributeValue::StringValue(value)), meta)
             }
             Annotated(Some(Value::I64(value)), meta) => {
-                Annotated(Some(AttributeValue::IntValue(value)), meta)
+                Annotated(Some(OurlogAttributeValue::IntValue(value)), meta)
             }
             Annotated(Some(Value::F64(value)), meta) => {
-                Annotated(Some(AttributeValue::DoubleValue(value)), meta)
+                Annotated(Some(OurlogAttributeValue::DoubleValue(value)), meta)
             }
             Annotated(Some(Value::Bool(value)), meta) => {
-                Annotated(Some(AttributeValue::BoolValue(value)), meta)
+                Annotated(Some(OurlogAttributeValue::BoolValue(value)), meta)
             }
             Annotated(Some(value), mut meta) => {
                 meta.add_error(Error::expected(
@@ -211,19 +211,19 @@ mod tests {
         let mut attributes = Object::new();
         attributes.insert(
             "string.attribute".into(),
-            Annotated::new(AttributeValue::StringValue("some string".into())),
+            Annotated::new(OurlogAttributeValue::StringValue("some string".into())),
         );
         attributes.insert(
             "boolean.attribute".into(),
-            Annotated::new(AttributeValue::BoolValue(true)),
+            Annotated::new(OurlogAttributeValue::BoolValue(true)),
         );
         attributes.insert(
             "int.attribute".into(),
-            Annotated::new(AttributeValue::IntValue(10)),
+            Annotated::new(OurlogAttributeValue::IntValue(10)),
         );
         attributes.insert(
             "double.attribute".into(),
-            Annotated::new(AttributeValue::DoubleValue(637.704)),
+            Annotated::new(OurlogAttributeValue::DoubleValue(637.704)),
         );
 
         let log = Annotated::new(OurLog {

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -2,7 +2,7 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 
 use crate::OtelLog;
 use relay_common::time::UnixTimestamp;
-use relay_event_schema::protocol::{AttributeValue, OurLog, SpanId, TraceId};
+use relay_event_schema::protocol::{OurLog, OurlogAttributeValue, SpanId, TraceId};
 use relay_protocol::{Annotated, Object};
 
 /// Transform an OtelLog to a Sentry log.
@@ -40,22 +40,25 @@ pub fn otel_to_sentry_log(otel_log: OtelLog) -> OurLog {
             match value {
                 OtelValue::ArrayValue(_) => {}
                 OtelValue::BoolValue(v) => {
-                    attribute_data.insert(key, Annotated::new(AttributeValue::BoolValue(v)));
+                    attribute_data.insert(key, Annotated::new(OurlogAttributeValue::BoolValue(v)));
                 }
                 OtelValue::BytesValue(v) => {
                     if let Ok(v) = String::from_utf8(v) {
-                        attribute_data.insert(key, Annotated::new(AttributeValue::StringValue(v)));
+                        attribute_data
+                            .insert(key, Annotated::new(OurlogAttributeValue::StringValue(v)));
                     }
                 }
                 OtelValue::DoubleValue(v) => {
-                    attribute_data.insert(key, Annotated::new(AttributeValue::DoubleValue(v)));
+                    attribute_data
+                        .insert(key, Annotated::new(OurlogAttributeValue::DoubleValue(v)));
                 }
                 OtelValue::IntValue(v) => {
-                    attribute_data.insert(key, Annotated::new(AttributeValue::IntValue(v)));
+                    attribute_data.insert(key, Annotated::new(OurlogAttributeValue::IntValue(v)));
                 }
                 OtelValue::KvlistValue(_) => {}
                 OtelValue::StringValue(v) => {
-                    attribute_data.insert(key, Annotated::new(AttributeValue::StringValue(v)));
+                    attribute_data
+                        .insert(key, Annotated::new(OurlogAttributeValue::StringValue(v)));
                 }
             }
         }

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use crate::annotated::{Annotated, MetaMap, MetaTree};
-use crate::value::{Val, Value};
+use crate::value::{Object, Val, Value};
 
 /// A value that can be empty.
 pub trait Empty {
@@ -86,6 +86,18 @@ pub trait FromValue: Debug {
         Self: Sized;
 }
 
+/// Implemented for all meta structures which can be created from key value pairs.
+///
+/// Only meta structures which implement [`FromObjectRef`] can be flattened.
+pub trait FromObjectRef: FromValue {
+    /// Creates a meta structure from key value pairs.
+    ///
+    /// The implementation is supposed remove used fields from the passed `value`.
+    fn from_object_ref(value: &mut Object<Value>) -> Self
+    where
+        Self: Sized;
+}
+
 /// Implemented for all meta structures.
 pub trait IntoValue: Debug + Empty {
     /// Boxes the meta structure back into a value.
@@ -123,6 +135,14 @@ pub trait IntoValue: Debug + Empty {
             },
         }
     }
+}
+
+/// Implemented for all meta structures which can be serialized into an object.
+///
+/// Only meta structures which implement [`IntoValueObject`] can be flattened.
+pub trait IntoValueObject: IntoValue {
+    /// Boxes the meta structure back into an object of values.
+    fn into_object_fields(self) -> Object<Value>;
 }
 
 /// A type-erased iterator over a collection of [`Getter`]s.

--- a/relay-protocol/tests/test_derive_flatten.rs
+++ b/relay-protocol/tests/test_derive_flatten.rs
@@ -1,0 +1,147 @@
+#![cfg(feature = "derive")]
+
+use relay_protocol::{
+    assert_annotated_snapshot, Annotated, Empty, FromValue, IntoValue, Object, Value,
+};
+
+#[test]
+fn test_from_value_flatten() {
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Outer {
+        id: Annotated<String>,
+
+        #[metastructure(flatten)]
+        inner: Inner,
+
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
+    }
+
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Inner {
+        #[metastructure(field = "foo")]
+        not_foo: Annotated<String>,
+        bar: Annotated<String>,
+    }
+
+    let outer = Annotated::<Outer>::from_json(
+        r#"
+        {
+            "id": "my id",
+            "foo": "foo_value",
+            "bar": "bar_value",
+            "future": "into"
+        }
+    "#,
+    )
+    .unwrap();
+
+    insta::assert_debug_snapshot!(outer, @r###"
+    Outer {
+        id: "my id",
+        inner: Inner {
+            not_foo: "foo_value",
+            bar: "bar_value",
+        },
+        other: {
+            "future": String(
+                "into",
+            ),
+        },
+    }
+    "###);
+
+    assert_annotated_snapshot!(outer, @r###"
+    {
+      "id": "my id",
+      "foo": "foo_value",
+      "bar": "bar_value",
+      "future": "into"
+    }
+    "###);
+}
+
+#[test]
+fn test_from_value_flatten_nested_additional_properties() {
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Outer {
+        #[metastructure(flatten)]
+        inner: Inner,
+
+        id: Annotated<String>,
+    }
+
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Inner {
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
+    }
+
+    let outer = Annotated::<Outer>::from_json(
+        r#"
+        {
+            "id": "my id",
+            "foo": "foo_value",
+            "bar": "bar_value",
+            "future": "into"
+        }
+    "#,
+    )
+    .unwrap();
+
+    insta::assert_debug_snapshot!(outer, @r###"
+    Outer {
+        inner: Inner {
+            other: {
+                "bar": String(
+                    "bar_value",
+                ),
+                "foo": String(
+                    "foo_value",
+                ),
+                "future": String(
+                    "into",
+                ),
+                "id": String(
+                    "my id",
+                ),
+            },
+        },
+        id: ~,
+    }
+    "###);
+
+    assert_annotated_snapshot!(outer, @r###"
+    {
+      "bar": "bar_value",
+      "foo": "foo_value",
+      "future": "into",
+      "id": "my id"
+    }
+    "###);
+}
+
+#[test]
+fn test_empty_flatten() {
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Outer {
+        #[metastructure(flatten)]
+        inner: Inner,
+
+        id: Annotated<String>,
+    }
+
+    #[derive(Debug, Empty, FromValue, IntoValue)]
+    struct Inner {
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
+    }
+
+    let outer: Annotated<Outer> = Annotated::empty();
+    assert!(outer.is_empty());
+    assert!(outer.is_deep_empty());
+
+    let inner: Annotated<Inner> = Annotated::empty();
+    assert!(inner.is_empty());
+    assert!(inner.is_deep_empty());
+}


### PR DESCRIPTION
Needed for #4592 and future EAP envelope items (Spans).

The PR itself only adds the data structure, but it is still unused, to prevent clashes with the still different OurLogs implementation, that one was renamed (until it is removed).

TODO: 
- Implement `ProcessValue`
- Figure out PII

#skip-changelog