### PR TITLE
fix(playstation): keep dump instead of discarding it

### DIFF
--- a/relay-server/src/services/processor/playstation.rs
+++ b/relay-server/src/services/processor/playstation.rs
@@ -31,7 +31,8 @@ pub fn process(
         return Ok(None);
     }
 
-    if let Some(item) = envelope.take_item_by(|item| {
+    // Get instead of take as we want to keep the dump as an attachment
+    if let Some(item) = envelope.get_item_by(|item| {
         item.ty() == &ItemType::Attachment
             && item.attachment_type() == Some(&AttachmentType::Prosperodump)
     }) {

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -139,6 +139,10 @@ def test_playstation_with_feature_flag(
     assert event_data["_metrics"]["bytes.ingested.event.minidump"] > 0
     assert event_data["_metrics"]["bytes.ingested.event.attachment"] > 0
 
+    assert len(event["attachments"]) == 3
+    attachment = event["attachments"][0]
+    assert attachment["attachment_type"] == "playstation.prosperodump"
+
 
 def test_playstation_attachment(
     mini_sentry,
@@ -218,6 +222,10 @@ def test_playstation_attachment(
     assert "_metrics" in event_data
     assert event_data["_metrics"]["bytes.ingested.event.minidump"] > 0
     assert event_data["_metrics"]["bytes.ingested.event.attachment"] > 0
+
+    assert len(event["attachments"]) == 3
+    attachment = event["attachments"][0]
+    assert attachment["attachment_type"] == "playstation.prosperodump"
 
 
 def test_playstation_attachment_no_feature_flag(


### PR DESCRIPTION
Previously we removed the dump, however we want to keep the dump as an attachment as it is interesting to the users. This is a preamble to https://github.com/getsentry/relay/pull/4755 since we need at least one dump with the new format inside it to write integration tests against.

#skip-changelog