### PR TITLE
fix(playstation): Make feature flag organisation wide

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -63,8 +63,8 @@ pub enum Feature {
     OtelEndpoint,
     /// Enable playstation crash dump ingestion via the `/playstation/` endpoint.
     ///
-    /// Serialized as `project:relay-playstation-ingestion`.
-    #[serde(rename = "projects:relay-playstation-ingestion")]
+    /// Serialized as `organizations:relay-playstation-ingestion`.
+    #[serde(rename = "organizations:relay-playstation-ingestion")]
     PlaystationIngestion,
     /// Discard transactions in a spans-only world.
     ///

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1606,9 +1606,12 @@ impl EnvelopeProcessorService {
                 event_fully_normalized = inner_event_fully_normalized;
             }
             #[cfg(all(sentry, feature = "processing"))]
-            if let Some(inner_event_fully_normalized) =
-                playstation::process(managed_envelope, &mut event, &self.inner.config)?
-            {
+            if let Some(inner_event_fully_normalized) = playstation::process(
+                managed_envelope,
+                &mut event,
+                &self.inner.config,
+                &project_info,
+            )? {
                 event_fully_normalized = inner_event_fully_normalized;
             }
             if let Some(inner_event_fully_normalized) =


### PR DESCRIPTION
Talked with Vjeran and concluded that this feature flag should be `organisations` rather than `project` while changing it over realised there is a bug and fixed that plus added a test to ensure that any regresion on that bug will be caught.

Sentry PR: https://github.com/getsentry/sentry/pull/91612
OA PR: https://github.com/getsentry/sentry-options-automator/pull/3887

#skip-changelog