### PR TITLE
fix(ourlogs): Add observed nanos for parity with OTel logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Use sentry prefix for browser name/version in logs. ([#4783](https://github.com/getsentry/relay/pull/4783))
 - Do not overcount the number of bytes in logs. ([#4786](https://github.com/getsentry/relay/pull/4786))
+- Record observed time for logs. ([#4795](https://github.com/getsentry/relay/pull/4795))
 
 **Internal**:
 


### PR DESCRIPTION
Missed this during the trace-item switch PR review.

This allows us to keep track of the collection time of an event. 



