### PR TITLE
ref(spans): Remove SpanKind::Unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+- Remove the "unspecified" variant of `SpanKind`. ([#4774](https://github.com/getsentry/relay/pull/4774))
+
 ## 25.5.1
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 **Internal**:
+
 - Remove the "unspecified" variant of `SpanKind`. ([#4774](https://github.com/getsentry/relay/pull/4774))
 
 ## 25.5.1

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 
-use opentelemetry_proto::tonic::trace::v1::span::SpanKind as OtelSpanKind;
 use relay_protocol::{
     Annotated, Array, Empty, Error, FromValue, Getter, IntoValue, Object, Val, Value,
 };
@@ -936,13 +935,12 @@ impl FromValue for Route {
 }
 
 #[derive(Clone, Debug, PartialEq, ProcessValue)]
-#[repr(i32)]
 pub enum SpanKind {
-    Internal = OtelSpanKind::Internal as i32,
-    Server = OtelSpanKind::Server as i32,
-    Client = OtelSpanKind::Client as i32,
-    Producer = OtelSpanKind::Producer as i32,
-    Consumer = OtelSpanKind::Consumer as i32,
+    Internal,
+    Server,
+    Client,
+    Producer,
+    Consumer,
 }
 
 impl SpanKind {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -938,7 +938,6 @@ impl FromValue for Route {
 #[derive(Clone, Debug, PartialEq, ProcessValue)]
 #[repr(i32)]
 pub enum SpanKind {
-    Unspecified = OtelSpanKind::Unspecified as i32,
     Internal = OtelSpanKind::Internal as i32,
     Server = OtelSpanKind::Server as i32,
     Client = OtelSpanKind::Client as i32,
@@ -949,7 +948,6 @@ pub enum SpanKind {
 impl SpanKind {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Unspecified => "unspecified",
             Self::Internal => "internal",
             Self::Server => "server",
             Self::Client => "client",
@@ -973,7 +971,6 @@ impl std::str::FromStr for SpanKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "unspecified" => SpanKind::Unspecified,
             "internal" => SpanKind::Internal,
             "server" => SpanKind::Server,
             "client" => SpanKind::Client,
@@ -987,19 +984,6 @@ impl std::str::FromStr for SpanKind {
 impl Default for SpanKind {
     fn default() -> Self {
         Self::Internal
-    }
-}
-
-impl From<OtelSpanKind> for SpanKind {
-    fn from(otel_kind: OtelSpanKind) -> Self {
-        match otel_kind {
-            OtelSpanKind::Unspecified => Self::Unspecified,
-            OtelSpanKind::Internal => Self::Internal,
-            OtelSpanKind::Server => Self::Server,
-            OtelSpanKind::Client => Self::Client,
-            OtelSpanKind::Producer => Self::Producer,
-            OtelSpanKind::Consumer => Self::Consumer,
-        }
     }
 }
 

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -46,7 +46,7 @@ pub struct SpanV2 {
     /// spans, e.g. a `server` and `client` span with the same name.
     ///
     /// See <https://opentelemetry.io/docs/specs/otel/trace/api/#spankind>
-    #[metastructure(required = true, skip_serialization = "empty", trim = false)]
+    #[metastructure(skip_serialization = "empty", trim = false)]
     pub kind: Annotated<SpanV2Kind>,
 
     /// Timestamp when the span started.

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -1,6 +1,7 @@
-use relay_protocol::{Annotated, Array, Empty, FromValue, IntoValue, Object, Value};
+use relay_protocol::{Annotated, Array, Empty, Error, FromValue, IntoValue, Object, Value};
 
 use std::fmt;
+use std::str::FromStr;
 
 use serde::Serialize;
 
@@ -181,19 +182,16 @@ pub enum SpanV2Kind {
     Producer,
     /// Processing of a scheduled operation.
     Consumer,
-    /// Catchall variant for forward compatibility.
-    Other(String),
 }
 
 impl SpanV2Kind {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Internal => "internal",
             Self::Server => "server",
             Self::Client => "client",
             Self::Producer => "producer",
             Self::Consumer => "consumer",
-            Self::Other(s) => s,
         }
     }
 }
@@ -216,25 +214,44 @@ impl fmt::Display for SpanV2Kind {
     }
 }
 
-impl From<String> for SpanV2Kind {
-    fn from(value: String) -> Self {
-        match value.as_str() {
+#[derive(Debug, Clone, Copy)]
+pub struct ParseSpanV2KindError;
+
+impl fmt::Display for ParseSpanV2KindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid span kind")
+    }
+}
+
+impl FromStr for SpanV2Kind {
+    type Err = ParseSpanV2KindError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let kind = match s {
             "internal" => Self::Internal,
             "server" => Self::Server,
             "client" => Self::Client,
             "producer" => Self::Producer,
             "consumer" => Self::Consumer,
-            _ => Self::Other(value),
-        }
+            _ => return Err(ParseSpanV2KindError),
+        };
+        Ok(kind)
     }
 }
 
 impl FromValue for SpanV2Kind {
-    fn from_value(value: Annotated<Value>) -> Annotated<Self>
+    fn from_value(Annotated(value, meta): Annotated<Value>) -> Annotated<Self>
     where
         Self: Sized,
     {
-        String::from_value(value).map_value(|s| s.into())
+        match &value {
+            Some(Value::String(s)) => match s.parse() {
+                Ok(kind) => Annotated(Some(kind), meta),
+                Err(_) => Annotated::from_error(Error::expected("a span kind"), value),
+            },
+            Some(_) => Annotated::from_error(Error::expected("a span kind"), value),
+            None => Annotated::empty(),
+        }
     }
 }
 

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -502,8 +502,7 @@ mod tests {
             "sentry.op": "myop"
           },
           "links": [],
-          "platform": "php",
-          "kind": "unspecified"
+          "platform": "php"
         }
         "###);
     }
@@ -532,8 +531,7 @@ mod tests {
           "is_remote": true,
           "status": "unknown",
           "data": {},
-          "links": [],
-          "kind": "unspecified"
+          "links": []
         }
         "###);
     }
@@ -562,8 +560,7 @@ mod tests {
           "is_remote": false,
           "status": "unknown",
           "data": {},
-          "links": [],
-          "kind": "unspecified"
+          "links": []
         }
         "###);
     }
@@ -661,8 +658,7 @@ mod tests {
                 "str_key": "str_value"
               }
             }
-          ],
-          "kind": "unspecified"
+          ]
         }
         "###);
     }

