### PR TITLE
fix(playstation): remove processing flag

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -63,11 +63,11 @@ pub enum BadStoreRequest {
     #[error("missing minidump")]
     MissingMinidump,
 
-    #[cfg(all(sentry, feature = "processing"))]
+    #[cfg(sentry)]
     #[error("invalid prosperodump")]
     InvalidProsperodump,
 
-    #[cfg(all(sentry, feature = "processing"))]
+    #[cfg(sentry)]
     #[error("missing prosperodump")]
     MissingProsperodump,
 

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -15,7 +15,7 @@ mod health_check;
 mod minidump;
 mod monitor;
 mod nel;
-#[cfg(all(sentry, feature = "processing"))]
+#[cfg(sentry)]
 mod playstation;
 mod project_configs;
 mod public_keys;
@@ -87,7 +87,7 @@ pub fn routes(config: &Config) -> Router<ServiceState>{
         // NOTE: If you add a new (non-experimental) route here, please also list it in
         // https://github.com/getsentry/sentry-docs/blob/master/docs/product/relay/operating-guidelines.mdx
 
-    #[cfg(all(sentry, feature = "processing"))]
+    #[cfg(sentry)]
     let store_routes = store_routes.route("/api/{project_id}/playstation/", playstation::route(config));
     let store_routes = store_routes.route_layer(middlewares::cors());
 


### PR DESCRIPTION
The endpoint should not be behind the `processing` flag.

#skip-changelog