### PR TITLE
fix(filter): Update iOS chrome translation error regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 - Bump the revision of `sysinfo` to the revision at `15b3be3273ba286740122fed7bb7dccd2a79dc8f`. ([#4613](https://github.com/getsentry/relay/pull/4613))
 - Switch the processor and store to `async`. ([#4552](https://github.com/getsentry/relay/pull/4552))
 - Validate the spooling memory configuration on startup. ([#4617](https://github.com/getsentry/relay/pull/4617))
-- Add logic to push docker image to internal registry. ([#4619](https://github.com/getsentry/relay/pull/4619))
 
 ## 25.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add naver.me / Yeti spider on the crawler filter list. ([#4602](https://github.com/getsentry/relay/pull/4602))
 - Add the item type that made the envelope too large to invalid outcomes. ([#4558](https://github.com/getsentry/relay/pull/4558))
 - Filter out certain AI crawlers. ([#4608](https://github.com/getsentry/relay/pull/4608))
+- Update iOS chrome translation error regex. ([#4634](https://github.com/getsentry/relay/pull/4634))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Bump the revision of `sysinfo` to the revision at `15b3be3273ba286740122fed7bb7dccd2a79dc8f`. ([#4613](https://github.com/getsentry/relay/pull/4613))
 - Switch the processor and store to `async`. ([#4552](https://github.com/getsentry/relay/pull/4552))
 - Validate the spooling memory configuration on startup. ([#4617](https://github.com/getsentry/relay/pull/4617))
+- Add logic to push docker image to internal registry. ([#4619](https://github.com/getsentry/relay/pull/4619))
 
 ## 25.3.0
 

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -48,7 +48,7 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
         # Googletag is also very similar, caused by adblockers
         Cannot\sredefine\sproperty:\s(solana|ethereum|googletag)|
         # Translation service errors in Chrome on iOS
-        undefined\sis\snot\san\sobject\s\(evaluating\s'a.L'\)|
+        undefined\sis\snot\san\sobject\s\(evaluating\s'a\..'\)|
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
         # Usually caused by extensions that do stuff that isn't allowed
         Permission\sdenied\sto\saccess\sproperty\s|
@@ -273,7 +273,8 @@ mod tests {
             "Cannot redefine property: solana",
             "Cannot redefine property: ethereum",
             "Cannot redefine property: googletag",
-            "undefined is not an object (evaluating 'a.L')",
+            "undefined is not an object (evaluating 'a.L')", // Old iOS Chrome translation error
+            "undefined is not an object (evaluating 'a.J')", // New iOS Chrome translation error
             "Permission denied to access property \"correspondingUseElement\"",
             "Permission denied to access property \"document\"",
             "Can't find variable: gmo",
@@ -295,6 +296,8 @@ mod tests {
         let events = [
             get_event_with_exception_source("https://some/resonable/source.js"),
             get_event_with_exception_value("some perfectly reasonable value"),
+            // Something that does not quite match the iOS Chrome translation error
+            get_event_with_exception_value("undefined is not an object (evaluating 'a!J')"),
         ];
 
         for event in &events {


### PR DESCRIPTION
It was brought to our attention by a user here (#4628) that the iOS chrome translation error has changed. This PR addresses this by modifying the regex to also catch the version while removing an inaccuracy on the `.` vs `\.`.

Fixes: #4628