### PR TITLE
feat(inbound filters): Enable filtering sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add logic to extract event json from userdata in prosperodumps. ([#4755](https://github.com/getsentry/relay/pull/4755)
 - Add browser name/version to logs. ([#4757](https://github.com/getsentry/relay/pull/4757))
 - Accept standalone spans in the V2 format. This feature is still highly experimental! ([#4771](https://github.com/getsentry/relay/pull/4771))
+- Enable filtering sessions by IP address, release, and user agent. ([#4745](https://github.com/getsentry/relay/pull/4745))
 
 **Internal**:
 

--- a/relay-event-schema/src/protocol/session.rs
+++ b/relay-event-schema/src/protocol/session.rs
@@ -275,7 +275,7 @@ impl Getter for SessionUpdate {
         let path = path.strip_prefix("session.")?;
 
         match path {
-            "session_id" => Some(self.session_id.into()),
+            "session_id" => Some((&self.session_id).into()),
             "distinct_id" => Some(self.distinct_id.as_deref()?.into()),
             "sequence" => Some(self.sequence.into()),
             "init" => Some(self.init.into()),

--- a/relay-event-schema/src/protocol/session.rs
+++ b/relay-event-schema/src/protocol/session.rs
@@ -270,18 +270,11 @@ impl SessionLike for SessionUpdate {
     }
 }
 
+// Dummy implementation of `Getter` to satisfy the bound of `should_filter`.
+// We don't actually want to use `get_value` at this time.`
 impl Getter for SessionUpdate {
-    fn get_value(&self, path: &str) -> Option<relay_protocol::Val<'_>> {
-        let path = path.strip_prefix("session.")?;
-
-        match path {
-            "release" => Some(self.attributes.release.as_str().into()),
-            "environment" => Some(self.attributes.environment.as_deref()?.into()),
-            "ip_address" => Some(self.attributes.ip_address.as_ref()?.as_str().into()),
-            "user_agent" => Some(self.attributes.user_agent.as_deref()?.into()),
-            // TODO: status, abnormal mechanism?
-            _ => None,
-        }
+    fn get_value(&self, _path: &str) -> Option<relay_protocol::Val<'_>> {
+        None
     }
 }
 
@@ -369,20 +362,12 @@ impl SessionAggregates {
     }
 }
 
+// Dummy implementation of `Getter` to satisfy the bound of `should_filter`.
+// We don't actually want to use `get_value` at this time.`
 impl Getter for SessionAggregates {
-    fn get_value(&self, path: &str) -> Option<relay_protocol::Val<'_>> {
-        let path = path.strip_prefix("sessions.")?;
-
-        match path {
-            "release" => Some(self.attributes.release.as_str().into()),
-            "environment" => Some(self.attributes.environment.as_deref()?.into()),
-            "ip_address" => Some(self.attributes.ip_address.as_ref()?.as_str().into()),
-            "user_agent" => Some(self.attributes.user_agent.as_deref()?.into()),
-            _ => None,
-        }
+    fn get_value(&self, _path: &str) -> Option<relay_protocol::Val<'_>> {
+        None
     }
-
-    // TODO: Implement get_iter?
 }
 
 #[cfg(test)]

--- a/relay-event-schema/src/protocol/session.rs
+++ b/relay-event-schema/src/protocol/session.rs
@@ -275,12 +275,6 @@ impl Getter for SessionUpdate {
         let path = path.strip_prefix("session.")?;
 
         match path {
-            "session_id" => Some((&self.session_id).into()),
-            "distinct_id" => Some(self.distinct_id.as_deref()?.into()),
-            "sequence" => Some(self.sequence.into()),
-            "init" => Some(self.init.into()),
-            "duration" => Some(self.duration?.into()),
-            "errors" => Some(self.errors.into()),
             "release" => Some(self.attributes.release.as_str().into()),
             "environment" => Some(self.attributes.environment.as_deref()?.into()),
             "ip_address" => Some(self.attributes.ip_address.as_ref()?.as_str().into()),

--- a/relay-filter/src/interface.rs
+++ b/relay-filter/src/interface.rs
@@ -3,7 +3,8 @@
 use url::Url;
 
 use relay_event_schema::protocol::{
-    Csp, Event, EventType, Exception, LogEntry, Replay, Span, Values,
+    Csp, Event, EventType, Exception, LogEntry, Replay, SessionAggregates, SessionUpdate, Span,
+    Values,
 };
 
 /// A data item to which filters can be applied.
@@ -173,6 +174,88 @@ impl Filterable for Span {
     }
 
     fn header(&self, _: &str) -> Option<&str> {
+        None
+    }
+}
+
+impl Filterable for SessionUpdate {
+    fn csp(&self) -> Option<&Csp> {
+        None
+    }
+
+    fn exceptions(&self) -> Option<&Values<Exception>> {
+        None
+    }
+
+    fn ip_addr(&self) -> Option<&str> {
+        self.attributes
+            .ip_address
+            .as_ref()
+            .map(|addr| addr.as_str())
+    }
+
+    fn logentry(&self) -> Option<&LogEntry> {
+        None
+    }
+
+    fn release(&self) -> Option<&str> {
+        Some(&self.attributes.release)
+    }
+
+    fn transaction(&self) -> Option<&str> {
+        None
+    }
+
+    fn url(&self) -> Option<Url> {
+        None
+    }
+
+    fn user_agent(&self) -> Option<&str> {
+        self.attributes.user_agent.as_deref()
+    }
+
+    fn header(&self, _header_name: &str) -> Option<&str> {
+        None
+    }
+}
+
+impl Filterable for SessionAggregates {
+    fn csp(&self) -> Option<&Csp> {
+        None
+    }
+
+    fn exceptions(&self) -> Option<&Values<Exception>> {
+        None
+    }
+
+    fn ip_addr(&self) -> Option<&str> {
+        self.attributes
+            .ip_address
+            .as_ref()
+            .map(|addr| addr.as_str())
+    }
+
+    fn logentry(&self) -> Option<&LogEntry> {
+        None
+    }
+
+    fn release(&self) -> Option<&str> {
+        Some(&self.attributes.release)
+    }
+
+    fn transaction(&self) -> Option<&str> {
+        None
+    }
+
+    fn url(&self) -> Option<Url> {
+        None
+    }
+
+    fn user_agent(&self) -> Option<&str> {
+        self.attributes.user_agent.as_deref()
+    }
+
+    fn header(&self, _header_name: &str) -> Option<&str> {
         None
     }
 }

--- a/relay-filter/src/lib.rs
+++ b/relay-filter/src/lib.rs
@@ -44,6 +44,10 @@ pub use interface::Filterable;
 ///
 /// If the event should be filtered, the `Err` returned contains a filter reason.
 /// The reason is the message returned by the first filter that didn't pass.
+///
+/// The `client_ip` parameter is the "client IP" extracted from the envelope. It's
+/// used for client IP filtering and should not be confused with a "user IP" that may
+/// be contained in the item, which is used for localhost filtering.
 pub fn should_filter<F: Filterable + Getter>(
     item: &F,
     client_ip: Option<IpAddr>,

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -153,9 +153,9 @@ fn process_session(
     extracted_metrics: &mut Vec<Bucket>,
 ) -> bool {
     let SessionProcessingConfig {
-        global_config: _global_config,
+        global_config,
         config,
-        filters_config: _filters_config,
+        filters_config,
         metrics_config,
         client,
         client_addr,
@@ -226,6 +226,17 @@ fn process_session(
         return false;
     }
 
+    if relay_filter::should_filter(
+        &session,
+        client_addr,
+        filters_config,
+        global_config.filters(),
+    )
+    .is_err()
+    {
+        return false;
+    };
+
     // Extract metrics if they haven't been extracted by a prior Relay
     if metrics_config.is_enabled()
         && !item.metrics_extracted()
@@ -275,9 +286,9 @@ fn process_session_aggregates(
     extracted_metrics: &mut Vec<Bucket>,
 ) -> bool {
     let SessionProcessingConfig {
-        global_config: _global_config,
+        global_config,
         config,
-        filters_config: _filters_config,
+        filters_config,
         metrics_config,
         client,
         client_addr,
@@ -331,6 +342,17 @@ fn process_session_aggregates(
             changed |= changed_attributes;
         }
     }
+
+    if relay_filter::should_filter(
+        &session,
+        client_addr,
+        filters_config,
+        global_config.filters(),
+    )
+    .is_err()
+    {
+        return false;
+    };
 
     // Extract metrics if they haven't been extracted by a prior Relay
     if metrics_config.is_enabled() && !item.metrics_extracted() {

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -5,11 +5,12 @@ use std::net;
 
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use relay_config::Config;
-use relay_dynamic_config::SessionMetricsConfig;
+use relay_dynamic_config::{GlobalConfig, SessionMetricsConfig};
 use relay_event_normalization::ClockDriftProcessor;
 use relay_event_schema::protocol::{
     IpAddr, SessionAggregates, SessionAttributes, SessionStatus, SessionUpdate,
 };
+use relay_filter::ProjectFiltersConfig;
 use relay_metrics::Bucket;
 use relay_statsd::metric;
 
@@ -19,18 +20,30 @@ use crate::services::projects::project::ProjectInfo;
 use crate::statsd::RelayTimers;
 use crate::utils::{ItemAction, TypedEnvelope};
 
+#[derive(Debug, Clone, Copy)]
+struct SessionProcessingConfig<'a> {
+    pub global_config: &'a GlobalConfig,
+    pub config: &'a Config,
+    pub filters_config: &'a ProjectFiltersConfig,
+    pub metrics_config: &'a SessionMetricsConfig,
+    pub client: Option<&'a str>,
+    pub client_addr: Option<std::net::IpAddr>,
+    pub received: DateTime<Utc>,
+    pub clock_drift_processor: &'a ClockDriftProcessor,
+}
+
 /// Validates all sessions and session aggregates in the envelope, if any.
 ///
 /// Both are removed from the envelope if they contain invalid JSON or if their timestamps
 /// are out of range after clock drift correction.
 pub fn process(
     managed_envelope: &mut TypedEnvelope<SessionGroup>,
+    global_config: &GlobalConfig,
+    config: &Config,
     extracted_metrics: &mut ProcessingExtractedMetrics,
     project_info: &ProjectInfo,
-    config: &Config,
 ) {
     let received = managed_envelope.received_at();
-    let metrics_config = project_info.config().session_metrics;
     let envelope = managed_envelope.envelope_mut();
     let client = envelope.meta().client().map(|x| x.to_owned());
     let client_addr = envelope.meta().client_addr();
@@ -38,29 +51,24 @@ pub fn process(
     let clock_drift_processor =
         ClockDriftProcessor::new(envelope.sent_at(), received).at_least(MINIMUM_CLOCK_DRIFT);
 
+    let spc = SessionProcessingConfig {
+        global_config,
+        config,
+        filters_config: &project_info.config().filter_settings,
+        metrics_config: &project_info.config().session_metrics,
+        client: client.as_deref(),
+        client_addr,
+        received,
+        clock_drift_processor: &clock_drift_processor,
+    };
+
     let mut session_extracted_metrics = Vec::new();
     managed_envelope.retain_items(|item| {
         let should_keep = match item.ty() {
-            ItemType::Session => process_session(
-                item,
-                config,
-                received,
-                client.as_deref(),
-                client_addr,
-                metrics_config,
-                &clock_drift_processor,
-                &mut session_extracted_metrics,
-            ),
-            ItemType::Sessions => process_session_aggregates(
-                item,
-                config,
-                received,
-                client.as_deref(),
-                client_addr,
-                metrics_config,
-                &clock_drift_processor,
-                &mut session_extracted_metrics,
-            ),
+            ItemType::Session => process_session(item, spc, &mut session_extracted_metrics),
+            ItemType::Sessions => {
+                process_session_aggregates(item, spc, &mut session_extracted_metrics)
+            }
             _ => true, // Keep all other item types
         };
         if should_keep {
@@ -141,14 +149,20 @@ fn is_valid_session_timestamp(
 #[allow(clippy::too_many_arguments)]
 fn process_session(
     item: &mut Item,
-    config: &Config,
-    received: DateTime<Utc>,
-    client: Option<&str>,
-    client_addr: Option<net::IpAddr>,
-    metrics_config: SessionMetricsConfig,
-    clock_drift_processor: &ClockDriftProcessor,
+    session_processing_config: SessionProcessingConfig,
     extracted_metrics: &mut Vec<Bucket>,
 ) -> bool {
+    let SessionProcessingConfig {
+        global_config: _global_config,
+        config,
+        filters_config: _filters_config,
+        metrics_config,
+        client,
+        client_addr,
+        received,
+        clock_drift_processor,
+    } = session_processing_config;
+
     let mut changed = false;
     let payload = item.payload();
     let max_secs_in_future = config.max_secs_in_future();
@@ -257,14 +271,20 @@ fn process_session(
 #[allow(clippy::too_many_arguments)]
 fn process_session_aggregates(
     item: &mut Item,
-    config: &Config,
-    received: DateTime<Utc>,
-    client: Option<&str>,
-    client_addr: Option<net::IpAddr>,
-    metrics_config: SessionMetricsConfig,
-    clock_drift_processor: &ClockDriftProcessor,
+    session_processing_config: SessionProcessingConfig,
     extracted_metrics: &mut Vec<Bucket>,
 ) -> bool {
+    let SessionProcessingConfig {
+        global_config: _global_config,
+        config,
+        filters_config: _filters_config,
+        metrics_config,
+        client,
+        client_addr,
+        received,
+        clock_drift_processor,
+    } = session_processing_config;
+
     let mut changed = false;
     let payload = item.payload();
     let max_secs_in_future = config.max_secs_in_future();
@@ -364,16 +384,17 @@ mod tests {
 
     impl TestProcessSessionArguments<'_> {
         fn run_session_producer(&mut self) -> bool {
-            process_session(
-                &mut self.item,
-                &Config::default(),
-                self.received,
-                self.client,
-                self.client_addr,
-                self.metrics_config,
-                &self.clock_drift_processor,
-                &mut self.extracted_metrics,
-            )
+            let spc = SessionProcessingConfig {
+                global_config: &Default::default(),
+                config: &Default::default(),
+                filters_config: &Default::default(),
+                metrics_config: &self.metrics_config,
+                client: self.client,
+                client_addr: self.client_addr,
+                received: self.received,
+                clock_drift_processor: &self.clock_drift_processor,
+            };
+            process_session(&mut self.item, spc, &mut self.extracted_metrics)
         }
 
         fn default() -> Self {

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -250,13 +250,13 @@ class SentryLike:
         response.raise_for_status()
         return response
 
-    def send_session(self, project_id, payload, item_headers=None):
+    def send_session(self, project_id, payload, item_headers=None, headers=None):
         envelope = Envelope()
         envelope.add_session(payload)
         if item_headers:
             item = envelope.items[0]
             item.headers = {**item.headers, **item_headers}
-        self.send_envelope(project_id, envelope)
+        self.send_envelope(project_id, envelope, headers=headers)
 
     def send_transaction(
         self,
@@ -292,10 +292,10 @@ class SentryLike:
 
         self.send_envelope(project_id, envelope)
 
-    def send_session_aggregates(self, project_id, payload):
+    def send_session_aggregates(self, project_id, payload, headers=None):
         envelope = Envelope()
         envelope.add_item(Item(payload=PayloadRef(json=payload), type="sessions"))
-        self.send_envelope(project_id, envelope)
+        self.send_envelope(project_id, envelope, headers=headers)
 
     def send_client_report(self, project_id, payload):
         envelope = Envelope()


### PR DESCRIPTION
This enables filtering for `SessionUpdate` and `SessionAggregate` items. In the course of this, it also
* adds `Filterable` and `Getter` implementations to `SessionUpdate` and `SessionAggregates`;
* introduces a `SessionProcessingConfig` struct to bundle all the auxiliary data needed in `process_session` and `process_session_aggregates` (modeled on `ReplayProcessingConfig`);
* slightly refactors how session processing is called.

Aside from this not having tests, my main open questions are around the `Getter` impls. To wit:
* Is there some sort of schema for what the path segments should be called? Is it just the names of the fields they return? Does anything break if they aren't chosen correctly?
* Are the names for the "roots" of the two types appropriate? Should they be closer to the actual type names (`"session_update"`/`"session_aggregates"`)?
* Are there any fields I made addressable that _shouldn't_ be?
* In practical terms, do the `Getter` impls change anything about the way filtering works? I believe `Filterable` already returns the fields we actually care about.

Closes RELAY-41.