### PR TITLE
fix(autoscaling): expose services with their instance ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Separates profiles into backend and ui profiles. ([#4595](https://github.com/getsentry/relay/pull/4595))
 - Normalize trace context information before writing it into transaction and span data. This ensures the correct sampling rates are stored for extrapolation in Sentry. ([#4625](https://github.com/getsentry/relay/pull/4625))
 - Adds u16 validation to the replay protocol's segment_id field. ([#4635](https://github.com/getsentry/relay/pull/4635))
-- Exposes all service utilizations with instance labels instead of the last. ([#4654](https://github.com/getsentry/relay/pull/4654))
+- Exposes all service utilization with instance labels instead of the last. ([#4654](https://github.com/getsentry/relay/pull/4654))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Separates profiles into backend and ui profiles. ([#4595](https://github.com/getsentry/relay/pull/4595))
 - Normalize trace context information before writing it into transaction and span data. This ensures the correct sampling rates are stored for extrapolation in Sentry. ([#4625](https://github.com/getsentry/relay/pull/4625))
 - Adds u16 validation to the replay protocol's segment_id field. ([#4635](https://github.com/getsentry/relay/pull/4635))
+- Exposes all service utilizations with instance labels instead of the last. ([#4654](https://github.com/getsentry/relay/pull/4654))
 
 **Internal**:
 

--- a/relay-server/src/services/autoscaling.rs
+++ b/relay-server/src/services/autoscaling.rs
@@ -61,7 +61,12 @@ impl Service for AutoscalingMetricService {
                             let metrics = self.handle
                                 .current_services_metrics()
                                 .iter()
-                                .map(|(id, metric)| ServiceUtilization(id.name(), metric.utilization))
+                                .map(|(id, metric)| ServiceUtilization {
+                                    name: id.name(),
+                                    instance_id: id.instance_id(),
+                                    utilization: metric.utilization
+                                }
+                            )
                                 .collect();
                             let worker_pool_utilization = self.async_pool.metrics().utilization() as u8;
                             let runtime_utilization = self.runtime_utilization();
@@ -137,4 +142,18 @@ pub struct AutoscalingData {
     pub runtime_utilization: u8,
 }
 
-pub struct ServiceUtilization(pub &'static str, pub u8);
+pub struct ServiceUtilization {
+    pub name: &'static str,
+    pub instance_id: u32,
+    pub utilization: u8,
+}
+
+impl ServiceUtilization {
+    pub fn new(name: &'static str, instance_id: u32, utilization: u8) -> Self {
+        Self {
+            name,
+            instance_id,
+            utilization,
+        }
+    }
+}

--- a/relay-server/src/services/autoscaling.rs
+++ b/relay-server/src/services/autoscaling.rs
@@ -132,19 +132,34 @@ impl FromMessage<AutoscalingMessageKind> for AutoscalingMetrics {
     }
 }
 
+/// Contains data that is used for autoscaling.
 pub struct AutoscalingData {
+    /// Memory usage of relay.
     pub memory_usage: f32,
+    /// Is `1` if relay is running, `0` if it's shutting down.
     pub up: u8,
+    /// The total number of bytes used by the spooler.
     pub total_size: u64,
+    /// The total number of envelopes in the spooler.
     pub item_count: u64,
+    /// Worker pool utilization in percent.
     pub worker_pool_utilization: u8,
+    /// List of service utilization.
     pub services_metrics: Vec<ServiceUtilization>,
+    /// Utilization of the async runtime.
     pub runtime_utilization: u8,
 }
 
+/// Contains the minimal required information for service utilization.
+///
+/// A service can have multiple instances which will all have the same name.
+/// Those instances are distinguished by the `instance_id`.
 pub struct ServiceUtilization {
+    /// The service name.
     pub name: &'static str,
+    /// The id of the specific service instance.
     pub instance_id: u32,
+    /// Utilization as percentage.
     pub utilization: u8,
 }
 

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -5,7 +5,6 @@ Tests the autoscaling endpoint.
 import os
 import signal
 import tempfile
-from cgi import parse
 from time import sleep
 
 import pytest
@@ -91,6 +90,5 @@ def test_service_utilization_metrics(mini_sentry, relay, metric_name):
     response = relay.get("/api/relay/autoscaling/")
     parsed = parse_prometheus(response.text)
     assert response.status_code == 200
-    print(parsed)
 
     assert 0 <= int(parsed[metric_name]) <= 100

--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -5,6 +5,7 @@ Tests the autoscaling endpoint.
 import os
 import signal
 import tempfile
+from cgi import parse
 from time import sleep
 
 import pytest
@@ -13,7 +14,7 @@ import pytest
 def parse_prometheus(input_string):
     result = {}
     for line in input_string.splitlines():
-        parts = line.split(" ")
+        parts = line.rsplit(" ", 1)
         result[parts[0]] = parts[1]
     return result
 
@@ -79,7 +80,7 @@ def test_memory_spooling_metrics(mini_sentry, relay):
 @pytest.mark.parametrize(
     "metric_name",
     (
-        'relay_service_utilization{relay_service="AggregatorService"}',
+        'relay_service_utilization{relay_service="AggregatorService", instance_id="0"}',
         "relay_worker_pool_utilization",
         "relay_runtime_utilization",
     ),
@@ -90,5 +91,6 @@ def test_service_utilization_metrics(mini_sentry, relay, metric_name):
     response = relay.get("/api/relay/autoscaling/")
     parsed = parse_prometheus(response.text)
     assert response.status_code == 200
+    print(parsed)
 
     assert 0 <= int(parsed[metric_name]) <= 100


### PR DESCRIPTION
Fixes a bug where only a single service metric was exported even though there were multiple with different instance IDs.