### PR TITLE
feat(profiles): Remove threads with 1 non-idle sample in profiling chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **Internal**:
 
-- Reject chunks with 1 sample only. ([#4694](https://github.com/getsentry/relay/pull/4694))
+- Remove threads with 1 non-idle sample in profiling chunks. ([#4694](https://github.com/getsentry/relay/pull/4694))
 
 ## 25.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Add `fenced-frame-src` to `CspDirective`. ([#4691](https://github.com/getsentry/relay/pull/4691))
 
+**Internal**:
+
+- Reject chunks with 1 sample only. ([#4694](https://github.com/getsentry/relay/pull/4694))
+
 ## 25.4.0
 
 - Extract searchable context fields into sentry tags for segment spans. ([#4651](https://github.com/getsentry/relay/pull/4651))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,6 +3921,7 @@ dependencies = [
  "bytes",
  "chrono",
  "data-encoding",
+ "hashbrown 0.14.5",
  "insta",
  "itertools 0.13.0",
  "relay-base-schema",

--- a/relay-profiling/Cargo.toml
+++ b/relay-profiling/Cargo.toml
@@ -17,6 +17,7 @@ android_trace_log = { workspace = true, features = ["serde"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
 data-encoding = { workspace = true }
+hashbrown = { workspace = true }
 itertools = { workspace = true }
 relay-base-schema = { workspace = true }
 relay-dynamic-config = { workspace = true }

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -132,8 +132,6 @@ impl ProfileData {
             return Err(ProfileError::NotEnoughSamples);
         }
 
-        self.samples.sort_by_key(|s| s.timestamp);
-
         if !self.all_stacks_referenced_by_samples_exist() {
             return Err(ProfileError::MalformedSamples);
         }
@@ -141,6 +139,8 @@ impl ProfileData {
         if !self.all_frames_referenced_by_stacks_exist() {
             return Err(ProfileError::MalformedStacks);
         }
+
+        self.samples.sort_by_key(|s| s.timestamp);
 
         if self.is_above_max_duration() {
             return Err(ProfileError::DurationIsTooLong);

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -192,6 +192,8 @@ impl ProfileData {
             .retain(|thread_id, _| thread_ids.contains(thread_id));
     }
 
+    /// Removes samples at the beginning and end of the chunks that are considered idle.
+    /// An idle sample is a sample where the stack is empty.
     fn remove_idle_samples_at_the_edge(&mut self) {
         let mut active_ranges: HashMap<String, Range<usize>> = HashMap::new();
 

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -9,7 +9,8 @@
 //!
 //! Spans are expected to carry the profiler ID to know which samples are associated with them.
 //!
-use std::collections::{BTreeMap, HashMap, HashSet};
+use hashbrown::HashMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ops::Range;
 
 use itertools::Itertools;
@@ -204,7 +205,7 @@ impl ProfileData {
             }
 
             active_ranges
-                .entry(sample.thread_id.clone())
+                .entry_ref(&sample.thread_id)
                 .and_modify(|range| range.end = i + 1)
                 .or_insert(i..i + 1);
         }

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -11,9 +11,7 @@
 //!
 use hashbrown::HashMap;
 use std::collections::{BTreeMap, HashSet};
-use std::ops::Range;
 
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use relay_event_schema::protocol::EventId;
@@ -128,7 +126,6 @@ impl ProfileData {
     /// Throws an error if the profile chunk is malformed.
     /// Removes extra metadata that are not referenced in the samples.
     pub fn normalize(&mut self, platform: &str) -> Result<(), ProfileError> {
-        self.remove_idle_samples_at_the_edge();
         self.remove_single_samples_per_thread();
 
         if self.samples.is_empty() {
@@ -192,50 +189,25 @@ impl ProfileData {
             .retain(|thread_id, _| thread_ids.contains(thread_id));
     }
 
-    /// Removes samples at the beginning and end of the chunks that are considered idle.
-    /// An idle sample is a sample where the stack is empty.
-    fn remove_idle_samples_at_the_edge(&mut self) {
-        let mut active_ranges: HashMap<String, Range<usize>> = HashMap::new();
+    /// Removes a sample when it's the only non-idle sample on its thread
+    fn remove_single_samples_per_thread(&mut self) {
+        let mut sample_count_by_thread_id: hashbrown::HashMap<String, u32> = HashMap::new();
 
-        for (i, sample) in self.samples.iter().enumerate() {
-            if self
-                .stacks
-                .get(sample.stack_id)
-                .is_none_or(|stack| stack.is_empty())
-            {
+        for s in &self.samples {
+            if let Some(stack) = self.stacks.get(s.stack_id) {
+                // We only count non-idle samples
+                if stack.is_empty() {
+                    continue;
+                }
+            } else {
                 continue;
             }
-
-            active_ranges
-                .entry_ref(&sample.thread_id)
-                .and_modify(|range| range.end = i + 1)
-                .or_insert(i..i + 1);
+            *sample_count_by_thread_id
+                .entry(s.thread_id.to_owned())
+                .or_default() += 1;
         }
 
-        self.samples = self
-            .samples
-            .drain(..)
-            .enumerate()
-            .filter(|(i, sample)| {
-                active_ranges
-                    .get(sample.thread_id.as_str())
-                    .is_some_and(|range| range.contains(i))
-            })
-            .map(|(_, sample)| sample)
-            .collect();
-    }
-
-    /// Removes a sample when it's the only sample on its thread
-    fn remove_single_samples_per_thread(&mut self) {
-        let sample_count_by_thread_id = &self
-            .samples
-            .iter()
-            .counts_by(|sample| sample.thread_id.clone())
-            // Only keep data from threads with more than 1 sample so we can calculate a duration
-            .into_iter()
-            .filter(|(_, count)| *count > 1)
-            .collect::<HashMap<_, _>>();
-
+        sample_count_by_thread_id.retain(|_, count| *count > 1);
         self.samples
             .retain(|sample| sample_count_by_thread_id.contains_key(&sample.thread_id));
     }
@@ -380,7 +352,22 @@ mod tests {
         let mut chunk = ProfileData {
             samples: vec![
                 Sample {
+                    stack_id: 1,
+                    thread_id: "1".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 1,
+                    thread_id: "1".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
+                Sample {
                     stack_id: 0,
+                    thread_id: "1".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 1,
                     thread_id: "1".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
@@ -389,37 +376,45 @@ mod tests {
                     thread_id: "2".to_string(),
                     timestamp: FiniteF64::new(30.0).unwrap(),
                 },
+                Sample {
+                    stack_id: 1,
+                    thread_id: "2".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 1,
+                    thread_id: "2".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 0,
+                    thread_id: "3".to_string(),
+                    timestamp: FiniteF64::new(30.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 0,
+                    thread_id: "3".to_string(),
+                    timestamp: FiniteF64::new(30.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 1,
+                    thread_id: "3".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
+                Sample {
+                    stack_id: 1,
+                    thread_id: "3".into(),
+                    timestamp: FiniteF64::new(60.0).unwrap(),
+                },
             ],
-            stacks: vec![vec![0]],
+            stacks: vec![vec![0], vec![]],
             frames: vec![Default::default()],
             ..Default::default()
         };
 
         chunk.remove_single_samples_per_thread();
-        assert!(chunk.samples.is_empty());
-    }
 
-    #[test]
-    fn test_idle_samples_are_removed() {
-        let mut chunk = ProfileData {
-            samples: vec![
-                Sample {
-                    stack_id: 0,
-                    thread_id: "1".into(),
-                    timestamp: FiniteF64::new(60.0).unwrap(),
-                },
-                Sample {
-                    stack_id: 0,
-                    thread_id: "1".to_string(),
-                    timestamp: FiniteF64::new(30.0).unwrap(),
-                },
-            ],
-            stacks: vec![],
-            frames: vec![Default::default()],
-            ..Default::default()
-        };
-
-        chunk.remove_idle_samples_at_the_edge();
-        assert!(chunk.samples.is_empty());
+        // Only 4 samples from thread_id 3 are retained.
+        assert_eq!(chunk.samples.len(), 4);
     }
 }


### PR DESCRIPTION
We thought it'd be beneficial to get chunks even with 1 sample as profiling is now continuous, turns out it's not since we still have the trace mode which has small chunks anyway.

With this PR, we'll now reject those chunks.