### PR TITLE
ci(librelay): Build aarch wheel natively on an ubuntu-arm runner

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -20,17 +20,16 @@ jobs:
           - aarch64
 
     name: Python Linux ${{ matrix.build-arch }}
-    runs-on: ubuntu-latest
+    runs-on: |-
+      ${{fromJson('{
+        "x86_64": "ubuntu-latest",
+        "aarch64": "ubuntu-24.04-arm"
+      }')[matrix.build-arch] }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - if: matrix.build-arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Build in Docker
         run: scripts/docker-manylinux.sh

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -7,11 +7,6 @@ if [ -z "$TARGET" ]; then
 fi
 
 TARGET_LINKER="CARGO_TARGET_$(echo $TARGET | tr '[:lower:]' '[:upper:]')_UNKNOWN_LINUX_GNU_LINKER"
-# Set cargo build arguments
-if [[ "x86_64" != "$TARGET" ]]; then
-  export CARGO_BUILD_TARGET="${TARGET}-unknown-linux-gnu"
-  export "${TARGET_LINKER}"="${TARGET}-linux-gnu-gcc"
-fi
 
 # Build docker image with all dependencies for cross compilation
 BUILDER_NAME="${BUILDER_NAME:-relay-cabi-builder-${TARGET}}"


### PR DESCRIPTION
Should speed up the build quite a lot, as it no longer needs to emulate.

[Successful Build](https://github.com/getsentry/relay/actions/runs/14792119255).

#skip-changelog