### PR TITLE
feat(ourlogs): Add per-project log ingestion flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bump the revision of `sysinfo` to the revision at `15b3be3273ba286740122fed7bb7dccd2a79dc8f`. ([#4613](https://github.com/getsentry/relay/pull/4613))
 - Switch the processor and store to `async`. ([#4552](https://github.com/getsentry/relay/pull/4552))
 - Validate the spooling memory configuration on startup. ([#4617](https://github.com/getsentry/relay/pull/4617))
+- Add feature flag to control ourlogs ingestion. ([#4631](https://github.com/getsentry/relay/pull/4631))
 
 ## 25.3.0
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -117,6 +117,12 @@ pub enum Feature {
     /// Serialized as `organizations:ourlogs-ingestion`.
     #[serde(rename = "organizations:ourlogs-ingestion")]
     OurLogsIngestion,
+    /// Controls log ingestion on a per project basis, only used to disable log ingestion for infrastructure concerns.
+    /// Set to true by default, use the organization feature flag to control the default behavior.
+    ///
+    /// Serialized as `projects:ourlogs-ingestion`.
+    #[serde(rename = "projects:ourlogs-ingestion")]
+    OurLogsIngestionForProject,
     /// This feature has graduated and is hard-coded for external Relays.
     #[doc(hidden)]
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -32,6 +32,8 @@ pub fn filter(
     global_config: &GlobalConfig,
 ) {
     let logging_disabled = should_filter(&config, &project_info, Feature::OurLogsIngestion);
+    let project_logging_disabled =
+        should_filter(&config, &project_info, Feature::OurLogsIngestionForProject);
     let logs_sampled = global_config
         .options
         .ourlogs_ingestion_sample_rate
@@ -39,7 +41,7 @@ pub fn filter(
         .unwrap_or(true);
 
     managed_envelope.retain_items(|_| {
-        if logging_disabled || !logs_sampled {
+        if logging_disabled || project_logging_disabled || !logs_sampled {
             ItemAction::DropSilently
         } else {
             ItemAction::Keep


### PR DESCRIPTION
### Summary
We want to be careful because of the shared blast radius in the EAP cluster that we have a way to disable specific projects if they're causing infrastructure concerns.

This flag is set to true by default so all existing projects should work.

Needs https://github.com/getsentry/sentry/pull/88335 before merging. 
