### PR TITLE
ref(server): Eliminate some of the unnecessary arcs passed

### DIFF
--- a/relay-server/src/services/processor/ourlog.rs
+++ b/relay-server/src/services/processor/ourlog.rs
@@ -1,5 +1,4 @@
 //! Log processing code.
-use std::sync::Arc;
 
 use crate::services::processor::LogGroup;
 use relay_config::Config;
@@ -28,11 +27,11 @@ use {
 /// Removes logs from the envelope if the feature is not enabled.
 pub fn filter(
     managed_envelope: &mut TypedEnvelope<LogGroup>,
-    config: Arc<Config>,
-    project_info: Arc<ProjectInfo>,
+    config: &Config,
+    project_info: &ProjectInfo,
     global_config: &GlobalConfig,
 ) {
-    let logging_disabled = should_filter(&config, &project_info, Feature::OurLogsIngestion);
+    let logging_disabled = should_filter(config, project_info, Feature::OurLogsIngestion);
     let logs_sampled = global_config
         .options
         .ourlogs_ingestion_sample_rate
@@ -54,7 +53,7 @@ pub fn filter(
 #[cfg(feature = "processing")]
 pub fn process(
     managed_envelope: &mut TypedEnvelope<LogGroup>,
-    project_info: Arc<ProjectInfo>,
+    project_info: &ProjectInfo,
 ) -> Result<(), ProcessingError> {
     let log_items = managed_envelope
         .envelope()
@@ -228,7 +227,7 @@ mod tests {
 
     use relay_system::Addr;
 
-    fn params() -> (TypedEnvelope<LogGroup>, Arc<ProjectInfo>) {
+    fn params() -> (TypedEnvelope<LogGroup>, ProjectInfo) {
         let bytes = Bytes::from(
             r#"{"dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}
 {"type":"otel_log"}
@@ -243,7 +242,6 @@ mod tests {
             .features
             .0
             .insert(Feature::OurLogsIngestion);
-        let project_info = Arc::new(project_info);
 
         let managed_envelope = ManagedEnvelope::new(
             dummy_envelope,
@@ -260,7 +258,7 @@ mod tests {
     #[test]
     fn test_logs_sampled_default() {
         let global_config = GlobalConfig::default();
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         assert!(
             global_config
                 .options
@@ -268,7 +266,12 @@ mod tests {
                 .is_none()
         );
         let (mut managed_envelope, project_info) = params();
-        filter(&mut managed_envelope, config, project_info, &global_config);
+        filter(
+            &mut managed_envelope,
+            &config,
+            &project_info,
+            &global_config,
+        );
         assert!(
             managed_envelope
                 .envelope()
@@ -283,9 +286,14 @@ mod tests {
     fn test_logs_sampled_explicit() {
         let mut global_config = GlobalConfig::default();
         global_config.options.ourlogs_ingestion_sample_rate = Some(1.0);
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let (mut managed_envelope, project_info) = params();
-        filter(&mut managed_envelope, config, project_info, &global_config);
+        filter(
+            &mut managed_envelope,
+            &config,
+            &project_info,
+            &global_config,
+        );
         assert!(
             managed_envelope
                 .envelope()
@@ -300,9 +308,14 @@ mod tests {
     fn test_logs_sampled_dropped() {
         let mut global_config = GlobalConfig::default();
         global_config.options.ourlogs_ingestion_sample_rate = Some(0.0);
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let (mut managed_envelope, project_info) = params();
-        filter(&mut managed_envelope, config, project_info, &global_config);
+        filter(
+            &mut managed_envelope,
+            &config,
+            &project_info,
+            &global_config,
+        );
         assert!(
             !managed_envelope
                 .envelope()

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -25,9 +25,9 @@ pub fn filter<Group>(
     event: &Annotated<Event>,
     config: Arc<Config>,
     project_id: ProjectId,
-    project_info: Arc<ProjectInfo>,
+    project_info: &ProjectInfo,
 ) -> Option<ProfileId> {
-    let profiling_disabled = should_filter(&config, &project_info, Feature::Profiling);
+    let profiling_disabled = should_filter(&config, project_info, Feature::Profiling);
     let has_transaction = event_type(event) == Some(EventType::Transaction);
     let keep_unsampled_profiles = true;
 

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -35,7 +35,7 @@ pub fn filter<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: 
 #[cfg(feature = "processing")]
 pub fn process(
     managed_envelope: &mut TypedEnvelope<ProfileChunkGroup>,
-    project_info: Arc<ProjectInfo>,
+    project_info: &ProjectInfo,
     global_config: &GlobalConfig,
     config: &Config,
 ) {

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -1,7 +1,6 @@
 //! Replay related processor code.
 use std::error::Error;
 use std::net::IpAddr;
-use std::sync::Arc;
 
 use crate::envelope::{ContentType, ItemType};
 use crate::services::outcome::DiscardReason;
@@ -28,12 +27,12 @@ use serde::{Deserialize, Serialize};
 pub fn process(
     managed_envelope: &mut TypedEnvelope<ReplayGroup>,
     global_config: &GlobalConfig,
-    config: Arc<Config>,
-    project_info: Arc<ProjectInfo>,
+    config: &Config,
+    project_info: &ProjectInfo,
     geoip_lookup: Option<&GeoIpLookup>,
 ) -> Result<(), ProcessingError> {
     // If the replay feature is not enabled drop the items silently.
-    if should_filter(&config, &project_info, Feature::SessionReplay) {
+    if should_filter(config, project_info, Feature::SessionReplay) {
         managed_envelope.drop_items_silently();
         return Ok(());
     }

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -2,7 +2,6 @@
 
 use std::collections::BTreeMap;
 use std::error::Error;
-use std::sync::Arc;
 
 use chrono::{Duration as SignedDuration, Utc};
 use relay_common::time::UnixTimestamp;
@@ -44,8 +43,8 @@ pub enum ClientReportField {
 /// system.
 pub fn process_client_reports(
     managed_envelope: &mut TypedEnvelope<ClientReportGroup>,
-    config: Arc<Config>,
-    project_info: Arc<ProjectInfo>,
+    config: &Config,
+    project_info: &ProjectInfo,
     outcome_aggregator: Addr<TrackOutcome>,
 ) {
     // if client outcomes are disabled we leave the client reports unprocessed

--- a/relay-server/src/services/processor/session.rs
+++ b/relay-server/src/services/processor/session.rs
@@ -2,7 +2,6 @@
 
 use std::error::Error;
 use std::net;
-use std::sync::Arc;
 
 use chrono::{DateTime, Duration as SignedDuration, Utc};
 use relay_config::Config;
@@ -27,7 +26,7 @@ use crate::utils::{ItemAction, TypedEnvelope};
 pub fn process(
     managed_envelope: &mut TypedEnvelope<SessionGroup>,
     extracted_metrics: &mut ProcessingExtractedMetrics,
-    project_info: Arc<ProjectInfo>,
+    project_info: &ProjectInfo,
     config: &Config,
 ) {
     let received = managed_envelope.received_at();


### PR DESCRIPTION
We have a lot of unnecessary arc clones, configs being passed as `Arc<T>`, whey they really should just take a reference. This cleans up some of these cases. I did specifically not touch the spans/transactions codepaths.

#skip-changelog