### PR TITLE
ref(clippy): Fixes upcoming clippy::io-other-error lint

### DIFF
--- a/relay-log/build.rs
+++ b/relay-log/build.rs
@@ -11,10 +11,10 @@ fn emit_release_var() -> Result<(), io::Error> {
         .output()?;
 
     if !cmd.status.success() {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("`git rev-parse' failed: {}", cmd.status),
-        ));
+        return Err(io::Error::other(format!(
+            "`git rev-parse' failed: {}",
+            cmd.status
+        )));
     }
 
     let version = std::env::var("CARGO_PKG_VERSION").unwrap();


### PR DESCRIPTION
```
error: this can be `std::io::Error::other(_)`
  --> relay-log/build.rs:14:20
   |
14 |           return Err(io::Error::new(
   |  ____________________^
15 | |             io::ErrorKind::Other,
16 | |             format!("`git rev-parse' failed: {}", cmd.status),
17 | |         ));
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
   = note: `-D clippy::io-other-error` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::io_other_error)]`
help: use `std::io::Error::other`
   |
14 ~         return Err(io::Error::other(
15 ~             format!("`git rev-parse' failed: {}", cmd.status),
   |
```

Lint fails in Rust beta.

#skip-changelog