### PR TITLE
feat: Add metrics around Spans V2

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -380,9 +380,10 @@ fn emit_envelope_metrics(envelope: &Envelope) {
     let client_name = envelope.meta().client_name().name();
     for item in envelope.items() {
         let item_type = item.ty().name();
-        let is_container = match item.content_type() {
-            Some(ContentType::LogContainer | ContentType::SpanV2Container) => "true",
-            _ => "false",
+        let is_container = if item.content_type().is_some_and(ContentType::is_container) {
+            "true"
+        } else {
+            "false"
         };
 
         metric!(

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -8,7 +8,9 @@ use relay_quotas::RateLimits;
 use relay_statsd::metric;
 use serde::Deserialize;
 
-use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
+use crate::envelope::{
+    AttachmentType, ContentType, Envelope, EnvelopeError, Item, ItemType, Items,
+};
 use crate::service::ServiceState;
 use crate::services::buffer::ProjectKeyPair;
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome};
@@ -375,21 +377,30 @@ pub async fn handle_envelope(
 }
 
 fn emit_envelope_metrics(envelope: &Envelope) {
-    let client_name = envelope.meta().client_name();
+    let client_name = envelope.meta().client_name().name();
     for item in envelope.items() {
+        let item_type = item.ty().name();
+        let is_container = match item.content_type() {
+            Some(ContentType::LogContainer | ContentType::SpanV2Container) => "true",
+            _ => "false",
+        };
+
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,
-            item_type = item.ty().name()
+            item_type = item_type,
+            is_container = is_container,
         );
         metric!(
             counter(RelayCounters::EnvelopeItems) += item.item_count().unwrap_or(1),
-            item_type = item.ty().name(),
-            sdk = client_name.name(),
+            item_type = item_type,
+            is_container = is_container,
+            sdk = client_name,
         );
         metric!(
             counter(RelayCounters::EnvelopeItemBytes) += item.payload().len() as u64,
-            item_type = item.ty().name(),
-            sdk = client_name.name(),
+            item_type = item_type,
+            is_container = is_container,
+            sdk = client_name,
         );
     }
 }

--- a/relay-server/src/envelope/content_type.rs
+++ b/relay-server/src/envelope/content_type.rs
@@ -51,6 +51,14 @@ impl ContentType {
         }
     }
 
+    /// Returns `true` if this is the content type of an [`ItemContainer`].
+    pub fn is_container(&self) -> bool {
+        matches!(
+            self,
+            ContentType::LogContainer | ContentType::SpanV2Container
+        )
+    }
+
     fn from_str(ct: &str) -> Option<Self> {
         if ct.eq_ignore_ascii_case(Self::Text.as_str()) {
             Some(Self::Text)

--- a/relay-server/src/envelope/content_type.rs
+++ b/relay-server/src/envelope/content_type.rs
@@ -51,7 +51,7 @@ impl ContentType {
         }
     }
 
-    /// Returns `true` if this is the content type of an [`ItemContainer`].
+    /// Returns `true` if this is the content type of an [`ItemContainer`](crate::envelope::ItemContainer).
     pub fn is_container(&self) -> bool {
         matches!(
             self,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2166,7 +2166,10 @@ impl EnvelopeProcessorService {
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
-        span::expand_v2_spans(managed_envelope)?;
+        relay_statsd::metric!(timer(RelayTimers::SpanV2Conversion), {
+            span::expand_v2_spans(managed_envelope)?;
+        });
+
         span::filter(managed_envelope, config.clone(), project_info.clone());
         span::convert_otel_traces_data(managed_envelope);
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2166,10 +2166,7 @@ impl EnvelopeProcessorService {
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
-        relay_statsd::metric!(timer(RelayTimers::SpanV2Conversion), {
-            span::expand_v2_spans(managed_envelope)?;
-        });
-
+        span::expand_v2_spans(managed_envelope)?;
         span::filter(managed_envelope, config.clone(), project_info.clone());
         span::convert_otel_traces_data(managed_envelope);
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -217,7 +217,9 @@ impl CounterMetric for RuntimeCounters {
 pub enum RelayHistograms {
     /// The number of bytes received by Relay for each individual envelope item type.
     ///
-    /// Metric is tagged by the item type.
+    /// This metric is tagged with:
+    ///  - `item_type`: The type of the items being counted.
+    ///  - `is_container`: Whether this item is a container holding multiple items.
     EnvelopeItemSize,
 
     /// Number of elements in the envelope buffer across all the stacks.
@@ -589,6 +591,8 @@ pub enum RelayTimers {
     BodyReadDuration,
     /// Timing in milliseconds to count spans in a serialized transaction payload.
     CheckNestedSpans,
+    /// The time in milliseconds it takes to expand a Span V2 container into Spans V1.
+    SpanV2Expansion,
 }
 
 impl TimerMetric for RelayTimers {
@@ -642,6 +646,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::BufferEnvelopeDecompression => "buffer.envelopes_decompression",
             RelayTimers::BodyReadDuration => "requests.body_read.duration",
             RelayTimers::CheckNestedSpans => "envelope.check_nested_spans",
+            RelayTimers::SpanV2Expansion => "envelope.span_v2_expansion",
         }
     }
 }
@@ -682,8 +687,20 @@ pub enum RelayCounters {
     ///
     /// Note: This does not count raw items, it counts the logical amount of items,
     /// e.g. a single item container counts all its contained items.
+    ///
+    /// This metric is tagged with:
+    ///  - `item_type`: The type of the items being counted.
+    ///  - `is_container`: Whether this item is a container holding multiple items.
+    ///  - `sdk`: The name of the Sentry SDK sending the envelope. This tag is only set for
+    ///    Sentry's SDKs and defaults to "proprietary".
     EnvelopeItems,
     /// Number of bytes we processed per envelope item.
+    ///
+    /// This metric is tagged with:
+    ///  - `item_type`: The type of the items being counted.
+    ///  - `is_container`: Whether this item is a container holding multiple items.
+    ///  - `sdk`: The name of the Sentry SDK sending the envelope. This tag is only set for
+    ///    Sentry's SDKs and defaults to "proprietary".
     EnvelopeItemBytes,
     /// Number of times an envelope from the buffer is trying to be popped.
     BufferTryPop,


### PR DESCRIPTION
This adds
* a new timer `SpanV2Expansion` that measures how long the expansion of V2 spans takes;
* a tag `is_container` to the counters `EnvelopeItems`, `EnvelopeItemSize`, and `EnvelopeItemBytes` according to whether the item is a container;
* some documentation about tags to the aforementioned counters.

#skip-changelog

Closes #4784. Closes RELAY-79.