### PR TITLE
feat(envoy): Allow to pass arbitrary http headers to upstream calls

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -854,6 +854,11 @@ pub struct Http {
     ///
     /// This option does not have any effect on processing mode.
     pub global_metrics: bool,
+    /// Additional HTTP headers to send with every request to the upstream.
+    ///
+    /// These headers are added to every request made to the upstream. They can be used to
+    /// configure custom authentication, routing, or other HTTP headers required by the upstream.
+    additional_headers: HashMap<String, String>,
 }
 
 impl Default for Http {
@@ -869,6 +874,7 @@ impl Default for Http {
             project_failure_interval: default_project_failure_interval(),
             encoding: HttpEncoding::Zstd,
             global_metrics: false,
+            additional_headers: HashMap::new(),
         }
     }
 }
@@ -1896,6 +1902,11 @@ impl Config {
     /// Returns the custom HTTP "Host" header.
     pub fn http_host_header(&self) -> Option<&str> {
         self.values.http.host_header.as_deref()
+    }
+
+    /// Returns additional HTTP headers to send with every request to the upstream.
+    pub fn http_additional_headers(&self) -> &HashMap<String, String> {
+        &self.values.http.additional_headers
     }
 
     /// Returns the listen address.

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -771,9 +771,13 @@ impl SharedClient {
                 .config
                 .http_host_header()
                 .unwrap_or_else(|| self.config.upstream_descriptor().host());
+            let additional_headers = self.config.http_additional_headers();
 
             let mut builder = RequestBuilder::reqwest(self.reqwest.request(request.method(), url));
             builder.header("Host", host_header.as_bytes());
+            for (key, value) in additional_headers {
+                builder.header(key, value);
+            }
 
             if request.set_relay_id() {
                 if let Some(credentials) = self.config.credentials() {


### PR DESCRIPTION
<!-- Describe your PR here. -->
Allow to configure and pass arbitrary headers to upstream calls.

https://github.com/getsentry/relay/issues/4712
