### PR TITLE
ref(instr): Count contained items instead of raw envelope items

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -410,7 +410,7 @@ fn emit_envelope_metrics(envelope: &Envelope) {
             item_type = item.ty().name()
         );
         metric!(
-            counter(RelayCounters::EnvelopeItems) += 1,
+            counter(RelayCounters::EnvelopeItems) += item.item_count().unwrap_or(1),
             item_type = item.ty().name(),
             sdk = client_name.name(),
         );

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -678,7 +678,10 @@ pub enum RelayCounters {
     ///  - `handling`: Either `"success"` if the envelope was handled correctly, or `"failure"` if
     ///    there was an error or bug.
     EnvelopeRejected,
-    /// Number of items we processed per envelope.
+    /// Number of total envelope items we received.
+    ///
+    /// Note: This does not count raw items, it counts the logical amount of items,
+    /// e.g. a single item container counts all its contained items.
     EnvelopeItems,
     /// Number of bytes we processed per envelope item.
     EnvelopeItemBytes,


### PR DESCRIPTION
Count the logical amount of items instead of the raw items in the envelop items metric.

#skip-changelog