### PR TITLE
ci: Add more rigorous checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,7 @@ jobs:
         "aarch64-unknown-linux-gnu": "ubuntu-22.04-arm"
       }')[matrix.target] }}
 
-    if: "!startsWith(github.ref, 'refs/heads/release-library/')"
+    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     env:
       RELAY_BIN: "target/${{ matrix.target }}/release/relay"
@@ -468,7 +468,7 @@ jobs:
       AR_DOCKER_IMAGE: "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}"
       REVISION: "${{ github.event.pull_request.head.sha || github.sha }}"
 
-    if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
+    if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add more rigorous checks on the CI such that the CI does not fail for external contributors.

Some of our CI relies on github secrets the problem with them is: 

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository" - [source](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)

As such these jobs in the CI would fail for an external contributor, this PR introduces more rigorous checks on these jobs (in line with the checks we have already) to ensure that these jobs are skipped for external contributors rather than fail.

See: https://github.com/getsentry/relay/pull/4679 for a proof of concept for these checks working.

#skip-changelog