### PR TITLE
feat(pii): allow pii scrubbing within all span sentry_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add the type of the attachment that made the envelope too large to invalid outcomes. ([#4695](https://github.com/getsentry/relay/pull/4695))
 - Add OTA Updates Event Context for Expo and other applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
 - Add data categories for Seer. ([#4692](https://github.com/getsentry/relay/pull/4692))
-- Allow pii scrubbing of all span `sentry_tags` values. ([#4698](https://github.com/getsentry/relay/pull/4698))
+- Allow pii scrubbing of all span `sentry_tags` fields. ([#4698](https://github.com/getsentry/relay/pull/4698))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Custom attachment expansion for Switch. ([#4566](https://github.com/getsentry/relay/pull/4566))
 - Add OTA Updates Event Context for Expo and other applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
+- Allow pii scrubbing of all span `sentry_tags` values. ([#4698](https://github.com/getsentry/relay/pull/4698))
 
 **Bug Fixes**:
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -209,7 +209,7 @@ impl Getter for Span {
 
 /// Indexable fields added by sentry (server-side).
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
-#[metastructure(trim = false)]
+#[metastructure(trim = false, pii = "maybe")]
 pub struct SentryTags {
     pub release: Annotated<String>,
     #[metastructure(pii = "true")]

--- a/tests/integration/test_pii.py
+++ b/tests/integration/test_pii.py
@@ -1,0 +1,37 @@
+def test_scrub_span_sentry_tags_advanced_rules(mini_sentry, relay):
+    project_id = 42
+    relay = relay(
+        mini_sentry,
+        options={"geoip": {"path": "tests/fixtures/GeoIP2-Enterprise-Test.mmdb"}},
+    )
+    config = mini_sentry.add_basic_project_config(project_id)
+    config["config"]["piiConfig"]["applications"][
+        "$span.sentry_tags.'user.geo.country_code'"
+    ] = ["@anything:mask"]
+    config["config"]["piiConfig"]["applications"][
+        "$span.sentry_tags.'user.geo.subregion'"
+    ] = ["@anything:mask"]
+
+    relay.send_event(
+        project_id,
+        {
+            "user": {"ip_address": "2.125.160.216"},
+            "spans": [
+                {
+                    "timestamp": 1746007551,
+                    "start_timestamp": 1746007545,
+                    "span_id": "aaaaaaaa00000000",
+                    "trace_id": "aaaaaaaaaaaaaaaaaaaa000000000000",
+                    "sentry_tags": {
+                        "user.geo.country_code": "AT",
+                        "user.geo.subregion": "12",
+                    },
+                }
+            ],
+        },
+    )
+
+    envelope = mini_sentry.captured_events.get(timeout=1)
+    event = envelope.get_event()
+    assert event["spans"][0]["sentry_tags"]["user.geo.country_code"] == "**"
+    assert event["spans"][0]["sentry_tags"]["user.geo.subregion"] == "**"


### PR DESCRIPTION
This PR enables pii scrubbing on all `sentry_tags` values within spans. This is done by introducing a struct level `pii` metastructure attribute which is then used as the default for all fields without explicit `pii` attributes.