### PR TITLE
fix(pool): Fix pool metrics

### DIFF
--- a/relay-system/src/monitor.rs
+++ b/relay-system/src/monitor.rs
@@ -22,9 +22,14 @@ pin_project_lite::pin_project! {
 impl<F> MonitoredFuture<F> {
     /// Wraps a future with the [`MonitoredFuture`].
     pub fn wrap(inner: F) -> Self {
+        Self::wrap_with_metrics(inner, Arc::new(RawMetrics::default()))
+    }
+
+    /// Wraps a future with the [`MonitoredFuture`].
+    pub fn wrap_with_metrics(inner: F, metrics: Arc<RawMetrics>) -> Self {
         Self {
             inner,
-            metrics: Arc::new(RawMetrics::default()),
+            metrics,
             // The last time the utilization was updated.
             last_utilization_update: Instant::now(),
             // The poll duration that was accumulated across zero or more polls since the last

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -106,6 +106,6 @@ impl AsyncPoolMetrics<'_> {
             .map(|m| m.active_tasks.load(Ordering::Relaxed))
             .sum();
 
-        (total_polled_futures as f32 / self.max_tasks as f32).clamp(0.0, 1.0) as u8 * 100
+        ((total_polled_futures as f32 / self.max_tasks as f32).clamp(0.0, 1.0) * 100.0) as u8
     }
 }

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -67,13 +67,16 @@ where
 
             let thread_name: Option<String> = builder.thread_name.as_mut().map(|f| f(thread_id));
             let metrics = Arc::new(ThreadMetrics::default());
-            let task = MonitoredFuture::wrap(Multiplexed::new(
-                pool_name,
-                builder.max_concurrency,
-                rx.into_stream(),
-                builder.task_panic_handler.clone(),
-                metrics.clone(),
-            ));
+            let task = MonitoredFuture::wrap_with_metrics(
+                Multiplexed::new(
+                    pool_name,
+                    builder.max_concurrency,
+                    rx.into_stream(),
+                    builder.task_panic_handler.clone(),
+                    metrics.clone(),
+                ),
+                metrics.raw_metrics.clone(),
+            );
 
             let thread = Thread {
                 id: thread_id,


### PR DESCRIPTION
This PR fixes the pool metrics which due to type conversions lost information in the data and correctly hooks the `RawMetrics` in the `ThreadMetrics`.

#skip-changelog