### PR TITLE
meta(vscode): Change `checkOnSave` to `check`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,13 +16,13 @@
 
   // Rust Analyzer
   "rust-analyzer.cargo.features": "all",
-  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.check.command": "clippy",
   "rust-analyzer.imports.granularity.group": "module",
   "rust-analyzer.imports.prefix": "crate",
 
   // Language-specific overrides
   "[markdown]": {
     "editor.rulers": [80],
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
   }
 }


### PR DESCRIPTION
As discussed [here](https://users.rust-lang.org/t/rust-analyzer-checkonsave-command-works-but-shows-invalid-config-warning/128652) `checkOnSave` has been renamed to `check` a while ago and now we reached the point where the extension complains about `checkOnSave.command` as it should be `check.command`.

#skip-changelog