### PR TITLE
feat(event_context): Add Expo Updates information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Custom attachment expansion for Switch. ([#4566](https://github.com/getsentry/relay/pull/4566))
-- Add Expo Updates Event Context for Expo applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
+- Add OTA Updates Event Context for Expo and other applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Custom attachment expansion for Switch. ([#4566](https://github.com/getsentry/relay/pull/4566))
+- Add Expo Updates Event Context for Expo applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
 
 ## 25.4.0
 

--- a/relay-event-schema/src/protocol/contexts/expo_updates.rs
+++ b/relay-event-schema/src/protocol/contexts/expo_updates.rs
@@ -1,0 +1,146 @@
+use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
+
+use crate::processor::ProcessValue;
+
+/// Expo Updates context.
+///
+/// Contains the Expo Updates constants present when the event was created.
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+pub struct ExpoUpdatesContext {
+    /// The channel name of the current build, if configured for use with EAS Update.
+    pub channel: Annotated<String>,
+
+    /// The runtime version of the current build.
+    pub runtime_version: Annotated<String>,
+
+    /// The UUID that uniquely identifies the currently running update.
+    pub update_id: Annotated<String>,
+
+    /// Additional arbitrary fields for forwards compatibility.
+    #[metastructure(additional_properties, retain = true, pii = "maybe")]
+    pub other: Object<Value>,
+}
+
+impl super::DefaultContext for ExpoUpdatesContext {
+    fn default_key() -> &'static str {
+        "expo_updates"
+    }
+
+    fn from_context(context: super::Context) -> Option<Self> {
+        match context {
+            super::Context::ExpoUpdates(c) => Some(*c),
+            _ => None,
+        }
+    }
+
+    fn cast(context: &super::Context) -> Option<&Self> {
+        match context {
+            super::Context::ExpoUpdates(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    fn cast_mut(context: &mut super::Context) -> Option<&mut Self> {
+        match context {
+            super::Context::ExpoUpdates(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    fn into_context(self) -> super::Context {
+        super::Context::ExpoUpdates(Box::new(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::Context;
+
+    #[test]
+    fn test_expo_updates_context_roundtrip() {
+        let json: &str = r#"{
+  "channel": "production",
+  "runtime_version": "1.0.0",
+  "update_id": "12345678-1234-1234-1234-1234567890ab",
+  "type": "expoupdates"
+}"#;
+        let context = Annotated::new(Context::ExpoUpdates(Box::new(ExpoUpdatesContext {
+            channel: Annotated::new("production".to_string()),
+            runtime_version: Annotated::new("1.0.0".to_string()),
+            update_id: Annotated::new("12345678-1234-1234-1234-1234567890ab".to_string()),
+            other: Object::default(),
+        })));
+
+        assert_eq!(context, Annotated::from_json(json).unwrap());
+        assert_eq!(json, context.to_json_pretty().unwrap());
+    }
+
+    #[test]
+    fn test_expo_updates_context_with_extra_keys() {
+        let json: &str = r#"{
+  "channel": "production",
+  "runtime_version": "1.0.0",
+  "update_id": "12345678-1234-1234-1234-1234567890ab",
+  "created_at": "2023-01-01T00:00:00.000Z",
+  "emergency_launch_reason": "some reason",
+  "is_embedded_launch": false,
+  "is_emergency_launch": true,
+  "is_enabled": true,
+  "launch_duration": 1000,
+  "type": "expoupdates"
+}"#;
+        let mut other = Object::new();
+        other.insert("is_enabled".to_string(), Annotated::new(Value::Bool(true)));
+        other.insert(
+            "is_embedded_launch".to_string(),
+            Annotated::new(Value::Bool(false)),
+        );
+        other.insert(
+            "is_emergency_launch".to_string(),
+            Annotated::new(Value::Bool(true)),
+        );
+        other.insert(
+            "emergency_launch_reason".to_string(),
+            Annotated::new(Value::String("some reason".to_string())),
+        );
+        other.insert(
+            "launch_duration".to_string(),
+            Annotated::new(Value::I64(1000)),
+        );
+        other.insert(
+            "created_at".to_string(),
+            Annotated::new(Value::String("2023-01-01T00:00:00.000Z".to_string())),
+        );
+
+        let context = Annotated::new(Context::ExpoUpdates(Box::new(ExpoUpdatesContext {
+            channel: Annotated::new("production".to_string()),
+            runtime_version: Annotated::new("1.0.0".to_string()),
+            update_id: Annotated::new("12345678-1234-1234-1234-1234567890ab".to_string()),
+            other,
+        })));
+
+        assert_eq!(context, Annotated::from_json(json).unwrap());
+        assert_eq!(json, context.to_json_pretty().unwrap());
+    }
+
+    #[test]
+    fn test_expo_updates_context_with_is_enabled_false() {
+        let json: &str = r#"{
+  "is_enabled": false,
+  "type": "expoupdates"
+}"#;
+        let mut other = Object::new();
+        other.insert("is_enabled".to_string(), Annotated::new(Value::Bool(false)));
+
+        let context = Annotated::new(Context::ExpoUpdates(Box::new(ExpoUpdatesContext {
+            channel: Annotated::empty(),
+            runtime_version: Annotated::empty(),
+            update_id: Annotated::empty(),
+            other,
+        })));
+
+        assert_eq!(context, Annotated::from_json(json).unwrap());
+        assert_eq!(json, context.to_json_pretty().unwrap());
+    }
+}

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -2,6 +2,7 @@ mod app;
 mod browser;
 mod cloud_resource;
 mod device;
+mod expo_updates;
 mod flags;
 mod gpu;
 mod monitor;
@@ -21,6 +22,7 @@ pub use app::*;
 pub use browser::*;
 pub use cloud_resource::*;
 pub use device::*;
+pub use expo_updates::*;
 pub use gpu::*;
 pub use monitor::*;
 pub use nel::*;
@@ -94,6 +96,8 @@ pub enum Context {
     PerformanceScore(Box<PerformanceScoreContext>),
     /// Spring / Spring Boot information.
     Spring(Box<SpringContext>),
+    /// Expo Updates information.
+    ExpoUpdates(Box<ExpoUpdatesContext>),
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(fallback_variant)]
     Other(#[metastructure(pii = "true")] Object<Value>),

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -2,12 +2,12 @@ mod app;
 mod browser;
 mod cloud_resource;
 mod device;
-mod expo_updates;
 mod flags;
 mod gpu;
 mod monitor;
 mod nel;
 mod os;
+mod ota_updates;
 mod otel;
 mod performance_score;
 mod profile;
@@ -22,11 +22,11 @@ pub use app::*;
 pub use browser::*;
 pub use cloud_resource::*;
 pub use device::*;
-pub use expo_updates::*;
 pub use gpu::*;
 pub use monitor::*;
 pub use nel::*;
 pub use os::*;
+pub use ota_updates::*;
 pub use otel::*;
 pub use performance_score::*;
 pub use profile::*;
@@ -96,8 +96,8 @@ pub enum Context {
     PerformanceScore(Box<PerformanceScoreContext>),
     /// Spring / Spring Boot information.
     Spring(Box<SpringContext>),
-    /// Expo Updates information.
-    ExpoUpdates(Box<ExpoUpdatesContext>),
+    /// OTA Updates information.
+    OTAUpdates(Box<OTAUpdatesContext>),
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(fallback_variant)]
     Other(#[metastructure(pii = "true")] Object<Value>),

--- a/relay-event-schema/src/protocol/contexts/ota_updates.rs
+++ b/relay-event-schema/src/protocol/contexts/ota_updates.rs
@@ -2,11 +2,11 @@ use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
 
 use crate::processor::ProcessValue;
 
-/// Expo Updates context.
+/// OTA (Expo) Updates context.
 ///
-/// Contains the Expo Updates constants present when the event was created.
+/// Contains the OTA Updates constants present when the event was created.
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
-pub struct ExpoUpdatesContext {
+pub struct OTAUpdatesContext {
     /// The channel name of the current build, if configured for use with EAS Update.
     pub channel: Annotated<String>,
 
@@ -21,34 +21,34 @@ pub struct ExpoUpdatesContext {
     pub other: Object<Value>,
 }
 
-impl super::DefaultContext for ExpoUpdatesContext {
+impl super::DefaultContext for OTAUpdatesContext {
     fn default_key() -> &'static str {
-        "expo_updates"
+        "ota_updates"
     }
 
     fn from_context(context: super::Context) -> Option<Self> {
         match context {
-            super::Context::ExpoUpdates(c) => Some(*c),
+            super::Context::OTAUpdates(c) => Some(*c),
             _ => None,
         }
     }
 
     fn cast(context: &super::Context) -> Option<&Self> {
         match context {
-            super::Context::ExpoUpdates(c) => Some(c),
+            super::Context::OTAUpdates(c) => Some(c),
             _ => None,
         }
     }
 
     fn cast_mut(context: &mut super::Context) -> Option<&mut Self> {
         match context {
-            super::Context::ExpoUpdates(c) => Some(c),
+            super::Context::OTAUpdates(c) => Some(c),
             _ => None,
         }
     }
 
     fn into_context(self) -> super::Context {
-        super::Context::ExpoUpdates(Box::new(self))
+        super::Context::OTAUpdates(Box::new(self))
     }
 }
 
@@ -58,14 +58,14 @@ mod tests {
     use crate::protocol::Context;
 
     #[test]
-    fn test_expo_updates_context_roundtrip() {
+    fn test_ota_updates_context_roundtrip() {
         let json: &str = r#"{
   "channel": "production",
   "runtime_version": "1.0.0",
   "update_id": "12345678-1234-1234-1234-1234567890ab",
-  "type": "expoupdates"
+  "type": "otaupdates"
 }"#;
-        let context = Annotated::new(Context::ExpoUpdates(Box::new(ExpoUpdatesContext {
+        let context = Annotated::new(Context::OTAUpdates(Box::new(OTAUpdatesContext {
             channel: Annotated::new("production".to_string()),
             runtime_version: Annotated::new("1.0.0".to_string()),
             update_id: Annotated::new("12345678-1234-1234-1234-1234567890ab".to_string()),
@@ -77,7 +77,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expo_updates_context_with_extra_keys() {
+    fn test_ota_updates_context_with_extra_keys() {
         let json: &str = r#"{
   "channel": "production",
   "runtime_version": "1.0.0",
@@ -88,7 +88,7 @@ mod tests {
   "is_emergency_launch": true,
   "is_enabled": true,
   "launch_duration": 1000,
-  "type": "expoupdates"
+  "type": "otaupdates"
 }"#;
         let mut other = Object::new();
         other.insert("is_enabled".to_string(), Annotated::new(Value::Bool(true)));
@@ -113,7 +113,7 @@ mod tests {
             Annotated::new(Value::String("2023-01-01T00:00:00.000Z".to_string())),
         );
 
-        let context = Annotated::new(Context::ExpoUpdates(Box::new(ExpoUpdatesContext {
+        let context = Annotated::new(Context::OTAUpdates(Box::new(OTAUpdatesContext {
             channel: Annotated::new("production".to_string()),
             runtime_version: Annotated::new("1.0.0".to_string()),
             update_id: Annotated::new("12345678-1234-1234-1234-1234567890ab".to_string()),
@@ -125,15 +125,15 @@ mod tests {
     }
 
     #[test]
-    fn test_expo_updates_context_with_is_enabled_false() {
+    fn test_ota_updates_context_with_is_enabled_false() {
         let json: &str = r#"{
   "is_enabled": false,
-  "type": "expoupdates"
+  "type": "otaupdates"
 }"#;
         let mut other = Object::new();
         other.insert("is_enabled".to_string(), Annotated::new(Value::Bool(false)));
 
-        let context = Annotated::new(Context::ExpoUpdates(Box::new(ExpoUpdatesContext {
+        let context = Annotated::new(Context::OTAUpdates(Box::new(OTAUpdatesContext {
             channel: Annotated::empty(),
             runtime_version: Annotated::empty(),
             update_id: Annotated::empty(),


### PR DESCRIPTION
This PR adds `Expo Updates` event context. The goal is to make events searchable by the `channel`, `runtime_version` and `update_id` fields.

### Part of:
- https://github.com/getsentry/sentry-react-native/pull/4767
- (this PR) https://github.com/getsentry/relay/pull/4690
- https://github.com/getsentry/sentry/pull/90148
- https://github.com/getsentry/sentry/pull/90162
- https://github.com/getsentry/sentry/pull/90475