### PR TITLE
ref(server): Use same counts for outcomes as rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Remove the "unspecified" variant of `SpanKind`. ([#4774](https://github.com/getsentry/relay/pull/4774))
 - Normalize AI data and measurements into new OTEL compatible fields and extracting metrics out of said fields. ([#4768](https://github.com/getsentry/relay/pull/4768))
 - Switch `sysinfo` dependency back to upstream and update to 0.35.1. ([#4776](https://github.com/getsentry/relay/pull/4776))
+- Consistently always emit session outcomes. ([#4798](https://github.com/getsentry/relay/pull/4798))
 
 ## 25.5.1
 

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -12,7 +12,7 @@ use relay_sampling::config::RuleType;
 use relay_sampling::evaluation::{ReservoirEvaluator, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
 
-use crate::envelope::{CountFor, ItemType};
+use crate::envelope::ItemType;
 use crate::services::outcome::Outcome;
 use crate::services::processor::{
     EventProcessing, Sampling, SpansExtracted, TransactionGroup, event_category,
@@ -131,7 +131,7 @@ pub fn drop_unsampled_items(
         .take_items_by(|item| *item.ty() != ItemType::Profile);
 
     for item in dropped_items {
-        for (category, quantity) in item.quantities(CountFor::Outcomes) {
+        for (category, quantity) in item.quantities() {
             // Dynamic sampling only drops indexed items. Upgrade the category to the index
             // category if one exists for this category, for example profiles will be upgraded to profiles indexed,
             // but attachments are still emitted as attachments.

--- a/relay-server/src/utils/managed_envelope.rs
+++ b/relay-server/src/utils/managed_envelope.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 
-use crate::envelope::{CountFor, Envelope, Item};
+use crate::envelope::{Envelope, Item};
 use crate::extractors::RequestMeta;
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::{Processed, ProcessingGroup};
@@ -252,7 +252,7 @@ impl ManagedEnvelope {
             ItemAction::Keep => true,
             ItemAction::DropSilently => false,
             ItemAction::Drop(outcome) => {
-                for (category, quantity) in item.quantities(CountFor::Outcomes) {
+                for (category, quantity) in item.quantities() {
                     if let Some(indexed) = category.index_category() {
                         outcomes.push((outcome.clone(), indexed, quantity));
                     };

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -8,7 +8,7 @@ use relay_quotas::{
     ReasonCode, Scoping,
 };
 
-use crate::envelope::{CountFor, Envelope, Item, ItemType};
+use crate::envelope::{Envelope, Item, ItemType};
 use crate::services::outcome::Outcome;
 use crate::utils::ManagedEnvelope;
 
@@ -235,7 +235,7 @@ impl EnvelopeSummary {
 
             summary.payload_size += item.len();
 
-            for (category, quantity) in item.quantities(CountFor::RateLimits) {
+            for (category, quantity) in item.quantities() {
                 summary.add_quantity(category, quantity);
             }
         }


### PR DESCRIPTION
This different code path was only used for session outcomes.

Session outcomes were already emitted for rate limits, this stream lines general purpose outcomes (e.g. for dropped envelopes) with the rate limiting. As there is inherently no reason why there can't or shouldn't be session outcomes.
