### PR TITLE
ci(artifacts): Upload artifacts for all platforms 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,8 @@ jobs:
     if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     steps:
+      - uses: docker/setup-qemu-action@v3
+
       - name: Google Auth
         id: auth
         uses: google-github-actions/auth@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,7 @@ jobs:
     strategy:
       matrix:
         image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
+        platform: ${{ fromJson(needs.build-setup.outputs.platforms) }}
 
     # required for google auth
     permissions:
@@ -641,14 +642,16 @@ jobs:
           version: ">= 390.0.0"
 
       - name: Upload gocd deployment assets
+        env:
+          LIB_PATH: ${{ fromJson('{"linux/amd64":"/lib/x86_64-linux-gnu","linux/arm64":"/lib/aarch64-linux-gnu"}')[matrix.platform] }}
         run: |
           set -euxo pipefail
           VERSION="$(docker run --rm "${AR_DOCKER_IMAGE}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
-          docker run --rm --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay-debug.zip > relay-debug.zip
-          docker run --rm --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay.src.zip > relay.src.zip
-          docker run --rm --entrypoint tar "${AR_DOCKER_IMAGE}:${REVISION}" -cf - /lib/x86_64-linux-gnu > libs.tar
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay-debug.zip > relay-debug.zip
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay.src.zip > relay.src.zip
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint tar "${AR_DOCKER_IMAGE}:${REVISION}" -cf - ${LIB_PATH} > libs.tar
 
           # debugging for mysterious "Couldn't write tracker file" issue:
           (env | grep runner) || true
@@ -660,7 +663,7 @@ jobs:
             /home/runner/.gsutil/tracker-files/upload_TRACKER_*.rc.zip__JSON.url \
           || true
           gsutil -m cp -L gsutil.log ./libs.tar ./relay-debug.zip ./relay.src.zip ./release-name \
-            "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/" || status=$? && status=$?
+            "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${{ matrix.platform }}/" || status=$? && status=$?
           cat gsutil.log
           exit "$status"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,7 +653,7 @@ jobs:
 
           docker run --rm --platform ${{ matrix.platform }} --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay-debug.zip > relay-debug.zip
           docker run --rm --platform ${{ matrix.platform }} --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay.src.zip > relay.src.zip
-          docker run --rm --platform ${{ matrix.platform }} --entrypoint tar "${AR_DOCKER_IMAGE}:${REVISION}" -cf - ${LIB_PATH} > libs.tar
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint tar "${AR_DOCKER_IMAGE}:${REVISION}" -cf - "${LIB_PATH}" > libs.tar
 
           # debugging for mysterious "Couldn't write tracker file" issue:
           (env | grep runner) || true

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -30,12 +30,6 @@ fi
 
 echo 'Downloading debug info, source bundle, system symbols...'
 for PLATFORM in "linux/amd64" "linux/arm64"; do
-  if [ "$PLATFORM" = "linux/amd64" ]; then
-    LIB_PATH="lib/x86_64-linux-gnu"
-  else
-    LIB_PATH="lib/aarch64-linux-gnu"
-  fi
-
   gsutil cp \
     "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/relay-debug.zip" \
     "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/relay.src.zip" \
@@ -46,7 +40,7 @@ for PLATFORM in "linux/amd64" "linux/arm64"; do
 
   echo "Uploading system symbols for $PLATFORM..."
   tar xf libs.tar
-  sentry-cli upload-dif $LIB_PATH
+  sentry-cli upload-dif lib/
 
   rm relay-debug.zip relay.src.zip libs.tar
   rm -rf lib

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -29,21 +29,30 @@ if [ -z "${SENTRY_ORG:-}" ] || [ -z "${SENTRY_PROJECT:-}" ]; then
 fi
 
 echo 'Downloading debug info, source bundle, system symbols...'
-gsutil cp \
-  "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/release-name" \
-  "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/relay-debug.zip" \
-  "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/relay.src.zip" \
-  "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/libs.tar" \
-  .
+for PLATFORM in "linux/amd64" "linux/arm64"; do
+  if [ "$PLATFORM" = "linux/amd64" ]; then
+    LIB_PATH="lib/x86_64-linux-gnu"
+  else
+    LIB_PATH="lib/aarch64-linux-gnu"
+  fi
 
-echo 'Uploading debug information and source bundle...'
-sentry-cli --version
-sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
+  gsutil cp \
+    "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/relay-debug.zip" \
+    "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/relay.src.zip" \
+    "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/libs.tar" \
+    .
+  echo "Uploading debug information and source bundle for $PLATFORM..."
+  sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
 
-echo 'Uploading system symbols...'
-tar xf libs.tar
-sentry-cli upload-dif lib/x86_64-linux-gnu
+  echo "Uploading system symbols for $PLATFORM..."
+  tar xf libs.tar
+  sentry-cli upload-dif $LIB_PATH
 
+  rm relay-debug.zip relay.src.zip libs.tar
+  rm -rf lib
+done
+
+gsutil cp "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/linux/amd64/release-name" .
 RELEASE=$(< ./release-name)
 echo "Creating a new release and deploy for ${RELEASE} in Sentry..."
 sentry-cli releases new "${RELEASE}"


### PR DESCRIPTION
Currently only the artifacts for the runners architecture are being processed, this PR makes the artifact uploading work with a matrix such that all platforms are being processed.

Also updates the release script to upload all the artifacts.

Fixes: https://github.com/getsentry/team-ingest/issues/687

#skip-changelog

---
**Note**: Ran the script localy into my own dummy project and it seems to work (upload the files and create the release)