### PR TITLE
ref(relay): Remove multi write option from configuration

### DIFF
--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -34,10 +34,6 @@ pub enum RedisError {
     /// An error that occurs when configuring Redis.
     #[error("failed to configure redis: {0}")]
     ConfigError(#[from] ConfigError),
-
-    /// An error that occurs when attempting multi-write operations on unsupported components.
-    #[error("multi write is not supported for {0}")]
-    MultiWriteNotSupported(&'static str),
 }
 
 /// A collection of Redis clients used by Relay for different purposes.

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -460,9 +460,6 @@ fn create_async_redis_client(config: &RedisConfigRef<'_>) -> Result<AsyncRedisCl
             options,
         } => AsyncRedisClient::cluster(cluster_nodes.iter().map(|s| s.as_str()), options),
         RedisConfigRef::Single { server, options } => AsyncRedisClient::single(server, options),
-        RedisConfigRef::MultiWrite { .. } => {
-            Err(RedisError::MultiWriteNotSupported("projectconfig"))
-        }
     }
 }
 


### PR DESCRIPTION
This PR removes the multi-write option from the configuration of Relay since it's not used anymore.

Closes: https://github.com/getsentry/team-ingest/issues/657

#skip-changelog