### PR TITLE
ref(relay): Reduce warnings, emit warnings to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow environment references in Relay configuration. ([#4750](https://github.com/getsentry/relay/pull/4750))
 
+**Internal**:
+
+- Reduce warning logs, emit warnings to the configured Sentry instance. ([#4753](https://github.com/getsentry/relay/pull/4753))
+
 ## 25.5.0
 
 **Features**:

--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use relay_common::impl_str_serde;
+use sentry::integrations::tracing::EventFilter;
 use sentry::types::Dsn;
 use sentry::{TracesSampler, TransactionContext};
 use serde::{Deserialize, Serialize};
@@ -327,7 +328,15 @@ pub unsafe fn init(config: &LogConfig, sentry: &SentryConfig) {
 
     tracing_subscriber::registry()
         .with(format.with_filter(config.level_filter()))
-        .with(sentry::integrations::tracing::layer())
+        .with(
+            // Same as the default filter, except it converts warnings into events instead of breadcrumbs.
+            sentry::integrations::tracing::layer().event_filter(|md| match *md.level() {
+                tracing::Level::ERROR => EventFilter::Exception,
+                tracing::Level::WARN => EventFilter::Event,
+                tracing::Level::INFO => EventFilter::Breadcrumb,
+                tracing::Level::DEBUG | tracing::Level::TRACE => EventFilter::Ignore,
+            }),
+        )
         .with(match env::var(EnvFilter::DEFAULT_ENV) {
             Ok(value) => EnvFilter::new(value),
             Err(_) => get_default_filters(),

--- a/relay-pii/src/attachments.rs
+++ b/relay-pii/src/attachments.rs
@@ -177,7 +177,7 @@ trait StringMods: AsRef<[u8]> {
             Redaction::Replace(replace) => {
                 self.swap_content(replace.text.as_str(), PADDING);
             }
-            Redaction::Other => relay_log::warn!("Incoming redaction is not supported"),
+            Redaction::Other => relay_log::debug!("Incoming redaction is not supported"),
         }
     }
 }

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -568,7 +568,7 @@ fn insert_replacement_chunks(rule: &RuleRef, text: &str, output: &mut Vec<Chunk<
                 text: Cow::Owned(replace.text.clone()),
             });
         }
-        Redaction::Other => relay_log::warn!("Incoming redaction is not supported"),
+        Redaction::Other => relay_log::debug!("Incoming redaction is not supported"),
     }
 }
 

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -176,7 +176,7 @@ pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<ProfileId
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {
-            relay_log::warn!(
+            relay_log::debug!(
                 error = &err as &dyn Error,
                 from = "minimal",
                 project_id = project_id.value(),
@@ -190,7 +190,7 @@ pub fn parse_metadata(payload: &[u8], project_id: ProjectId) -> Result<ProfileId
             let _: sample::v1::ProfileMetadata = match serde_path_to_error::deserialize(d) {
                 Ok(profile) => profile,
                 Err(err) => {
-                    relay_log::warn!(
+                    relay_log::debug!(
                         error = &err as &dyn Error,
                         from = "metadata",
                         platform = profile.platform,
@@ -235,7 +235,7 @@ pub fn expand_profile(
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {
-            relay_log::warn!(
+            relay_log::debug!(
                 error = &err as &dyn Error,
                 from = "minimal",
                 platform = event.platform.as_str(),
@@ -273,7 +273,7 @@ pub fn expand_profile(
         Ok(payload) => Ok((profile.event_id, payload)),
         Err(err) => match err {
             ProfileError::InvalidJson(err) => {
-                relay_log::warn!(
+                relay_log::debug!(
                     error = &err as &dyn Error,
                     from = "parsing",
                     platform = profile.platform,

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -106,7 +106,7 @@ fn scrub_minidump(item: &mut crate::envelope::Item, config: &relay_pii::PiiConfi
                 timer(RelayTimers::MinidumpScrubbing) = start.elapsed(),
                 status = "error"
             );
-            relay_log::warn!(
+            relay_log::debug!(
                 error = &scrub_error as &dyn Error,
                 "failed to scrub minidump",
             );
@@ -143,7 +143,7 @@ fn scrub_view_hierarchy(item: &mut crate::envelope::Item, config: &relay_pii::Pi
             item.set_payload(content_type, output);
         }
         Err(e) => {
-            relay_log::warn!(error = &e as &dyn Error, "failed to scrub view hierarchy",);
+            relay_log::debug!(error = &e as &dyn Error, "failed to scrub view hierarchy",);
             metric!(
                 timer(RelayTimers::ViewHierarchyScrubbing) = start.elapsed(),
                 status = "error"

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -168,7 +168,7 @@ fn handle_replay_event_item(
             }
         }
         Err(error) => {
-            relay_log::warn!(
+            relay_log::debug!(
                 error = &error as &dyn Error,
                 event_id = ?config.event_id,
                 project_id = config.project_id.map(|v| v.value()),

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -776,7 +776,7 @@ impl StoreService {
 
         // If the recording payload can not fit in to the message do not produce and quit early.
         if payload_size >= max_payload_size {
-            relay_log::warn!("replay_recording over maximum size.");
+            relay_log::debug!("replay_recording over maximum size.");
             self.outcome_aggregator.send(TrackOutcome {
                 category: DataCategory::Replay,
                 event_id,

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -308,7 +308,7 @@ def mini_sentry(request):  # noqa
         if (
             event is not None
             and sentry.fail_on_relay_error
-            and event.get("level") != "info"
+            and event.get("level") not in ("info", "warning")
         ):
             error = AssertionError("Relay sent us event: " + get_error_message(event))
             sentry.test_failures.put(("/api/666/envelope/", error))

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -213,11 +213,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             # Filter out health check failures, which can happen during startup
             filtered_test_failures = Queue()
             for f in mini_sentry.current_test_failures():
-                filtered = [
-                    "Health check probe",
-                    "network outage, scheduling another check",
-                ]
-                if all(f not in str(f) for f in filtered):
+                if "Health check probe" not in str(f):
                     filtered_test_failures.put(f)
             mini_sentry.test_failures = filtered_test_failures
 

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -213,7 +213,11 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             # Filter out health check failures, which can happen during startup
             filtered_test_failures = Queue()
             for f in mini_sentry.current_test_failures():
-                if "Health check probe" not in str(f):
+                filtered = [
+                    "Health check probe",
+                    "network outage, scheduling another check",
+                ]
+                if all(f not in str(f) for f in filtered):
                     filtered_test_failures.put(f)
             mini_sentry.test_failures = filtered_test_failures
 


### PR DESCRIPTION
Warnings generated based on invalid user input are useless, we cannot control it and they are usually not actionable. All warnings that are outside the path of user input are kept.

Also promotes these warnings to Sentry issues, so they become actionable.
