### PR TITLE
chore(eap): Remove unused feature flags to ingest in EAP

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -91,7 +91,6 @@ pub enum Feature {
     /// Serialized as `projects:span-metrics-extraction`.
     #[serde(rename = "projects:span-metrics-extraction")]
     ExtractCommonSpanMetricsFromEvent,
-
     /// Enables metric extraction from spans for addon modules.
     ///
     /// Serialized as `projects:span-metrics-extraction-addons`.
@@ -102,16 +101,6 @@ pub enum Feature {
     /// Serialized as `organizations:indexed-spans-extraction`.
     #[serde(rename = "organizations:indexed-spans-extraction")]
     ExtractSpansFromEvent,
-    /// Indicate if the EAP consumers should ingest a span for a given organization.
-    ///
-    /// Serialized as `organizations:ingest-spans-in-eap`
-    #[serde(rename = "organizations:ingest-spans-in-eap")]
-    IngestSpansInEapForOrganization,
-    /// Indicate if the EAP consumers should ingest a span for a given project.
-    ///
-    /// Serialized as `projects:ingest-spans-in-eap`
-    #[serde(rename = "projects:ingest-spans-in-eap")]
-    IngestSpansInEapForProject,
     /// Enable log ingestion for our log product (this is not internal logging).
     ///
     /// Serialized as `organizations:ourlogs-ingestion`.

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -48,7 +48,6 @@ impl Item {
                 spans_extracted: false,
                 sampled: true,
                 fully_normalized: false,
-                ingest_span_in_eap: false,
                 profile_type: None,
                 platform: None,
             },
@@ -331,16 +330,6 @@ impl Item {
     /// Sets the fully normalized flag.
     pub fn set_fully_normalized(&mut self, fully_normalized: bool) {
         self.headers.fully_normalized = fully_normalized;
-    }
-
-    /// Returns whether or not to ingest the span in EAP.
-    pub fn ingest_span_in_eap(&self) -> bool {
-        self.headers.ingest_span_in_eap
-    }
-
-    /// Set whether or not to ingest the span in EAP.
-    pub fn set_ingest_span_in_eap(&mut self, ingest_span_in_eap: bool) {
-        self.headers.ingest_span_in_eap = ingest_span_in_eap;
     }
 
     /// Returns the associated platform.
@@ -835,12 +824,6 @@ pub struct ItemHeaders {
     /// for which the transaction was dropped as `sampled: false`.
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     sampled: bool,
-
-    /// Indicates if we should ingest the item in the EAP
-    ///
-    /// NOTE: This is internal-only and not exposed into the Envelope.
-    #[serde(default, skip)]
-    ingest_span_in_eap: bool,
 
     /// Tracks whether the item is a backend or ui profile chunk.
     ///

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1896,7 +1896,6 @@ impl EnvelopeProcessorService {
                     &event,
                     &global_config,
                     config,
-                    project_info.clone(),
                     server_sample_rate,
                     event_metrics_extracted,
                     spans_extracted,

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -885,13 +885,12 @@ mod tests {
         let global_config = GlobalConfig::default();
         let config = Arc::new(Config::default());
         assert!(global_config.options.span_extraction_sample_rate.is_none());
-        let (mut managed_envelope, event, project_info) = params();
+        let (mut managed_envelope, event, _) = params();
         extract_from_event(
             &mut managed_envelope,
             &event,
             &global_config,
             config,
-            project_info,
             None,
             EventMetricsExtracted(false),
             SpansExtracted(false),
@@ -911,13 +910,12 @@ mod tests {
         let mut global_config = GlobalConfig::default();
         global_config.options.span_extraction_sample_rate = Some(1.0);
         let config = Arc::new(Config::default());
-        let (mut managed_envelope, event, project_info) = params();
+        let (mut managed_envelope, event, _) = params();
         extract_from_event(
             &mut managed_envelope,
             &event,
             &global_config,
             config,
-            project_info,
             None,
             EventMetricsExtracted(false),
             SpansExtracted(false),
@@ -937,13 +935,12 @@ mod tests {
         let mut global_config = GlobalConfig::default();
         global_config.options.span_extraction_sample_rate = Some(0.0);
         let config = Arc::new(Config::default());
-        let (mut managed_envelope, event, project_info) = params();
+        let (mut managed_envelope, event, _) = params();
         extract_from_event(
             &mut managed_envelope,
             &event,
             &global_config,
             config,
-            project_info,
             None,
             EventMetricsExtracted(false),
             SpansExtracted(false),
@@ -963,13 +960,12 @@ mod tests {
         let mut global_config = GlobalConfig::default();
         global_config.options.span_extraction_sample_rate = Some(1.0); // force enable
         let config = Arc::new(Config::default());
-        let (mut managed_envelope, event, project_info) = params(); // client sample rate is 0.2
+        let (mut managed_envelope, event, _) = params(); // client sample rate is 0.2
         extract_from_event(
             &mut managed_envelope,
             &event,
             &global_config,
             config,
-            project_info,
             Some(0.1),
             EventMetricsExtracted(false),
             SpansExtracted(false),

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -238,16 +238,6 @@ pub async fn process(
         };
         new_item.set_payload(ContentType::Json, payload);
         new_item.set_metrics_extracted(item.metrics_extracted());
-        new_item.set_ingest_span_in_eap(
-            project_info
-                .config
-                .features
-                .has(Feature::IngestSpansInEapForOrganization)
-                || project_info
-                    .config
-                    .features
-                    .has(Feature::IngestSpansInEapForProject),
-        );
 
         *item = new_item;
 
@@ -289,7 +279,6 @@ pub fn extract_from_event(
     event: &Annotated<Event>,
     global_config: &GlobalConfig,
     config: Arc<Config>,
-    project_info: Arc<ProjectInfo>,
     server_sample_rate: Option<f64>,
     event_metrics_extracted: EventMetricsExtracted,
     spans_extracted: SpansExtracted,
@@ -313,14 +302,6 @@ pub fn extract_from_event(
         .envelope()
         .dsc()
         .and_then(|ctx| ctx.sample_rate);
-    let ingest_in_eap = project_info
-        .config
-        .features
-        .has(Feature::IngestSpansInEapForOrganization)
-        || project_info
-            .config
-            .features
-            .has(Feature::IngestSpansInEapForProject);
 
     let mut add_span = |mut span: Span| {
         add_sample_rate(
@@ -372,7 +353,6 @@ pub fn extract_from_event(
         item.set_payload(ContentType::Json, span);
         // If metrics extraction happened for the event, it also happened for its spans:
         item.set_metrics_extracted(event_metrics_extracted.0);
-        item.set_ingest_span_in_eap(ingest_in_eap);
 
         relay_log::trace!("Adding span to envelope");
         managed_envelope.envelope_mut().add_item(item);

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -927,13 +927,10 @@ impl StoreService {
         self.produce(
             KafkaTopic::Spans,
             KafkaMessage::Span {
-                headers: BTreeMap::from([
-                    ("project_id".to_string(), scoping.project_id.to_string()),
-                    (
-                        "ingest_in_eap".to_string(),
-                        item.ingest_span_in_eap().to_string(),
-                    ),
-                ]),
+                headers: BTreeMap::from([(
+                    "project_id".to_string(),
+                    scoping.project_id.to_string(),
+                )]),
                 message: span,
             },
         )?;


### PR DESCRIPTION
Dedicated to @Dav1dde .

We do not use those feature flags anymore for anything EAP related. The consumer reading this header was shut down.

#skip-changelog