### PR TITLE
feat: Limit number/size of V2 spans and Logs

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -616,6 +616,8 @@ pub struct Limits {
     pub max_envelope_size: ByteSize,
     /// The maximum number of session items per envelope.
     pub max_session_count: usize,
+    /// The maximum number of standalone span items per envelope.
+    pub max_span_count: usize,
     /// The maximum payload size for general API requests.
     pub max_api_payload_size: ByteSize,
     /// The maximum payload size for file uploads and chunks.
@@ -628,6 +630,8 @@ pub struct Limits {
     pub max_log_size: ByteSize,
     /// The maximum payload size for a span.
     pub max_span_size: ByteSize,
+    /// The maximum payload size for a span container.
+    pub max_span_container_size: ByteSize,
     /// The maximum payload size for a statsd metric.
     pub max_statsd_size: ByteSize,
     /// The maximum payload size for metric buckets.
@@ -696,12 +700,14 @@ impl Default for Limits {
             max_check_in_size: ByteSize::kibibytes(100),
             max_envelope_size: ByteSize::mebibytes(100),
             max_session_count: 100,
+            max_span_count: 1000,
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
             max_profile_size: ByteSize::mebibytes(50),
             max_log_size: ByteSize::mebibytes(1),
             max_span_size: ByteSize::mebibytes(1),
+            max_span_container_size: ByteSize::mebibytes(5),
             max_statsd_size: ByteSize::mebibytes(1),
             max_metric_buckets_size: ByteSize::mebibytes(1),
             max_replay_compressed_size: ByteSize::mebibytes(10),
@@ -2279,6 +2285,11 @@ impl Config {
         self.values.limits.max_span_size.as_bytes()
     }
 
+    /// Returns the maximum payload size of a span container in bytes.
+    pub fn max_span_container_size(&self) -> usize {
+        self.values.limits.max_span_container_size.as_bytes()
+    }
+
     /// Returns the maximum size of an envelope payload in bytes.
     ///
     /// Individual item size limits still apply.
@@ -2289,6 +2300,11 @@ impl Config {
     /// Returns the maximum number of sessions per envelope.
     pub fn max_session_count(&self) -> usize {
         self.values.limits.max_session_count
+    }
+
+    /// Returns the maximum number of standalone spans per envelope.
+    pub fn max_span_count(&self) -> usize {
+        self.values.limits.max_span_count
     }
 
     /// Returns the maximum payload size of a statsd metric in bytes.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -618,6 +618,8 @@ pub struct Limits {
     pub max_session_count: usize,
     /// The maximum number of standalone span items per envelope.
     pub max_span_count: usize,
+    /// The maximum number of log items per envelope.
+    pub max_log_count: usize,
     /// The maximum payload size for general API requests.
     pub max_api_payload_size: ByteSize,
     /// The maximum payload size for file uploads and chunks.
@@ -630,8 +632,8 @@ pub struct Limits {
     pub max_log_size: ByteSize,
     /// The maximum payload size for a span.
     pub max_span_size: ByteSize,
-    /// The maximum payload size for a span container.
-    pub max_span_container_size: ByteSize,
+    /// The maximum payload size for an item container.
+    pub max_container_size: ByteSize,
     /// The maximum payload size for a statsd metric.
     pub max_statsd_size: ByteSize,
     /// The maximum payload size for metric buckets.
@@ -701,13 +703,14 @@ impl Default for Limits {
             max_envelope_size: ByteSize::mebibytes(100),
             max_session_count: 100,
             max_span_count: 1000,
+            max_log_count: 1000,
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
             max_profile_size: ByteSize::mebibytes(50),
             max_log_size: ByteSize::mebibytes(1),
             max_span_size: ByteSize::mebibytes(1),
-            max_span_container_size: ByteSize::mebibytes(5),
+            max_container_size: ByteSize::mebibytes(3),
             max_statsd_size: ByteSize::mebibytes(1),
             max_metric_buckets_size: ByteSize::mebibytes(1),
             max_replay_compressed_size: ByteSize::mebibytes(10),
@@ -2285,9 +2288,9 @@ impl Config {
         self.values.limits.max_span_size.as_bytes()
     }
 
-    /// Returns the maximum payload size of a span container in bytes.
-    pub fn max_span_container_size(&self) -> usize {
-        self.values.limits.max_span_container_size.as_bytes()
+    /// Returns the maximum payload size of an item container in bytes.
+    pub fn max_container_size(&self) -> usize {
+        self.values.limits.max_container_size.as_bytes()
     }
 
     /// Returns the maximum size of an envelope payload in bytes.
@@ -2305,6 +2308,11 @@ impl Config {
     /// Returns the maximum number of standalone spans per envelope.
     pub fn max_span_count(&self) -> usize {
         self.values.limits.max_span_count
+    }
+
+    /// Returns the maximum number of logs per envelope.
+    pub fn max_log_count(&self) -> usize {
+        self.values.limits.max_log_count
     }
 
     /// Returns the maximum payload size of a statsd metric in bytes.

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -8,9 +8,7 @@ use relay_quotas::RateLimits;
 use relay_statsd::metric;
 use serde::Deserialize;
 
-use crate::envelope::{
-    AttachmentType, ContentType, Envelope, EnvelopeError, Item, ItemType, Items,
-};
+use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
 use crate::service::ServiceState;
 use crate::services::buffer::ProjectKeyPair;
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome};

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -380,11 +380,7 @@ fn emit_envelope_metrics(envelope: &Envelope) {
     let client_name = envelope.meta().client_name().name();
     for item in envelope.items() {
         let item_type = item.ty().name();
-        let is_container = if item.content_type().is_some_and(ContentType::is_container) {
-            "true"
-        } else {
-            "false"
-        };
+        let is_container = if item.is_container() { "true" } else { "false" };
 
         metric!(
             histogram(RelayHistograms::EnvelopeItemSize) = item.payload().len() as u64,

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -492,6 +492,11 @@ impl Item {
             ItemType::Unknown(_) => false,
         }
     }
+
+    /// Determines if this item is an `ItemContainer` based on its content type.
+    pub fn is_container(&self) -> bool {
+        self.content_type().is_some_and(ContentType::is_container)
+    }
 }
 
 pub type Items = SmallVec<[Item; 3]>;

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -23,6 +23,9 @@ use crate::utils::{ItemAction, ManagedEnvelope};
 ///  - `max_session_count`
 ///  - `max_span_size`
 ///  - `max_statsd_size`
+///  - `max_container_size`
+///  - `max_span_count`
+///  - `max_log_count`
 pub fn check_envelope_size_limits(
     config: &Config,
     envelope: &Envelope,
@@ -32,10 +35,18 @@ pub fn check_envelope_size_limits(
     let mut event_size = 0;
     let mut attachments_size = 0;
     let mut session_count = 0;
-    let mut client_reports_size = 0;
     let mut span_count = 0;
+    let mut log_count = 0;
+    let mut client_reports_size = 0;
 
     for item in envelope.items() {
+        if item.is_container() && item.len() > config.max_container_size() {
+            return Err(item
+                .attachment_type()
+                .map(|t| t.into())
+                .unwrap_or_else(|| item.ty().into()));
+        }
+
         let max_size = match item.ty() {
             ItemType::Event
             | ItemType::Transaction
@@ -66,21 +77,24 @@ pub fn check_envelope_size_limits(
             ItemType::CheckIn => config.max_check_in_size(),
             ItemType::Statsd => config.max_statsd_size(),
             ItemType::MetricBuckets => config.max_metric_buckets_size(),
-            ItemType::Log => config.max_log_size(),
-            ItemType::OtelLog => config.max_log_size(),
+            ItemType::Log | ItemType::OtelLog => {
+                log_count += item.item_count().unwrap_or(1) as usize;
+                config.max_log_size()
+            }
             ItemType::Span | ItemType::OtelSpan => {
                 span_count += item.item_count().unwrap_or(1) as usize;
-                match item.content_type() {
-                    Some(ty) if ty.is_container() => config.max_span_container_size(),
-                    _ => config.max_span_size(),
-                }
+                config.max_span_size()
             }
             ItemType::OtelTracesData => config.max_event_size(), // a spans container similar to `Transaction`
             ItemType::ProfileChunk => config.max_profile_size(),
             ItemType::Unknown(_) => NO_LIMIT,
         };
 
-        if item.len() > max_size {
+        // For item containers, we want to check that the contained items obey
+        // the size limits *on average*.
+        // For standalone items, this is just the item size itself.
+        let avg_item_size = item.len() / (item.item_count().unwrap_or(1) as usize);
+        if avg_item_size > max_size {
             return Err(item
                 .attachment_type()
                 .map(|t| t.into())
@@ -101,6 +115,9 @@ pub fn check_envelope_size_limits(
     }
     if span_count > config.max_span_count() {
         return Err(DiscardItemType::Span);
+    }
+    if log_count > config.max_log_count() {
+        return Err(DiscardItemType::Log);
     }
     if client_reports_size > config.max_client_reports_size() {
         return Err(DiscardItemType::ClientReport);

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -41,10 +41,7 @@ pub fn check_envelope_size_limits(
 
     for item in envelope.items() {
         if item.is_container() && item.len() > config.max_container_size() {
-            return Err(item
-                .attachment_type()
-                .map(|t| t.into())
-                .unwrap_or_else(|| item.ty().into()));
+            return Err(item.ty().into());
         }
 
         let max_size = match item.ty() {


### PR DESCRIPTION
Putting this up for discussion, it's not necessarily finished.

This adds two new config parameters, `max_span_count` (defaults to 1000) and `max_span_container_size` (defaults to 5MiB). The numbers are subject to change.

The `max_span_count` is used to limit the number of _logical_ span items in an envelope; logical meaning that a container item containing 500 V2 spans counts as 500 spans.

The `max_span_container_size` is used to limit the total size of a V2 span container. The way it works without this change is that each span item in an envelope has the `max_span_size` limit applied to it, regardless of how many spans it contains. That doesn't seem correct to me. So I opted to create another limit for containers specifically.

Without this change:
| span version | individual size limit | total size limit | count limit |
| --- | --- | --- | --- |
| v1 | 1MiB | N/A | N/A |
| v2 | N/A | 1MiB | N/A |

With this change:
| span version | individual size limit | total size limit | count limit |
| --- | --- | --- | --- |
| v1 | 1MiB | N/A | 1000 |
| v2 | N/A | 5MiB | 1000 |

A different way to do this, that sort of unifies both cases, would be to take `max_span_size` * `item_count`, with a maximum value. So the limit for a span item, regardless of whether it's a container or not, would be 1MiB per contained span, up to a maximum of 5MiB.

There are some questions to be answered before deciding on a way forward:
* Is total v1 span size a concern?
* Is individual v2 span size a concern?

It should also be noted that this might be broken for logs as well—the `max_log_size` is supposedly the maximum size of _a log_, but we apply this limit to containers too. 

ref: RELAY-65

#skip-changelog