### PR TITLE
ref: add comment to update docs if OS version changes

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Use an older docker container to build the binary to guarantee glibc compatibility.
+      # Ubuntu needs to be supported until 2027-05-31 (EOL + 2 Years).
+      # Make sure to update documentation once the version is updated:
+      # https://docs.sentry.io/product/relay/operating-guidelines/
       image: ubuntu:20.04
 
     steps:
@@ -57,6 +60,8 @@ jobs:
 
   linux-aarch64:
     name: Linux Aarch64
+    # Ubuntu 22.04 needs to be supported until Apr 2029 (EOL + 2 Years)
+    # Make sure to update documentation if this changes: https://docs.sentry.io/product/relay/operating-guidelines/
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -89,6 +94,8 @@ jobs:
 
   macos:
     name: macOS
+    # Make sure to change documentation once this version changes
+    # https://docs.sentry.io/product/relay/operating-guidelines/
     runs-on: macos-14
 
     steps:
@@ -120,6 +127,8 @@ jobs:
 
   windows:
     name: Windows
+    # Make sure to change documentation once this version changes
+    # https://docs.sentry.io/product/relay/operating-guidelines/
     runs-on: windows-2019
 
     steps:

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -60,8 +60,9 @@ jobs:
 
   linux-aarch64:
     name: Linux Aarch64
-    # Ubuntu 22.04 needs to be supported until Apr 2029 (EOL + 2 Years)
-    # Make sure to update documentation if this changes: https://docs.sentry.io/product/relay/operating-guidelines/
+    # Ubuntu 22.04 needs to be supported until Apr 2029 (EOL + 2 Years).
+    # Make sure to update documentation once the version is updated:
+    # https://docs.sentry.io/product/relay/operating-guidelines/
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -94,7 +95,7 @@ jobs:
 
   macos:
     name: macOS
-    # Make sure to change documentation once this version changes
+    # Make sure to update documentation once the version is updated:
     # https://docs.sentry.io/product/relay/operating-guidelines/
     runs-on: macos-14
 
@@ -127,7 +128,7 @@ jobs:
 
   windows:
     name: Windows
-    # Make sure to change documentation once this version changes
+    # Make sure to update documentation once the version is updated:
     # https://docs.sentry.io/product/relay/operating-guidelines/
     runs-on: windows-2019
 

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Use an older docker container to build the binary to guarantee glibc compatibility.
-      # Ubuntu needs to be supported until 2027-05-31 (EOL + 2 Years).
+      # Ubuntu 20.04 needs to be supported until 2027-05-31 (EOL + 2 Years).
       # Make sure to update documentation once the version is updated:
       # https://docs.sentry.io/product/relay/operating-guidelines/
       image: ubuntu:20.04


### PR DESCRIPTION
This PR adds comments to remember to update documentation if the OS version in the build configuration changes.

#skip-changelog