### PR TITLE
ref(relay): bump statsdproxy to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,8 +5055,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "statsdproxy"
-version = "0.2.0"
-source = "git+https://github.com/getsentry/statsdproxy?rev=50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f#50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d989f4c2230a3c1e0454e8361886943f3f998cf4f8c649ab76b9cc5ab54072"
 dependencies = [
  "anyhow",
  "cadence",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,8 @@ socket2 = "0.5.8"
 sqlparser = "0.44.0"
 sqlx = { version = "0.8.2", default-features = false }
 # See statsdproxy PR: https://github.com/getsentry/statsdproxy/pull/55
-statsdproxy = { git = "https://github.com/getsentry/statsdproxy", rev = "50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f", default-features = false }
+#statsdproxy = { git = "https://github.com/getsentry/statsdproxy", rev = "50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f", default-features = false }
+statsdproxy = { version = "0.3.0", default-features = false }
 symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }
 syn = { version = "2.0.90" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,8 +178,6 @@ smallvec = { version = "1.13.2", features = ["serde"] }
 socket2 = "0.5.8"
 sqlparser = "0.44.0"
 sqlx = { version = "0.8.2", default-features = false }
-# See statsdproxy PR: https://github.com/getsentry/statsdproxy/pull/55
-#statsdproxy = { git = "https://github.com/getsentry/statsdproxy", rev = "50155c5c5dc103fb1557e5ccde6b2cf6dfe82b9f", default-features = false }
 statsdproxy = { version = "0.3.0", default-features = false }
 symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }


### PR DESCRIPTION
Now that the PR was merged in statsdproxy and released, we can change the dependency to a version instead of a commit hash.

#skip-changelog