### PR TITLE
ref(logs): Disallow multiple log containers in the same envelope

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2143,7 +2143,7 @@ impl EnvelopeProcessorService {
         .await?;
 
         if_processing!(self.inner.config, {
-            ourlog::process(managed_envelope, project_info.clone());
+            ourlog::process(managed_envelope, project_info.clone())?;
         });
 
         Ok(Some(extracted_metrics))


### PR DESCRIPTION
Implements the mentioned limit of one log item per envelope.

#skip-changelog