### PR TITLE
fix(ourlog): use sentry prefix for browser name/version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add browser name/version to logs. ([#4757](https://github.com/getsentry/relay/pull/4757))
 - Accept standalone spans in the V2 format. This feature is still highly experimental! ([#4771](https://github.com/getsentry/relay/pull/4771))
 
+**Bug Fixes**:
+
+- Use sentry prefix for browser name/version in logs. ([#4783](https://github.com/getsentry/relay/pull/4783))
+
 **Internal**:
 
 - Remove the "unspecified" variant of `SpanKind`. ([#4774](https://github.com/getsentry/relay/pull/4774))

--- a/relay-server/src/services/processor/ourlog/processing.rs
+++ b/relay-server/src/services/processor/ourlog/processing.rs
@@ -151,10 +151,10 @@ fn populate_ua_fields(log: &mut OurLog, user_agent: Option<&str>, client_hints: 
         user_agent,
         client_hints,
     }) {
-        if !attributes.contains_key("browser.name") {
+        if !attributes.contains_key("sentry.browser.name") {
             if let Some(name) = context.name.value() {
                 attributes.insert(
-                    "browser.name".to_owned(),
+                    "sentry.browser.name".to_owned(),
                     Annotated::new(Attribute::new(
                         AttributeType::String,
                         Value::String(name.to_owned()),
@@ -163,10 +163,10 @@ fn populate_ua_fields(log: &mut OurLog, user_agent: Option<&str>, client_hints: 
             }
         }
 
-        if !attributes.contains_key("browser.version") {
+        if !attributes.contains_key("sentry.browser.version") {
             if let Some(version) = context.version.value() {
                 attributes.insert(
-                    "browser.version".to_owned(),
+                    "sentry.browser.version".to_owned(),
                     Annotated::new(Attribute::new(
                         AttributeType::String,
                         Value::String(version.to_owned()),
@@ -502,7 +502,7 @@ mod tests {
         let attributes = log.attributes.value().unwrap();
         assert_eq!(
             attributes
-                .get("browser.name")
+                .get("sentry.browser.name")
                 .unwrap()
                 .value()
                 .unwrap()
@@ -512,7 +512,7 @@ mod tests {
         );
         assert_eq!(
             attributes
-                .get("browser.version")
+                .get("sentry.browser.version")
                 .unwrap()
                 .value()
                 .unwrap()

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -111,11 +111,11 @@ def test_ourlog_extraction_with_otel_logs(
                 item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
                 attributes={
                     "boolean.attribute": AnyValue(bool_value=True),
-                    "browser.name": AnyValue(string_value="Python Requests"),
-                    "browser.version": AnyValue(string_value="2.32"),
                     "double.attribute": AnyValue(double_value=637.704),
                     "int.attribute": AnyValue(int_value=10),
                     "sentry.body": AnyValue(string_value="Example log record"),
+                    "sentry.browser.name": AnyValue(string_value="Python Requests"),
+                    "sentry.browser.version": AnyValue(string_value="2.32"),
                     "sentry.severity_number": AnyValue(int_value=10),
                     "sentry.severity_text": AnyValue(string_value="Information"),
                     "sentry.span_id": AnyValue(string_value="eee19b7ec3c1b174"),
@@ -286,9 +286,9 @@ def test_ourlog_extraction_with_sentry_logs(
                 ),
                 item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
                 attributes={
-                    "browser.name": AnyValue(string_value="Python Requests"),
-                    "browser.version": AnyValue(string_value="2.32"),
                     "sentry.body": AnyValue(string_value="This is really bad"),
+                    "sentry.browser.name": AnyValue(string_value="Python Requests"),
+                    "sentry.browser.version": AnyValue(string_value="2.32"),
                     "sentry.severity_number": AnyValue(int_value=17),
                     "sentry.severity_text": AnyValue(string_value="error"),
                     "sentry.span_id": AnyValue(string_value="eee19b7ec3c1b175"),
@@ -318,12 +318,12 @@ def test_ourlog_extraction_with_sentry_logs(
                 item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
                 attributes={
                     "boolean.attribute": AnyValue(bool_value=True),
-                    "browser.name": AnyValue(string_value="Python Requests"),
-                    "browser.version": AnyValue(string_value="2.32"),
                     "double.attribute": AnyValue(double_value=1.23),
                     "integer.attribute": AnyValue(int_value=42),
                     "pii": AnyValue(string_value="[creditcard]"),
                     "sentry.body": AnyValue(string_value="Example log record"),
+                    "sentry.browser.name": AnyValue(string_value="Python Requests"),
+                    "sentry.browser.version": AnyValue(string_value="2.32"),
                     "sentry.severity_number": AnyValue(int_value=9),
                     "sentry.severity_text": AnyValue(string_value="info"),
                     "sentry.trace_flags": AnyValue(int_value=0),
@@ -402,9 +402,9 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
                 ),
                 item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
                 attributes={
-                    "browser.name": AnyValue(string_value="Python Requests"),
-                    "browser.version": AnyValue(string_value="2.32"),
                     "sentry.body": AnyValue(string_value="Example log record 2"),
+                    "sentry.browser.name": AnyValue(string_value="Python Requests"),
+                    "sentry.browser.version": AnyValue(string_value="2.32"),
                     "sentry.observed_timestamp_nanos": AnyValue(
                         string_value=str(timestamp_nanos)
                     ),
@@ -562,9 +562,11 @@ def test_browser_name_version_extraction(
             ),
             item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
             attributes={
-                "browser.name": AnyValue(string_value=expected_browser_name),
-                "browser.version": AnyValue(string_value=expected_browser_version),
                 "sentry.body": AnyValue(string_value="This is really bad"),
+                "sentry.browser.name": AnyValue(string_value=expected_browser_name),
+                "sentry.browser.version": AnyValue(
+                    string_value=expected_browser_version
+                ),
                 "sentry.severity_number": AnyValue(int_value=17),
                 "sentry.severity_text": AnyValue(string_value="error"),
                 "sentry.span_id": AnyValue(string_value="eee19b7ec3c1b175"),


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/4757 we decided to attach browser name and version to logs.

Right now for spans, we prefix browser information with `sentry.X`, see https://github.com/getsentry/sentry/blob/34c738613c9b39e3b0d64336d13b4551a4075c66/src/sentry/search/eap/spans/attributes.py#L334.

This is causing inconsistencies between the queries for spans and logs, which is breaking the current queries for the logs view. Considering we are "enhancing" the data via relay, I think it makes sense to also add a `sentry.X` prefix for logs. This PR makes that change.

resolves https://linear.app/getsentry/issue/LOGS-152