### PR TITLE
ref(logging): Hide warnings from the minidump crate

### DIFF
--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -268,6 +268,7 @@ fn get_default_filters() -> EnvFilter {
         sqlx=WARN,\
         tower_http=TRACE,\
         trust_dns_proto=WARN,\
+        minidump=ERROR,\
         ",
     );
 


### PR DESCRIPTION
The warnings show up in production but are not actionable, as they are triggered by user input.

#skip-changelog