### PR TITLE
fix(logs): Correctly filter log items, not all items

### DIFF
--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -48,6 +48,7 @@ impl Handling {
 }
 
 /// Represents the decision on whether or not to keep an envelope item.
+#[derive(Debug, Clone)]
 pub enum ItemAction {
     /// Keep the item.
     Keep,


### PR DESCRIPTION
The current logic drops all items of the envelope, while this currently works because some other code elsewhere splits all logs into a single envelope, it's almost pure coincidence and most definitely bad code.

#skip-changelog