### PR TITLE
feat(spans): Toggle perf issue detection on spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Improve descriptiveness of autoscaling metric name. ([#4629](https://github.com/getsentry/relay/pull/4629))
 - Serialize span's `_meta` information when producing to Kafka. ([#4646](https://github.com/getsentry/relay/pull/4646))
 - Enable connection pooling for asynchronous Redis connections. ([#4622](https://github.com/getsentry/relay/pull/4622))
+- Add the internal `_performance_issues_spans` field to control perf issue detection. ([#4652](https://github.com/getsentry/relay/pull/4652))
 
 ## 25.3.0
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -275,6 +275,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         replay_id: config.replay_id,
         span_allowed_hosts: &[],              // only supported in relay
         span_op_defaults: Default::default(), // only supported in relay
+        performance_issues_spans: Default::default(),
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -132,6 +132,9 @@ pub enum Feature {
     #[doc(hidden)]
     #[serde(rename = "organizations:view-hierarchy-scrubbing")]
     ViewHierarchyScrubbing,
+    /// Detect performance issues in the new standalone spans pipeline instead of on transactions.
+    #[serde(rename = "organizations:performance-issues-spans")]
+    PerformanceIssuesSpans,
     /// Forward compatibility.
     #[doc(hidden)]
     #[serde(other)]

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -162,6 +162,9 @@ pub struct NormalizationConfig<'a> {
 
     /// Rules to infer `span.op` from other span fields.
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
+
+    /// Set a flag to enable performance issue detection on spans.
+    pub performance_issues_spans: bool,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -196,6 +199,7 @@ impl Default for NormalizationConfig<'_> {
             replay_id: Default::default(),
             span_allowed_hosts: Default::default(),
             span_op_defaults: Default::default(),
+            performance_issues_spans: Default::default(),
         }
     }
 }
@@ -333,6 +337,10 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
         crate::normalize::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
+    }
+
+    if config.performance_issues_spans && event.ty.value() == Some(&EventType::Transaction) {
+        event._performance_issues_spans = Annotated::new(true);
     }
 
     if config.enrich_spans {

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1784,6 +1784,7 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
+                _performance_issues_spans: ~,
                 other: {},
             },
         ]
@@ -1831,6 +1832,7 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
+                _performance_issues_spans: ~,
                 other: {},
             },
         ]
@@ -1878,6 +1880,7 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
+                _performance_issues_spans: ~,
                 other: {},
             },
         ]

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -486,6 +486,13 @@ pub struct Event {
     #[metastructure(omit_from_schema)]
     pub _dsc: Annotated<Value>,
 
+    /// Temporary flag that controls where performance issues are detected.
+    ///
+    /// When the flag is set to true, this transaction event will be skipped for performance issue
+    /// detection in favor of the spans pipeline.
+    #[metastructure(skip_serialization = "empty", trim = false)]
+    pub _performance_issues_spans: Annotated<bool>,
+
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, pii = "true")]
     pub other: Object<Value>,

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -121,6 +121,15 @@ pub struct Span {
     #[metastructure(skip_serialization = "empty", trim = false)]
     pub kind: Annotated<SpanKind>,
 
+    /// Temporary flag that controls where performance issues are detected.
+    ///
+    /// When the flag is set to true, performance issues will be detected on this span provided it
+    /// is a root (segment) instead of the transaction event.
+    ///
+    /// Only set on root spans extracted from transactions.
+    #[metastructure(skip_serialization = "empty", trim = false)]
+    pub _performance_issues_spans: Annotated<bool>,
+
     // TODO remove retain when the api stabilizes
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = true, pii = "maybe")]

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -17,6 +17,7 @@ impl From<&Event> for Span {
 
             measurements,
             _metrics,
+            _performance_issues_spans,
             ..
         } = event;
 
