### PR TITLE
fix(eap): Fix flakey timestamp assertion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,13 +16,13 @@
 
   // Rust Analyzer
   "rust-analyzer.cargo.features": "all",
-  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.check.command": "clippy",
   "rust-analyzer.imports.granularity.group": "module",
   "rust-analyzer.imports.prefix": "crate",
 
   // Language-specific overrides
   "[markdown]": {
     "editor.rulers": [80],
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
   }
 }

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -122,7 +122,6 @@ def test_ourlog_extraction_with_otel_logs(
                     "sentry.trace_flags": AnyValue(int_value=0),
                     "string.attribute": AnyValue(string_value="some string"),
                 },
-                received=timestamp_proto,
                 retention_days=90,
                 client_sample_rate=1.0,
                 server_sample_rate=1.0,
@@ -136,6 +135,7 @@ def test_ourlog_extraction_with_otel_logs(
         # we can't generate uuid7 with a specific timestamp
         # in Python just yet so we're overriding it
         expected_log["itemId"] = log["itemId"]
+        expected_log["received"] = time_within_delta()
 
         # This field is set by Relay so we need to remove it
         del log["attributes"]["sentry.observed_timestamp_nanos"]
@@ -295,7 +295,6 @@ def test_ourlog_extraction_with_sentry_logs(
                         string_value=str(timestamp_nanos)
                     ),
                 },
-                received=timestamp_proto,
                 retention_days=90,
                 client_sample_rate=1.0,
                 server_sample_rate=1.0,
@@ -331,7 +330,6 @@ def test_ourlog_extraction_with_sentry_logs(
                         string_value=str(timestamp_nanos)
                     ),
                 },
-                received=timestamp_proto,
                 retention_days=90,
                 client_sample_rate=1.0,
                 server_sample_rate=1.0,
@@ -345,6 +343,7 @@ def test_ourlog_extraction_with_sentry_logs(
         # we can't generate uuid7 with a specific timestamp
         # in Python just yet so we're overriding it
         expected_log["itemId"] = log["itemId"]
+        expected_log["received"] = time_within_delta()
 
     assert logs == expected_logs
 
@@ -407,7 +406,6 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
                     "sentry.timestamp_precise": AnyValue(int_value=timestamp_nanos),
                     "sentry.trace_flags": AnyValue(int_value=0),
                 },
-                received=timestamp_proto,
                 retention_days=90,
                 client_sample_rate=1.0,
                 server_sample_rate=1.0,
@@ -421,6 +419,7 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
         # we can't generate uuid7 with a specific timestamp
         # in Python just yet so we're overriding it
         expected_log["itemId"] = log["itemId"]
+        expected_log["received"] = time_within_delta()
 
     assert logs == expected_logs
 


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/4707 Introduced a flakey timestamp assertion this fixes that.

#skip-changelog

---

_NOTE:_ Just using `time_within_delta` in the `TraceItem` does sadly not work since there is some internal logic that is incompatible.