### PR TITLE
chore: Fix 1.87.0 clippy lints

### DIFF
--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -60,8 +60,8 @@ pub fn normalize_parsed_queries(
     string: &str,
 ) -> Result<(String, Vec<Statement>), ()> {
     let mut parsed = parse_query(db_system, string).map_err(|_| ())?;
-    parsed.visit(&mut NormalizeVisitor);
-    parsed.visit(&mut MaxDepthVisitor::new());
+    let _ = parsed.visit(&mut NormalizeVisitor);
+    let _ = parsed.visit(&mut MaxDepthVisitor::new());
 
     let concatenated = parsed
         .iter()

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1322,7 +1322,7 @@ fn sql_tables_from_query(
             let mut visitor = SqlTableNameVisitor {
                 table_names: Default::default(),
             };
-            ast.visit(&mut visitor);
+            let _ = ast.visit(&mut visitor);
             let comma_size: usize = 1;
             let mut s = String::with_capacity(
                 visitor

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -463,6 +463,7 @@ impl<'a> ProcessingState<'a> {
     ///
     /// - Returns `Ok(None)` if the current state is the root.
     /// - Returns `Err(self)` if the current state does not own the parent state.
+    #[allow(clippy::result_large_err)]
     pub fn try_into_parent(self) -> Result<Option<Self>, Self> {
         match self.parent {
             Some(BoxCow::Borrowed(_)) => Err(self),

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -463,7 +463,10 @@ impl<'a> ProcessingState<'a> {
     ///
     /// - Returns `Ok(None)` if the current state is the root.
     /// - Returns `Err(self)` if the current state does not own the parent state.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "this method returns `self` in the error case"
+    )]
     pub fn try_into_parent(self) -> Result<Option<Self>, Self> {
         match self.parent {
             Some(BoxCow::Borrowed(_)) => Err(self),

--- a/relay-metrics/benches/benches.rs
+++ b/relay-metrics/benches/benches.rs
@@ -34,9 +34,7 @@ impl NumbersGenerator {
 
     fn next(&self) -> usize {
         let dist = Uniform::new(self.min, self.max + 1);
-        let value = self.generator.borrow_mut().sample(dist);
-
-        value
+        self.generator.borrow_mut().sample(dist)
     }
 }
 

--- a/relay-pii/src/transform.rs
+++ b/relay-pii/src/transform.rs
@@ -729,11 +729,10 @@ where
             return self.inner.visit_borrowed_str(v);
         };
 
-        let res = match self.transformer.transform_str(v) {
+        match self.transformer.transform_str(v) {
             Cow::Borrowed(v) => self.inner.visit_borrowed_str(v),
             Cow::Owned(v) => self.inner.visit_string(v),
-        };
-        res
+        }
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -146,7 +146,7 @@ impl ItemScoping {
         // skip `Unknown` categories silently. If the list of categories only contains `Unknown`s,
         // we do **not** match, since apparently the quota is meant for some data this Relay does
         // not support yet.
-        categories.is_empty() || categories.iter().any(|cat| *cat == self.category)
+        categories.is_empty() || categories.contains(&self.category)
     }
 
     /// Returns `true` if the rate limit namespace matches the namespace of the item.

--- a/relay-server/src/services/global_rate_limits.rs
+++ b/relay-server/src/services/global_rate_limits.rs
@@ -67,7 +67,7 @@ impl GlobalLimiter for GlobalRateLimitsServiceHandle {
                 quantity,
             })
             .await
-            .map_err(|_| RateLimitingError::UnreachableGlobalRateLimits)?;
+            .map_err(|_| RateLimitingError::UnreachableGlobalRateLimits)??;
 
         // Perform a reverse lookup to match each owned quota with its original reference.
         // If multiple identical quotas exist, the first match will be reused. Equality is determined
@@ -80,18 +80,15 @@ impl GlobalLimiter for GlobalRateLimitsServiceHandle {
         //
         // The operation has a time complexity of O(n^2), but the number of quotas is assumed
         // to be small, as they are currently used only for metric bucket limiting.
-        let rate_limited_global_quotas =
-            rate_limited_owned_global_quotas.map(|owned_global_quotas| {
-                owned_global_quotas
-                    .iter()
-                    .filter_map(|owned_global_quota| {
-                        let global_quota = owned_global_quota.build_ref();
-                        global_quotas.iter().find(|x| **x == global_quota)
-                    })
-                    .collect::<Vec<_>>()
-            });
 
-        rate_limited_global_quotas
+        let res = rate_limited_owned_global_quotas
+            .iter()
+            .filter_map(|owned_global_quota| {
+                let global_quota = owned_global_quota.build_ref();
+                global_quotas.iter().find(|x| **x == global_quota)
+            })
+            .collect::<Vec<_>>();
+        Ok(res)
     }
 }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -526,7 +526,7 @@ pub enum ProcessingError {
     PiiConfigError(PiiConfigError),
 
     #[error("invalid processing group type")]
-    InvalidProcessingGroup(#[from] InvalidProcessingGroupType),
+    InvalidProcessingGroup(Box<InvalidProcessingGroupType>),
 
     #[error("invalid replay")]
     InvalidReplay(DiscardReason),
@@ -617,6 +617,12 @@ impl From<ExtractMetricsError> for ProcessingError {
                 Self::InvalidTimestamp
             }
         }
+    }
+}
+
+impl From<InvalidProcessingGroupType> for ProcessingError {
+    fn from(value: InvalidProcessingGroupType) -> Self {
+        Self::InvalidProcessingGroup(Box::new(value))
     }
 }
 

--- a/relay-server/src/services/processor/nnswitch.rs
+++ b/relay-server/src/services/processor/nnswitch.rs
@@ -203,10 +203,8 @@ fn get_zstd_dictionary(id: usize) -> Option<&'static zstd::dict::DecoderDictiona
 }
 
 fn decompress_data_zstd(data: Bytes, dictionary_id: u8) -> std::io::Result<Vec<u8>> {
-    let dictionary = get_zstd_dictionary(dictionary_id as usize).ok_or(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "Unknown compression dictionary",
-    ))?;
+    let dictionary = get_zstd_dictionary(dictionary_id as usize)
+        .ok_or(std::io::Error::other("Unknown compression dictionary"))?;
 
     let mut decompressor = ZstdDecompressor::with_prepared_dictionary(dictionary)?;
     decompressor.decompress(data.as_ref(), MAX_DECOMPRESSED_SIZE)

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -68,7 +68,7 @@ struct EnvelopeContext {
 }
 
 #[derive(Debug)]
-pub struct InvalidProcessingGroupType(pub ManagedEnvelope);
+pub struct InvalidProcessingGroupType(pub Box<ManagedEnvelope>);
 
 impl Display for InvalidProcessingGroupType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -115,7 +115,7 @@ impl<G: TryFrom<ProcessingGroup>> TryFrom<ManagedEnvelope> for TypedEnvelope<G> 
     fn try_from(value: ManagedEnvelope) -> Result<Self, Self::Error> {
         match value.group().try_into() {
             Ok(group) => Ok(TypedEnvelope::new(value, group)),
-            Err(_) => Err(InvalidProcessingGroupType(value)),
+            Err(_) => Err(InvalidProcessingGroupType(Box::new(value))),
         }
     }
 }

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -68,7 +68,7 @@ struct EnvelopeContext {
 }
 
 #[derive(Debug)]
-pub struct InvalidProcessingGroupType(pub Box<ManagedEnvelope>);
+pub struct InvalidProcessingGroupType(pub ManagedEnvelope);
 
 impl Display for InvalidProcessingGroupType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -115,7 +115,7 @@ impl<G: TryFrom<ProcessingGroup>> TryFrom<ManagedEnvelope> for TypedEnvelope<G> 
     fn try_from(value: ManagedEnvelope) -> Result<Self, Self::Error> {
         match value.group().try_into() {
             Ok(group) => Ok(TypedEnvelope::new(value, group)),
-            Err(_) => Err(InvalidProcessingGroupType(Box::new(value))),
+            Err(_) => Err(InvalidProcessingGroupType(value)),
         }
     }
 }


### PR DESCRIPTION
The only potentially controversial change is the `result_large_err` one:
* In `attrs.rs` I opted for an `#allow`, although the functions could be changed to not return `Self` in the `Err` case because it's never used.
* In `managed_envelope.rs` I boxed the `ManagedEnvelope` in `InvalidProcessingGroupType` because that variant is what makes `ProcessingError` huge.

#skip-changelog