--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -7,7 +7,7 @@ use relay_event_schema::protocol::{
     EventId, Span as SpanV1, SpanData, SpanId, SpanLink, SpanStatus, SpanV2, SpanV2Kind,
     SpanV2Status,
 };
-use relay_protocol::{Annotated, ErrorKind, FromValue, Object, Value};
+use relay_protocol::{Annotated, FromValue, Object, Value};
 
 /// Transforms a Sentry span V2 to a Sentry span V1.
 ///
@@ -120,7 +120,7 @@ pub fn span_v2_to_span_v1(span_v2: SpanV2) -> SpanV1 {
         timestamp: end_timestamp,
         trace_id,
         platform,
-        kind: kind.and_then(span_v2_kind_to_span_v1_kind),
+        kind: kind.map_value(span_v2_kind_to_span_v1_kind),
         links,
         ..Default::default()
     }
@@ -150,16 +150,13 @@ fn span_v2_status_to_span_v1_status(
         .or_else(|| Annotated::new(SpanStatus::Unknown))
 }
 
-fn span_v2_kind_to_span_v1_kind(kind: SpanV2Kind) -> Annotated<SpanKind> {
+fn span_v2_kind_to_span_v1_kind(kind: SpanV2Kind) -> SpanKind {
     match kind {
-        SpanV2Kind::Internal => Annotated::new(SpanKind::Internal),
-        SpanV2Kind::Server => Annotated::new(SpanKind::Server),
-        SpanV2Kind::Client => Annotated::new(SpanKind::Client),
-        SpanV2Kind::Producer => Annotated::new(SpanKind::Producer),
-        SpanV2Kind::Consumer => Annotated::new(SpanKind::Consumer),
-        SpanV2Kind::Other(s) => {
-            Annotated::from_error(ErrorKind::InvalidData, Some(Value::String(s)))
-        }
+        SpanV2Kind::Internal => SpanKind::Internal,
+        SpanV2Kind::Server => SpanKind::Server,
+        SpanV2Kind::Client => SpanKind::Client,
+        SpanV2Kind::Producer => SpanKind::Producer,
+        SpanV2Kind::Consumer => SpanKind::Consumer,
     }
 }
 

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -670,7 +670,6 @@ def test_span_ingestion(
             "exclusive_time_ms": 500.0,
             "is_segment": True,
             "is_remote": False,
-            "kind": "unspecified",
             "links": [
                 {
                     "trace_id": "89143b0763095bd9c9955e8175d1fb24",


### PR DESCRIPTION
Since the `kind` field of `Span` is not mandatory, and the `Unspecified` variant of `SpanKind` transports no more information than an empty `kind`, we remove `SpanKind::Unspecified` and use `Annotated::empty` instead.

Moreover, we remove `SpanV2Kind::Other` because the list of kinds is very unlikely to be extended in the future.

In detail this means:

* When converting from OTEL to Span V2:
  * Both `Unspecified` and an empty span kind map to `empty`
  * All other valid OTEL span kinds map to the corresponding V2 span kinds
  * All other `i32` values map to errors
* When converting from Span V2 to Span V1:
  * All variants of `SpanV2Kind` map to the corresponding V1 kinds
* When converting from OTEL to Span V1:
  * Both `Unspecified` and an empty span kind map to `empty`
  * All other valid OTEL span kinds map to the corresponding V1 span kinds
  * All other `i32` values map to errors

ref: RELAY-63