### PR TITLE
feat(config): Allow environment references in Relay configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Allow environment references in Relay configuration. ([#4748](https://github.com/getsentry/relay/pull/4748))
+
 ## 25.5.0
 
 **Features**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
  "relay-metrics",
  "relay-redis",
  "serde",
+ "serde-vars",
  "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
@@ -4912,6 +4913,15 @@ name = "serde-transcode"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-vars"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577fb3336823d1dddf55e68ae14780d461de69924d983912e02317a091ba4ec6"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ sentry-types = "0.36.0"
 sentry_protos = "0.2.0"
 serde = { version = "1.0.215", features = ["derive", "rc"] }
 serde-transcode = "1.1.1"
+serde-vars = "0.1"
 serde_bytes = "0.11"
 serde_json = "1.0.133"
 serde_path_to_error = "0.1.16"

--- a/relay-config/Cargo.toml
+++ b/relay-config/Cargo.toml
@@ -27,6 +27,7 @@ relay-log = { workspace = true, features = ["init"] }
 relay-metrics = { workspace = true }
 relay-redis = { workspace = true }
 serde = { workspace = true }
+serde-vars = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -28,3 +28,19 @@ def test_invalid_topics_raise_error(mini_sentry, relay_with_processing):
 
     error = str(mini_sentry.test_failures.get_nowait())
     assert "failed to validate the topic with name" in error
+
+
+def test_missing_env_var_in_config(mini_sentry, relay, relay_credentials):
+    credentials = relay_credentials()
+    relay = relay(
+        mini_sentry,
+        credentials=credentials,
+        wait_health_check=False,
+        options={
+            "http": {
+                "encoding": "${THIS_DOES_NOT_EXIST_OTHER_WISE_THE_TEST_WILL_PASS}",
+            }
+        },
+    )
+
+    assert relay.wait_for_exit() != 0


### PR DESCRIPTION
Allow `${VAR}` references in Relay's config. Any leaf value can now be a reference to an environment variable.

Fixes: #4647

