### PR TITLE
feat(pool): Expose additional metrics from the redis pool

### DIFF
--- a/relay-server/src/services/stats.rs
+++ b/relay-server/src/services/stats.rs
@@ -165,6 +165,15 @@ impl RelayStats {
             gauge(RelayGauges::RedisPoolIdleConnections) = u64::from(stats.idle_connections),
             pool = name
         );
+        metric!(
+            gauge(RelayGauges::RedisPoolMaxConnections) = u64::from(stats.max_connections),
+            pool = name
+        );
+        metric!(
+            gauge(RelayGauges::RedisPoolWaitingForConnection) =
+                u64::from(stats.waiting_for_connection),
+            pool = name
+        );
     }
 
     #[cfg(not(feature = "processing"))]

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -50,6 +50,12 @@ pub enum RelayGauges {
     /// The number of idle connections in the Redis Pool.
     #[cfg(feature = "processing")]
     RedisPoolIdleConnections,
+    /// The maximum number of connections in the Redis pool.
+    #[cfg(feature = "processing")]
+    RedisPoolMaxConnections,
+    /// The number of futures waiting to grab a connection.
+    #[cfg(feature = "processing")]
+    RedisPoolWaitingForConnection,
     /// The number of notifications in the broadcast channel of the project cache.
     ProjectCacheNotificationChannel,
     /// The number of scheduled and in progress fetches in the project cache.
@@ -88,6 +94,10 @@ impl GaugeMetric for RelayGauges {
             RelayGauges::RedisPoolConnections => "redis.pool.connections",
             #[cfg(feature = "processing")]
             RelayGauges::RedisPoolIdleConnections => "redis.pool.idle_connections",
+            #[cfg(feature = "processing")]
+            RelayGauges::RedisPoolMaxConnections => "redis.pool.max_connections",
+            #[cfg(feature = "processing")]
+            RelayGauges::RedisPoolWaitingForConnection => "redis.pool.waiting_for_connection",
             RelayGauges::ProjectCacheNotificationChannel => {
                 "project_cache.notification_channel.size"
             }


### PR DESCRIPTION
This PR exposes new metrics from the Redis pool.

#skip-changelog