### PR TITLE
feat(ci): Add internal build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,10 +347,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm curl
 
-      # Skip this for the time being
-      # - name: Install sentry-cli
-      #   run: |
-      #     curl -sL https://sentry.io/get-cli/ | bash
+      Skip this for the time being
+      - name: Install sentry-cli
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
 
       - uses: actions/checkout@v4
         with:
@@ -366,12 +366,12 @@ jobs:
           cargo build --release --locked --features "${FEATURES}" --target "${{ matrix.target }}"
 
       - name: Split debug info
-      # Omit: sentry-cli difutil bundle-sources "${RELAY_BIN}.debug" for the time being.
         run: |
           llvm-objcopy --only-keep-debug "${RELAY_BIN}"{,.debug}
           llvm-objcopy --strip-debug --strip-unneeded "${RELAY_BIN}"
           llvm-objcopy --add-gnu-debuglink "${RELAY_BIN}"{.debug,}
 
+          sentry-cli difutil bundle-sources "${RELAY_BIN}.debug"
           zip "${RELAY_BIN}-debug.zip" "${RELAY_BIN}.debug"
 
       - name: Prepare Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm curl
 
-      Skip this for the time being
       - name: Install sentry-cli
         run: |
           curl -sL https://sentry.io/get-cli/ | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,83 @@ jobs:
           name: ${{ matrix.image_name }}@${{ matrix.target }}
           path: "./artifacts/*"
 
