### PR TITLE
ref(kafka): Switch default topic for spans to `ingest-spans`

### DIFF
--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -139,7 +139,7 @@ define_topic_assignments! {
     replay_recordings: (KafkaTopic::ReplayRecordings, "ingest-replay-recordings", "Recordings topic name."),
     ourlogs: (KafkaTopic::OurLogs, "snuba-ourlogs", "Logs from our logs product."),
     monitors: (KafkaTopic::Monitors, "ingest-monitors", "Monitor check-ins."),
-    spans: (KafkaTopic::Spans, "snuba-spans", "Standalone spans without a transaction."),
+    spans: (KafkaTopic::Spans, "ingest-spans", "Standalone spans without a transaction."),
     feedback: (KafkaTopic::Feedback, "ingest-feedback-events", "Feedback events topic."),
     items: (KafkaTopic::Items, "snuba-items", "Items topic."),
 }


### PR DESCRIPTION
Set the default topic for spans to `ingest-spans`, which enables the spans
pipeline including the span buffer in local development.

- [x] Please wait for https://github.com/getsentry/sentry/pull/92811 before merging.

VIEPF-37

