### PR TITLE
ci(internal-build): Change final check from GCR to AR

### DIFF
--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -5,5 +5,5 @@
     "${GO_REVISION_RELAY_REPO}" \
     "Integration Tests" \
     "Test All Features (ubuntu-latest)" \
-    "Publish Relay to GCR (relay)" \
-    "Publish Relay to GCR (relay-pop)"
+    "Publish Relay to Internal AR (relay)" \
+    "Publish Relay to Internal AR (relay-pop)"


### PR DESCRIPTION
The previous PR (https://github.com/getsentry/relay/pull/4650) works (deployed to S4S) however during the deploy I noticed there is one more place that references GCR, this should be changed (like the others already have) to make sure that the pipeline waits for the the correct step to have completed.

#skip-changelog