### PR TITLE
feat(replay): Add `release.version.short` to Replay Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add data categories for Seer. ([#4692](https://github.com/getsentry/relay/pull/4692))
 - Allow pii scrubbing of all span `sentry_tags` fields. ([#4698](https://github.com/getsentry/relay/pull/4698))
 - Add killswitch for trace id partitioning. ([#4706](https://github.com/getsentry/relay/pull/4706))
+- Add `release.version.short` to Replay Events. ([#4714](https://github.com/getsentry/relay/pull/4714))
 
 **Bug Fixes**:
 


### PR DESCRIPTION
This is part of Sentry Expo integration.

We want replays filterable using the `release.version` property.

Previous related Relay changes:
- (this) https://github.com/getsentry/relay/pull/4714
- https://github.com/getsentry/relay/pull/4711
- https://github.com/getsentry/relay/pull/4690
