### PR TITLE
ref(spooler): Update outdated rust docs

### DIFF
--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -65,7 +65,7 @@ pub trait StackProvider: std::fmt::Debug {
     /// Returns the string representation of the stack type offered by this [`StackProvider`].
     fn stack_type<'a>(&self) -> &'a str;
 
-    /// Flushes the supplied [`EnvelopeStack`]s and consumes the [`StackProvider`].
+    /// Flushes the supplied [`EnvelopeStack`]s.
     fn flush(
         &mut self,
         envelope_stacks: impl IntoIterator<Item = Self::Stack>,


### PR DESCRIPTION
This PR updates the rust docs on the spooler that are outdated.

#skip-changelog