@@ -71,6 +72,7 @@ impl From<&Event> for Span {
             platform: platform.clone(),
             was_transaction: true.into(),
             kind: Default::default(),
+            _performance_issues_spans: _performance_issues_spans.clone(),
             other: Default::default(),
         }
     }

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -271,6 +271,7 @@ mod tests {
             platform: "php",
             was_transaction: true,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         }
         "###);

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__does_not_scrub_if_no_graphql.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__does_not_scrub_if_no_graphql.snap
@@ -109,5 +109,6 @@ Event {
     scraping_attempts: ~,
     _metrics: ~,
     _dsc: ~,
+    _performance_issues_spans: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_with_variables.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_with_variables.snap
@@ -109,5 +109,6 @@ Event {
     scraping_attempts: ~,
     _metrics: ~,
     _dsc: ~,
+    _performance_issues_spans: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_without_variables.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_graphql_response_data_without_variables.snap
@@ -90,5 +90,6 @@ Event {
     scraping_attempts: ~,
     _metrics: ~,
     _dsc: ~,
+    _performance_issues_spans: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_original_value.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_original_value.snap
@@ -122,5 +122,6 @@ Event {
     scraping_attempts: ~,
     _metrics: ~,
     _dsc: ~,
+    _performance_issues_spans: ~,
     other: {},
 }

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__sentry_user.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__sentry_user.snap
@@ -107,5 +107,6 @@ Event {
     scraping_attempts: ~,
     _metrics: ~,
     _dsc: ~,
+    _performance_issues_spans: ~,
     other: {},
 }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -87,6 +87,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -272,6 +273,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -357,6 +359,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -442,6 +445,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -527,6 +531,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -612,6 +617,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -770,6 +776,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -928,6 +935,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -1013,6 +1021,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -1171,6 +1180,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
         Span {
@@ -1329,6 +1339,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             platform: ~,
             was_transaction: ~,
             kind: ~,
+            _performance_issues_spans: ~,
             other: {},
         },
     ],

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -652,6 +652,7 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
+                _performance_issues_spans: ~,
                 other: {},
             },
         ]

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1536,6 +1536,7 @@ impl EnvelopeProcessorService {
                     .and_then(|ctx| ctx.replay_id),
                 span_allowed_hosts: http_span_allowed_hosts,
                 span_op_defaults: global_config.span_op_defaults.borrow(),
+                performance_issues_spans: project_info.has_feature(Feature::PerformanceIssuesSpans),
             };
 
             metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1399,6 +1399,9 @@ struct SpanKafkaMessage<'a> {
         skip_serializing_if = "none_or_empty_object"
     )]
     meta: Option<&'a RawValue>,
+
+    #[serde(default)]
+    _performance_issues_spans: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1400,8 +1400,8 @@ struct SpanKafkaMessage<'a> {
     )]
     meta: Option<&'a RawValue>,
 
-    #[serde(default)]
-    _performance_issues_spans: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    _performance_issues_spans: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -743,6 +743,7 @@ mod tests {
             platform: "php",
             was_transaction: ~,
             kind: Unspecified,
+            _performance_issues_spans: ~,
             other: {},
         }
         "###);

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -149,7 +149,7 @@ def test_span_extraction(
     transaction_span = spans_consumer.get_span()
     del transaction_span["received"]
     if performance_issues_spans:
-        assert transaction_span.pop("_performance_issues_spans") == True
+        assert transaction_span.pop("_performance_issues_spans") is True
     assert transaction_span == {
         "data": {
             "sentry.sdk.name": "raven-node",


### PR DESCRIPTION
Performance issue detection currently runs on transaction events in `save-transaction`. We want to cut over atomically so that no single transaction/root span is processed twice by issue detection. The last place where the span and transaction are joined is in Relay, so we will introduce a flag in Relay that allows us to define where issue detection runs.

The flag is controlled by an organization feature flag `organizations:performance-issues-spans`. The flag is exposed to Relay. When enabled, Relay writes attributes into the root span and transactions, which control whether detection runs in their respective processing routine.

See https://github.com/getsentry/streaming-planning/issues/121