### PR TITLE
fix(eap): Encode item type in headers to a smaller representation

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1053,7 +1053,7 @@ impl StoreService {
                     ("project_id".to_owned(), scoping.project_id.to_string()),
                     (
                         "item_type".to_owned(),
-                        TraceItemType::Log.as_str_name().to_owned(),
+                        (TraceItemType::Log as i32).to_string(),
                     ),
                 ]),
                 message: trace_item,


### PR DESCRIPTION
If we use the string representation of the enum, we end up sending `TRACE_ITEM_TYPE_LOG` in the headers. We don't need this, it's smaller and more efficient to just send the enum value which is an integer.

#skip-changelog