### PR TITLE
feat: Add span links to Span V2

### DIFF
--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -867,7 +867,7 @@ pub struct SpanLink {
     pub attributes: Annotated<Object<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(additional_properties, retain = true, pii = "maybe", trim = false)]
+    #[metastructure(additional_properties, pii = "maybe", trim = false)]
     pub other: Object<Value>,
 }
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -867,7 +867,7 @@ pub struct SpanLink {
     pub attributes: Annotated<Object<Value>>,
 
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(additional_properties, pii = "maybe", trim = false)]
+    #[metastructure(additional_properties, retain = true, pii = "maybe", trim = false)]
     pub other: Object<Value>,
 }
 

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -280,7 +280,7 @@ pub struct SpanV2Link {
     pub attributes: Annotated<Object<Attribute>>,
 
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(additional_properties, retain = true, pii = "maybe", trim = false)]
+    #[metastructure(additional_properties, pii = "maybe", trim = false)]
     pub other: Object<Value>,
 }
 


### PR DESCRIPTION
The link schema for Span V2 has been finalized. This implements it according to the Notion doc, which means that it's the same as the schema for V1 span links, except for the `attributes` collection containing typed values.

Closes RELAY-71.

#skip-changelog