### PR TITLE
ref(autoscaling): delete old metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bump the revision of `sysinfo` to the revision at `15b3be3273ba286740122fed7bb7dccd2a79dc8f`. ([#4613](https://github.com/getsentry/relay/pull/4613))
 - Switch the processor and store to `async`. ([#4552](https://github.com/getsentry/relay/pull/4552))
 - Validate the spooling memory configuration on startup. ([#4617](https://github.com/getsentry/relay/pull/4617))
+- Improve descriptiveness of autoscaling metric name. ([#4629](https://github.com/getsentry/relay/pull/4629))
 
 ## 25.3.0
 

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -33,14 +33,6 @@ fn to_prometheus_string(data: &AutoscalingData) -> String {
     append_data_row(&mut result, "spool_total_size", data.total_size, &[]);
     for utilization in &data.services_metrics {
         let service_name = extract_service_name(utilization.0);
-        // Expose both names temporarily so we can phase out `utilization` in favor
-        // of `service_utilization`
-        append_data_row(
-            &mut result,
-            "utilization",
-            utilization.1,
-            &[("relay_service", service_name)],
-        );
         append_data_row(
             &mut result,
             "service_utilization",
@@ -159,9 +151,7 @@ mod test {
 relay_up 1
 relay_spool_item_count 10
 relay_spool_total_size 30
-relay_utilization{relay_service="test"} 10
 relay_service_utilization{relay_service="test"} 10
-relay_utilization{relay_service="envelope"} 50
 relay_service_utilization{relay_service="envelope"} 50
 relay_worker_pool_utilization 61
 relay_runtime_utilization 41

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -79,7 +79,6 @@ def test_memory_spooling_metrics(mini_sentry, relay):
 @pytest.mark.parametrize(
     "metric_name",
     (
-        'relay_utilization{relay_service="AggregatorService"}',
         'relay_service_utilization{relay_service="AggregatorService"}',
         "relay_worker_pool_utilization",
         "relay_runtime_utilization",


### PR DESCRIPTION
This PR removes the undescriptive metric name in favour of the new one.

This can only be merged once everything uses the new name.