### PR TITLE
ref(relay): Split envelopes only in processing instead of all over

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -10,9 +10,9 @@ use serde::Deserialize;
 
 use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
 use crate::service::ServiceState;
-use crate::services::buffer::{EnvelopeBuffer, ProjectKeyPair};
+use crate::services::buffer::ProjectKeyPair;
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome};
-use crate::services::processor::{BucketSource, MetricData, ProcessMetrics, ProcessingGroup};
+use crate::services::processor::{BucketSource, MetricData, ProcessMetrics};
 use crate::statsd::{RelayCounters, RelayHistograms};
 use crate::utils::{self, ApiErrorResponse, FormDataIter, ManagedEnvelope};
 
@@ -288,35 +288,14 @@ fn queue_envelope(
         }
     }
 
-    // Split off the envelopes by item type.
-    let scoping = managed_envelope.scoping();
-    let envelopes = ProcessingGroup::split_envelope(*managed_envelope.take_envelope());
-    for (group, envelope) in envelopes {
-        let mut envelope = ManagedEnvelope::new(
-            envelope,
-            state.outcome_aggregator().clone(),
-            state.test_store().clone(),
-            group,
-        );
-        envelope.scope(scoping);
-
-        let project_key_pair = ProjectKeyPair::from_envelope(envelope.envelope());
-        let buffer = state.envelope_buffer(project_key_pair);
-        if !buffer.has_capacity() {
-            return Err(BadStoreRequest::QueueFailed);
-        }
-
-        // NOTE: This assumes that a `prefetch` has already been scheduled for both the
-        // envelope's projects. See `handle_check_envelope`.
-        relay_log::trace!("Pushing envelope to V2 buffer");
-
-        buffer
-            .addr()
-            .send(EnvelopeBuffer::Push(envelope.into_envelope()));
+    let project_key_pair = ProjectKeyPair::from_envelope(&*envelope);
+    if let Err(mut envelope) = state
+        .envelope_buffer(project_key_pair)
+        .push(managed_envelope)
+    {
+        envelope.reject(Outcome::Invalid(DiscardReason::Internal));
+        return Err(BadStoreRequest::QueueFailed);
     }
-    // The entire envelope is taken for a split above, and it's empty at this point, we can just
-    // accept it without additional checks.
-    managed_envelope.accept();
 
     Ok(())
 }
@@ -343,9 +322,6 @@ pub async fn handle_envelope(
         envelope,
         state.outcome_aggregator().clone(),
         state.test_store().clone(),
-        // It's not clear at this point which group this envelope belongs to.
-        // The decision will be made while queueing in `queue_envelope` function.
-        ProcessingGroup::Ungrouped,
     );
 
     // If configured, remove unknown items at the very beginning. If the envelope is

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -288,12 +288,8 @@ fn queue_envelope(
         }
     }
 
