### PR TITLE
ci(deploy): Also check that artifact upload has completed

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -42,7 +42,11 @@ pipelines:
                     "Integration Tests" \
                     "Test All Features (ubuntu-latest)" \
                     "Publish Relay to Internal AR (relay)" \
-                    "Publish Relay to Internal AR (relay-pop)"
+                    "Publish Relay to Internal AR (relay-pop)" \
+                    "Upload build artifacts to gocd (relay, linux/amd64)" \
+                    "Upload build artifacts to gocd (relay, linux/arm64)" \
+                    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
+                    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \
 
       - deploy-experimental:
           approval:

--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -42,7 +42,11 @@ pipelines:
                     "Integration Tests" \
                     "Test All Features (ubuntu-latest)" \
                     "Publish Relay to Internal AR (relay)" \
-                    "Publish Relay to Internal AR (relay-pop)"
+                    "Publish Relay to Internal AR (relay-pop)" \
+                    "Upload build artifacts to gocd (relay, linux/amd64)" \
+                    "Upload build artifacts to gocd (relay, linux/arm64)" \
+                    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
+                    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \
 
       - deploy-experimental:
           approval:

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -6,4 +6,8 @@
     "Integration Tests" \
     "Test All Features (ubuntu-latest)" \
     "Publish Relay to Internal AR (relay)" \
-    "Publish Relay to Internal AR (relay-pop)"
+    "Publish Relay to Internal AR (relay-pop)" \
+    "Upload build artifacts to gocd (relay, linux/amd64)" \
+    "Upload build artifacts to gocd (relay, linux/arm64)" \
+    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
+    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \


### PR DESCRIPTION
As part of the deploy pipeline we call this [script](https://github.com/getsentry/devinfra-deployment-service/blob/fa1e4bd252feb75b18b7b0d703da7b601549ca05/gocd_agent/scripts/checks/githubactions/checkruns.py#L126) which ensures that the 'github runs' that are passed (as arguments to the script) are completed before the script terminates.

Previously we did not wait for the upload of the artifacts to GOCD which could cause the [`create-sentry-release`](https://github.com/getsentry/relay/blob/master/scripts/create-sentry-release) script to fails as the files it tries for pull from GOCD were not yet in GOCD. (This only happens though if you triggered the pipeline very shortly after the CI 'finished').

This PR adds the logic to also wait for the upload of the artifacts to GOCD such that it is impossible for the [`create-sentry-release`](https://github.com/getsentry/relay/blob/master/scripts/create-sentry-release) script to run (and fail) before the upload of the artifacts has finished.

#skip-changelog