### PR TITLE
feat(span): serialize span _meta to kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Switch the processor and store to `async`. ([#4552](https://github.com/getsentry/relay/pull/4552))
 - Validate the spooling memory configuration on startup. ([#4617](https://github.com/getsentry/relay/pull/4617))
 - Improve descriptiveness of autoscaling metric name. ([#4629](https://github.com/getsentry/relay/pull/4629))
+- Serialize span's `_meta` information when producing to Kafka. ([#4646](https://github.com/getsentry/relay/pull/4646))
 
 ## 25.3.0
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1392,6 +1392,13 @@ struct SpanKafkaMessage<'a> {
 
     #[serde(borrow, default, skip_serializing)]
     platform: Cow<'a, str>, // We only use this for logging for now
+
+    #[serde(
+        default,
+        rename = "_meta",
+        skip_serializing_if = "none_or_empty_object"
+    )]
+    meta: Option<&'a RawValue>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1302,6 +1302,24 @@ def test_span_ingestion_with_performance_scores(
             },
         },
         {
+            "_meta": {
+                "data": {
+                    "sentry.segment.name": {
+                        "": {
+                            "rem": [
+                                [
+                                    "int",
+                                    "s",
+                                    34,
+                                    37,
+                                ],
+                                ["**/interaction/*/**", "s"],
+                            ],
+                            "val": "/page/with/click/interaction/jane/123",
+                        }
+                    }
+                }
+            },
             "data": {
                 "browser.name": "Python Requests",
                 "client.address": "127.0.0.1",
@@ -2024,6 +2042,17 @@ def test_scrubs_ip_addresses(
     del child_span["received"]
 
     expected = {
+        "_meta": {
+            "sentry_tags": {
+                "user.email": {"": {"len": 15, "rem": [["@email", "s", 0, 7]]}},
+                "user.ip": {
+                    "": {
+                        "len": 9,
+                        "rem": [["@ip:replace", "s", 0, 4], ["@anything:remove", "x"]],
+                    }
+                },
+            }
+        },
         "description": "GET /api/0/organizations/?member=1",
         "duration_ms": int(duration.total_seconds() * 1e3),
         "event_id": "cbf6960622e14a45abc1f03b2055b186",
@@ -2062,6 +2091,8 @@ def test_scrubs_ip_addresses(
     }
     if scrub_ip_addresses:
         del expected["sentry_tags"]["user.ip"]
+    else:
+        del expected["_meta"]["sentry_tags"]["user.ip"]
     assert child_span == expected
 
     start_timestamp = datetime.fromisoformat(event["start_timestamp"]).replace(


### PR DESCRIPTION
Events have a `_meta` property that contains information on transformations made in Relay to incoming data. Sentry is deprecating events and using EAP as the source of truth for all span information, so spans need their related `_meta` information too for the Sentry frontend to eventually use. The first step is to write the info to Kafka so that it can be written to EAP downstream.