### PR TITLE
fix(crawlers): Filter out meta crawlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,7 +508,7 @@
 - Consider "Bearer" (case-insensitive) a password. PII will scrub all strings matching that substring. ([#3484](https://github.com/getsentry/relay/pull/3484))
 - Add support for `CF-Connecting-IP` header. ([#3496](https://github.com/getsentry/relay/pull/3496))
 - Add `received_at` timestamp to `BucketMetadata` to measure the oldest received timestamp of the `Bucket`. ([#3488](https://github.com/getsentry/relay/pull/3488))
-- Properly identify meta web crawlers when filtering out web crawlers
+- Properly identify meta web crawlers when filtering out web crawlers. ([#4699](https://github.com/getsentry/relay/pull/4699))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,7 @@
 - Consider "Bearer" (case-insensitive) a password. PII will scrub all strings matching that substring. ([#3484](https://github.com/getsentry/relay/pull/3484))
 - Add support for `CF-Connecting-IP` header. ([#3496](https://github.com/getsentry/relay/pull/3496))
 - Add `received_at` timestamp to `BucketMetadata` to measure the oldest received timestamp of the `Bucket`. ([#3488](https://github.com/getsentry/relay/pull/3488))
+- Properly identify meta web crawlers when filtering out web crawlers
 
 **Internal**:
 

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -18,6 +18,7 @@ static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
         Slurp|                      # Yahoo
         Sogou|                      # Sogou
         facebook|                   # facebook
+        meta-|                      # meta/facebook
         ia_archiver|                # Alexa
         bots?[/\s\);]|              # Generic bot
         spider[/\s\);]|             # Generic spider
@@ -106,6 +107,10 @@ mod tests {
             "Slurp",
             "Sogou",
             "facebook",
+            "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+            "facebookcatalog/1.0",
+            "meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)",
+            "meta-externalfetcher/1.1",
             "ia_archiver",
             "bots ",
             "bots;",


### PR DESCRIPTION
I'm investigating https://linear.app/getsentry/issue/RTC-739/facebook-crawler-ignored. We should be blocking facebook crawlers already, but we should include meta here as well.

Also adds some more thorough test user agents based on https://developers.facebook.com/docs/sharing/webmasters/web-crawlers.