### PR TITLE
feat(playstation): Skip large attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Switch `sysinfo` dependency back to upstream and update to 0.35.1. ([#4776](https://github.com/getsentry/relay/pull/4776))
 - Consistently always emit session outcomes. ([#4798](https://github.com/getsentry/relay/pull/4798))
 - Set default sdk name for playstation crashes. ([#4802](https://github.com/getsentry/relay/pull/4802))
+- Skip large attachments on playstation crashes. ([#4793](https://github.com/getsentry/relay/pull/4793))
 
 ## 25.5.1
 

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -45,8 +45,7 @@ async fn extract_multipart(
     meta: RequestMeta,
     config: &Config,
 ) -> Result<Box<Envelope>, BadStoreRequest> {
-    let mut items =
-        utils::filtered_multipart_items(multipart, infer_attachment_type, config).await?;
+    let mut items = utils::multipart_items(multipart, infer_attachment_type, config, true).await?;
 
     let prosperodump_item = items
         .iter_mut()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,7 @@ from .fixtures.processing import (  # noqa
     get_topic_name,
     processing_config,
     relay_with_processing,
+    relay_with_playstation,
     relay_processing_with_playstation,
     consumer_fixture,
     events_consumer,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,7 +23,7 @@ from .fixtures.processing import (  # noqa
     get_topic_name,
     processing_config,
     relay_with_processing,
-    relay_with_playstation,
+    relay_processing_with_playstation,
     consumer_fixture,
     events_consumer,
     outcomes_consumer,

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -423,23 +423,37 @@ class SentryLike:
         response.raise_for_status()
         return response
 
-    def send_playstation_request(self, project_id, file_content, dsn_key_idx=0):
+    def send_playstation_request(
+        self,
+        project_id,
+        crash_file_content,
+        crash_video_content=None,
+        dsn_key_idx=0,
+    ):
         """
         Sends a request to the playstation endpoint
         :param project_id: the project id
         :param file_content: the unreal file content
         """
+        files = {}
+        if crash_video_content:
+            files["upload_file_crash_video"] = (
+                "crash-video.webm",
+                crash_video_content,
+                "video/webm",
+            )
+
+        files["upload_file_minidump"] = (
+            "playstation.prosperodmp",
+            crash_file_content,
+            "application/octet-stream",
+        )
+
         response = self.post(
             "/api/{}/playstation/?sentry_key={}".format(
                 project_id, self.get_dsn_public_key(project_id, dsn_key_idx)
             ),
-            files={
-                "upload_file_minidump": (
-                    "playstation.prosperodmp",
-                    file_content,
-                    "application/octet-stream",
-                )
-            },
+            files=files,
         )
 
         response.raise_for_status()

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -96,7 +96,7 @@ def relay_with_processing(relay, mini_sentry, processing_config):
 
 
 @pytest.fixture
-def relay_with_playstation(relay_with_processing):
+def relay_processing_with_playstation(relay_with_processing):
     """
     Skips the test if Relay is not compiled with Playstation support else behaves like
     `relay_with_processing`
@@ -109,6 +109,21 @@ def relay_with_playstation(relay_with_processing):
     except Exception:
         pytest.skip("Test requires Relay compiled with PlayStation support")
     return relay_with_processing
+
+
+@pytest.fixture
+def relay_with_playstation(mini_sentry, relay):
+    """
+    Skips the test if Relay is not compiled with Playstation support else behaves like `relay`
+    """
+    internal_relay = relay(mini_sentry)
+    try:
+        response = internal_relay.post("/api/42/playstation/")
+        if response.status_code == 404:
+            pytest.skip("Test requires Relay compiled with PlayStation support")
+    except Exception:
+        pytest.skip("Test requires Relay compiled with PlayStation support")
+    return relay
 
 
 def kafka_producer(options):

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -268,8 +268,6 @@ def test_playstation_user_data_extraction(
 def test_playstation_ignore_large_fields(
     mini_sentry,
     relay_with_playstation,
-    outcomes_consumer,
-    attachments_consumer,
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("user_data.prosperodmp")
@@ -277,8 +275,6 @@ def test_playstation_ignore_large_fields(
         PROJECT_ID,
         extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
     )
-    outcomes_consumer = outcomes_consumer()
-    attachments_consumer = attachments_consumer()
 
     # Make a dummy video that is larger than the dump
     video_content = "1" * (len(playstation_dump) + 100)
@@ -295,7 +291,9 @@ def test_playstation_ignore_large_fields(
         PROJECT_ID, playstation_dump, video_content
     )
     assert response.ok
-    assert len(mini_sentry.captured_events.get().items) == 1
+    assert [
+        item.headers["filename"] for item in mini_sentry.captured_events.get().items
+    ] == ["playstation.prosperodmp"]
 
 
 def test_playstation_attachment(


### PR DESCRIPTION
In a multi part form skip large attachments if the overall body size is not exceeded rather than stoping at the first field that is too large.

Part of: https://linear.app/getsentry/issue/TEMPEST-23/add-logic-to-discard-large-fields

---
Follow ups:
- [x] Bump the `attachment_size` and `attachments_size` in the relay configs: Turned out to not be necessary
- [x] Bump the size limit in the infra ops: Also not necessary
- [x] Create outcomes for the dropped fields: https://github.com/getsentry/relay/pull/4862