### PR TITLE
fix(spans): Add `gen_ai.request.max_tokens` to `SpanData`

### DIFF
--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -455,6 +455,11 @@ pub struct SpanData {
     #[metastructure(field = "app_start_type")] // TODO: no dot?
     pub app_start_type: Annotated<Value>,
 
+    /// The maximum number of tokens that should be used by an
+    /// LLM call.
+    #[metastructure(field = "gen_ai.request.max_tokens")]
+    pub gen_ai_request_max_tokens: Annotated<Value>,
+
     /// The total tokens that were used by an LLM call
     #[metastructure(
         field = "gen_ai.usage.total_tokens",
@@ -809,6 +814,7 @@ impl Getter for SpanData {
             "db.operation" => self.db_operation.value()?.into(),
             "db\\.system" => self.db_system.value()?.into(),
             "environment" => self.environment.as_str()?.into(),
+            "gen_ai\\.request\\.max_tokens" => self.gen_ai_request_max_tokens.value()?.into(),
             "gen_ai\\.usage\\.total_tokens" => self.gen_ai_usage_total_tokens.value()?.into(),
             "gen_ai\\.usage\\.total_cost" => self.gen_ai_usage_total_cost.value()?.into(),
             "http\\.decoded_response_content_length" => {
@@ -1257,9 +1263,10 @@ mod tests {
             .unwrap()
             .into_value()
             .unwrap();
-        insta::assert_debug_snapshot!(data, @r#"
+        insta::assert_debug_snapshot!(data, @r###"
         SpanData {
             app_start_type: ~,
+            gen_ai_request_max_tokens: ~,
             gen_ai_usage_total_tokens: ~,
             gen_ai_usage_input_tokens: ~,
             gen_ai_usage_output_tokens: ~,
@@ -1364,7 +1371,7 @@ mod tests {
                 ),
             },
         }
-        "#);
+        "###);
 
         assert_eq!(data.get_value("foo"), Some(Val::U64(2)));
         assert_eq!(data.get_value("bar"), Some(Val::String("3")));

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -455,8 +455,7 @@ pub struct SpanData {
     #[metastructure(field = "app_start_type")] // TODO: no dot?
     pub app_start_type: Annotated<Value>,
 
-    /// The maximum number of tokens that should be used by an
-    /// LLM call.
+    /// The maximum number of tokens that should be used by an LLM call.
     #[metastructure(field = "gen_ai.request.max_tokens")]
     pub gen_ai_request_max_tokens: Annotated<Value>,
 

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -134,7 +134,7 @@ mod tests {
         .unwrap();
 
         let span_from_event = Span::from(&event);
-        insta::assert_debug_snapshot!(span_from_event, @r#"
+        insta::assert_debug_snapshot!(span_from_event, @r###"
         Span {
             timestamp: ~,
             start_timestamp: ~,
@@ -155,6 +155,7 @@ mod tests {
             ),
             data: SpanData {
                 app_start_type: ~,
+                gen_ai_request_max_tokens: ~,
                 gen_ai_usage_total_tokens: ~,
                 gen_ai_usage_input_tokens: ~,
                 gen_ai_usage_output_tokens: ~,
@@ -263,6 +264,6 @@ mod tests {
             _performance_issues_spans: ~,
             other: {},
         }
-        "#);
+        "###);
     }
 }

--- a/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
+++ b/relay-server/src/metrics_extraction/snapshots/relay_server__metrics_extraction__event__tests__extract_span_metrics_mobile.snap
@@ -137,6 +137,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             profile_id: ~,
             data: SpanData {
                 app_start_type: ~,
+                gen_ai_request_max_tokens: ~,
                 gen_ai_usage_total_tokens: ~,
                 gen_ai_usage_input_tokens: ~,
                 gen_ai_usage_output_tokens: ~,
@@ -795,6 +796,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
                 app_start_type: String(
                     "cold",
                 ),
+                gen_ai_request_max_tokens: ~,
                 gen_ai_usage_total_tokens: ~,
                 gen_ai_usage_input_tokens: ~,
                 gen_ai_usage_output_tokens: ~,
@@ -980,6 +982,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
                 app_start_type: String(
                     "cold",
                 ),
+                gen_ai_request_max_tokens: ~,
                 gen_ai_usage_total_tokens: ~,
                 gen_ai_usage_input_tokens: ~,
                 gen_ai_usage_output_tokens: ~,
@@ -1274,6 +1277,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             profile_id: ~,
             data: SpanData {
                 app_start_type: ~,
+                gen_ai_request_max_tokens: ~,
                 gen_ai_usage_total_tokens: ~,
                 gen_ai_usage_input_tokens: ~,
                 gen_ai_usage_output_tokens: ~,
@@ -1459,6 +1463,7 @@ expression: "(&event.value().unwrap().spans, metrics.project_metrics)"
             profile_id: ~,
             data: SpanData {
                 app_start_type: ~,
+                gen_ai_request_max_tokens: ~,
                 gen_ai_usage_total_tokens: ~,
                 gen_ai_usage_input_tokens: ~,
                 gen_ai_usage_output_tokens: ~,


### PR DESCRIPTION
Leaving this field implicit subsumes it into the `Other` variant, which is marked with `pii = "true"`. Since the field name contains the word "token", that means it gets erroneously PII scrubbed by password rules. Splitting out the field remedies that.

#skip-changelog