### PR TITLE
ref(imports): Reformat imports correctly across the entire code

### DIFF
--- a/relay-base-schema/src/metrics/mod.rs
+++ b/relay-base-schema/src/metrics/mod.rs
@@ -4,12 +4,13 @@ mod mri;
 mod name;
 mod units;
 
+use std::{borrow::Cow, sync::OnceLock};
+
+use regex::Regex;
+
 pub use self::mri::*;
 pub use self::name::*;
 pub use self::units::*;
-
-use regex::Regex;
-use std::{borrow::Cow, sync::OnceLock};
 
 /// The limit is determined by the unit size (15) and the maximum MRI length (200).
 /// By choosing a metric name length of 150, we ensure that 35 characters remain available

--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 use std::{borrow::Cow, error::Error};
 
-use crate::metrics::MetricUnit;
 use serde::{Deserialize, Serialize};
+
+use crate::metrics::MetricUnit;
 
 /// The type of a [`MetricResourceIdentifier`], determining its aggregation and evaluation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
@@ -346,9 +347,8 @@ fn parse_name_unit(string: &str) -> Option<(&str, MetricUnit)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::metrics::{CustomUnit, DurationUnit};
-
     use super::*;
+    use crate::metrics::{CustomUnit, DurationUnit};
 
     #[test]
     fn test_sizeof_unit() {

--- a/relay-cabi/src/glob.rs
+++ b/relay-cabi/src/glob.rs
@@ -2,12 +2,12 @@
 
 use std::borrow::Cow;
 use std::num::NonZeroUsize;
+use std::sync::{Mutex, PoisonError};
 
 use globset::GlobBuilder;
 use lru::LruCache;
 use once_cell::sync::Lazy;
 use regex::bytes::{Regex, RegexBuilder};
-use std::sync::{Mutex, PoisonError};
 
 use crate::{RelayBuf, RelayStr};
 

--- a/relay-cardinality/src/limiter.rs
+++ b/relay-cardinality/src/limiter.rs
@@ -349,9 +349,8 @@ impl<'a, T> CardinalityLimits<'a, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CardinalityScope, SlidingWindow};
-
     use super::*;
+    use crate::{CardinalityScope, SlidingWindow};
 
     #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     struct Item {