+  build-internal:
+    needs: build-setup
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
+        target: ${{ fromJson(needs.build-setup.outputs.targets) }}
+
+    name: Build Relay Binary
+    runs-on: |-
+      ${{fromJson('{
+        "x86_64-unknown-linux-gnu": "ubuntu-22.04",
+        "aarch64-unknown-linux-gnu": "ubuntu-22.04-arm"
+      }')[matrix.target] }}
+
+    if: "!startsWith(github.ref, 'refs/heads/release-library/')"
+
+    env:
+      RELAY_BIN: "target/${{ matrix.target }}/release/relay"
+      FEATURES: |-
+        ${{fromJson('{
+          "relay": "processing,crash-handler",
+          "relay-pop": "crash-handler"
+        }')[matrix.image_name] }}
+      DOCKER_PLATFORM: |-
+        ${{fromJson('{
+          "x86_64-unknown-linux-gnu": "linux/amd64",
+          "aarch64-unknown-linux-gnu": "linux/arm64"
+        }')[matrix.target] }}
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm curl
+
+      # Skip this for the time being
+      # - name: Install sentry-cli
+      #   run: |
+      #     curl -sL https://sentry.io/get-cli/ | bash
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: "${{ github.job }}-${{ matrix.target }}-${{ matrix.image_name }}"
+
+      - name: Compile
+        run: |
+          cargo build --release --locked --features "${FEATURES}" --target "${{ matrix.target }}"
+
+      - name: Split debug info
+      # Omit: sentry-cli difutil bundle-sources "${RELAY_BIN}.debug" for the time being.
+        run: |
+          llvm-objcopy --only-keep-debug "${RELAY_BIN}"{,.debug}
+          llvm-objcopy --strip-debug --strip-unneeded "${RELAY_BIN}"
+          llvm-objcopy --add-gnu-debuglink "${RELAY_BIN}"{.debug,}
+
+          zip "${RELAY_BIN}-debug.zip" "${RELAY_BIN}.debug"
+
+      - name: Prepare Artifacts
+        run: |
+          mkdir -p "artifacts/${DOCKER_PLATFORM}"
+          cp "${RELAY_BIN}"{,-debug.zip,.src.zip} "artifacts/${DOCKER_PLATFORM}"
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          name: internal-${{ matrix.image_name }}@${{ matrix.target }}
+          path: "./artifacts/*"
+
+
   build-docker:
     timeout-minutes: 5
     needs: [build-setup, build]
@@ -370,7 +447,7 @@ jobs:
 
   publish-to-ar-internal:
     timeout-minutes: 5
-    needs: [build-setup, build]
+    needs: [build-setup, build-internal]
 
     name: Build and Push Internal Docker Image
     runs-on: ubuntu-latest
@@ -409,7 +486,7 @@ jobs:
       # Logic taken from: build-docker
       - uses: actions/download-artifact@v4
         with:
-          pattern: "${{ matrix.image_name }}@*"
+          pattern: "internal-${{ matrix.image_name }}@*"
           merge-multiple: true
 
       - name: Build and push to Internal AR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,7 @@ jobs:
     steps:
       - id: set-outputs
         run: |
-          PASSPHRASE=$(openssl rand -hex 32)
-          echo "passphrase=$PASSPHRASE" >> $GITHUB_OUTPUT
-
+          echo "passphrase=$(openssl rand -hex 32)" >> $GITHUB_OUTPUT
           echo "full_ci=$FULL_CI" >> $GITHUB_OUTPUT
 
           if [[ "$FULL_CI" == "true" ]]; then
@@ -323,7 +321,7 @@ jobs:
         image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
         target: ${{ fromJson(needs.build-setup.outputs.targets) }}
 
-    name: Build Relay Binary
+    name: Build Internal Relay Binary
     runs-on: |-
       ${{fromJson('{
         "x86_64-unknown-linux-gnu": "ubuntu-22.04",
@@ -393,7 +391,6 @@ jobs:
           retention-days: 1
           name: internal-${{ matrix.image_name }}@${{ matrix.target }}
           path: "./artifacts/*"
-
 
   build-docker:
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
     steps:
       - id: set-outputs
         run: |
+          PASSPHRASE=$(openssl rand -hex 32)
+          echo "passphrase=$PASSPHRASE" >> $GITHUB_OUTPUT
+
           echo "full_ci=$FULL_CI" >> $GITHUB_OUTPUT
 
           if [[ "$FULL_CI" == "true" ]]; then
@@ -234,6 +237,7 @@ jobs:
       targets: "${{ steps.set-outputs.outputs.targets }}"
       platforms: "${{ steps.set-outputs.outputs.platforms }}"
       full_ci: "${{ steps.set-outputs.outputs.full_ci }}"
+      passphrase: "${{ steps.set-outputs.outputs.passphrase }}"
 
   build:
     needs: build-setup
@@ -373,10 +377,15 @@ jobs:
           sentry-cli difutil bundle-sources "${RELAY_BIN}.debug"
           zip "${RELAY_BIN}-debug.zip" "${RELAY_BIN}.debug"
 
-      - name: Prepare Artifacts
+      - name: Prepare and Encrypt Artifacts
         run: |
           mkdir -p "artifacts/${DOCKER_PLATFORM}"
-          cp "${RELAY_BIN}"{,-debug.zip,.src.zip} "artifacts/${DOCKER_PLATFORM}"
+
+          for file in "${RELAY_BIN}" "${RELAY_BIN}-debug.zip" "${RELAY_BIN}.src.zip"; do
+            gpg --quiet --batch --yes --symmetric --cipher-algo AES256 \
+                --passphrase "${{ needs.build-setup.outputs.passphrase }}" \
+                --output "artifacts/${DOCKER_PLATFORM}/$(basename $file).gpg" "$file"
+          done
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -487,6 +496,16 @@ jobs:
         with:
           pattern: "internal-${{ matrix.image_name }}@*"
           merge-multiple: true
+
+      - name: Decrypt Artifacts
+        run: |
+          find . -name "*.gpg" | while read file; do
+            output_file="${file%.gpg}"
+            gpg --quiet --batch --yes --decrypt \
+                --passphrase "${{ needs.build-setup.outputs.passphrase }}" \
+                --output "$output_file" "$file"
+            rm "$file"
+          done
 
       - name: Build and push to Internal AR
         run: |


### PR DESCRIPTION
Add internal build step that builds the images that are pushed to the internal artifact registry.

For now the logic is taken over from the `build` steps, but in the future the build logic will deviate.

Fixes https://github.com/getsentry/tempest/issues/110

#skip-changelog
