### PR TITLE
inc: Add killswitch for trace id partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Custom attachment expansion for Switch. ([#4566](https://github.com/getsentry/relay/pull/4566))
 - Add OTA Updates Event Context for Expo and other applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
+- Add killswitch for trace id partitioning. ([#4706](https://github.com/getsentry/relay/pull/4706))
 
 **Bug Fixes**:
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -225,6 +225,19 @@ pub struct Options {
     )]
     pub deprecated2: f32,
 
+    /// Disable semantic partitioning of spans by trace ID for these projects. Use this in case
+    /// there is partition imbalance on the spans topic produced to by Relay (either snuba-spans or
+    /// ingest-spans). This will break the span buffer, and anything that depends on segments being
+    /// assembled by it (performance issue, etc). As of 2025-05-06, the span buffer is not yet
+    /// rolled out to most regions though.
+    ///
+    /// Argument is a list of project IDs. `[0]` means disable for all projects.
+    #[serde(
+        rename = "relay.spans-ignore-trace-id-partitioning.projects",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub spans_ignore_trace_id_partitioning_projects: Vec<u64>,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -225,18 +225,16 @@ pub struct Options {
     )]
     pub deprecated2: f32,
 
-    /// Disable semantic partitioning of spans by trace ID for these projects. Use this in case
-    /// there is partition imbalance on the spans topic produced to by Relay (either snuba-spans or
-    /// ingest-spans). This will break the span buffer, and anything that depends on segments being
-    /// assembled by it (performance issue, etc). As of 2025-05-06, the span buffer is not yet
-    /// rolled out to most regions though.
-    ///
-    /// Argument is a list of project IDs. `[0]` means disable for all projects.
+    /// Disable semantic partitioning of spans by trace ID. Use this in case there is partition
+    /// imbalance on the spans topic produced to by Relay (either snuba-spans or ingest-spans).
+    /// This will break the span buffer, and anything that depends on segments being assembled by
+    /// it (performance issue, etc). As of 2025-05-06, the span buffer is not yet rolled out to
+    /// most regions though.
     #[serde(
         rename = "relay.spans-ignore-trace-id-partitioning.projects",
-        skip_serializing_if = "Vec::is_empty"
+        skip_serializing_if = "is_default"
     )]
-    pub spans_ignore_trace_id_partitioning_projects: Vec<u64>,
+    pub spans_ignore_trace_id_partitioning: bool,
 
     /// All other unknown options.
     #[serde(flatten)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -512,16 +512,12 @@ impl StoreService {
 
         if let KafkaMessage::Span {
             ref mut ignore_trace_id_partitioning,
-            message: ref span,
             ..
         } = message
         {
             let global_config = self.global_config.current();
-            let config_projects = &global_config
-                .options
-                .spans_ignore_trace_id_partitioning_projects;
             *ignore_trace_id_partitioning =
-                config_projects.contains(&0) || config_projects.contains(&span.project_id);
+                global_config.options.spans_ignore_trace_id_partitioning;
         }
 
         let topic_name = self.producer.client.send_message(topic, &message)?;


### PR DESCRIPTION
ref INC-1143

Some projects send such heavy abuse into single trace IDs that this
causes problems in production today. A better solution is needed
long-term as disabling this partition will lead to product
degradation once span buffer is rolled out.

Why a global option instead of a projectconfig? I think global options
are easier to reason about wrt how they propagate, and it's easier to
globally disable trace id partitioning this way.