--- a/relay-cardinality/src/redis/cache.rs
+++ b/relay-cardinality/src/redis/cache.rs
@@ -199,11 +199,10 @@ mod tests {
     use relay_base_schema::organization::OrganizationId;
     use relay_base_schema::project::ProjectId;
 
+    use super::*;
     use crate::limiter::{Entry, EntryId};
     use crate::redis::quota::PartialQuotaScoping;
     use crate::{CardinalityLimit, CardinalityScope, Scoping, SlidingWindow};
-
-    use super::*;
 
     fn build_scoping(organization_id: OrganizationId, window: SlidingWindow) -> QuotaScoping {
         PartialQuotaScoping::new(

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
+use relay_common::time::UnixTimestamp;
 use relay_redis::{AsyncRedisClient, AsyncRedisConnection};
 use relay_statsd::metric;
-use std::time::Duration;
 
 use crate::{
     limiter::{CardinalityReport, Entry, Limiter, Reporter, Scoping},
@@ -14,7 +16,6 @@ use crate::{
     statsd::{CardinalityLimiterHistograms, CardinalityLimiterTimers},
     CardinalityLimit, Result,
 };
-use relay_common::time::UnixTimestamp;
 
 /// Configuration options for the [`RedisSetLimiter`].
 pub struct RedisSetLimiterOptions {
@@ -276,11 +277,10 @@ mod tests {
     use relay_base_schema::project::ProjectId;
     use relay_redis::{redis, RedisConfigOptions};
 
+    use super::*;
     use crate::limiter::EntryId;
     use crate::redis::{KEY_PREFIX, KEY_VERSION};
     use crate::{CardinalityScope, SlidingWindow};
-
-    use super::*;
 
     fn build_limiter() -> RedisSetLimiter {
         let url = std::env::var("RELAY_REDIS_URL")

--- a/relay-cardinality/src/redis/quota.rs
+++ b/relay-cardinality/src/redis/quota.rs
@@ -1,7 +1,7 @@
-use hash32::Hasher;
 use std::fmt::{self, Write};
 use std::hash::Hash;
 
+use hash32::Hasher;
 use relay_base_schema::metrics::{MetricName, MetricNamespace, MetricType};
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;

--- a/relay-cogs/src/cogs.rs
+++ b/relay-cogs/src/cogs.rs
@@ -1,9 +1,9 @@
-use crate::time::Instant;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use crate::time::Instant;
 use crate::{AppFeature, Measurements, ResourceId};
 use crate::{CogsMeasurement, CogsRecorder, Value};
 

--- a/relay-cogs/src/lib.rs
+++ b/relay-cogs/src/lib.rs
@@ -72,11 +72,10 @@ mod test;
 pub(crate) mod time;
 
 pub use self::cogs::*;
+pub(crate) use self::measurement::*;
 pub use self::recorder::*;
 #[cfg(test)]
 pub use self::test::*;
-
-pub(crate) use self::measurement::*;
 
 /// Records a categorized measurement of the passed `body`, in `category` on `token`.
 ///

--- a/relay-dynamic-config/src/metrics.rs
+++ b/relay-dynamic-config/src/metrics.rs
@@ -669,8 +669,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use similar_asserts::assert_eq;
+
+    use super::*;
 
     #[test]
     fn test_empty_metrics_deserialize() {

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -216,9 +216,8 @@ fn is_false(value: &bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::Feature;
-
     use super::*;
+    use crate::Feature;
 
     #[test]
     fn graduated_feature_flag_gets_inserted() {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -3,7 +3,6 @@
 //! This module provides a function to normalize events.
 
 use std::collections::hash_map::DefaultHasher;
-
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::sync::OnceLock;

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -33,6 +33,7 @@ pub use normalize::breakdowns::*;
 pub use normalize::*;
 pub use remove_other::RemoveOtherProcessor;
 pub use schema::SchemaProcessor;
+pub use sentry_release_parser::{validate_environment, validate_release};
 pub use timestamp::TimestampProcessor;
 pub use transactions::*;
 pub use trimming::TrimmingProcessor;
@@ -40,8 +41,6 @@ pub use user_agent::*;
 
 pub use self::clock_drift::*;
 pub use self::geo::*;
-
-pub use sentry_release_parser::{validate_environment, validate_release};
 
 /// Maximum number of characters allowed for a field value.
 ///

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -282,11 +282,10 @@ mod tests {
     use similar_asserts::assert_eq;
     use uuid::Uuid;
 
+    use super::*;
     use crate::stacktrace::normalize_non_raw_frame;
     use crate::validation::validate_event;
     use crate::{normalize_event, EventValidationConfig, GeoIpLookup, NormalizationConfig};
-
-    use super::*;
 
     #[test]
     fn test_model_cost_config() {

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -1,8 +1,9 @@
 //! AI cost calculation.
 
-use crate::ModelCosts;
 use relay_base_schema::metrics::MetricUnit;
 use relay_event_schema::protocol::{Event, Measurement, Span};
+
+use crate::ModelCosts;
 
 /// Calculated cost is in US dollars.
 fn calculate_ai_model_cost(

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -2,17 +2,17 @@
 mod redis;
 mod resource;
 mod sql;
+use std::borrow::Cow;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::path::Path;
+
 use once_cell::sync::Lazy;
 use psl;
+use relay_event_schema::protocol::Span;
 use relay_filter::matches_any_origin;
 use serde_json::Value;
 #[cfg(test)]
 pub use sql::{scrub_queries, Mode};
-
-use relay_event_schema::protocol::Span;
-use std::borrow::Cow;
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::path::Path;
 use url::{Host, Url};
 
 use crate::regexes::{
@@ -617,9 +617,10 @@ fn scrub_mongodb_visit_node(value: &mut Value, recursion_limit: usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_protocol::Annotated;
     use similar_asserts::assert_eq;
+
+    use super::*;
 
     macro_rules! span_description_test {
         // Tests the scrubbed span description for the given op.

--- a/relay-event-normalization/src/normalize/span/description/sql/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/mod.rs
@@ -4,10 +4,11 @@ mod parser;
 use std::borrow::Cow;
 use std::time::Instant;
 
-use crate::statsd::Timers;
 use once_cell::sync::Lazy;
 use parser::normalize_parsed_queries;
 use regex::Regex;
+
+use crate::statsd::Timers;
 
 /// Removes SQL comments starting with "--" or "#".
 static COMMENTS: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:--|#).*(?P<newline>\n|$)").unwrap());

--- a/relay-event-normalization/src/normalize/utils.rs
+++ b/relay-event-normalization/src/normalize/utils.rs
@@ -199,9 +199,10 @@ pub fn calculate_cdf_score(value: f64, p10: f64, p50: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{get_event_user_tag, http_status_code_from_span};
     use relay_event_schema::protocol::{Span, User};
     use relay_protocol::Annotated;
+
+    use crate::utils::{get_event_user_tag, http_status_code_from_span};
 
     #[test]
     fn test_get_event_user_tag() {

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -182,12 +182,11 @@ mod tests {
 
     use chrono::{TimeZone, Utc};
     use insta::assert_json_snapshot;
-    use relay_protocol::{assert_annotated_snapshot, get_value, SerializableAnnotated};
-    use uuid::Uuid;
-
     use relay_event_schema::protocol::{
         BrowserContext, Context, DeviceContext, EventId, OsContext, TagEntry, Tags,
     };
+    use relay_protocol::{assert_annotated_snapshot, get_value, SerializableAnnotated};
+    use uuid::Uuid;
 
     use super::*;
 

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -408,10 +408,9 @@ mod tests {
     use relay_protocol::{assert_annotated_snapshot, get_value};
     use serde_json::json;
 
+    use super::*;
     use crate::validation::validate_event;
     use crate::{EventValidationConfig, RedactionRule};
-
-    use super::*;
 
     #[test]
     fn test_is_high_cardinality_sdk_ruby_ok() {

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -444,9 +444,8 @@ mod tests {
     use relay_protocol::{get_value, Map, Remark, SerializableAnnotated};
     use similar_asserts::assert_eq;
 
-    use crate::MaxChars;
-
     use super::*;
+    use crate::MaxChars;
 
     #[test]
     fn test_string_trimming() {

--- a/relay-event-schema/src/protocol/clientsdk.rs
+++ b/relay-event-schema/src/protocol/clientsdk.rs
@@ -1,11 +1,13 @@
-use crate::processor::ProcessValue;
-use crate::protocol::IpAddr;
+use std::str::FromStr;
+
 use relay_protocol::{
     Annotated, Array, Empty, ErrorKind, FromValue, IntoValue, Object, SkipSerialization, Value,
 };
 use serde::{Serialize, Serializer};
-use std::str::FromStr;
 use thiserror::Error;
+
+use crate::processor::ProcessValue;
+use crate::protocol::IpAddr;
 
 /// An installed and loaded package as part of the Sentry SDK.
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]

--- a/relay-event-schema/src/protocol/contexts/flags.rs
+++ b/relay-event-schema/src/protocol/contexts/flags.rs
@@ -1,5 +1,6 @@
-use crate::processor::ProcessValue;
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
+
+use crate::processor::ProcessValue;
 
 /// Flags context.
 ///

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -28,6 +28,7 @@ pub use os::*;
 pub use otel::*;
 pub use performance_score::*;
 pub use profile::*;
+use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
 pub use replay::*;
 pub use reprocessing::*;
 pub use response::*;
@@ -35,8 +36,6 @@ pub use runtime::*;
 pub use spring::*;
 pub use trace::*;
 pub use user_report_v2::*;
-
-use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
 
 use crate::processor::ProcessValue;
 

--- a/relay-event-schema/src/protocol/contexts/spring.rs
+++ b/relay-event-schema/src/protocol/contexts/spring.rs
@@ -1,5 +1,6 @@
-use crate::processor::ProcessValue;
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
+
+use crate::processor::ProcessValue;
 
 /// Spring context.
 ///

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -824,10 +824,11 @@ impl Getter for Event {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use chrono::{TimeZone, Utc};
     use relay_protocol::{ErrorKind, Map, Meta};
     use similar_asserts::assert_eq;
-    use std::collections::BTreeMap;
     use uuid::uuid;
 
     use super::*;

--- a/relay-event-schema/src/protocol/ourlog.rs
+++ b/relay-event-schema/src/protocol/ourlog.rs
@@ -1,6 +1,6 @@
-use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, SkipSerialization, Value};
 use std::fmt::{self, Display};
 
+use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, SkipSerialization, Value};
 use serde::{Serialize, Serializer};
 
 use crate::processor::ProcessValue;
@@ -253,8 +253,9 @@ impl Empty for OurLogLevel {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_protocol::SerializableAnnotated;
+
+    use super::*;
 
     #[test]
     fn test_ourlog_serialization() {

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -26,6 +26,7 @@
 //! ```
 
 use relay_protocol::{Annotated, Array, Empty, FromValue, Getter, IntoValue, Val};
+use uuid::Uuid;
 
 use crate::processor::ProcessValue;
 use crate::protocol::{
@@ -33,7 +34,6 @@ use crate::protocol::{
     LenientString, OsContext, ProfileContext, Request, ResponseContext, Tags, Timestamp,
     TraceContext, User,
 };
-use uuid::Uuid;
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 #[metastructure(process_func = "process_replay", value_type = "Replay")]
@@ -387,9 +387,8 @@ fn or_none(string: &Annotated<impl AsRef<str>>) -> Option<&str> {
 mod tests {
     use chrono::{TimeZone, Utc};
 
-    use crate::protocol::TagEntry;
-
     use super::*;
+    use crate::protocol::TagEntry;
 
     #[test]
     fn test_event_roundtrip() {

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -1205,8 +1205,9 @@ impl SecurityReportType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_protocol::assert_annotated_snapshot;
+
+    use super::*;
 
     #[test]
     fn test_unsplit_uri() {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -1043,13 +1043,13 @@ impl IntoValue for SpanKind {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::Measurement;
     use chrono::{TimeZone, Utc};
     use relay_base_schema::metrics::{InformationUnit, MetricUnit};
     use relay_protocol::RuleCondition;
     use similar_asserts::assert_eq;
 
     use super::*;
+    use crate::protocol::Measurement;
 
     #[test]
     fn test_span_serialization() {

--- a/relay-event-schema/src/protocol/stacktrace.rs
+++ b/relay-event-schema/src/protocol/stacktrace.rs
@@ -513,10 +513,10 @@ impl From<Stacktrace> for RawStacktrace {
 
 #[cfg(test)]
 mod tests {
-    use crate::protocol::{LockReasonType, ThreadId};
     use similar_asserts::assert_eq;
 
     use super::*;
+    use crate::protocol::{LockReasonType, ThreadId};
 
     #[test]
     fn test_frame_roundtrip() {

--- a/relay-event-schema/src/protocol/user.rs
+++ b/relay-event-schema/src/protocol/user.rs
@@ -92,10 +92,10 @@ pub struct User {
 
 #[cfg(test)]
 mod tests {
+    use relay_protocol::{Error, Map};
     use similar_asserts::assert_eq;
 
     use super::*;
-    use relay_protocol::{Error, Map};
 
     #[test]
     fn test_geo_roundtrip() {

--- a/relay-filter/src/generic.rs
+++ b/relay-filter/src/generic.rs
@@ -6,9 +6,9 @@
 
 use std::iter::FusedIterator;
 
-use crate::{FilterStatKey, GenericFilterConfig, GenericFiltersConfig, GenericFiltersMap};
-
 use relay_protocol::{Getter, RuleCondition};
+
+use crate::{FilterStatKey, GenericFilterConfig, GenericFiltersConfig, GenericFiltersMap};
 
 /// Maximum supported version of the generic filters schema.
 ///
@@ -175,10 +175,10 @@ impl<'a> From<&'a GenericFilterConfig> for GenericFilterConfigRef<'a> {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
-
     use relay_event_schema::protocol::{Event, LenientString};
     use relay_protocol::{Annotated, FromValue as _};
+
+    use super::*;
 
     fn mock_filters() -> GenericFiltersMap {
         vec![

--- a/relay-filter/src/interface.rs
+++ b/relay-filter/src/interface.rs
@@ -1,10 +1,9 @@
 //! This module contains the trait for items that can be filtered by Inbound Filters, plus
 //! the implementation for [`Event`].
-use url::Url;
-
 use relay_event_schema::protocol::{
     Csp, Event, EventType, Exception, LogEntry, Replay, Span, Values,
 };
+use url::Url;
 
 /// A data item to which filters can be applied.
 pub trait Filterable {

--- a/relay-filter/src/lib.rs
+++ b/relay-filter/src/lib.rs
@@ -34,11 +34,12 @@ mod releases;
 #[cfg(test)]
 mod testutils;
 
+pub use interface::Filterable;
+
 pub use crate::common::*;
 pub use crate::config::*;
 pub use crate::csp::matches_any_origin;
 pub use crate::generic::are_generic_filters_supported;
-pub use interface::Filterable;
 
 /// Checks whether an event should be filtered for a particular configuration.
 ///

--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -124,9 +124,9 @@ pub use test::*;
 
 mod utils;
 // Expose the minimal log facade.
-#[doc(inline)]
-pub use tracing::{debug, error, info, trace, warn, Level};
 // Expose the minimal error reporting API.
 #[doc(inline)]
 pub use sentry_core::{self as sentry, capture_error, configure_scope, protocol, with_scope, Hub};
+#[doc(inline)]
+pub use tracing::{debug, error, info, trace, warn, Level};
 pub use utils::*;

--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -1,3 +1,9 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::ops::Range;
+use std::time::SystemTime;
+
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use rand::distributions::Uniform;
 use rand::rngs::SmallRng;
@@ -9,11 +15,6 @@ use relay_metrics::{
     aggregator::{Aggregator, AggregatorConfig},
     Bucket, BucketValue, DistributionValue, FiniteF64,
 };
-use std::cell::RefCell;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::ops::Range;
-use std::time::SystemTime;
 
 struct NumbersGenerator {
     min: usize,

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -861,9 +861,8 @@ impl FusedIterator for ParseBuckets<'_> {}
 mod tests {
     use similar_asserts::assert_eq;
 
-    use crate::protocol::{DurationUnit, MetricUnit};
-
     use super::*;
+    use crate::protocol::{DurationUnit, MetricUnit};
 
     #[test]
     fn test_distribution_value_size() {

--- a/relay-metrics/src/protocol.rs
+++ b/relay-metrics/src/protocol.rs
@@ -1,7 +1,6 @@
 use std::hash::Hasher as _;
 
 use hash32::{FnvHasher, Hasher as _};
-
 #[doc(inline)]
 pub use relay_base_schema::metrics::{
     CustomUnit, DurationUnit, FractionUnit, InformationUnit, MetricName, MetricNamespace,
@@ -169,9 +168,8 @@ pub(crate) fn hash_set_value(string: &str) -> u32 {
 mod tests {
     use insta::assert_json_snapshot;
 
-    use crate::BucketValue;
-
     use super::*;
+    use crate::BucketValue;
 
     #[test]
     fn test_unescape_tag_value() {

--- a/relay-metrics/src/view.rs
+++ b/relay-metrics/src/view.rs
@@ -1,17 +1,17 @@
-use relay_common::time::UnixTimestamp;
-use serde::ser::{SerializeMap, SerializeSeq};
-use serde::Serialize;
-
-use crate::{
-    BucketMetadata, CounterType, DistributionType, GaugeValue, MetricName, SetType, SetValue,
-};
-use relay_base_schema::metrics::MetricType;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Range;
 
+use relay_base_schema::metrics::MetricType;
+use relay_common::time::UnixTimestamp;
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::Serialize;
+
 use crate::bucket::Bucket;
 use crate::BucketValue;
+use crate::{
+    BucketMetadata, CounterType, DistributionType, GaugeValue, MetricName, SetType, SetValue,
+};
 
 /// The fraction of size passed to [`BucketsView::by_size()`] at which buckets will be split. A value of
 /// `2` means that all buckets smaller than half of `metrics_max_batch_size` will be moved in their entirety,

--- a/relay-ourlogs/src/lib.rs
+++ b/relay-ourlogs/src/lib.rs
@@ -6,8 +6,9 @@
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
 
+pub use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLog;
+
 pub use crate::ourlog::otel_to_sentry_log;
 pub use crate::ourlog::ourlog_merge_otel;
-pub use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLog;
 
 mod ourlog;

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -1,12 +1,12 @@
 use chrono::{TimeZone, Utc};
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
-
-use crate::OtelLog;
 use relay_common::time::UnixTimestamp;
 use relay_event_schema::protocol::{
     OurLog, OurLogAttribute, OurLogAttributeType, OurLogLevel, SpanId, Timestamp, TraceId,
 };
 use relay_protocol::{Annotated, Object, Value};
+
+use crate::OtelLog;
 
 fn otel_value_to_log_attribute(value: OtelValue) -> Option<OurLogAttribute> {
     match value {
@@ -282,8 +282,9 @@ fn level_to_otel_severity_number(level: Option<OurLogLevel>) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_protocol::{get_path, SerializableAnnotated};
+
+    use super::*;
 
     #[test]
     fn parse_otel_log() {

--- a/relay-pattern/benches/benches.rs
+++ b/relay-pattern/benches/benches.rs
@@ -1,6 +1,5 @@
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
-
 use relay_pattern::Pattern;
 
 fn bench(group: &mut BenchmarkGroup<'_, WallTime>, haystack: &str, needle: &str) {

--- a/relay-pii/src/attachments.rs
+++ b/relay-pii/src/attachments.rs
@@ -1,9 +1,10 @@
+use std::borrow::Cow;
+use std::iter::FusedIterator;
+
 use regex::bytes::RegexBuilder as BytesRegexBuilder;
 use regex::{Match, Regex};
 use relay_event_schema::processor::{FieldAttrs, Pii, ProcessingState, ValueType};
 use smallvec::SmallVec;
-use std::borrow::Cow;
-use std::iter::FusedIterator;
 use utf16string::{LittleEndian, WStr};
 
 use crate::compiledconfig::RuleRef;

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -177,10 +177,9 @@ mod tests {
     use relay_protocol::{assert_annotated_snapshot, FromValue};
     use similar_asserts::assert_eq;
 
-    use crate::PiiProcessor;
-
     use super::to_pii_config as to_pii_config_impl;
     use super::*;
+    use crate::PiiProcessor;
 
     // These tests are ported from Sentry's Python testsuite (test_data_scrubber). Each testcase
     // has an equivalent testcase in Python.

--- a/relay-pii/src/json.rs
+++ b/relay-pii/src/json.rs
@@ -1,8 +1,10 @@
-use crate::transform::Transform;
-use crate::{CompiledPiiConfig, PiiProcessor};
+use std::borrow::Cow;
+
 use relay_event_schema::processor::{FieldAttrs, Pii, ProcessingState, Processor, ValueType};
 use relay_protocol::Meta;
-use std::borrow::Cow;
+
+use crate::transform::Transform;
+use crate::{CompiledPiiConfig, PiiProcessor};
 
 const FIELD_ATTRS_PII_TRUE: FieldAttrs = FieldAttrs::new().pii(Pii::True);
 
@@ -76,8 +78,9 @@ impl<'de> Transform<'de> for JsonScrubVisitor<'de> {
 
 #[cfg(test)]
 mod test {
-    use crate::{PiiAttachmentsProcessor, PiiConfig};
     use serde_json::Value;
+
+    use crate::{PiiAttachmentsProcessor, PiiConfig};
 
     #[test]
     pub fn test_view_hierarchy() {

--- a/relay-pii/src/selector.rs
+++ b/relay-pii/src/selector.rs
@@ -5,9 +5,8 @@ use pest::error::Error;
 use pest::iterators::Pair;
 use pest::Parser;
 use relay_event_schema::processor::Path;
-use smallvec::SmallVec;
-
 use relay_event_schema::processor::{Pii, ProcessingState, ValueType};
+use smallvec::SmallVec;
 
 /// Error for invalid PII selectors.
 #[derive(Debug, thiserror::Error)]

--- a/relay-profiling/src/error.rs
+++ b/relay-profiling/src/error.rs
@@ -1,5 +1,4 @@
 use relay_filter::FilterStatKey;
-
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/relay-profiling/src/extract_from_transaction.rs
+++ b/relay-profiling/src/extract_from_transaction.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use chrono::SecondsFormat;
-
 use relay_event_schema::protocol::{AppContext, AsPair, Event, SpanStatus, TraceContext};
 
 pub fn extract_transaction_metadata(event: &Event) -> BTreeMap<String, String> {
@@ -109,8 +108,9 @@ fn extract_http_method(transaction: &Event) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_protocol::FromValue;
+
+    use super::*;
 
     #[test]
     fn test_extract_transaction_metadata() {

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -44,8 +44,6 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use bytes::Bytes;
-use url::Url;
-
 use relay_base_schema::project::ProjectId;
 use relay_dynamic_config::GlobalConfig;
 use relay_event_schema::protocol::{Csp, Event, EventId, Exception, LogEntry, Values};
@@ -53,10 +51,10 @@ use relay_filter::{Filterable, ProjectFiltersConfig};
 use relay_protocol::{Getter, Val};
 use serde::Deserialize;
 use serde_json::Deserializer;
-
-use crate::extract_from_transaction::{extract_transaction_metadata, extract_transaction_tags};
+use url::Url;
 
 pub use crate::error::ProfileError;
+use crate::extract_from_transaction::{extract_transaction_metadata, extract_transaction_tags};
 pub use crate::outcomes::discard_reason;
 
 mod android;

--- a/relay-profiling/src/sample/mod.rs
+++ b/relay-profiling/src/sample/mod.rs
@@ -1,7 +1,7 @@
+use relay_event_schema::protocol::Addr;
 use serde::{Deserialize, Serialize};
 
 use crate::debug_image::DebugImage;
-use relay_event_schema::protocol::Addr;
 
 pub mod v1;
 pub mod v2;

--- a/relay-profiling/src/sample/v1.rs
+++ b/relay-profiling/src/sample/v1.rs
@@ -376,8 +376,9 @@ pub fn parse_sample_profile(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::time::Duration;
+
+    use super::*;
 
     #[test]
     fn test_roundtrip() {

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -11,10 +11,9 @@
 //!
 use std::collections::{BTreeMap, HashSet};
 
-use serde::{Deserialize, Serialize};
-
 use relay_event_schema::protocol::EventId;
 use relay_metrics::FiniteF64;
+use serde::{Deserialize, Serialize};
 
 use crate::error::ProfileError;
 use crate::measurements::ChunkMeasurement;

--- a/relay-protocol/src/lib.rs
+++ b/relay-protocol/src/lib.rs
@@ -26,6 +26,9 @@ mod size;
 mod traits;
 mod value;
 
+#[cfg(feature = "derive")]
+pub use relay_protocol_derive::{Empty, FromValue, IntoValue};
+
 pub use self::annotated::*;
 pub use self::condition::RuleCondition;
 pub use self::impls::*;
@@ -33,6 +36,3 @@ pub use self::meta::*;
 pub use self::size::*;
 pub use self::traits::*;
 pub use self::value::*;
-
-#[cfg(feature = "derive")]
-pub use relay_protocol_derive::{Empty, FromValue, IntoValue};

--- a/relay-protocol/src/size.rs
+++ b/relay-protocol/src/size.rs
@@ -437,7 +437,6 @@ impl ser::SerializeStructVariant for &mut SizeEstimatingSerializer {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::annotated::Annotated;
     use crate::value::{Object, Value};
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -1,14 +1,13 @@
 use std::fmt;
 use std::str::FromStr;
 
+#[doc(inline)]
+pub use relay_base_schema::data_category::DataCategory;
 use relay_base_schema::metrics::MetricNamespace;
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::{ProjectId, ProjectKey};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-
-#[doc(inline)]
-pub use relay_base_schema::data_category::DataCategory;
 
 /// Data scoping information for rate limiting and quota enforcement.
 ///

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -376,10 +376,6 @@ impl<T: GlobalLimiter> RedisRateLimiter<T> {
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::*;
-    use crate::quota::{DataCategories, DataCategory, ReasonCode, Scoping};
-    use crate::rate_limit::RateLimitScope;
-    use crate::{GlobalRateLimiter, MetricNamespaceScoping};
     use relay_base_schema::metrics::MetricNamespace;
     use relay_base_schema::organization::OrganizationId;
     use relay_base_schema::project::{ProjectId, ProjectKey};
@@ -387,6 +383,11 @@ mod tests {
     use relay_redis::RedisConfigOptions;
     use smallvec::smallvec;
     use tokio::sync::Mutex;
+
+    use super::*;
+    use crate::quota::{DataCategories, DataCategory, ReasonCode, Scoping};
+    use crate::rate_limit::RateLimitScope;
+    use crate::{GlobalRateLimiter, MetricNamespaceScoping};
 
     struct MockGlobalLimiter {
         client: AsyncRedisClient,

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -1,8 +1,9 @@
+use std::ops::{Deref, DerefMut};
+
 use deadpool::managed::{Manager, Metrics, Object, Pool, RecycleError, RecycleResult};
 use deadpool_redis::cluster::Manager as ClusterManager;
 use deadpool_redis::Manager as SingleManager;
 use futures::FutureExt;
-use std::ops::{Deref, DerefMut};
 
 use crate::redis;
 use crate::redis::aio::MultiplexedConnection;

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -1,13 +1,13 @@
+use std::time::Duration;
+
 use deadpool::managed::{BuildError, Manager, Metrics, Object, Pool, PoolError};
 use deadpool_redis::{ConfigError, Runtime};
+pub use redis;
 use redis::{Cmd, Pipeline, RedisFuture, Value};
-use std::time::Duration;
 use thiserror::Error;
 
 use crate::config::RedisConfigOptions;
 use crate::pool;
-
-pub use redis;
 
 /// An error type that represents various failure modes when interacting with Redis.
 ///

--- a/relay-redis/src/scripts.rs
+++ b/relay-redis/src/scripts.rs
@@ -1,5 +1,6 @@
-use deadpool_redis::redis::Script;
 use std::sync::OnceLock;
+
+use deadpool_redis::redis::Script;
 
 /// A collection of static methods to load predefined Redis scripts.
 pub struct RedisScripts;

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -22,12 +22,11 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use once_cell::sync::Lazy;
 use relay_event_schema::processor::{FieldAttrs, Pii, ProcessingState, Processor, ValueType};
+use relay_pii::transform::Transform;
 use relay_pii::{PiiConfig, PiiProcessor};
 use relay_protocol::Meta;
 use serde::{de, ser, Deserializer};
 use serde_json::value::RawValue;
-
-use relay_pii::transform::Transform;
 
 /// Paths to fields on which datascrubbing rules should be applied.
 ///
@@ -413,9 +412,8 @@ mod tests {
 
     use relay_pii::{DataScrubbingConfig, PiiConfig};
 
-    use crate::recording::scrub_at_path;
-
     use super::RecordingScrubber;
+    use crate::recording::scrub_at_path;
 
     fn default_pii_config() -> PiiConfig {
         let mut scrubbing_config = DataScrubbingConfig::default();

--- a/relay-sampling/src/config.rs
+++ b/relay-sampling/src/config.rs
@@ -3,9 +3,8 @@
 use std::fmt;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-
 use relay_protocol::RuleCondition;
+use serde::{Deserialize, Serialize};
 
 /// Maximum supported version of dynamic sampling.
 ///

--- a/relay-sampling/src/evaluation.rs
+++ b/relay-sampling/src/evaluation.rs
@@ -409,11 +409,10 @@ mod tests {
     use relay_protocol::RuleCondition;
     use similar_asserts::assert_eq;
 
+    use super::*;
     use crate::config::{DecayingFunction, RuleType, TimeRange};
     use crate::dsc::TraceUserContext;
     use crate::DynamicSamplingContext;
-
-    use super::*;
 
     fn mock_reservoir_evaluator(vals: Vec<(u32, i64)>) -> ReservoirEvaluator<'static> {
         let mut map = BTreeMap::default();

--- a/relay-server/benches/benches.rs
+++ b/relay-server/benches/benches.rs
@@ -1,20 +1,20 @@
-use bytes::Bytes;
-use chrono::Utc;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use relay_config::Config;
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
-use sqlx::{Pool, Sqlite};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tempfile::TempDir;
-use tokio::runtime::Runtime;
 
+use bytes::Bytes;
+use chrono::Utc;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use relay_base_schema::project::ProjectKey;
+use relay_config::Config;
 use relay_server::{
     Envelope, EnvelopeStack, MemoryChecker, MemoryStat, PolymorphicEnvelopeBuffer,
     SqliteEnvelopeStack, SqliteEnvelopeStore,
 };
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use sqlx::{Pool, Sqlite};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
 
 fn setup_db(path: &PathBuf) -> Pool<Sqlite> {
     let options = SqliteConnectOptions::new()

--- a/relay-server/src/endpoints/autoscaling.rs
+++ b/relay-server/src/endpoints/autoscaling.rs
@@ -1,8 +1,9 @@
+use std::fmt::Display;
+use std::fmt::Write;
+
 use crate::http::StatusCode;
 use crate::service::ServiceState;
 use crate::services::autoscaling::{AutoscalingData, AutoscalingMessageKind};
-use std::fmt::Display;
-use std::fmt::Write;
 
 /// Returns internal metrics data for relay.
 pub async fn handle(state: ServiceState) -> (StatusCode, String) {

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -1,3 +1,8 @@
+use std::convert::Infallible;
+use std::error::Error;
+use std::io::Cursor;
+use std::io::Read;
+
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{post, MethodRouter};
@@ -9,10 +14,6 @@ use liblzma::read::XzDecoder;
 use multer::Multipart;
 use relay_config::Config;
 use relay_event_schema::protocol::EventId;
-use std::convert::Infallible;
-use std::error::Error;
-use std::io::Cursor;
-use std::io::Read;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT};
@@ -250,8 +251,8 @@ pub fn route(config: &Config) -> MethodRouter<ServiceState> {
 
 #[cfg(test)]
 mod tests {
-    use crate::envelope::ContentType;
-    use crate::utils::{multipart_items, FormDataIter};
+    use std::io::Write;
+
     use axum::body::Body;
     use bzip2::write::BzEncoder;
     use bzip2::Compression as BzCompression;
@@ -259,10 +260,11 @@ mod tests {
     use flate2::Compression as GzCompression;
     use liblzma::write::XzEncoder;
     use relay_config::Config;
-    use std::io::Write;
     use zstd::stream::Encoder as ZstdEncoder;
 
     use super::*;
+    use crate::envelope::ContentType;
+    use crate::utils::{multipart_items, FormDataIter};
 
     #[test]
     fn test_validate_minidump() {

--- a/relay-server/src/endpoints/monitor.rs
+++ b/relay-server/src/endpoints/monitor.rs
@@ -1,4 +1,3 @@
-use crate::constants::DEFAULT_CHECK_IN_CLIENT;
 use axum::extract::{DefaultBodyLimit, Path, Query, Request};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -10,6 +9,7 @@ use relay_monitors::{CheckIn, CheckInStatus};
 use serde::Deserialize;
 use uuid::Uuid;
 
+use crate::constants::DEFAULT_CHECK_IN_CLIENT;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{ContentType, Envelope, Item, ItemType};
 use crate::extractors::{RawContentType, RequestMeta};

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -1,16 +1,16 @@
-use relay_profiling::ProfileType;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::AddAssign;
-use uuid::Uuid;
 
 use bytes::Bytes;
 use relay_event_schema::protocol::EventType;
+use relay_profiling::ProfileType;
 use relay_protocol::Value;
 use relay_quotas::DataCategory;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
+use uuid::Uuid;
 
 use crate::envelope::{AttachmentType, ContentType, EnvelopeError};
 

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -30,7 +30,6 @@
 //!
 //! ```
 
-use relay_base_schema::project::ProjectKey;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::io::{self, Write};
@@ -38,6 +37,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use relay_base_schema::project::ProjectKey;
 use relay_dynamic_config::{ErrorBoundary, Feature};
 use relay_event_normalization::{normalize_transaction_name, TransactionNameRule};
 use relay_event_schema::protocol::{Event, EventId};

--- a/relay-server/src/extractors/forwarded_for.rs
+++ b/relay-server/src/extractors/forwarded_for.rs
@@ -99,8 +99,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use axum::http::HeaderValue;
+
+    use super::*;
 
     #[test]
     fn test_prefer_vercel_forwarded() {

--- a/relay-server/src/metrics/outcomes.rs
+++ b/relay-server/src/metrics/outcomes.rs
@@ -1,4 +1,6 @@
 use chrono::Utc;
+#[cfg(feature = "processing")]
+use relay_cardinality::{CardinalityLimit, CardinalityReport};
 use relay_metrics::{
     Bucket, BucketMetadata, BucketView, BucketViewValue, MetricName, MetricNamespace,
     MetricResourceIdentifier, MetricType,
@@ -9,8 +11,6 @@ use relay_system::Addr;
 use crate::envelope::SourceQuantities;
 use crate::metrics::MetricStats;
 use crate::services::outcome::{Outcome, TrackOutcome};
-#[cfg(feature = "processing")]
-use relay_cardinality::{CardinalityLimit, CardinalityReport};
 
 /// [`MetricOutcomes`] takes care of creating the right outcomes for metrics at the end of their
 /// lifecycle.

--- a/relay-server/src/metrics/rate_limits.rs
+++ b/relay-server/src/metrics/rate_limits.rs
@@ -220,9 +220,8 @@ mod tests {
     use relay_system::Addr;
     use smallvec::smallvec;
 
-    use crate::metrics::MetricStats;
-
     use super::*;
+    use crate::metrics::MetricStats;
 
     fn deny(category: DataCategory) -> Vec<Quota> {
         vec![Quota {

--- a/relay-server/src/middlewares/body_timing.rs
+++ b/relay-server/src/middlewares/body_timing.rs
@@ -1,14 +1,16 @@
-use crate::statsd::RelayTimers;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
 use axum::body::{Body, HttpBody};
 use axum::extract::MatchedPath;
 use axum::http::Request;
 use hyper::body::Frame;
 use relay_statsd::metric;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 use tokio::time::Instant;
 use tower::{Layer, Service};
+
+use crate::statsd::RelayTimers;
 
 /// Middleware layer that wraps the request [`Body`] to measure body reading duration.
 ///
@@ -151,10 +153,11 @@ fn size_category(size: usize) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use axum::body::HttpBody;
     use futures::task::noop_waker_ref;
     use relay_statsd::with_capturing_test_client;
+
+    use super::*;
 
     struct ErrorBody;
 

--- a/relay-server/src/middlewares/metrics.rs
+++ b/relay-server/src/middlewares/metrics.rs
@@ -1,8 +1,9 @@
+use std::time::Instant;
+
 use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::Response;
 use axum::RequestExt;
-use std::time::Instant;
 
 use crate::extractors::ReceivedAt;
 use crate::statsd::{RelayCounters, RelayTimers};

--- a/relay-server/src/middlewares/normalize_path.rs
+++ b/relay-server/src/middlewares/normalize_path.rs
@@ -67,8 +67,9 @@ fn fold_duplicate_slashes(uri: &mut Uri) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use similar_asserts::assert_eq;
+
+    use super::*;
 
     #[test]
     fn root() {

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -2,6 +2,23 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(feature = "processing")]
+use anyhow::Context;
+use anyhow::Result;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use relay_cogs::Cogs;
+use relay_config::Config;
+#[cfg(feature = "processing")]
+use relay_config::{RedisConfigRef, RedisConfigsRef};
+#[cfg(feature = "processing")]
+use relay_redis::redis::Script;
+#[cfg(feature = "processing")]
+use relay_redis::AsyncRedisClient;
+#[cfg(feature = "processing")]
+use relay_redis::{RedisClients, RedisError, RedisScripts};
+use relay_system::{channel, Addr, Service, ServiceSpawn, ServiceSpawnExt as _};
+
 use crate::metrics::{MetricOutcomes, MetricStats};
 use crate::services::autoscaling::{AutoscalingMetricService, AutoscalingMetrics};
 use crate::services::buffer::{
@@ -27,22 +44,6 @@ use crate::services::store::{StoreService, StoreServicePool};
 use crate::services::test_store::{TestStore, TestStoreService};
 use crate::services::upstream::{UpstreamRelay, UpstreamRelayService};
 use crate::utils::{MemoryChecker, MemoryStat, ThreadKind};
-#[cfg(feature = "processing")]
-use anyhow::Context;
-use anyhow::Result;
-use axum::extract::FromRequestParts;
-use axum::http::request::Parts;
-use relay_cogs::Cogs;
-use relay_config::Config;
-#[cfg(feature = "processing")]
-use relay_config::{RedisConfigRef, RedisConfigsRef};
-#[cfg(feature = "processing")]
-use relay_redis::redis::Script;
-#[cfg(feature = "processing")]
-use relay_redis::AsyncRedisClient;
-#[cfg(feature = "processing")]
-use relay_redis::{RedisClients, RedisError, RedisScripts};
-use relay_system::{channel, Addr, Service, ServiceSpawn, ServiceSpawnExt as _};
 
 /// Indicates the type of failure of the server.
 #[derive(Debug, thiserror::Error)]

--- a/relay-server/src/services/autoscaling.rs
+++ b/relay-server/src/services/autoscaling.rs
@@ -1,10 +1,11 @@
-use crate::services::buffer::PartitionedEnvelopeBuffer;
-use crate::services::processor::EnvelopeProcessorServicePool;
-use crate::MemoryStat;
 use relay_system::{
     AsyncResponse, Controller, FromMessage, Handle, Interface, RuntimeMetrics, Sender, Service,
 };
 use tokio::time::Instant;
+
+use crate::services::buffer::PartitionedEnvelopeBuffer;
+use crate::services::processor::EnvelopeProcessorServicePool;
+use crate::MemoryStat;
 
 /// Service that tracks internal relay metrics so that they can be exposed.
 pub struct AutoscalingMetricService {

--- a/relay-server/src/services/buffer/common.rs
+++ b/relay-server/src/services/buffer/common.rs
@@ -40,8 +40,9 @@ impl ProjectKeyPair {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashSet;
+
+    use super::*;
 
     #[test]
     fn test_project_key_pair_new() {

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -712,13 +712,15 @@ impl Readiness {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
     use relay_common::Dsn;
     use relay_event_schema::protocol::EventId;
     use relay_sampling::DynamicSamplingContext;
-    use std::str::FromStr;
-    use std::sync::Arc;
     use uuid::Uuid;
 
+    use super::*;
     use crate::envelope::{Item, ItemType};
     use crate::extractors::RequestMeta;
     use crate::services::buffer::common::ProjectKeyPair;
@@ -726,8 +728,6 @@ mod tests {
     use crate::services::buffer::testutils::utils::mock_envelopes;
     use crate::utils::MemoryStat;
     use crate::SqliteEnvelopeStore;
-
-    use super::*;
 
     impl Peek {
         fn is_empty(&self) -> bool {

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -2,9 +2,8 @@ use std::convert::Infallible;
 
 use chrono::{DateTime, Utc};
 
-use crate::Envelope;
-
 use super::EnvelopeStack;
+use crate::Envelope;
 
 #[derive(Debug)]
 pub struct MemoryEnvelopeStack(#[allow(clippy::vec_box)] Vec<Box<Envelope>>);

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -202,9 +202,10 @@ impl EnvelopeStack for SqliteEnvelopeStack {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use chrono::Utc;
     use relay_base_schema::project::ProjectKey;
-    use std::time::Duration;
 
     use super::*;
     use crate::services::buffer::testutils::utils::{mock_envelope, mock_envelopes, setup_db};

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -4,11 +4,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::envelope::EnvelopeError;
-
-use crate::services::buffer::common::ProjectKeyPair;
-use crate::statsd::{RelayGauges, RelayHistograms, RelayTimers};
-use crate::Envelope;
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, Utc};
 use futures::stream::StreamExt;
@@ -25,6 +20,11 @@ use sqlx::sqlite::{
 use sqlx::{Pool, Row, Sqlite};
 use tokio::fs::DirBuilder;
 use tokio::time::sleep;
+
+use crate::envelope::EnvelopeError;
+use crate::services::buffer::common::ProjectKeyPair;
+use crate::statsd::{RelayGauges, RelayHistograms, RelayTimers};
+use crate::Envelope;
 
 /// Fixed first 4 bytes for zstd compressed envelopes.
 ///
@@ -660,9 +660,9 @@ pub fn build_count_all<'a>() -> Query<'a, Sqlite, SqliteArguments<'a>> {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-    use tokio::time::sleep;
 
     use relay_base_schema::project::ProjectKey;
+    use tokio::time::sleep;
 
     use super::*;
     use crate::services::buffer::testutils::utils::{mock_envelopes, setup_db};

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -10,6 +10,17 @@ use std::time::Duration;
 use ahash::RandomState;
 use chrono::DateTime;
 use chrono::Utc;
+pub use common::ProjectKeyPair;
+// pub for benchmarks
+pub use envelope_buffer::EnvelopeBufferError;
+// pub for benchmarks
+pub use envelope_buffer::PolymorphicEnvelopeBuffer;
+// pub for benchmarks
+pub use envelope_stack::sqlite::SqliteEnvelopeStack;
+// pub for benchmarks
+pub use envelope_stack::EnvelopeStack;
+// pub for benchmarks
+pub use envelope_store::sqlite::SqliteEnvelopeStore;
 use relay_config::Config;
 use relay_system::Receiver;
 use relay_system::ServiceSpawn;
@@ -27,26 +38,12 @@ use crate::services::outcome::Outcome;
 use crate::services::outcome::TrackOutcome;
 use crate::services::processor::{EnvelopeProcessor, ProcessEnvelope, ProcessingGroup};
 use crate::services::projects::cache::{CheckedEnvelope, ProjectCacheHandle, ProjectChange};
+use crate::services::projects::project::ProjectState;
 use crate::services::test_store::TestStore;
 use crate::statsd::RelayCounters;
-
 use crate::utils::ManagedEnvelope;
 use crate::MemoryChecker;
 use crate::MemoryStat;
-
-// pub for benchmarks
-pub use envelope_buffer::EnvelopeBufferError;
-// pub for benchmarks
-pub use envelope_buffer::PolymorphicEnvelopeBuffer;
-// pub for benchmarks
-pub use envelope_stack::sqlite::SqliteEnvelopeStack;
-// pub for benchmarks
-pub use envelope_stack::EnvelopeStack;
-// pub for benchmarks
-pub use envelope_store::sqlite::SqliteEnvelopeStore;
-
-use crate::services::projects::project::ProjectState;
-pub use common::ProjectKeyPair;
 
 mod common;
 mod envelope_buffer;
@@ -692,18 +689,20 @@ impl Service for EnvelopeBufferService {
 /// `tokio::time::pause` *after* the connection is established.
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::services::projects::project::{ProjectInfo, ProjectState};
-    use crate::testutils::new_envelope;
-    use crate::MemoryStat;
+    use std::time::Duration;
+
     use chrono::Utc;
     use relay_base_schema::project::ProjectKey;
     use relay_dynamic_config::GlobalConfig;
     use relay_quotas::DataCategory;
     use relay_system::TokioServiceSpawn;
-    use std::time::Duration;
     use tokio::sync::mpsc;
     use uuid::Uuid;
+
+    use super::*;
+    use crate::services::projects::project::{ProjectInfo, ProjectState};
+    use crate::testutils::new_envelope;
+    use crate::MemoryStat;
 
     struct EnvelopeBufferServiceResult {
         service: EnvelopeBufferService,

--- a/relay-server/src/services/buffer/stack_provider/mod.rs
+++ b/relay-server/src/services/buffer/stack_provider/mod.rs
@@ -1,7 +1,9 @@
+use std::future::Future;
+
+use hashbrown::HashSet;
+
 use crate::services::buffer::common::ProjectKeyPair;
 use crate::EnvelopeStack;
-use hashbrown::HashSet;
-use std::future::Future;
 
 pub mod memory;
 pub mod sqlite;

--- a/relay-server/src/services/buffer/testutils.rs
+++ b/relay-server/src/services/buffer/testutils.rs
@@ -1,12 +1,13 @@
 #[cfg(test)]
 pub mod utils {
+    use std::collections::BTreeMap;
+
     use chrono::{DateTime, Utc};
     use relay_base_schema::project::ProjectKey;
     use relay_event_schema::protocol::EventId;
     use relay_sampling::DynamicSamplingContext;
     use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
     use sqlx::{Pool, Sqlite};
-    use std::collections::BTreeMap;
     use tokio::fs::DirBuilder;
     use uuid::Uuid;
 

--- a/relay-server/src/services/health_check.rs
+++ b/relay-server/src/services/health_check.rs
@@ -1,8 +1,8 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use relay_config::Config;
 use relay_system::{Addr, AsyncResponse, Controller, FromMessage, Interface, Sender, Service};
-use std::future::Future;
 use tokio::sync::watch;
 use tokio::time::{timeout, Instant};
 

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -12,13 +12,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, mem};
 
-use crate::envelope::ItemType;
-#[cfg(feature = "processing")]
-use crate::service::ServiceError;
-use crate::services::processor::{EnvelopeProcessor, SubmitClientReports};
-use crate::services::upstream::{Method, SendQuery, UpstreamQuery, UpstreamRelay};
-use crate::statsd::RelayCounters;
-use crate::utils::SleepHandle;
 use chrono::{DateTime, SecondsFormat, Utc};
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
@@ -35,6 +28,14 @@ use relay_sampling::evaluation::MatchedRuleIds;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
 use serde::{Deserialize, Serialize};
+
+use crate::envelope::ItemType;
+#[cfg(feature = "processing")]
+use crate::service::ServiceError;
+use crate::services::processor::{EnvelopeProcessor, SubmitClientReports};
+use crate::services::upstream::{Method, SendQuery, UpstreamQuery, UpstreamRelay};
+use crate::statsd::RelayCounters;
+use crate::utils::SleepHandle;
 
 /// Defines the structure of the HTTP outcomes requests
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -4,15 +4,9 @@ use std::error::Error;
 use std::sync::Arc;
 use std::time::Instant;
 
+use relay_dynamic_config::Feature;
 use relay_pii::{PiiAttachmentsProcessor, SelectorPathItem, SelectorSpec};
 use relay_statsd::metric;
-
-use crate::envelope::{AttachmentType, ContentType, ItemType};
-use crate::statsd::RelayTimers;
-
-use crate::services::projects::project::ProjectInfo;
-use crate::utils::TypedEnvelope;
-use relay_dynamic_config::Feature;
 #[cfg(feature = "processing")]
 use {
     crate::services::processor::{ErrorGroup, EventFullyNormalized},
@@ -20,6 +14,11 @@ use {
     relay_event_schema::protocol::{Event, Metrics},
     relay_protocol::Annotated,
 };
+
+use crate::envelope::{AttachmentType, ContentType, ItemType};
+use crate::services::projects::project::ProjectInfo;
+use crate::statsd::RelayTimers;
+use crate::utils::TypedEnvelope;
 
 /// Adds processing placeholders for special attachments.
 ///

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -287,6 +287,7 @@ mod tests {
     use relay_system::Addr;
     use uuid::Uuid;
 
+    use super::*;
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
     use crate::services::processor::{ProcessEnvelope, ProcessingGroup, SpanGroup};
@@ -295,8 +296,6 @@ mod tests {
         self, create_test_processor, new_envelope, state_with_rule_and_condition,
     };
     use crate::utils::ManagedEnvelope;
-
-    use super::*;
 
     fn mocked_event(event_type: EventType, transaction: &str, release: &str) -> Event {
         Event {

--- a/relay-server/src/services/processor/metrics.rs
+++ b/relay-server/src/services/processor/metrics.rs
@@ -74,10 +74,9 @@ mod tests {
     use relay_metrics::{BucketValue, UnixTimestamp};
     use relay_system::Addr;
 
+    use super::*;
     use crate::metrics::MetricStats;
     use crate::services::metrics::Aggregator;
-
-    use super::*;
 
     fn create_custom_bucket_with_name(name: String) -> Bucket {
         Bucket {

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -1,15 +1,8 @@
 //! Log processing code.
 use std::sync::Arc;
 
-use crate::services::processor::LogGroup;
 use relay_config::Config;
 use relay_dynamic_config::{Feature, GlobalConfig};
-
-use crate::services::processor::should_filter;
-use crate::services::projects::project::ProjectInfo;
-use crate::utils::sample;
-use crate::utils::{ItemAction, TypedEnvelope};
-
 #[cfg(feature = "processing")]
 use {
     crate::envelope::ContentType,
@@ -24,6 +17,12 @@ use {
     relay_pii::PiiProcessor,
     relay_protocol::{Annotated, ErrorKind, Value},
 };
+
+use crate::services::processor::should_filter;
+use crate::services::processor::LogGroup;
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::sample;
+use crate::utils::{ItemAction, TypedEnvelope};
 
 /// Removes logs from the envelope if the feature is not enabled.
 pub fn filter(
@@ -180,15 +179,14 @@ fn process_attribute_types(ourlog: &mut OurLog) {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use relay_dynamic_config::GlobalConfig;
+    use relay_system::Addr;
+
     use super::*;
     use crate::envelope::{Envelope, ItemType};
     use crate::services::processor::ProcessingGroup;
     use crate::utils::ManagedEnvelope;
-    use bytes::Bytes;
-
-    use relay_dynamic_config::GlobalConfig;
-
-    use relay_system::Addr;
 
     fn params() -> (TypedEnvelope<LogGroup>, Arc<ProjectInfo>) {
         let bytes = Bytes::from(

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -1,11 +1,11 @@
 //! Profiles related processor code.
-use relay_dynamic_config::{Feature, GlobalConfig};
 use std::net::IpAddr;
 use std::sync::Arc;
 
 use relay_base_schema::events::EventType;
 use relay_base_schema::project::ProjectId;
 use relay_config::Config;
+use relay_dynamic_config::{Feature, GlobalConfig};
 use relay_event_schema::protocol::{Contexts, Event, ProfileContext};
 use relay_filter::ProjectFiltersConfig;
 use relay_profiling::{ProfileError, ProfileId};
@@ -189,14 +189,13 @@ mod tests {
     use relay_sampling::evaluation::ReservoirCounters;
     use relay_system::Addr;
 
+    use super::*;
     use crate::envelope::Envelope;
     use crate::extractors::RequestMeta;
     use crate::services::processor::{ProcessEnvelope, ProcessingGroup};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::create_test_processor;
     use crate::utils::ManagedEnvelope;
-
-    use super::*;
 
     #[cfg(feature = "processing")]
     #[tokio::test]

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -1,12 +1,8 @@
 //! Profile chunks processor code.
 
-use relay_dynamic_config::Feature;
 use std::sync::Arc;
 
-use crate::envelope::ItemType;
-use crate::utils::{ItemAction, TypedEnvelope};
-
-use crate::services::projects::project::ProjectInfo;
+use relay_dynamic_config::Feature;
 #[cfg(feature = "processing")]
 use {
     crate::envelope::ContentType,
@@ -16,6 +12,10 @@ use {
     relay_dynamic_config::GlobalConfig,
     relay_profiling::ProfileError,
 };
+
+use crate::envelope::ItemType;
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::{ItemAction, TypedEnvelope};
 
 /// Removes profile chunks from the envelope if the feature is not enabled.
 pub fn filter<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: Arc<ProjectInfo>) {

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -3,12 +3,6 @@ use std::error::Error;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use crate::envelope::{ContentType, ItemType};
-use crate::services::outcome::DiscardReason;
-use crate::services::processor::{should_filter, ProcessingError, ReplayGroup};
-use crate::services::projects::project::ProjectInfo;
-use crate::statsd::{RelayCounters, RelayTimers};
-use crate::utils::{sample, TypedEnvelope};
 use bytes::Bytes;
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
@@ -23,6 +17,13 @@ use relay_protocol::Annotated;
 use relay_replays::recording::RecordingScrubber;
 use relay_statsd::metric;
 use serde::{Deserialize, Serialize};
+
+use crate::envelope::{ContentType, ItemType};
+use crate::services::outcome::DiscardReason;
+use crate::services::processor::{should_filter, ProcessingError, ReplayGroup};
+use crate::services::projects::project::ProjectInfo;
+use crate::statsd::{RelayCounters, RelayTimers};
+use crate::utils::{sample, TypedEnvelope};
 
 /// Removes replays if the feature flag is not enabled.
 pub fn process(

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -275,6 +275,7 @@ mod tests {
     use relay_event_schema::protocol::EventId;
     use relay_sampling::evaluation::ReservoirCounters;
 
+    use super::*;
     use crate::envelope::{Envelope, Item};
     use crate::extractors::RequestMeta;
     use crate::services::outcome::RuleCategory;
@@ -282,8 +283,6 @@ mod tests {
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{self, create_test_processor};
     use crate::utils::ManagedEnvelope;
-
-    use super::*;
 
     #[tokio::test]
     async fn test_client_report_removal() {

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -20,10 +20,11 @@ use crate::utils::TypedEnvelope;
 
 #[cfg(feature = "processing")]
 mod processing;
-use crate::services::projects::project::ProjectInfo;
 #[cfg(feature = "processing")]
 pub use processing::*;
 use relay_config::Config;
+
+use crate::services::projects::project::ProjectInfo;
 
 pub fn filter(
     managed_envelope: &mut TypedEnvelope<SpanGroup>,
@@ -159,13 +160,14 @@ pub fn extract_transaction_span(
 mod tests {
     use std::collections::BTreeMap;
 
+    use bytes::Bytes;
+    use relay_spans::otel_trace::Span as OtelSpan;
+    use relay_system::Addr;
+
     use super::*;
     use crate::services::processor::ProcessingGroup;
     use crate::utils::{ManagedEnvelope, TypedEnvelope};
     use crate::Envelope;
-    use bytes::Bytes;
-    use relay_spans::otel_trace::Span as OtelSpan;
-    use relay_system::Addr;
 
     #[test]
     fn attribute_denormalization() {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -3,16 +3,6 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use crate::envelope::{ContentType, Item, ItemType};
-use crate::metrics_extraction::{event, generic};
-use crate::services::outcome::{DiscardReason, Outcome};
-use crate::services::processor::span::extract_transaction_span;
-use crate::services::processor::{
-    dynamic_sampling, event_type, EventMetricsExtracted, ProcessingError,
-    ProcessingExtractedMetrics, SpanGroup, SpansExtracted, TransactionGroup,
-};
-use crate::services::projects::project::ProjectInfo;
-use crate::utils::{sample, ItemAction, ManagedEnvelope, TypedEnvelope};
 use chrono::{DateTime, Utc};
 use relay_base_schema::events::EventType;
 use relay_base_schema::project::ProjectId;
@@ -40,6 +30,17 @@ use relay_quotas::DataCategory;
 use relay_sampling::evaluation::ReservoirEvaluator;
 use relay_spans::otel_trace::Span as OtelSpan;
 use thiserror::Error;
+
+use crate::envelope::{ContentType, Item, ItemType};
+use crate::metrics_extraction::{event, generic};
+use crate::services::outcome::{DiscardReason, Outcome};
+use crate::services::processor::span::extract_transaction_span;
+use crate::services::processor::{
+    dynamic_sampling, event_type, EventMetricsExtracted, ProcessingError,
+    ProcessingExtractedMetrics, SpanGroup, SpansExtracted, TransactionGroup,
+};
+use crate::services::projects::project::ProjectInfo;
+use crate::utils::{sample, ItemAction, ManagedEnvelope, TypedEnvelope};
 
 #[derive(Error, Debug)]
 #[error(transparent)]
@@ -833,12 +834,11 @@ mod tests {
     use relay_protocol::get_value;
     use relay_system::Addr;
 
+    use super::*;
     use crate::envelope::Envelope;
     use crate::services::processor::ProcessingGroup;
     use crate::services::projects::project::ProjectInfo;
     use crate::utils::ManagedEnvelope;
-
-    use super::*;
 
     fn params() -> (
         TypedEnvelope<TransactionGroup>,

--- a/relay-server/src/services/processor/unreal.rs
+++ b/relay-server/src/services/processor/unreal.rs
@@ -2,13 +2,14 @@
 //!
 //! These functions are included only in the processing mode.
 
+use relay_config::Config;
+use relay_event_schema::protocol::Event;
+use relay_protocol::Annotated;
+
 use crate::envelope::ItemType;
 use crate::services::processor::{ErrorGroup, EventFullyNormalized, ProcessingError};
 use crate::utils;
 use crate::utils::TypedEnvelope;
-use relay_config::Config;
-use relay_event_schema::protocol::Event;
-use relay_protocol::Annotated;
 
 /// Expands Unreal 4 items inside an envelope.
 ///

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -184,16 +184,16 @@ fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use crate::envelope::{ContentType, Envelope, Item};
-    use crate::extractors::RequestMeta;
-    use crate::services::processor::ProcessingGroup;
-    use crate::services::projects::project::{ProjectInfo, PublicKeyConfig};
     use relay_base_schema::project::{ProjectId, ProjectKey};
     use relay_event_schema::protocol::EventId;
     use serde_json::json;
     use smallvec::smallvec;
 
     use super::*;
+    use crate::envelope::{ContentType, Envelope, Item};
+    use crate::extractors::RequestMeta;
+    use crate::services::processor::ProcessingGroup;
+    use crate::services::projects::project::{ProjectInfo, PublicKeyConfig};
 
     fn create_project(config: &Config, data: Option<serde_json::Value>) -> Project<'_> {
         let mut project_info = ProjectInfo {

--- a/relay-server/src/services/projects/cache/state.rs
+++ b/relay-server/src/services/projects/cache/state.rs
@@ -1,14 +1,14 @@
-use futures::StreamExt;
 use std::fmt;
 use std::sync::Arc;
-use tokio::time::Instant;
 
 use arc_swap::ArcSwap;
+use futures::StreamExt;
 use relay_base_schema::project::ProjectKey;
 use relay_config::Config;
 use relay_quotas::CachedRateLimits;
 use relay_sampling::evaluation::ReservoirCounters;
 use relay_statsd::metric;
+use tokio::time::Instant;
 
 use crate::services::projects::project::{ProjectState, Revision};
 use crate::services::projects::source::SourceProjectState;

--- a/relay-server/src/services/projects/project/info.rs
+++ b/relay-server/src/services/projects/project/info.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::{ProjectId, ProjectKey};
 #[cfg(feature = "processing")]

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -1,10 +1,9 @@
 //! Types that represent the current project state.
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
 use relay_base_schema::project::ProjectKey;
 use relay_quotas::Scoping;
+use serde::{Deserialize, Serialize};
 
 mod info;
 

--- a/relay-server/src/services/projects/source/mod.rs
+++ b/relay-server/src/services/projects/source/mod.rs
@@ -1,23 +1,23 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+
 use relay_base_schema::project::ProjectKey;
 use relay_config::{Config, RelayMode};
 #[cfg(feature = "processing")]
 use relay_redis::RedisClients;
 use relay_system::{Addr, ServiceSpawn, ServiceSpawnExt as _};
-use std::convert::Infallible;
-use std::sync::Arc;
 
 pub mod local;
 #[cfg(feature = "processing")]
 pub mod redis;
 pub mod upstream;
 
-use crate::services::projects::project::{ProjectState, Revision};
-use crate::services::upstream::UpstreamRelay;
-
 use self::local::{LocalProjectSource, LocalProjectSourceService};
 #[cfg(feature = "processing")]
 use self::redis::RedisProjectSource;
 use self::upstream::{UpstreamProjectSource, UpstreamProjectSourceService};
+use crate::services::projects::project::{ProjectState, Revision};
+use crate::services::upstream::UpstreamRelay;
 
 /// Helper type that contains all configured sources for project cache fetching.
 #[derive(Clone, Debug)]

--- a/relay-server/src/services/projects/source/redis.rs
+++ b/relay-server/src/services/projects/source/redis.rs
@@ -1,14 +1,15 @@
-use relay_base_schema::project::ProjectKey;
-use relay_config::Config;
-use relay_redis::{AsyncRedisClient, RedisError};
-use relay_statsd::metric;
 use std::fmt::Debug;
 use std::sync::Arc;
+
+use relay_base_schema::project::ProjectKey;
+use relay_config::Config;
+use relay_redis::redis::cmd;
+use relay_redis::{AsyncRedisClient, RedisError};
+use relay_statsd::metric;
 
 use crate::services::projects::project::{ParsedProjectState, ProjectState, Revision};
 use crate::services::projects::source::SourceProjectState;
 use crate::statsd::{RelayCounters, RelayHistograms, RelayTimers};
-use relay_redis::redis::cmd;
 
 #[derive(Clone, Debug)]
 pub struct RedisProjectSource {

--- a/relay-server/src/services/projects/source/upstream.rs
+++ b/relay-server/src/services/projects/source/upstream.rs
@@ -654,10 +654,10 @@ impl Service for UpstreamProjectSourceService {
 
 #[cfg(test)]
 mod tests {
-    use crate::http::Response;
     use futures::future::poll_immediate;
 
     use super::*;
+    use crate::http::Response;
 
     fn to_response(body: &impl serde::Serialize) -> Response {
         let body = serde_json::to_vec(body).unwrap();

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1,8 +1,6 @@
 //! This module contains the service that forwards events and attachments to the Sentry store.
 //! The service uses Kafka topics to forward data to Sentry
 
-use relay_base_schema::organization::OrganizationId;
-use serde::ser::SerializeMap;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -13,12 +11,11 @@ use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use relay_base_schema::data_category::DataCategory;
+use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
 use relay_config::Config;
 use relay_event_schema::protocol::{EventId, VALID_PLATFORMS};
-
-use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use relay_kafka::{ClientError, KafkaClient, KafkaTopic, Message};
 use relay_metrics::{
     Bucket, BucketView, BucketViewValue, BucketsView, ByNamespace, FiniteF64, GaugeValue,
@@ -28,11 +25,13 @@ use relay_quotas::Scoping;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
 use relay_threading::AsyncPool;
+use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use serde_json::Deserializer;
 use uuid::Uuid;
 
+use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::metrics::{ArrayEncoding, BucketEncoder, MetricOutcomes};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -7,7 +7,6 @@ use relay_dynamic_config::ErrorBoundary;
 use relay_event_schema::protocol::EventId;
 use relay_protocol::RuleCondition;
 use relay_sampling::config::{DecayingFunction, RuleId, RuleType, SamplingRule, SamplingValue};
-
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 use relay_system::Addr;
 #[cfg(feature = "processing")]

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -552,8 +552,9 @@ impl<G> From<TypedEnvelope<G>> for ManagedEnvelope {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bytes::Bytes;
+
+    use super::*;
 
     #[test]
     fn span_metrics_are_reported() {

--- a/relay-server/src/utils/memory.rs
+++ b/relay-server/src/utils/memory.rs
@@ -1,13 +1,15 @@
-use crate::statsd::RelayGauges;
-use arc_swap::ArcSwap;
-use relay_config::Config;
-use relay_statsd::metric;
 use std::fmt;
 use std::fmt::Formatter;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+
+use arc_swap::ArcSwap;
+use relay_config::Config;
+use relay_statsd::metric;
 use sysinfo::{MemoryRefreshKind, System};
+
+use crate::statsd::RelayGauges;
 
 /// The representation of the current memory state.
 #[derive(Clone, Copy, Debug)]
@@ -239,11 +241,12 @@ impl MemoryChecker {
 
 #[cfg(test)]
 mod tests {
-    use relay_config::Config;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::thread::sleep;
     use std::time::Duration;
+
+    use relay_config::Config;
 
     use crate::utils::{Memory, MemoryChecker, MemoryStat};
 

--- a/relay-server/src/utils/scheduled/futures.rs
+++ b/relay-server/src/utils/scheduled/futures.rs
@@ -4,12 +4,13 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::utils::ScheduledQueue;
 use futures::{
     stream::{FusedStream, FuturesUnordered},
     Stream, StreamExt,
 };
 use tokio::time::Instant;
+
+use crate::utils::ScheduledQueue;
 
 /// A set of tasks/futures that can be scheduled for execution.
 #[derive(Debug)]

--- a/relay-server/src/utils/scheduled/queue.rs
+++ b/relay-server/src/utils/scheduled/queue.rs
@@ -1,4 +1,3 @@
-use priority_queue::PriorityQueue;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::fmt;
@@ -8,9 +7,9 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::stream::FusedStream;
-use tokio::time::Instant;
-
 use futures::Stream;
+use priority_queue::PriorityQueue;
+use tokio::time::Instant;
 
 /// A scheduled queue that can be polled for when the next item is ready.
 pub struct ScheduledQueue<T> {

--- a/relay-server/src/utils/thread_pool.rs
+++ b/relay-server/src/utils/thread_pool.rs
@@ -1,9 +1,8 @@
 use std::future::Future;
 use std::{io, thread};
 
-use tokio::runtime::Handle;
-
 use relay_threading::{AsyncPool, AsyncPoolBuilder};
+use tokio::runtime::Handle;
 
 /// A thread kind.
 ///
@@ -135,12 +134,14 @@ fn set_current_thread_priority(_kind: ThreadKind) {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{ThreadKind, ThreadPoolBuilder};
-    use futures::FutureExt;
     use std::sync::atomic::{AtomicI32, Ordering};
     use std::sync::Arc;
+
+    use futures::FutureExt;
     use tokio::runtime::Handle;
     use tokio::sync::Barrier;
+
+    use crate::utils::{ThreadKind, ThreadPoolBuilder};
 
     #[tokio::test]
     async fn test_thread_pool_panic() {

--- a/relay-spans/src/lib.rs
+++ b/relay-spans/src/lib.rs
@@ -6,9 +6,9 @@
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
 
-pub use crate::span::otel_to_sentry_span;
-
 pub use opentelemetry_proto::tonic::trace::v1 as otel_trace;
+
+pub use crate::span::otel_to_sentry_span;
 
 mod span;
 mod status_codes;

--- a/relay-spans/src/span.rs
+++ b/relay-spans/src/span.rs
@@ -6,15 +6,15 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use opentelemetry_proto::tonic::trace::v1::span::Link as OtelLink;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind as OtelSpanKind;
 use relay_event_schema::protocol::SpanKind;
+use relay_event_schema::protocol::{
+    EventId, Span as EventSpan, SpanData, SpanId, SpanLink, SpanStatus, Timestamp, TraceId,
+};
+use relay_protocol::{Annotated, FromValue, Object, Value};
 
 use crate::otel_trace::{
     status::StatusCode as OtelStatusCode, Span as OtelSpan, SpanFlags as OtelSpanFlags,
 };
 use crate::status_codes;
-use relay_event_schema::protocol::{
-    EventId, Span as EventSpan, SpanData, SpanId, SpanLink, SpanStatus, Timestamp, TraceId,
-};
-use relay_protocol::{Annotated, FromValue, Object, Value};
 
 /// convert_from_otel_to_sentry_status returns a status as defined by Sentry based on the OTel status.
 fn convert_from_otel_to_sentry_status(
@@ -256,8 +256,9 @@ fn otel_to_sentry_value(value: OtelValue) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use relay_protocol::get_path;
+
+    use super::*;
 
     #[test]
     fn parse_span() {

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -56,16 +56,17 @@
 //! ```
 //!
 //! [Metric Types]: https://github.com/statsd/statsd/blob/master/docs/metric_types.md
-use cadence::{Metric, MetricBuilder, StatsdClient};
-use parking_lot::RwLock;
-use rand::distributions::{Distribution, Uniform};
-use statsdproxy::cadence::StatsdProxyMetricSink;
-use statsdproxy::config::AggregateMetricsConfig;
 use std::collections::BTreeMap;
 use std::net::ToSocketAddrs;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::time::Duration;
+
+use cadence::{Metric, MetricBuilder, StatsdClient};
+use parking_lot::RwLock;
+use rand::distributions::{Distribution, Uniform};
+use statsdproxy::cadence::StatsdProxyMetricSink;
+use statsdproxy::config::AggregateMetricsConfig;
 
 /// Maximum number of metric events that can be queued before we start dropping them
 const METRICS_MAX_QUEUE_SIZE: usize = 100_000;

--- a/relay-system/src/monitor.rs
+++ b/relay-system/src/monitor.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
+
 use tokio::time::{Duration, Instant};
 
 /// Minimum interval when utilization is recalculated.

--- a/relay-system/src/service/registry.rs
+++ b/relay-system/src/service/registry.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
 use crate::monitor::MonitoredFuture;
-
 use crate::service::status::{ServiceJoinHandle, ServiceStatusJoinHandle};
 use crate::{RawMetrics, ServiceObj, TaskId};
 

--- a/relay-system/src/service/status.rs
+++ b/relay-system/src/service/status.rs
@@ -3,9 +3,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use tokio::task::JoinHandle;
-
 use futures::future::{FutureExt as _, Shared};
+use tokio::task::JoinHandle;
 
 /// The service failed.
 #[derive(Debug)]

--- a/relay-threading/src/metrics.rs
+++ b/relay-threading/src/metrics.rs
@@ -1,7 +1,8 @@
-use relay_system::RawMetrics;
 use std::cmp::max;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+use relay_system::RawMetrics;
 
 /// Metrics for a single thread in an asynchronous pool.
 ///

--- a/relay-threading/src/multiplexing.rs
+++ b/relay-threading/src/multiplexing.rs
@@ -208,7 +208,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::{future::BoxFuture, FutureExt};
     use std::future;
     use std::sync::atomic::AtomicBool;
     use std::sync::{
@@ -216,6 +215,8 @@ mod tests {
         Arc, Mutex,
     };
     use std::time::Duration;
+
+    use futures::{future::BoxFuture, FutureExt};
 
     use super::*;
 

--- a/relay-threading/src/pool.rs
+++ b/relay-threading/src/pool.rs
@@ -3,13 +3,14 @@ use std::io;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use relay_system::MonitoredFuture;
+
 use crate::builder::AsyncPoolBuilder;
 use crate::metrics::AsyncPoolMetrics;
 use crate::multiplexing::Multiplexed;
 use crate::{PanicHandler, ThreadMetrics};
-use futures::future::BoxFuture;
-use futures::FutureExt;
-use relay_system::MonitoredFuture;
 
 /// Default name of the pool.
 const DEFAULT_POOL_NAME: &str = "unnamed";

--- a/relay-ua/src/lib.rs
+++ b/relay-ua/src/lib.rs
@@ -7,10 +7,9 @@
 //! consumer.
 
 use once_cell::sync::Lazy;
-use uaparser::{Parser, UserAgentParser};
-
 #[doc(inline)]
 pub use uaparser::{Device, UserAgent, OS};
+use uaparser::{Parser, UserAgentParser};
 
 /// The global [`UserAgentParser`] already configured with a user agent database.
 ///

--- a/tools/bench-buffer/src/main.rs
+++ b/tools/bench-buffer/src/main.rs
@@ -1,12 +1,13 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use bytes::Bytes;
 use chrono::Utc;
 use clap::{Parser, ValueEnum};
 use rand::RngCore;
 use relay_config::Config;
 use relay_server::{Envelope, MemoryChecker, MemoryStat, PolymorphicEnvelopeBuffer};
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum Impl {

--- a/tools/document-pii/src/main.rs
+++ b/tools/document-pii/src/main.rs
@@ -167,9 +167,8 @@ fn main() {
 mod tests {
     use path_slash::PathBufExt;
 
-    use crate::item_collector::TypesAndScopedPaths;
-
     use super::*;
+    use crate::item_collector::TypesAndScopedPaths;
 
     const RUST_TEST_CRATE: &str = "../../tests/test_pii_docs";
 


### PR DESCRIPTION
This PR reformats the imports correctly thanks to a new cargo fmt feature which can be enabled with:
```toml
group_imports = "StdExternalCrate"
reorder_imports = true
```

This has been run locally with a nightly version since it's not out yet, but I felt like it was good to let it run on our code to align imports.

#skip-changelog