### PR TITLE
feat: Backfill `name` and `version` in browser context via new `user_agent` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
 - Add naver.me / Yeti spider on the crawler filter list. ([#4602](https://github.com/getsentry/relay/pull/4602))
 - Add the item type that made the envelope too large to invalid outcomes. ([#4558](https://github.com/getsentry/relay/pull/4558))
 - Filter out certain AI crawlers. ([#4608](https://github.com/getsentry/relay/pull/4608))
-- Update iOS chrome translation error regex. ([#4634](https://github.com/getsentry/relay/pull/4634))
-- Infer the attachment type of view hierarchy items in multipart messages. ([#4624](https://github.com/getsentry/relay/pull/4624))
-- Make default Apple device class high. ([#4609](https://github.com/getsentry/relay/pull/4609))
-- Backfill `name` and `version` in browser context via new `user_agent` field ([#4659](https://github.com/getsentry/relay/pull/4659))
+- Update iOS chrome translation error regex. ([#4634](https://github.com/getsentry/relay/pull/4634)).
+- Infer the attachment type of view hierarchy items in multipart messages. ([#4624](https://github.com/getsentry/relay/pull/4624)).
+- Make default Apple device class high. ([#4609](https://github.com/getsentry/relay/pull/4609)).
+- Backfill `name` and `version` in browser context via new `user_agent` field. ([#4659](https://github.com/getsentry/relay/pull/4659)).
 
 **Bug Fixes**:
 
@@ -1704,7 +1704,7 @@ Monitors:
 **Bug Fixes**:
 
 - Log on INFO level when recovering from network outages. ([#918](https://github.com/getsentry/relay/pull/918))
-- Fix a panic in processing minidumps with invalid location descriptors. ([#919](https://github.com/getsentry/relay/pull/919))
+- Fix a panic in CSP filters. ([#919](https://github.com/getsentry/relay/pull/919))
 
 **Internal**:
 
@@ -2038,7 +2038,7 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 **Internal**:
 
 - Fix a bug in the PII processor that would always remove the entire string on `pattern` rules.
-- Ability to correct some clock drift and wrong system time in transaction events.
+- Fix a bug where old `redactPair` rules would stop working.
 
 ## 0.5.0
 
@@ -2126,9 +2126,13 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 
 ## 0.4.58
 
+**Internal**:
+
 - Evict project caches after some time ([#287](https://github.com/getsentry/relay/pull/287))
 - Selectively log internal errors to stderr ([#285](https://github.com/getsentry/relay/pull/285))
 - Add an error boundary to parsing project states ([#281](https://github.com/getsentry/relay/pull/281))
+
+## 0.4.57
 
 **Internal**:
 
@@ -2138,23 +2142,17 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 - Refactor outcomes for parity with Sentry ([#282](https://github.com/getsentry/relay/pull/282))
 - Add flag that relay processed an event ([#279](https://github.com/getsentry/relay/pull/279))
 
-## 0.4.57
+## 0.4.56
 
 **Internal**:
 
 - Stricter validation of transaction events.
 
-## 0.4.56
-
-**Internal**:
-
-- Fix a panic in trimming.
-
 ## 0.4.55
 
 **Internal**:
 
-- Fix more bugs in datascrubbing converter.
+- Fix a panic in trimming.
 
 ## 0.4.54
 
@@ -2178,12 +2176,7 @@ We have switched to [CalVer](https://calver.org/)! Relay's version is always in 
 
 **Internal**:
 
-- Fix a few bugs in datascrubbing converter.
-- Accept trailing slashes.
-
-**Normalization**:
-
-- Fix a panic on overflowing timestamps.
+- Fix more bugs in datascrubbing converter.
 
 ## 0.4.50
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update iOS chrome translation error regex. ([#4634](https://github.com/getsentry/relay/pull/4634))
 - Infer the attachment type of view hierarchy items in multipart messages. ([#4624](https://github.com/getsentry/relay/pull/4624))
 - Make default Apple device class high. ([#4609](https://github.com/getsentry/relay/pull/4609))
+- Backfill `name` and `version` in browser context via new `user_agent` field ([#4659](https://github.com/getsentry/relay/pull/4659))
 
 **Bug Fixes**:
 

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -125,7 +125,7 @@ def test_normalize_user_agent(must_normalize):
                 "name": "Firefox",
                 "version": "15.0.1",
                 "type": "browser",
-                'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1'
+                "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
             },
             "client_os": {"name": "Ubuntu", "type": "os"},
         }

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -125,6 +125,7 @@ def test_normalize_user_agent(must_normalize):
                 "name": "Firefox",
                 "version": "15.0.1",
                 "type": "browser",
+                'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1'
             },
             "client_os": {"name": "Ubuntu", "type": "os"},
         }

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -277,6 +277,7 @@ mod tests {
             Some(&BrowserContext {
                 name: Annotated::new("Safari".to_string()),
                 version: Annotated::new("15.5".to_string()),
+                user_agent: Annotated::new("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15".to_string()),
                 ..Default::default()
             })
         );

--- a/relay-event-schema/src/protocol/contexts/browser.rs
+++ b/relay-event-schema/src/protocol/contexts/browser.rs
@@ -9,10 +9,14 @@ pub struct BrowserContext {
     pub browser: Annotated<String>,
 
     /// Display name of the browser application.
+    /// This field is optional and can be inferred from user_agent if not provided.
     pub name: Annotated<String>,
 
     /// Version string of the browser.
     pub version: Annotated<String>,
+
+    /// Original user agent string.
+    pub user_agent: Annotated<String>,
 
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = true, pii = "maybe")]
@@ -61,6 +65,7 @@ mod tests {
   "browser": "Google Chrome 67.0.3396.99",
   "name": "Google Chrome",
   "version": "67.0.3396.99",
+  "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36",
   "other": "value",
   "type": "browser"
 }"#;
@@ -68,6 +73,7 @@ mod tests {
             browser: Annotated::new(String::from("Google Chrome 67.0.3396.99")),
             name: Annotated::new("Google Chrome".to_string()),
             version: Annotated::new("67.0.3396.99".to_string()),
+            user_agent: Annotated::new("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36".to_string()),
             other: {
                 let mut map = Object::new();
                 map.insert(

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3976,7 +3976,7 @@ mod tests {
         let contexts = event.contexts.into_value().unwrap();
         let browser = contexts.0.get("browser").unwrap();
         assert_eq!(
-            r#"{"browser":"Chrome 103.0.0","name":"Chrome","version":"103.0.0","type":"browser"}"#,
+            r#"{"browser":"Chrome 103.0.0","name":"Chrome","version":"103.0.0","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36","type":"browser"}"#,
             browser.to_json().unwrap()
         );
     }

--- a/tests/fixtures/extended-event-output.json
+++ b/tests/fixtures/extended-event-output.json
@@ -79,7 +79,8 @@
             "browser": "Python Requests 2.26",
             "name": "Python Requests",
             "version": "2.26",
-            "type": "browser"
+            "type": "browser",
+            "user_agent": "python-requests/2.26.0"
         }
     },
     "exception": {

--- a/tests/integration/fixtures/security_report/csp.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/csp.normalized.output.json
+++ b/tests/integration/fixtures/security_report/csp.normalized.output.json
@@ -19,7 +19,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/csp_chrome.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_chrome.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/csp_chrome_blocked_asset.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_chrome_blocked_asset.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/csp_firefox_blocked_asset.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/csp_firefox_blocked_asset.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/expect_ct.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/expect_ct.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/expect_staple.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/expect_staple.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/fixtures/security_report/hpkp.no_processing.output.json
+++ b/tests/integration/fixtures/security_report/hpkp.no_processing.output.json
@@ -5,7 +5,8 @@
       "browser": "Chrome 74.0.3729",
       "name": "Chrome",
       "type": "browser",
-      "version": "74.0.3729"
+      "version": "74.0.3729",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
     },
     "client_os": {
       "os": "Windows >=10",

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -75,6 +75,7 @@ def assert_expected_feedback(parsed_feedback, sent_feedback):
             "name": "Safari",
             "version": "15.5",
             "type": "browser",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15",
         },
         "device": {"brand": "Apple", "family": "Mac", "model": "Mac", "type": "device"},
         "os": {

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -83,7 +83,12 @@ def assert_replay_payload_matches(produced, consumed):
 
     # Assert contexts object was pulled out.
     assert consumed["contexts"] == {
-        "browser": {"name": "Safari", "version": "15.5", "type": "browser"},
+        "browser": {
+            "name": "Safari",
+            "version": "15.5",
+            "type": "browser",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15",
+        },
         "device": {"brand": "Apple", "family": "Mac", "model": "Mac", "type": "device"},
         "os": {"name": "Mac OS X", "version": ">=10.15.7", "type": "os"},
         "replay": {


### PR DESCRIPTION
100% organically vibe-coded.

Ref https://github.com/getsentry/sentry-docs/pull/13205