### PR TITLE
chore(devservices): Bump devservices to 1.1.5

### DIFF
--- a/devservices/programs.conf
+++ b/devservices/programs.conf
@@ -1,0 +1,3 @@
+[program:devserver]
+command=cargo run
+autostart=false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 black==24.3.0
 blinker==1.8.2
 click==8.1.7
-devservices==1.0.18
+devservices==1.1.5
 flake8==7.0.0
 confluent-kafka==2.1.1
 flask==3.0.3


### PR DESCRIPTION
This bumps devservices to version 1.1.5

https://github.com/getsentry/devservices/releases/tag/1.1.5

It also adds a programs.conf file to specify the entrypoint for running the relay development server to devservices

#skip-changelog