### PR TITLE
fix(ourlogs): Do not overcount the outcome bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**:
 
 - Use sentry prefix for browser name/version in logs. ([#4783](https://github.com/getsentry/relay/pull/4783))
+- Do not overcount the number of bytes in logs. ([#4786](https://github.com/getsentry/relay/pull/4786))
 
 **Internal**:
 


### PR DESCRIPTION
Right now, if we have a 17kb envelope with 100 logs in it, we will record 100 * 17kb of total usage to outcomes