### PR TITLE
fix(replays): Add u16 segment-id cap to match snuba processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Separates profiles into backend and ui profiles. ([#4595](https://github.com/getsentry/relay/pull/4595))
 - Normalize trace context information before writing it into transaction and span data. This ensures the correct sampling rates are stored for extrapolation in Sentry. ([#4625](https://github.com/getsentry/relay/pull/4625))
+- Adds u16 validation to the replay protocol's segment_id field. ([#4635](https://github.com/getsentry/relay/pull/4635))
 
 **Internal**:
 

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -47,10 +47,16 @@ pub fn validate(replay: &Replay) -> Result<(), ReplayError> {
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing replay_id".to_string()))?;
 
-    replay
+    let segment_id = *replay
         .segment_id
         .value()
         .ok_or_else(|| ReplayError::InvalidPayload("missing segment_id".to_string()))?;
+
+    if segment_id > u16::MAX as u64 {
+        return Err(ReplayError::InvalidPayload(
+            "segment_id exceeded u16 limit".to_string(),
+        ));
+    }
 
     if replay
         .error_ids
@@ -499,5 +505,30 @@ mod tests {
     }
   }
 }"#);
+    }
+
+    #[test]
+    fn test_validate_u16_segment_id() {
+        // Does not fit within a u16.
+        let replay_id =
+            Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
+        let segment_id: Annotated<u64> = Annotated::new(u16::MAX as u64 + 1);
+        let mut replay = Annotated::new(Replay {
+            replay_id,
+            segment_id,
+            ..Default::default()
+        });
+        assert!(validate(replay.value_mut().as_mut().unwrap()).is_err());
+
+        // Fits within a u16.
+        let replay_id =
+            Annotated::new(EventId("52df9022835246eeb317dbd739ccd059".parse().unwrap()));
+        let segment_id: Annotated<u64> = Annotated::new(u16::MAX as u64);
+        let mut replay = Annotated::new(Replay {
+            replay_id,
+            segment_id,
+            ..Default::default()
+        });
+        assert!(validate(replay.value_mut().as_mut().unwrap()).is_ok());
     }
 }


### PR DESCRIPTION
Due to a comedy of errors the u16 max validation was inadvertently removed.  This PR re-adds it.  This validation was present for most of replays history.

Previous PRs on the subject (not necessary to read -- put here to explain the situation for future readers should this issue come back).

https://github.com/getsentry/relay/pull/2434
https://github.com/getsentry/relay/pull/3280
https://github.com/getsentry/relay/pull/3961
https://github.com/getsentry/relay/pull/3984