-    let project_key_pair = ProjectKeyPair::from_envelope(&*envelope);
-    if let Err(mut envelope) = state
-        .envelope_buffer(project_key_pair)
-        .push(managed_envelope)
-    {
-        envelope.reject(Outcome::Invalid(DiscardReason::Internal));
+    let pkp = ProjectKeyPair::from_envelope(&*envelope);
+    if !state.envelope_buffer(pkp).try_push(managed_envelope) {
         return Err(BadStoreRequest::QueueFailed);
     }
 

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -195,6 +195,10 @@ impl ObservableEnvelopeBuffer {
     /// Attempts to push an envelope into the envelope buffer.
     ///
     /// Returns the original envelope, when the buffer is out of capacity.
+    #[expect(
+        clippy::result_large_err,
+        reason = "this method returns the argument back to the caller in the error case"
+    )]
     pub fn push(&self, envelope: ManagedEnvelope) -> Result<(), ManagedEnvelope> {
         match self.has_capacity() {
             true => {

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -25,7 +25,7 @@ use crate::services::global_config;
 use crate::services::outcome::DiscardReason;
 use crate::services::outcome::Outcome;
 use crate::services::outcome::TrackOutcome;
-use crate::services::processor::{EnvelopeProcessor, ProcessEnvelope, ProcessingGroup};
+use crate::services::processor::{EnvelopeProcessor, ProcessEnvelope};
 use crate::services::projects::cache::{CheckedEnvelope, ProjectCacheHandle, ProjectChange};
 use crate::services::test_store::TestStore;
 use crate::statsd::RelayCounters;
@@ -59,7 +59,7 @@ mod testutils;
 #[derive(Debug)]
 pub enum EnvelopeBuffer {
     /// A fresh envelope that gets pushed into the buffer by the request handler.
-    Push(Box<Envelope>),
+    Push(ManagedEnvelope),
 }
 
 impl Interface for EnvelopeBuffer {}
@@ -190,6 +190,19 @@ impl ObservableEnvelopeBuffer {
     /// Returns the address of the buffer service.
     pub fn addr(&self) -> Addr<EnvelopeBuffer> {
         self.addr.clone()
+    }
+
+    /// Attempts to push an envelope into the envelope buffer.
+    ///
+    /// Returns the original envelope, when the buffer is out of capacity.
+    pub fn push(&self, envelope: ManagedEnvelope) -> Result<(), ManagedEnvelope> {
+        match self.has_capacity() {
+            true => {
+                self.addr.send(EnvelopeBuffer::Push(envelope));
+                Ok(())
+            }
+            false => Err(envelope),
+        }
     }
 
     /// Returns `true` if the buffer has the capacity to accept more elements.
@@ -409,7 +422,6 @@ impl EnvelopeBufferService {
             envelope,
             services.outcome_aggregator.clone(),
             services.test_store.clone(),
-            ProcessingGroup::Ungrouped,
         );
         managed_envelope.reject(Outcome::Invalid(DiscardReason::Timestamp));
     }
@@ -422,7 +434,7 @@ impl EnvelopeBufferService {
                 // For better separation of concerns, this prefetch should be triggered from here
                 // once buffer V1 has been removed.
                 relay_log::trace!("EnvelopeBufferService: received push message");
-                Self::push(buffer, envelope).await;
+                Self::push(buffer, envelope.into_envelope()).await;
             }
         };
     }
@@ -518,7 +530,6 @@ impl EnvelopeBufferService {
                 envelope,
                 services.outcome_aggregator.clone(),
                 services.test_store.clone(),
-                ProcessingGroup::Ungrouped,
             );
             managed_envelope.reject(Outcome::Invalid(DiscardReason::ProjectId));
 
@@ -529,31 +540,29 @@ impl EnvelopeBufferService {
         let sampling_project_info = sampling_project_info
             .filter(|info| info.organization_id == own_project_info.organization_id);
 
-        for (group, envelope) in ProcessingGroup::split_envelope(*envelope) {
-            let managed_envelope = ManagedEnvelope::new(
-                envelope,
-                services.outcome_aggregator.clone(),
-                services.test_store.clone(),
-                group,
-            );
+        let managed_envelope = ManagedEnvelope::new(
+            envelope,
+            services.outcome_aggregator.clone(),
+            services.test_store.clone(),
+        );
 
-            let Ok(CheckedEnvelope {
-                envelope: Some(managed_envelope),
-                ..
-            }) = own_project.check_envelope(managed_envelope).await
-            else {
-                continue; // Outcomes are emitted by `check_envelope`.
-            };
+        let Ok(CheckedEnvelope {
+            envelope: Some(managed_envelope),
+            ..
+        }) = own_project.check_envelope(managed_envelope).await
+        else {
+            // Outcomes are emitted by `check_envelope`.
+            return Ok(());
+        };
 
-            let reservoir_counters = own_project.reservoir_counters().clone();
-            services.envelope_processor.send(ProcessEnvelope {
-                envelope: managed_envelope,
-                project_info: own_project_info.clone(),
-                rate_limits: own_project.rate_limits().current_limits(),
-                sampling_project_info: sampling_project_info.clone(),
-                reservoir_counters,
-            });
-        }
+        let reservoir_counters = own_project.reservoir_counters().clone();
+        services.envelope_processor.send(ProcessEnvelope {
+            envelope: managed_envelope,
+            project_info: own_project_info.clone(),
+            rate_limits: own_project.rate_limits().current_limits(),
+            sampling_project_info: sampling_project_info.clone(),
+            reservoir_counters,
+        });
 
         Ok(())
     }
@@ -695,7 +704,7 @@ mod tests {
     use super::*;
     use crate::MemoryStat;
     use crate::services::projects::project::{ProjectInfo, ProjectState};
-    use crate::testutils::new_envelope;
+    use crate::testutils::new_managed_envelope;
     use chrono::Utc;
     use relay_base_schema::project::ProjectKey;
     use relay_dynamic_config::GlobalConfig;
@@ -789,12 +798,12 @@ mod tests {
 
         let addr = service.start_detached();
 
-        let envelope = new_envelope(false, "foo");
+        let envelope = new_managed_envelope(false, "foo");
         let project_key = envelope.meta().public_key();
         let project_info = Arc::new(ProjectInfo::default());
         project_cache_handle
             .test_set_project_state(project_key, ProjectState::Enabled(project_info));
-        addr.send(EnvelopeBuffer::Push(envelope.clone()));
+        addr.send(EnvelopeBuffer::Push(envelope));
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
@@ -825,10 +834,10 @@ mod tests {
 
         let addr = service.start_detached();
 
-        let envelope = new_envelope(false, "foo");
+        let envelope = new_managed_envelope(false, "foo");
         let project_key = envelope.meta().public_key();
         project_cache_handle.test_set_project_state(project_key, ProjectState::Pending);
-        addr.send(EnvelopeBuffer::Push(envelope.clone()));
+        addr.send(EnvelopeBuffer::Push(envelope));
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
@@ -843,10 +852,10 @@ mod tests {
         assert_eq!(envelope_processor_rx.len(), 1);
         assert!(envelope_processor_rx.recv().await.is_some());
 
-        let envelope = new_envelope(false, "foo");
+        let envelope = new_managed_envelope(false, "foo");
         let project_key = envelope.meta().public_key();
         project_cache_handle.test_set_project_state(project_key, ProjectState::Disabled);
-        addr.send(EnvelopeBuffer::Push(envelope.clone()));
+        addr.send(EnvelopeBuffer::Push(envelope));
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
@@ -880,9 +889,9 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::time::pause();
 
-        let envelope = new_envelope(false, "foo");
+        let envelope = new_managed_envelope(false, "foo");
         let project_key = envelope.meta().public_key();
-        addr.send(EnvelopeBuffer::Push(envelope.clone()));
+        addr.send(EnvelopeBuffer::Push(envelope));
         project_cache_handle.test_set_project_state(project_key, ProjectState::Disabled);
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
@@ -915,8 +924,8 @@ mod tests {
         assert_eq!(addr.metrics.item_count.load(Ordering::Relaxed), 0);
 
         for _ in 0..10 {
-            let envelope = new_envelope(false, "foo");
-            addr.addr().send(EnvelopeBuffer::Push(envelope.clone()));
+            let envelope = new_managed_envelope(false, "foo");
+            addr.addr().send(EnvelopeBuffer::Push(envelope));
         }
 
         tokio::time::sleep(Duration::from_millis(1100)).await;
@@ -948,8 +957,8 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let mut envelope = new_envelope(false, "foo");
-        envelope.meta_mut().set_received_at(
+        let mut envelope = new_managed_envelope(false, "foo");
+        envelope.envelope_mut().meta_mut().set_received_at(
             Utc::now()
                 - chrono::Duration::seconds(2 * config.spool_envelopes_max_age().as_secs() as i64),
         );
@@ -1010,13 +1019,13 @@ mod tests {
         };
 
         // Create two envelopes with different project keys
-        let envelope1 = new_envelope(false, "foo");
+        let envelope1 = new_managed_envelope(false, "foo");
         let project_key = envelope1.meta().public_key();
         let project_info = Arc::new(ProjectInfo::default());
         project_cache_handle
             .test_set_project_state(project_key, ProjectState::Enabled(project_info));
 
-        let envelope2 = new_envelope(false, "bar");
+        let envelope2 = new_managed_envelope(false, "bar");
         let project_key = envelope2.meta().public_key();
         let project_info = Arc::new(ProjectInfo::default());
         project_cache_handle

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -194,18 +194,14 @@ impl ObservableEnvelopeBuffer {
 
     /// Attempts to push an envelope into the envelope buffer.
     ///
-    /// Returns the original envelope, when the buffer is out of capacity.
-    #[expect(
-        clippy::result_large_err,
-        reason = "this method returns the argument back to the caller in the error case"
-    )]
-    pub fn push(&self, envelope: ManagedEnvelope) -> Result<(), ManagedEnvelope> {
-        match self.has_capacity() {
-            true => {
-                self.addr.send(EnvelopeBuffer::Push(envelope));
-                Ok(())
-            }
-            false => Err(envelope),
+    /// Returns `false`, if the envelope buffer does not have enough capacity.
+    pub fn try_push(&self, mut envelope: ManagedEnvelope) -> bool {
+        if self.has_capacity() {
+            self.addr.send(EnvelopeBuffer::Push(envelope));
+            true
+        } else {
+            envelope.reject(Outcome::Invalid(DiscardReason::Internal));
+            false
         }
     }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -855,17 +855,6 @@ impl ProcessingResult {
     }
 }
 
-/// Response of the [`ProcessEnvelope`] message.
-#[cfg_attr(not(feature = "processing"), allow(dead_code))]
-pub struct ProcessEnvelopeResponse {
-    /// The processed envelope.
-    ///
-    /// This is `Some` if the envelope passed inbound filtering and rate limiting. Invalid items are
-    /// removed from the envelope. Otherwise, if the envelope is empty or the entire envelope needs
-    /// to be dropped, this is `None`.
-    pub envelope: Option<TypedEnvelope<Processed>>,
-}
-
 /// Applies processing to all contents of the given envelope.
 ///
 /// Depending on the contents of the envelope and Relay's mode, this includes:
@@ -877,6 +866,23 @@ pub struct ProcessEnvelopeResponse {
 ///  - Rate limiters and inbound filters on events in processing mode.
 #[derive(Debug)]
 pub struct ProcessEnvelope {
+    /// Envelope to process.
+    pub envelope: ManagedEnvelope,
+    /// The project info.
+    pub project_info: Arc<ProjectInfo>,
+    /// Currently active cached rate limits for this project.
+    pub rate_limits: Arc<RateLimits>,
+    /// Root sampling project info.
+    pub sampling_project_info: Option<Arc<ProjectInfo>>,
+    /// Sampling reservoir counters.
+    pub reservoir_counters: ReservoirCounters,
+}
+
+/// Like a [`ProcessEnvelope`], but with an envelope which has been grouped.
+#[derive(Debug)]
+struct ProcessEnvelopeGroup {
+    /// The group the envelope belongs to.
+    pub group: ProcessingGroup,
     /// Envelope to process.
     pub envelope: ManagedEnvelope,
     /// The project info.
@@ -1015,12 +1021,6 @@ impl BucketSource {
     }
 }
 
-/// Sends an envelope to the upstream or Kafka.
-#[derive(Debug)]
-pub struct SubmitEnvelope {
-    pub envelope: TypedEnvelope<Processed>,
-}
-
 /// Sends a client report to the upstream.
 #[derive(Debug)]
 pub struct SubmitClientReports {
@@ -1037,7 +1037,6 @@ pub enum EnvelopeProcessor {
     ProcessProjectMetrics(Box<ProcessMetrics>),
     ProcessBatchedMetrics(Box<ProcessBatchedMetrics>),
     FlushBuckets(Box<FlushBuckets>),
-    SubmitEnvelope(Box<SubmitEnvelope>),
     SubmitClientReports(Box<SubmitClientReports>),
 }
 
@@ -1049,7 +1048,6 @@ impl EnvelopeProcessor {
             EnvelopeProcessor::ProcessProjectMetrics(_) => "ProcessProjectMetrics",
             EnvelopeProcessor::ProcessBatchedMetrics(_) => "ProcessBatchedMetrics",
             EnvelopeProcessor::FlushBuckets(_) => "FlushBuckets",
-            EnvelopeProcessor::SubmitEnvelope(_) => "SubmitEnvelope",
             EnvelopeProcessor::SubmitClientReports(_) => "SubmitClientReports",
         }
     }
@@ -1086,14 +1084,6 @@ impl FromMessage<FlushBuckets> for EnvelopeProcessor {
 
     fn from_message(message: FlushBuckets, _: ()) -> Self {
         Self::FlushBuckets(Box::new(message))
-    }
-}
-
-impl FromMessage<SubmitEnvelope> for EnvelopeProcessor {
-    type Response = NoResponse;
-
-    fn from_message(message: SubmitEnvelope, _: ()) -> Self {
-        Self::SubmitEnvelope(Box::new(message))
     }
 }
 
@@ -2214,20 +2204,20 @@ impl EnvelopeProcessorService {
         Ok(Some(extracted_metrics))
     }
 
-    #[expect(clippy::too_many_arguments)]
     async fn process_envelope(
         &self,
         cogs: &mut Token,
-        mut managed_envelope: ManagedEnvelope,
         project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
-        rate_limits: Arc<RateLimits>,
-        sampling_project_info: Option<Arc<ProjectInfo>>,
-        reservoir_counters: ReservoirCounters,
+        message: ProcessEnvelopeGroup,
     ) -> Result<ProcessingResult, ProcessingError> {
-        // Get the group from the managed envelope context, and if it's not set, try to guess it
-        // from the contents of the envelope.
-        let group = managed_envelope.group();
+        let ProcessEnvelopeGroup {
+            group,
+            envelope: mut managed_envelope,
+            project_info,
+            rate_limits,
+            sampling_project_info,
+            reservoir_counters,
+        } = message;
 
         // Pre-process the envelope headers.
         if let Some(sampling_state) = sampling_project_info.as_ref() {
@@ -2256,7 +2246,7 @@ impl EnvelopeProcessorService {
         macro_rules! run {
             ($fn_name:ident $(, $args:expr)*) => {
                 async {
-                    let mut managed_envelope = managed_envelope.try_into()?;
+                    let mut managed_envelope = (managed_envelope, group).try_into()?;
                     match self.$fn_name(&mut managed_envelope, $($args),*).await {
                         Ok(extracted_metrics) => Ok(ProcessingResult {
                             managed_envelope: managed_envelope.into_processed(),
@@ -2372,47 +2362,39 @@ impl EnvelopeProcessorService {
         }
     }
 
+    /// Processes the envelope and returns the processed envelope back.
+    ///
+    /// Returns `Some` if the envelope passed inbound filtering and rate limiting. Invalid items are
+    /// removed from the envelope. Otherwise, if the envelope is empty or the entire envelope needs
+    /// to be dropped, this is `None`.
     async fn process(
         &self,
         cogs: &mut Token,
-        message: ProcessEnvelope,
-    ) -> Result<ProcessEnvelopeResponse, ProcessingError> {
-        let ProcessEnvelope {
-            envelope: mut managed_envelope,
-            project_info,
-            rate_limits,
-            sampling_project_info,
-            reservoir_counters,
-        } = message;
-
+        mut message: ProcessEnvelopeGroup,
+    ) -> Result<Option<TypedEnvelope<Processed>>, ProcessingError> {
         // Prefer the project's project ID, and fall back to the stated project id from the
         // envelope. The project ID is available in all modes, other than in proxy mode, where
         // envelopes for unknown projects are forwarded blindly.
         //
         // Neither ID can be available in proxy mode on the /store/ endpoint. This is not supported,
         // since we cannot process an envelope without project ID, so drop it.
-        let project_id = match project_info
+        let project_id = match message
+            .project_info
             .project_id
-            .or_else(|| managed_envelope.envelope().meta().project_id())
+            .or_else(|| message.envelope.envelope().meta().project_id())
         {
             Some(project_id) => project_id,
             None => {
-                managed_envelope.reject(Outcome::Invalid(DiscardReason::Internal));
+                message
+                    .envelope
+                    .reject(Outcome::Invalid(DiscardReason::Internal));
                 return Err(ProcessingError::MissingProjectId);
             }
         };
 
-        let client = managed_envelope
-            .envelope()
-            .meta()
-            .client()
-            .map(str::to_owned);
-
-        let user_agent = managed_envelope
-            .envelope()
-            .meta()
-            .user_agent()
-            .map(str::to_owned);
+        let envelope = message.envelope.envelope();
+        let client = envelope.meta().client().map(str::to_owned);
+        let user_agent = envelope.meta().user_agent().map(str::to_owned);
 
         // We set additional information on the scope, which will be removed after processing the
         // envelope.
@@ -2426,18 +2408,7 @@ impl EnvelopeProcessorService {
             }
         });
 
-        let result = match self
-            .process_envelope(
-                cogs,
-                managed_envelope,
-                project_id,
-                project_info,
-                rate_limits,
-                sampling_project_info,
-                reservoir_counters,
-            )
-            .await
-        {
+        let result = match self.process_envelope(cogs, project_id, message).await {
             Ok(result) => {
                 let (mut managed_envelope, extracted_metrics) = result.into_inner();
 
@@ -2467,9 +2438,7 @@ impl EnvelopeProcessorService {
                     Some(managed_envelope)
                 };
 
-                Ok(ProcessEnvelopeResponse {
-                    envelope: envelope_response,
-                })
+                Ok(envelope_response)
             }
             Err(err) => Err(err),
         };
@@ -2488,25 +2457,56 @@ impl EnvelopeProcessorService {
         let wait_time = message.envelope.age();
         metric!(timer(RelayTimers::EnvelopeWaitTime) = wait_time);
 
-        let group = message.envelope.group().variant();
-        let result = metric!(timer(RelayTimers::EnvelopeProcessingTime), group = group, {
-            self.process(cogs, message).await
-        });
-        match result {
-            Ok(response) => {
-                if let Some(envelope) = response.envelope {
-                    self.handle_submit_envelope(cogs, SubmitEnvelope { envelope });
-                };
-            }
-            Err(error) => {
-                // Errors are only logged for what we consider infrastructure or implementation
-                // bugs. In other cases, we "expect" errors and log them as debug level.
-                if error.is_unexpected() {
+        // This COGS handling may need an overhaul in the future:
+        // Cancel the passed in token, to start individual measurements per envelope instead.
+        cogs.cancel();
+
+        let scoping = message.envelope.scoping();
+        for (group, envelope) in ProcessingGroup::split_envelope(*message.envelope.into_envelope())
+        {
+            let mut cogs = self
+                .inner
+                .cogs
+                .timed(ResourceId::Relay, AppFeature::from(group));
+
+            let mut envelope = ManagedEnvelope::new(
+                envelope,
+                self.inner.addrs.outcome_aggregator.clone(),
+                self.inner.addrs.test_store.clone(),
+            );
+            envelope.scope(scoping);
+
+            let message = ProcessEnvelopeGroup {
+                group,
+                envelope,
+                project_info: Arc::clone(&message.project_info),
+                rate_limits: Arc::clone(&message.rate_limits),
+                sampling_project_info: message.sampling_project_info.as_ref().map(Arc::clone),
+                reservoir_counters: Arc::clone(&message.reservoir_counters),
+            };
+
+            let result = metric!(
+                timer(RelayTimers::EnvelopeProcessingTime),
+                group = group.variant(),
+                { self.process(&mut cogs, message).await }
+            );
+
+            match result {
+                Ok(Some(envelope)) => self.submit_envelope(&mut cogs, envelope),
+                Ok(None) => {}
+                Err(error) if error.is_unexpected() => {
                     relay_log::error!(
                         tags.project_key = %project_key,
                         error = &error as &dyn Error,
                         "error processing envelope"
-                    );
+                    )
+                }
+                Err(error) => {
+                    relay_log::debug!(
+                        tags.project_key = %project_key,
+                        error = &error as &dyn Error,
+                        "error processing envelope"
+                    )
                 }
             }
         }
@@ -2610,10 +2610,8 @@ impl EnvelopeProcessorService {
         }
     }
 
-    fn handle_submit_envelope(&self, cogs: &mut Token, message: SubmitEnvelope) {
+    fn submit_envelope(&self, cogs: &mut Token, mut envelope: TypedEnvelope<Processed>) {
         let _submit = cogs.start_category("submit");
-
-        let SubmitEnvelope { mut envelope } = message;
 
         #[cfg(feature = "processing")]
         if self.inner.config.processing_enabled() {
@@ -2693,14 +2691,8 @@ impl EnvelopeProcessorService {
             envelope,
             self.inner.addrs.outcome_aggregator.clone(),
             self.inner.addrs.test_store.clone(),
-            ProcessingGroup::ClientReport,
         );
-        self.handle_submit_envelope(
-            cogs,
-            SubmitEnvelope {
-                envelope: envelope.into_processed(),
-            },
-        );
+        self.submit_envelope(cogs, envelope.into_processed());
     }
 
     fn check_buckets(
@@ -3074,7 +3066,6 @@ impl EnvelopeProcessorService {
                     envelope,
                     self.inner.addrs.outcome_aggregator.clone(),
                     self.inner.addrs.test_store.clone(),
-                    ProcessingGroup::Metrics,
                 );
                 envelope
                     .set_partition_key(Some(partition_key))
@@ -3084,12 +3075,7 @@ impl EnvelopeProcessorService {
                     histogram(RelayHistograms::BucketsPerBatch) = batch.len() as u64
                 );
 
-                self.handle_submit_envelope(
-                    cogs,
-                    SubmitEnvelope {
-                        envelope: envelope.into_processed(),
-                    },
-                );
+                self.submit_envelope(cogs, envelope.into_processed());
                 num_batches += 1;
             }
 
@@ -3225,7 +3211,6 @@ impl EnvelopeProcessorService {
                 EnvelopeProcessor::FlushBuckets(m) => {
                     self.handle_flush_buckets(&mut cogs, *m).await
                 }
-                EnvelopeProcessor::SubmitEnvelope(m) => self.handle_submit_envelope(&mut cogs, *m),
                 EnvelopeProcessor::SubmitClientReports(m) => {
                     self.handle_submit_client_reports(&mut cogs, *m)
                 }
@@ -3235,7 +3220,8 @@ impl EnvelopeProcessorService {
 
     fn feature_weights(&self, message: &EnvelopeProcessor) -> FeatureWeights {
         match message {
-            EnvelopeProcessor::ProcessEnvelope(v) => AppFeature::from(v.envelope.group()).into(),
+            // Envelope is split later and tokens are attributed then.
+            EnvelopeProcessor::ProcessEnvelope(_) => AppFeature::Unattributed.into(),
             EnvelopeProcessor::ProcessProjectMetrics(_) => AppFeature::Unattributed.into(),
             EnvelopeProcessor::ProcessBatchedMetrics(_) => AppFeature::Unattributed.into(),
             EnvelopeProcessor::FlushBuckets(v) => v
@@ -3251,7 +3237,6 @@ impl EnvelopeProcessorService {
                     }
                 })
                 .fold(FeatureWeights::none(), FeatureWeights::merge),
-            EnvelopeProcessor::SubmitEnvelope(v) => AppFeature::from(v.envelope.group()).into(),
             EnvelopeProcessor::SubmitClientReports(_) => AppFeature::ClientReports.into(),
         }
     }
@@ -3966,9 +3951,10 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
 
         let (group, envelope) = envelopes.pop().unwrap();
-        let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store, group);
+        let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
 
-        let message = ProcessEnvelope {
+        let message = ProcessEnvelopeGroup {
+            group,
             envelope,
             project_info: Arc::new(project_info),
             rate_limits: Default::default(),
@@ -3976,12 +3962,12 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor
+        let mut new_envelope = processor
             .process(&mut Token::noop(), message)
             .await
+            .unwrap()
             .unwrap();
-        let new_envelope = envelope_response.envelope.unwrap();
-        let new_envelope = new_envelope.envelope();
+        let new_envelope = new_envelope.envelope_mut();
 
         let event_item = new_envelope.items().last().unwrap();
         let annotated_event: Annotated<Event> =
@@ -4034,12 +4020,7 @@ mod tests {
         envelope.add_item(item);
 
         let (outcome_aggregator, test_store) = testutils::processor_services();
-        let managed_envelope = ManagedEnvelope::new(
-            envelope,
-            outcome_aggregator,
-            test_store,
-            ProcessingGroup::Error,
-        );
+        let managed_envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
 
         let mut project_info = ProjectInfo::default();
         project_info.public_keys.push(PublicKeyConfig {
@@ -4048,7 +4029,8 @@ mod tests {
         });
         let project_info = Arc::new(project_info);
 
-        let process_message = ProcessEnvelope {
+        let process_message = ProcessEnvelopeGroup {
+            group: ProcessingGroup::Transaction,
             envelope: managed_envelope,
             project_info: project_info.clone(),
             rate_limits: Default::default(),
@@ -4065,12 +4047,13 @@ mod tests {
         .unwrap();
 
         let processor = create_test_processor(config).await;
-        let response = processor
+        let envelope = processor
             .process(&mut Token::noop(), process_message)
             .await
+            .unwrap()
             .unwrap();
-        let envelope = response.envelope.as_ref().unwrap().envelope();
         let event = envelope
+            .envelope()
             .get_item_by(|item| item.ty() == &ItemType::Event)
             .unwrap();
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -291,7 +291,7 @@ mod tests {
 
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
-    use crate::services::processor::{ProcessEnvelopeGroup, ProcessingGroup, SpanGroup};
+    use crate::services::processor::{ProcessEnvelopeGrouped, ProcessingGroup, SpanGroup};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{
         self, create_test_processor, new_envelope, state_with_rule_and_condition,
@@ -335,7 +335,7 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
         let (group, envelope) = envelopes.pop().unwrap();
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope: ManagedEnvelope::new(envelope, outcome_aggregator, test_store),
             project_info: Arc::new(ProjectInfo::default()),

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -291,7 +291,7 @@ mod tests {
 
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
-    use crate::services::processor::{ProcessEnvelope, ProcessingGroup, SpanGroup};
+    use crate::services::processor::{ProcessEnvelopeGroup, ProcessingGroup, SpanGroup};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{
         self, create_test_processor, new_envelope, state_with_rule_and_condition,
@@ -335,20 +335,22 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
         let (group, envelope) = envelopes.pop().unwrap();
 
-        let message = ProcessEnvelope {
-            envelope: ManagedEnvelope::new(envelope, outcome_aggregator, test_store, group),
+        let message = ProcessEnvelopeGroup {
+            group,
+            envelope: ManagedEnvelope::new(envelope, outcome_aggregator, test_store),
             project_info: Arc::new(ProjectInfo::default()),
             rate_limits: Default::default(),
             sampling_project_info,
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor
+        processor
             .process(&mut Token::noop(), message)
             .await
-            .unwrap();
-        let ctx = envelope_response.envelope.unwrap();
-        ctx.envelope().clone()
+            .unwrap()
+            .unwrap()
+            .envelope()
+            .clone()
     }
 
     fn extract_first_event_from_envelope(envelope: Envelope) -> Event {
@@ -474,14 +476,12 @@ mod tests {
             }
 
             let envelope = new_envelope(false, "foo");
-            let managed_envelope: TypedEnvelope<TransactionGroup> = ManagedEnvelope::new(
-                envelope,
-                outcome_aggregator.clone(),
-                test_store.clone(),
+            let managed_envelope: TypedEnvelope<TransactionGroup> = (
+                ManagedEnvelope::new(envelope, outcome_aggregator.clone(), test_store.clone()),
                 ProcessingGroup::Transaction,
             )
-            .try_into()
-            .unwrap();
+                .try_into()
+                .unwrap();
 
             let event = Annotated::from(event);
 
@@ -771,10 +771,12 @@ mod tests {
         let envelope = Envelope::parse_bytes(bytes).unwrap();
         let config = Arc::new(Config::default());
 
-        let mut managed_envelope: TypedEnvelope<Group> =
-            ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy(), processing_group)
-                .try_into()
-                .unwrap();
+        let mut managed_envelope: TypedEnvelope<Group> = (
+            ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy()),
+            processing_group,
+        )
+            .try_into()
+            .unwrap();
 
         let mut event = Annotated::new(Event::default());
 

--- a/relay-server/src/services/processor/nnswitch.rs
+++ b/relay-server/src/services/processor/nnswitch.rs
@@ -242,14 +242,13 @@ mod tests {
 {"message":"hello world","level":"error","map":{"a":"val"}}
 {"type":"attachment","filename":"dying_message.dat","length":<len>}
 "#.replace("<len>", &dying_message.len().to_string());
-        ManagedEnvelope::new(
+
+        let envelope = ManagedEnvelope::new(
             Envelope::parse_bytes([Bytes::from(envelope), dying_message].concat().into()).unwrap(),
             Addr::dummy(),
             Addr::dummy(),
-            ProcessingGroup::Error,
-        )
-        .try_into()
-        .unwrap()
+        );
+        (envelope, ProcessingGroup::Error).try_into().unwrap()
     }
 
     #[test]

--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -245,14 +245,8 @@ mod tests {
             .insert(Feature::OurLogsIngestion);
         let project_info = Arc::new(project_info);
 
-        let managed_envelope = ManagedEnvelope::new(
-            dummy_envelope,
-            Addr::dummy(),
-            Addr::dummy(),
-            ProcessingGroup::Log,
-        );
-
-        let managed_envelope = managed_envelope.try_into().unwrap();
+        let managed_envelope = ManagedEnvelope::new(dummy_envelope, Addr::dummy(), Addr::dummy());
+        let managed_envelope = (managed_envelope, ProcessingGroup::Log).try_into().unwrap();
 
         (managed_envelope, project_info)
     }

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -191,7 +191,7 @@ mod tests {
 
     use crate::envelope::Envelope;
     use crate::extractors::RequestMeta;
-    use crate::services::processor::{ProcessEnvelopeGroup, ProcessingGroup};
+    use crate::services::processor::{ProcessEnvelopeGrouped, ProcessingGroup};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::create_test_processor;
     use crate::utils::ManagedEnvelope;
@@ -297,7 +297,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(project_state),
@@ -432,7 +432,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(project_info),
@@ -506,7 +506,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope.clone(), Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(project_state),
@@ -582,7 +582,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(project_state),

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -191,7 +191,7 @@ mod tests {
 
     use crate::envelope::Envelope;
     use crate::extractors::RequestMeta;
-    use crate::services::processor::{ProcessEnvelope, ProcessingGroup};
+    use crate::services::processor::{ProcessEnvelopeGroup, ProcessingGroup};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::create_test_processor;
     use crate::utils::ManagedEnvelope;
@@ -202,6 +202,7 @@ mod tests {
     #[tokio::test]
     async fn test_profile_id_transfered() {
         // Setup
+
         let config = Config::from_json_value(serde_json::json!({
             "processing": {
                 "enabled": true,
@@ -294,9 +295,10 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
 
         let (group, envelope) = envelopes.pop().unwrap();
-        let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy(), group);
+        let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelope {
+        let message = ProcessEnvelopeGroup {
+            group,
             envelope,
             project_info: Arc::new(project_state),
             rate_limits: Default::default(),
@@ -304,12 +306,12 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor
+        let new_envelope = processor
             .process(&mut Token::noop(), message)
             .await
+            .unwrap()
             .unwrap();
-        let ctx = envelope_response.envelope.unwrap();
-        let new_envelope = ctx.envelope();
+        let new_envelope = new_envelope.envelope();
 
         // Get the re-serialized context.
         let item = new_envelope
@@ -428,9 +430,10 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
 
         let (group, envelope) = envelopes.pop().unwrap();
-        let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy(), group);
+        let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelope {
+        let message = ProcessEnvelopeGroup {
+            group,
             envelope,
             project_info: Arc::new(project_info),
             rate_limits: Default::default(),
@@ -438,12 +441,12 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor
+        let new_envelope = processor
             .process(&mut Token::noop(), message)
             .await
+            .unwrap()
             .unwrap();
-        let ctx = envelope_response.envelope.unwrap();
-        let new_envelope = ctx.envelope();
+        let new_envelope = new_envelope.envelope();
 
         // Get the re-serialized context.
         let item = new_envelope
@@ -501,9 +504,10 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
 
         let (group, envelope) = envelopes.pop().unwrap();
-        let envelope = ManagedEnvelope::new(envelope.clone(), Addr::dummy(), Addr::dummy(), group);
+        let envelope = ManagedEnvelope::new(envelope.clone(), Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelope {
+        let message = ProcessEnvelopeGroup {
+            group,
             envelope,
             project_info: Arc::new(project_state),
             rate_limits: Default::default(),
@@ -511,11 +515,11 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor
+        let envelope = processor
             .process(&mut Token::noop(), message)
             .await
             .unwrap();
-        assert!(envelope_response.envelope.is_none());
+        assert!(envelope.is_none());
     }
 
     #[cfg(feature = "processing")]
@@ -576,9 +580,10 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
 
         let (group, envelope) = envelopes.pop().unwrap();
-        let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy(), group);
+        let envelope = ManagedEnvelope::new(envelope, Addr::dummy(), Addr::dummy());
 
-        let message = ProcessEnvelope {
+        let message = ProcessEnvelopeGroup {
+            group,
             envelope,
             project_info: Arc::new(project_state),
             rate_limits: Default::default(),
@@ -586,12 +591,12 @@ mod tests {
             reservoir_counters: ReservoirCounters::default(),
         };
 
-        let envelope_response = processor
+        let new_envelope = processor
             .process(&mut Token::noop(), message)
             .await
+            .unwrap()
             .unwrap();
-        let ctx = envelope_response.envelope.unwrap();
-        let new_envelope = ctx.envelope();
+        let new_envelope = new_envelope.envelope();
 
         // Get the re-serialized context.
         let item = new_envelope

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -278,7 +278,7 @@ mod tests {
     use crate::envelope::{Envelope, Item};
     use crate::extractors::RequestMeta;
     use crate::services::outcome::RuleCategory;
-    use crate::services::processor::{ProcessEnvelopeGroup, ProcessingGroup};
+    use crate::services::processor::{ProcessEnvelopeGrouped, ProcessingGroup};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{self, create_test_processor};
     use crate::utils::ManagedEnvelope;
@@ -327,7 +327,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
 
         let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
@@ -386,7 +386,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
@@ -453,7 +453,7 @@ mod tests {
 
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
@@ -498,7 +498,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
 
         let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(ProjectInfo::default()),
@@ -551,7 +551,7 @@ mod tests {
         let (group, envelope) = envelopes.pop().unwrap();
         let envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
 
-        let message = ProcessEnvelopeGroup {
+        let message = ProcessEnvelopeGrouped {
             group,
             envelope,
             project_info: Arc::new(ProjectInfo::default()),

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -226,13 +226,10 @@ mod tests {
         let envelope = Envelope::parse_bytes(bytes).unwrap();
         let (test_store, _) = Addr::custom();
         let (outcome_aggregator, _) = Addr::custom();
-        let managed_envelope = ManagedEnvelope::new(
-            envelope,
-            outcome_aggregator,
-            test_store,
-            ProcessingGroup::Span,
-        );
-        let mut typed_envelope: TypedEnvelope<_> = managed_envelope.try_into().unwrap();
+        let managed_envelope = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
+        let mut typed_envelope: TypedEnvelope<_> = (managed_envelope, ProcessingGroup::Span)
+            .try_into()
+            .unwrap();
         let mut item = Item::new(ItemType::OtelTracesData);
         item.set_payload(ContentType::Json, traces_data);
         typed_envelope.envelope_mut().add_item(item.clone());

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -866,14 +866,10 @@ mod tests {
             ..Default::default()
         };
 
-        let managed_envelope = ManagedEnvelope::new(
-            dummy_envelope,
-            Addr::dummy(),
-            Addr::dummy(),
-            ProcessingGroup::Transaction,
-        );
-
-        let managed_envelope = managed_envelope.try_into().unwrap();
+        let managed_envelope = ManagedEnvelope::new(dummy_envelope, Addr::dummy(), Addr::dummy());
+        let managed_envelope = (managed_envelope, ProcessingGroup::Transaction)
+            .try_into()
+            .unwrap();
 
         let event = Annotated::from(event);
 

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -186,7 +186,6 @@ fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
 mod tests {
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
-    use crate::services::processor::ProcessingGroup;
     use crate::services::projects::project::{ProjectInfo, PublicKeyConfig};
     use relay_base_schema::project::{ProjectId, ProjectKey};
     use relay_event_schema::protocol::EventId;
@@ -281,12 +280,8 @@ mod tests {
         let (outcome_aggregator, mut outcome_aggregator_rx) = relay_system::Addr::custom();
         let (test_store, _) = relay_system::Addr::custom();
 
-        let managed_envelope = ManagedEnvelope::new(
-            envelope,
-            outcome_aggregator.clone(),
-            test_store,
-            ProcessingGroup::Transaction,
-        );
+        let managed_envelope =
+            ManagedEnvelope::new(envelope, outcome_aggregator.clone(), test_store);
 
         project.check_envelope(managed_envelope).await.unwrap();
         drop(outcome_aggregator);

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -26,7 +26,7 @@ use crate::services::processor::{self, EnvelopeProcessorService, EnvelopeProcess
 use crate::services::projects::cache::ProjectCacheHandle;
 use crate::services::projects::project::ProjectInfo;
 use crate::services::test_store::TestStore;
-use crate::utils::ThreadPoolBuilder;
+use crate::utils::{ManagedEnvelope, ThreadPoolBuilder};
 
 pub fn state_with_rule_and_condition(
     sample_rate: Option<f64>,
@@ -105,6 +105,17 @@ pub fn new_envelope<T: Into<String>>(with_dsc: bool, transaction_name: T) -> Box
     envelope.add_item(item3);
 
     envelope
+}
+
+pub fn new_managed_envelope<T: Into<String>>(
+    with_dsc: bool,
+    transaction_name: T,
+) -> ManagedEnvelope {
+    ManagedEnvelope::new(
+        new_envelope(with_dsc, transaction_name),
+        Addr::dummy(),
+        Addr::dummy(),
+    )
 }
 
 pub async fn create_test_processor(config: Config) -> EnvelopeProcessorService {

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -64,17 +64,16 @@ struct EnvelopeContext {
     scoping: Scoping,
     partition_key: Option<u32>,
     done: bool,
-    group: ProcessingGroup,
 }
 
 #[derive(Debug)]
-pub struct InvalidProcessingGroupType(pub ManagedEnvelope);
+pub struct InvalidProcessingGroupType(pub ManagedEnvelope, pub ProcessingGroup);
 
 impl Display for InvalidProcessingGroupType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
             "failed to convert to the processing group {} based on the provided type",
-            self.0.group().variant()
+            self.1.variant()
         ))
     }
 }
@@ -89,7 +88,7 @@ impl<G> TypedEnvelope<G> {
     ///
     /// Once it's marked processed it can be submitted to upstream.
     pub fn into_processed(self) -> TypedEnvelope<Processed> {
-        TypedEnvelope::new(self.0, Processed)
+        TypedEnvelope::new(self.0)
     }
 
     /// Accepts the envelope and drops the internal managed envelope with its context.
@@ -105,17 +104,19 @@ impl<G> TypedEnvelope<G> {
     ///
     /// Note: this method is private to make sure that only `TryFrom` implementation is used, which
     /// requires the check for the error if conversion is failing.
-    fn new(managed_envelope: ManagedEnvelope, _ty: G) -> Self {
-        Self(managed_envelope, PhantomData::<G> {})
+    fn new(managed_envelope: ManagedEnvelope) -> Self {
+        Self(managed_envelope, Default::default())
     }
 }
 
-impl<G: TryFrom<ProcessingGroup>> TryFrom<ManagedEnvelope> for TypedEnvelope<G> {
+impl<G: TryFrom<ProcessingGroup>> TryFrom<(ManagedEnvelope, ProcessingGroup)> for TypedEnvelope<G> {
     type Error = InvalidProcessingGroupType;
-    fn try_from(value: ManagedEnvelope) -> Result<Self, Self::Error> {
-        match value.group().try_into() {
-            Ok(group) => Ok(TypedEnvelope::new(value, group)),
-            Err(_) => Err(InvalidProcessingGroupType(value)),
+    fn try_from(
+        (envelope, group): (ManagedEnvelope, ProcessingGroup),
+    ) -> Result<Self, Self::Error> {
+        match <ProcessingGroup as TryInto<G>>::try_into(group) {
+            Ok(_) => Ok(TypedEnvelope::new(envelope)),
+            Err(_) => Err(InvalidProcessingGroupType(envelope, group)),
         }
     }
 }
@@ -171,7 +172,6 @@ impl ManagedEnvelope {
         envelope: Box<Envelope>,
         outcome_aggregator: Addr<TrackOutcome>,
         test_store: Addr<TestStore>,
-        group: ProcessingGroup,
     ) -> Self {
         let meta = &envelope.meta();
         let summary = EnvelopeSummary::compute(envelope.as_ref());
@@ -184,7 +184,6 @@ impl ManagedEnvelope {
                 scoping,
                 partition_key: None,
                 done: false,
-                group,
             },
             outcome_aggregator,
             test_store,
@@ -197,12 +196,7 @@ impl ManagedEnvelope {
         outcome_aggregator: Addr<TrackOutcome>,
         test_store: Addr<TestStore>,
     ) -> Self {
-        let mut envelope = Self::new(
-            envelope,
-            outcome_aggregator,
-            test_store,
-            ProcessingGroup::Ungrouped,
-        );
+        let mut envelope = Self::new(envelope, outcome_aggregator, test_store);
         envelope.context.done = true;
         envelope
     }
@@ -210,11 +204,6 @@ impl ManagedEnvelope {
     /// Returns a reference to the contained [`Envelope`].
     pub fn envelope(&self) -> &Envelope {
         self.envelope.as_ref()
-    }
-
-    /// Returns the [`ProcessingGroup`] where this envelope belongs to.
-    pub fn group(&self) -> ProcessingGroup {
-        self.context.group
     }
 
     /// Returns a mutable reference to the contained [`Envelope`].
@@ -232,7 +221,7 @@ impl ManagedEnvelope {
     ///
     /// Once it's marked processed it can be submitted to upstream.
     pub fn into_processed(self) -> TypedEnvelope<Processed> {
-        TypedEnvelope::new(self, Processed)
+        TypedEnvelope::new(self)
     }
 
     /// Take the envelope out of the context and replace it with a dummy.
@@ -564,12 +553,7 @@ mod tests {
 
         let (test_store, _) = Addr::custom();
         let (outcome_aggregator, mut rx) = Addr::custom();
-        let mut env = ManagedEnvelope::new(
-            envelope,
-            outcome_aggregator,
-            test_store,
-            ProcessingGroup::Ungrouped,
-        );
+        let mut env = ManagedEnvelope::new(envelope, outcome_aggregator, test_store);
         env.context.summary.span_quantity = 123;
         env.context.summary.secondary_span_quantity = 456;
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -955,7 +955,6 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
-    use crate::services::processor::ProcessingGroup;
     use crate::{
         envelope::{AttachmentType, ContentType, SourceQuantities},
         extractors::RequestMeta,
@@ -1167,7 +1166,6 @@ mod tests {
                 envelope,
                 outcome_aggregator,
                 test_store,
-                ProcessingGroup::Ungrouped,
             )
         }}
     }


### PR DESCRIPTION
Instead of splitting the envelope in the endpoint *and* buffer and afterwards relying on properly set envelope groups in the processor, the splitting is now moved into the processor.

This is the first refactor to allow for a more specialized and typed envelope processor, which is supposed to take items out of an envelope on demand to create a typed 'unit of work'. Such a design is in the current Relay design not possible, as buffering requires an envelope.

As a side effect, with this change we actually also optimize the envelope buffer a bit, since we store larger envelopes, but fewer.

Most changes are due to the processing group no longer being directly tied to the envelope. This makes sense as the envelope never guaranteed what items it contained. It is now kept outside the envelope and fused into the envelope when constructing the `TypedEnvelope`.

#skip-changelog