### PR TITLE
feat(playstation): Set default `sdk.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Normalize AI data and measurements into new OTEL compatible fields and extracting metrics out of said fields. ([#4768](https://github.com/getsentry/relay/pull/4768))
 - Switch `sysinfo` dependency back to upstream and update to 0.35.1. ([#4776](https://github.com/getsentry/relay/pull/4776))
 - Consistently always emit session outcomes. ([#4798](https://github.com/getsentry/relay/pull/4798))
-- Set default sdk name for playstation crashes ([#4802](https://github.com/getsentry/relay/pull/4802))
+- Set default sdk name for playstation crashes. ([#4802](https://github.com/getsentry/relay/pull/4802))
 
 ## 25.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Normalize AI data and measurements into new OTEL compatible fields and extracting metrics out of said fields. ([#4768](https://github.com/getsentry/relay/pull/4768))
 - Switch `sysinfo` dependency back to upstream and update to 0.35.1. ([#4776](https://github.com/getsentry/relay/pull/4776))
 - Consistently always emit session outcomes. ([#4798](https://github.com/getsentry/relay/pull/4798))
+- Set default sdk name for playstation crashes ([#4802](https://github.com/getsentry/relay/pull/4802))
 
 ## 25.5.1
 

--- a/relay-server/src/services/processor/playstation.rs
+++ b/relay-server/src/services/processor/playstation.rs
@@ -5,7 +5,8 @@
 use relay_config::Config;
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::{
-    AppContext, Context, Contexts, DeviceContext, LenientString, OsContext, RuntimeContext, Tags,
+    AppContext, ClientSdkInfo, Context, Contexts, DeviceContext, LenientString, OsContext,
+    RuntimeContext, Tags,
 };
 use relay_event_schema::protocol::{Event, TagEntry};
 use relay_prosperoconv::{self, ProsperoDump};
@@ -268,6 +269,12 @@ fn merge_playstation_context(event: &mut Event, prospero: &ProsperoDump) {
             ..Default::default()
         });
     }
+
+    event.client_sdk.get_or_insert_with(|| ClientSdkInfo {
+        name: Annotated::new("sentry.playstation".to_owned()),
+        version: Annotated::new("0.1.0".to_owned()),
+        ..Default::default()
+    });
 }
 
 fn infer_content_type(filename: &str) -> ContentType {

--- a/relay-server/src/services/processor/playstation.rs
+++ b/relay-server/src/services/processor/playstation.rs
@@ -272,7 +272,7 @@ fn merge_playstation_context(event: &mut Event, prospero: &ProsperoDump) {
 
     event.client_sdk.get_or_insert_with(|| ClientSdkInfo {
         name: Annotated::new("sentry.playstation".to_owned()),
-        version: Annotated::new("0.1.0".to_owned()),
+        version: Annotated::new("0.0.1".to_owned()),
         ..Default::default()
     });
 }

--- a/relay-server/src/services/processor/playstation.rs
+++ b/relay-server/src/services/processor/playstation.rs
@@ -271,7 +271,7 @@ fn merge_playstation_context(event: &mut Event, prospero: &ProsperoDump) {
     }
 
     event.client_sdk.get_or_insert_with(|| ClientSdkInfo {
-        name: Annotated::new("sentry.playstation".to_owned()),
+        name: Annotated::new("sentry.playstation.devkit".to_owned()),
         version: Annotated::new("0.0.1".to_owned()),
         ..Default::default()
     });

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -281,7 +281,7 @@ def test_playstation_attachment(
         "type": "error",
         "exception": {"values": [{"type": "ValueError", "value": "Should not happen"}]},
         "sdk": {
-            "name": "sentry.playstation.crs",
+            "name": "sentry.native.playstation",
             "version": "0.1.0",
         },
     }
@@ -348,7 +348,7 @@ def test_playstation_attachment(
         attachment["name"] for attachment in event["attachments"]
     ]
 
-    assert event_data["sdk"]["name"] == "sentry.playstation.crs"
+    assert event_data["sdk"]["name"] == "sentry.native.playstation"
 
 
 def test_playstation_attachment_no_feature_flag(

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -145,7 +145,7 @@ def test_playstation_with_feature_flag(
         attachment["name"] for attachment in event["attachments"]
     ]
 
-    assert event_data["sdk"]["name"] == "sentry.playstation"
+    assert event_data["sdk"]["name"] == "sentry.playstation.devkit"
 
 
 def test_playstation_user_data_extraction(

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -145,6 +145,8 @@ def test_playstation_with_feature_flag(
         attachment["name"] for attachment in event["attachments"]
     ]
 
+    assert event_data["sdk"]["name"] == "sentry.playstation"
+
 
 def test_playstation_user_data_extraction(
     mini_sentry,
@@ -278,6 +280,10 @@ def test_playstation_attachment(
         "event_id": "cbf6960622e14a45abc1f03b2055b186",
         "type": "error",
         "exception": {"values": [{"type": "ValueError", "value": "Should not happen"}]},
+        "sdk": {
+            "name": "sentry.playstation.crs",
+            "version": "0.1.0",
+        },
     }
     envelope = Envelope()
     envelope.add_event(bogus_error)
@@ -341,6 +347,8 @@ def test_playstation_attachment(
     assert "playstation.prosperodmp" in [
         attachment["name"] for attachment in event["attachments"]
     ]
+
+    assert event_data["sdk"]["name"] == "sentry.playstation.crs"
 
 
 def test_playstation_attachment_no_feature_flag(


### PR DESCRIPTION
If the `sdk.name` is not populated because the users are not using an SDK we should populate the `sdk.name` field with a default value. This is done so that they can still filer on the events.

--- 
Follow-up for this will be the appending of `devkit` and `crs` as Bruno mentioned below.