### PR TITLE
fix(csp): add new CspDirective item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Custom attachment expansion for Switch. ([#4566](https://github.com/getsentry/relay/pull/4566))
 
+**Bug Fixes**:
+
+- Add `fenced-frame-src` to `CspDirective`. ([#4691](https://github.com/getsentry/relay/pull/4691))
+
 ## 25.4.0
 
 - Extract searchable context fields into sentry tags for segment spans. ([#4651](https://github.com/getsentry/relay/pull/4651))

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -2134,18 +2134,18 @@ mod tests {
     fn test_csp_report_fenced_frame_src() {
         let json = r#"
             {
-          "csp-report": {
-            "document-uri": "https://example.com",
-            "referrer": "https://www.google.com/",
-            "violated-directive": "fenced-frame-src",
-            "effective-directive": "fenced-frame-src",
-            "original-policy": "default-src 'self' 'unsafe-eval'",
-            "disposition": "enforce",
-            "blocked-uri": "",
-            "status-code": 200,
-            "script-sample": ""
-          }
-        }
+              "csp-report": {
+                "document-uri": "https://example.com",
+                "referrer": "https://www.google.com/",
+                "violated-directive": "fenced-frame-src",
+                "effective-directive": "fenced-frame-src",
+                "original-policy": "default-src 'self' 'unsafe-eval'",
+                "disposition": "enforce",
+                "blocked-uri": "",
+                "status-code": 200,
+                "script-sample": ""
+              }
+            }
         "#;
         let raw_report = serde_json::from_slice::<CspReportRaw>(json.as_bytes()).unwrap();
         let raw_csp = raw_report.csp_report;

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -32,6 +32,7 @@ pub enum CspDirective {
     ChildSrc,
     ConnectSrc,
     DefaultSrc,
+    FencedFrameSrc,
     FontSrc,
     FormAction,
     FrameAncestors,
@@ -66,6 +67,7 @@ relay_common::derive_fromstr_and_display!(CspDirective, InvalidSecurityError, {
     CspDirective::ChildSrc => "child-src",
     CspDirective::ConnectSrc => "connect-src",
     CspDirective::DefaultSrc => "default-src",
+    CspDirective::FencedFrameSrc => "fenced-frame-src",
     CspDirective::FontSrc => "font-src",
     CspDirective::FormAction => "form-action",
     CspDirective::FrameAncestors => "frame-ancestors",
@@ -2126,5 +2128,28 @@ mod tests {
         let effective_directive = raw_csp.effective_directive().unwrap();
 
         assert_eq!(effective_directive, CspDirective::ScriptSrc);
+    }
+
+    #[test]
+    fn test_csp_report_fenced_frame_src() {
+        let json = r#"
+            {
+          "csp-report": {
+            "document-uri": "https://example.com",
+            "referrer": "https://www.google.com/",
+            "violated-directive": "fenced-frame-src",
+            "effective-directive": "fenced-frame-src",
+            "original-policy": "default-src 'self' 'unsafe-eval'",
+            "disposition": "enforce",
+            "blocked-uri": "",
+            "status-code": 200,
+            "script-sample": ""
+          }
+        }
+        "#;
+        let raw_report = serde_json::from_slice::<CspReportRaw>(json.as_bytes()).unwrap();
+        let raw_csp = raw_report.csp_report;
+
+        assert!(raw_csp.effective_directive().is_ok());
     }
 }


### PR DESCRIPTION
This PR adds a new `CspDirective` so we can parse CSP reports using this experimental value.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/fenced-frame-src