### PR TITLE
ref: Tie ContainerItem to an ItemType

### DIFF
--- a/relay-server/src/envelope/container.rs
+++ b/relay-server/src/envelope/container.rs
@@ -18,6 +18,8 @@ use smallvec::SmallVec;
 
 use crate::envelope::{ContentType, Item};
 
+use super::ItemType;
+
 /// Error emitted when failing to parse an [`ItemContainer`].
 #[derive(thiserror::Error, Debug)]
 pub enum ContainerParseError {
@@ -26,6 +28,12 @@ pub enum ContainerParseError {
     MismatchedContentType {
         expected: ContentType,
         actual: Option<ContentType>,
+    },
+    /// The item container was expected to have a different item type.
+    #[error("expected item with item type {expected} but got {actual:?}")]
+    MismatchedItemType {
+        expected: ItemType,
+        actual: ItemType,
     },
     /// The item container specified length does not match the amount of items contained in the
     /// container.
@@ -52,6 +60,8 @@ pub enum ContainerWriteError {
 
 /// Any item contained in an [`ItemContainer`] needs to implement this trait.
 pub trait ContainerItem: FromValue + IntoValue {
+    /// The expected item type of the container for this type.
+    const ITEM_TYPE: ItemType;
     /// The expected content type of the container for this type.
     const CONTENT_TYPE: ContentType;
 }
@@ -98,6 +108,13 @@ impl<T: ContainerItem> ItemContainer<T> {
             });
         }
 
+        if item.ty() != &T::ITEM_TYPE {
+            return Err(ContainerParseError::MismatchedItemType {
+                expected: T::ITEM_TYPE,
+                actual: item.ty().clone(),
+            });
+        }
+
         let payload = item.payload();
         // Currently we assume every payload is JSON, but in the future we may allow other formats.
         let mut de = serde_json::Deserializer::from_slice(&payload);
@@ -130,6 +147,11 @@ impl<T: ContainerItem> ItemContainer<T> {
         );
 
         Ok(())
+    }
+
+    /// Checks whether a given item is a container of `T`s, according to its item and content types.
+    pub fn is_container(item: &Item) -> bool {
+        item.ty() == &T::ITEM_TYPE && item.content_type() == Some(&T::CONTENT_TYPE)
     }
 
     fn deserialize<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -168,10 +190,12 @@ impl<T> From<ContainerItems<T>> for ItemContainer<T> {
 }
 
 impl ContainerItem for relay_event_schema::protocol::OurLog {
+    const ITEM_TYPE: ItemType = ItemType::Log;
     const CONTENT_TYPE: ContentType = ContentType::LogContainer;
 }
 
 impl ContainerItem for relay_event_schema::protocol::SpanV2 {
+    const ITEM_TYPE: ItemType = ItemType::Span;
     const CONTENT_TYPE: ContentType = ContentType::SpanV2Container;
 }
 
@@ -254,6 +278,7 @@ mod tests {
         message: Annotated<String>,
     }
     impl ContainerItem for TestLog {
+        const ITEM_TYPE: ItemType = ItemType::Log;
         const CONTENT_TYPE: ContentType = ContentType::LogContainer;
     }
 
@@ -319,6 +344,25 @@ mod tests {
             Err(ContainerParseError::MismatchedContentType {
                 expected: ContentType::LogContainer,
                 actual: Some(ContentType::Json),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_container_deserialize_invalid_item_type() {
+        let (item, _) = Item::parse(Bytes::from_static(
+            br#"{"type":"span","content_type":"application/vnd.sentry.items.log+json","item_count":1}
+{"items":[{"level":"info","message":"foobar"}]}
+        "#,
+        ))
+        .unwrap();
+
+        assert_eq!(item.item_count(), Some(1));
+        assert!(matches!(
+            ItemContainer::<TestLog>::parse(&item),
+            Err(ContainerParseError::MismatchedItemType {
+                expected: ItemType::Log,
+                actual: ItemType::Span,
             })
         ));
     }

--- a/relay-server/src/envelope/container.rs
+++ b/relay-server/src/envelope/container.rs
@@ -16,9 +16,7 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize, de, ser};
 use smallvec::SmallVec;
 
-use crate::envelope::{ContentType, Item};
-
-use super::ItemType;
+use crate::envelope::{ContentType, Item, ItemType};
 
 /// Error emitted when failing to parse an [`ItemContainer`].
 #[derive(thiserror::Error, Debug)]

--- a/relay-server/src/services/processor/ourlog/processing.rs
+++ b/relay-server/src/services/processor/ourlog/processing.rs
@@ -25,7 +25,7 @@ pub fn process(
     let log_items = managed_envelope
         .envelope()
         .items()
-        .filter(|item| matches!(item.ty(), ItemType::Log))
+        .filter(|item| ItemContainer::<OurLog>::is_container(item))
         .count();
 
     // The `Log` item must always be sent as an `ItemContainer`, currently it is not allowed to

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -7,7 +7,7 @@ use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use prost::Message;
 use relay_dynamic_config::Feature;
 use relay_event_normalization::span::tag_extraction;
-use relay_event_schema::protocol::{Event, Span};
+use relay_event_schema::protocol::{Event, Span, SpanV2};
 use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 use relay_spans::otel_trace::TracesData;
@@ -57,7 +57,7 @@ pub fn expand_v2_spans(
 ) -> Result<(), ProcessingError> {
     let span_v2_items = managed_envelope
         .envelope_mut()
-        .take_items_by(is_span_v2_item);
+        .take_items_by(ItemContainer::<SpanV2>::is_container);
 
     // V2 spans must always be sent as an `ItemContainer`, currently it is not allowed to
     // send multiple containers for V2 spans.
@@ -101,10 +101,6 @@ pub fn expand_v2_spans(
     }
 
     Ok(())
-}
-
-fn is_span_v2_item(item: &Item) -> bool {
-    item.ty() == &ItemType::Span && item.content_type() == Some(&ContentType::SpanV2Container)
 }
 
 pub fn convert_otel_traces_data(managed_envelope: &mut TypedEnvelope<SpanGroup>) {


### PR DESCRIPTION
This adds a constant of type `ItemType` to the `ContainerItem` trait. Consequently it also adds a parse error variant in analogy to the content type, as well as a function to check whether an `Item` is a container of `T`.

#skip-changelog