### PR TITLE
build: Don't use zip for Python sdist

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -105,7 +105,7 @@ jobs:
           python-version: "3.10"
 
       - name: Build sdist
-        run: python setup.py sdist --format=zip
+        run: python setup.py sdist
         working-directory: py
 
       - uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-release-with-bundles: build-linux-release collect-source-bundle
 .PHONY: build-relase-with-bundles
 
 sdist: setup-git setup-venv ## create a sdist of the Python library
-	cd py && ../.venv/bin/python setup.py sdist --format=zip
+	cd py && ../.venv/bin/python setup.py sdist
 .PHONY: sdist
 
 wheel: setup-git setup-venv ## build a wheel of the Python library


### PR DESCRIPTION
Corresponding PR in `symbolic`: https://github.com/getsentry/symbolic/pull/910

Closes Ingest-99.

#skip-changelog