### PR TITLE
feat(replay): Add OTA Updates Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add OTA Updates Event Context for Expo and other applications. ([#4690](https://github.com/getsentry/relay/pull/4690))
 - Add data categories for Seer. ([#4692](https://github.com/getsentry/relay/pull/4692))
 - Allow pii scrubbing of all span `sentry_tags` fields. ([#4698](https://github.com/getsentry/relay/pull/4698))
+- Add OTA Updates Event Context for Replay Events. ([#4711](https://github.com/getsentry/relay/pull/4711))
 
 **Bug Fixes**:
 

--- a/relay-event-schema/src/protocol/replay.rs
+++ b/relay-event-schema/src/protocol/replay.rs
@@ -33,7 +33,6 @@ use crate::protocol::{
     LenientString, OTAUpdatesContext, OsContext, ProfileContext, Request, ResponseContext, Tags,
     Timestamp, TraceContext, User,
 };
-use sentry_release_parser::Release as ParsedRelease;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
@@ -384,26 +383,11 @@ impl Getter for Replay {
                         .value()?
                         .get_header(rest)?
                         .into()
-                } else if let Some(rest) = path.strip_prefix("release.") {
-                    let release = self.parse_release()?;
-                    match rest {
-                        "build" => release.build_hash()?.into(),
-                        "package" => release.package()?.into(),
-                        "version.short" => release.version()?.raw_short().into(),
-                        _ => return None,
-                    }
                 } else {
                     return None;
                 }
             }
         })
-    }
-}
-
-impl Replay {
-    /// Returns parsed components of the Release string in [`Self::release`].
-    pub fn parse_release(&self) -> Option<ParsedRelease<'_>> {
-        sentry_release_parser::Release::parse(self.release.as_str()?).ok()
     }
 }
 


### PR DESCRIPTION
This is part of Sentry Expo integration.

We want replays filterable using the OTA Updates properties.

Making Replays filterable is in-progress:
- (this) https://github.com/getsentry/relay/pull/4711
- https://github.com/getsentry/snuba/pull/7163
- https://github.com/getsentry/snuba/pull/7164
- https://github.com/getsentry/snuba/pull/7165
- https://github.com/getsentry/snuba/pull/7166
- https://github.com/getsentry/sentry/pull/91163
- https://github.com/getsentry/sentry/pull/91214

~Related changes for making `release.version` searchable:~
`release.version` can be replaced by `release:*${VERSION}*`
- https://github.com/getsentry/relay/pull/4714

For Errors and Transactions this context was added in:
- https://github.com/getsentry/relay/pull/4690
- https://github.com/getsentry/sentry/pull/90148
- https://github.com/getsentry/sentry/pull/90162
- https://github.com/getsentry/sentry/pull/90475