### PR TITLE
feat(redis): Implement trackable connection that allows detaching on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Serialize span's `_meta` information when producing to Kafka. ([#4646](https://github.com/getsentry/relay/pull/4646))
 - Enable connection pooling for asynchronous Redis connections. ([#4622](https://github.com/getsentry/relay/pull/4622))
 - Add the internal `_performance_issues_spans` field to control perf issue detection. ([#4652](https://github.com/getsentry/relay/pull/4652))
+- Improve handling of failed Redis connections. ([#4657](https://github.com/getsentry/relay/pull/4657))
 
 ## 25.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ version = "25.3.0"
 dependencies = [
  "deadpool",
  "deadpool-redis",
+ "futures",
  "redis",
  "relay-system",
  "serde",

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 deadpool = { workspace = true, optional = true }
 deadpool-redis = { workspace = true, optional = true, features = ["rt_tokio_1", "cluster", "script"] }
+futures = { workspace = true }
 redis = { workspace = true, optional = true, features = [
     "cluster",
     "r2d2",

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -17,6 +17,7 @@ pub type CustomClusterPool = Pool<CustomClusterManager, CustomClusterConnection>
 /// A connection pool for single Redis instance deployments.
 pub type CustomSinglePool = Pool<CustomSingleManager, CustomSingleConnection>;
 
+/// A wrapper for a connection that can be tracked with metadata.
 pub struct TrackedConnection<C> {
     connection: C,
     detach: bool,

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -47,6 +47,7 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
     fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         async move {
             let result = self.connection.req_packed_command(cmd).await;
+
             if let Err(error) = &result {
                 self.detach = self.detach || Self::should_be_detached(error);
             }
@@ -67,6 +68,7 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
                 .connection
                 .req_packed_commands(cmd, offset, count)
                 .await;
+
             if let Err(error) = &result {
                 self.detach = self.detach || Self::should_be_detached(error);
             }

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -18,6 +18,9 @@ pub type CustomClusterPool = Pool<CustomClusterManager, CustomClusterConnection>
 pub type CustomSinglePool = Pool<CustomSingleManager, CustomSingleConnection>;
 
 /// A wrapper for a connection that can be tracked with metadata.
+///
+/// A connection is considered detached as soon as it is marked as detached and it can't be
+/// un-detached.
 pub struct TrackedConnection<C> {
     connection: C,
     detach: bool,
@@ -53,8 +56,6 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
             let result = self.connection.req_packed_command(cmd).await;
             if let Err(error) = &result {
                 self.detach = Self::should_be_detached(error);
-            } else {
-                self.detach = false;
             }
 
             result
@@ -75,8 +76,6 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
                 .await;
             if let Err(error) = &result {
                 self.detach = Self::should_be_detached(error);
-            } else {
-                self.detach = false;
             }
 
             result

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -31,7 +31,7 @@ impl<C> TrackedConnection<C> {
         }
     }
 
-    /// Returns `true` when a [`RedisError`] should lead to the [`TrackedConnection`] be detached
+    /// Returns `true` when a [`RedisError`] should lead to the [`TrackedConnection`] being detached
     /// from the pool.
     fn should_be_detached(error: &RedisError) -> bool {
         match error.retry_method() {

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -8,7 +8,7 @@ use crate::redis;
 use crate::redis::aio::MultiplexedConnection;
 use crate::redis::cluster_async::ClusterConnection;
 use crate::redis::{
-    Cmd, ErrorKind, IntoConnectionInfo, Pipeline, RedisError, RedisFuture, RedisResult, Value,
+    Cmd, IntoConnectionInfo, Pipeline, RedisError, RedisFuture, RedisResult, Value,
 };
 
 /// A connection pool for Redis cluster deployments.

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -34,10 +34,10 @@ impl<C> TrackedConnection<C> {
     /// Returns `true` when a [`RedisError`] should lead to the [`TrackedConnection`] be detached
     /// from the pool.
     ///
-    /// This is done since some errors can be recoverable, meaning that the connection can be dropped
-    /// while recycling and a new one can be fetched.
+    /// This is done since some errors can be recoverable, in that case, we want to detach the
+    /// connection to let the pool use or create another one.
     fn should_be_detached(error: &RedisError) -> bool {
-        error.is_unrecoverable_error()
+        !error.is_unrecoverable_error()
     }
 }
 

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -47,6 +47,8 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
             let result = self.connection.req_packed_command(cmd).await;
             if let Err(error) = &result {
                 self.detach = Self::should_be_detached(error);
+            } else {
+                self.detach = false;
             }
 
             result
@@ -67,6 +69,8 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
                 .await;
             if let Err(error) = &result {
                 self.detach = Self::should_be_detached(error);
+            } else {
+                self.detach = false;
             }
 
             result

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -1,12 +1,14 @@
-use deadpool::managed::{Manager, Metrics, Object, Pool, RecycleResult};
+use deadpool::managed::{Manager, Metrics, Object, Pool, RecycleError, RecycleResult};
 use deadpool_redis::cluster::Manager as ClusterManager;
 use deadpool_redis::Manager as SingleManager;
+use futures::FutureExt;
+use std::ops::{Deref, DerefMut};
 
 use crate::redis;
 use crate::redis::aio::MultiplexedConnection;
 use crate::redis::cluster_async::ClusterConnection;
 use crate::redis::{
-    Cmd, IntoConnectionInfo, Pipeline, RedisError, RedisFuture, RedisResult, Value,
+    Cmd, ErrorKind, IntoConnectionInfo, Pipeline, RedisError, RedisFuture, RedisResult, Value,
 };
 
 /// A connection pool for Redis cluster deployments.
@@ -14,6 +16,87 @@ pub type CustomClusterPool = Pool<CustomClusterManager, CustomClusterConnection>
 
 /// A connection pool for single Redis instance deployments.
 pub type CustomSinglePool = Pool<CustomSingleManager, CustomSingleConnection>;
+
+pub struct TrackedConnection<C> {
+    connection: C,
+    detach: bool,
+}
+
+impl<C> TrackedConnection<C> {
+    fn new(connection: C) -> Self {
+        Self {
+            connection,
+            detach: false,
+        }
+    }
+
+    /// Returns `true` when a [`RedisError`] should lead to the [`TrackedConnection`] be detached
+    /// from the pool.
+    ///
+    /// This is done since some errors can be recoverable, meaning that the connection can be dropped
+    /// while recycling and a new one can be fetched.
+    fn should_be_detached(error: &RedisError) -> bool {
+        error.is_unrecoverable_error()
+    }
+}
+
+impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for TrackedConnection<C> {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        async move {
+            let result = self.connection.req_packed_command(cmd).await;
+            if let Err(error) = &result {
+                self.detach = Self::should_be_detached(error);
+            }
+
+            result
+        }
+        .boxed()
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<'a, Vec<Value>> {
+        async move {
+            let result = self
+                .connection
+                .req_packed_commands(cmd, offset, count)
+                .await;
+            if let Err(error) = &result {
+                self.detach = Self::should_be_detached(error);
+            }
+
+            result
+        }
+        .boxed()
+    }
+
+    fn get_db(&self) -> i64 {
+        self.connection.get_db()
+    }
+}
+
+impl<C> From<C> for TrackedConnection<C> {
+    fn from(value: C) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<C> Deref for TrackedConnection<C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+impl<C> DerefMut for TrackedConnection<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.connection
+    }
+}
 
 /// A managed Redis cluster connection that implements [`redis::aio::ConnectionLike`].
 ///
@@ -69,18 +152,26 @@ impl CustomClusterManager {
 }
 
 impl Manager for CustomClusterManager {
-    type Type = ClusterConnection;
+    type Type = TrackedConnection<ClusterConnection>;
     type Error = RedisError;
 
-    async fn create(&self) -> Result<ClusterConnection, RedisError> {
-        self.manager.create().await
+    async fn create(&self) -> Result<TrackedConnection<ClusterConnection>, RedisError> {
+        self.manager.create().await.map(TrackedConnection::from)
     }
 
     async fn recycle(
         &self,
-        conn: &mut ClusterConnection,
+        conn: &mut TrackedConnection<ClusterConnection>,
         metrics: &Metrics,
     ) -> RecycleResult<RedisError> {
+        // If the connection is marked to be detached, we return and error, signaling that this
+        // connection must be detached from the pool.
+        if conn.detach {
+            return Err(RecycleError::Message(
+                "the tracked connection was marked as detached".into(),
+            ));
+        }
+
         // If the interval has been reached, we optimistically assume the connection is active
         // without doing an actual `PING`.
         if metrics.recycle_count % self.recycle_check_frequency != 0 {
@@ -149,18 +240,26 @@ impl CustomSingleManager {
 }
 
 impl Manager for CustomSingleManager {
-    type Type = MultiplexedConnection;
+    type Type = TrackedConnection<MultiplexedConnection>;
     type Error = RedisError;
 
-    async fn create(&self) -> Result<MultiplexedConnection, RedisError> {
-        self.manager.create().await
+    async fn create(&self) -> Result<TrackedConnection<MultiplexedConnection>, RedisError> {
+        self.manager.create().await.map(TrackedConnection::from)
     }
 
     async fn recycle(
         &self,
-        conn: &mut MultiplexedConnection,
+        conn: &mut TrackedConnection<MultiplexedConnection>,
         metrics: &Metrics,
     ) -> RecycleResult<RedisError> {
+        // If the connection is marked to be detached, we return and error, signaling that this
+        // connection must be detached from the pool.
+        if conn.detach {
+            return Err(RecycleError::Message(
+                "the tracked connection was marked as detached".into(),
+            ));
+        }
+
         // If the interval has been reached, we optimistically assume the connection is active
         // without doing an actual `PING`.
         if metrics.recycle_count % self.recycle_check_frequency != 0 {

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -55,7 +55,7 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
         async move {
             let result = self.connection.req_packed_command(cmd).await;
             if let Err(error) = &result {
-                self.detach = Self::should_be_detached(error);
+                self.detach = self.detach || Self::should_be_detached(error);
             }
 
             result
@@ -75,7 +75,7 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
                 .req_packed_commands(cmd, offset, count)
                 .await;
             if let Err(error) = &result {
-                self.detach = Self::should_be_detached(error);
+                self.detach = self.detach || Self::should_be_detached(error);
             }
 
             result


### PR DESCRIPTION
This PR implements a new `TrackedConnection` that is used to determine whether a connection has failed and to recycle it on the next run.

For the sake of simplicity, this implementation marks a connection as detachable whenever it encounters an error. When the call with the error fails, the connection will be marked as detachable, meaning that on the next usage it will be detached and a different one will be used.