### PR TITLE
fix(profiling): Add profile_chunk_ui as item type alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - Exposes all service utilization with instance labels instead of the last. ([#4654](https://github.com/getsentry/relay/pull/4654))
 - Ensure that every span's parent exists. ([#4661](https://github.com/getsentry/relay/pull/4661))
 - Serialize trace ids consistently in events. ([#4673](https://github.com/getsentry/relay/pull/4673))
+- Add profile_chunk_ui as item type alias. ([#4697](https://github.com/getsentry/relay/pull/4697))
+
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@
 - Serialize trace ids consistently in events. ([#4673](https://github.com/getsentry/relay/pull/4673))
 - Add profile_chunk_ui as item type alias. ([#4697](https://github.com/getsentry/relay/pull/4697))
 
-
 **Internal**:
 
 - Add ui chunk profiling data category. ([#4593](https://github.com/getsentry/relay/pull/4593))

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -701,6 +701,8 @@ impl std::str::FromStr for ItemType {
             "otel_span" => Self::OtelSpan,
             "otel_traces_data" => Self::OtelTracesData,
             "profile_chunk" => Self::ProfileChunk,
+            // "profile_chunk_ui" is to be treated as an alias for `ProfileChunk`
+            // because Android 8.10.0 and 8.11.0 is sending it as the item type.
             "profile_chunk_ui" => Self::ProfileChunk,
             other => Self::Unknown(other.to_owned()),
         })

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -701,6 +701,7 @@ impl std::str::FromStr for ItemType {
             "otel_span" => Self::OtelSpan,
             "otel_traces_data" => Self::OtelTracesData,
             "profile_chunk" => Self::ProfileChunk,
+            "profile_chunk_ui" => Self::ProfileChunk,
             other => Self::Unknown(other.to_owned()),
         })
     }

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 from copy import deepcopy
 from pathlib import Path


### PR DESCRIPTION
Android 8.10.0 and 8.11.0 released with `profile_chunk_ui` as the item type unintentionally. To support those SDKs, add `profile_chunk_ui` as an alias to `ItemType::ProfileChunk`.