### PR TITLE
feat(spans): Backfill `data` from `sentry_tags`

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1489,7 +1489,7 @@ impl SpanKafkaMessage<'_> {
             return;
         };
 
-        let mut data = self.data.take().unwrap_or_default();
+        let data = self.data.get_or_insert_default();
 
         for (key, value) in sentry_tags {
             let Some(value) = value else {
@@ -1504,10 +1504,6 @@ impl SpanKafkaMessage<'_> {
 
             // TODO: Should a a tag supersede an existing value?
             data.insert(key, Some(value));
-        }
-
-        if data.values().any(Option::is_some) {
-            self.data = Some(data);
         }
     }
 }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1504,7 +1504,7 @@ impl SpanKafkaMessage<'_> {
             data.insert(key, Some(serde_json::Value::String(value.clone())));
         }
 
-        if data.values().filter(|v| v.is_some()).count() > 0 {
+        if data.values().any(Option::is_some) {
             self.data = Some(data);
         }
     }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1502,7 +1502,6 @@ impl SpanKafkaMessage<'_> {
                 format!("sentry.{key}")
             };
 
-            // TODO: Should a a tag supersede an existing value?
             data.insert(Cow::Owned(key), Some(value));
         }
     }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1421,7 +1421,7 @@ struct SpanKafkaMessage<'a> {
     is_remote: bool,
 
     #[serde(default, skip_serializing_if = "none_or_empty_map", borrow)]
-    data: Option<BTreeMap<String, Option<&'a RawValue>>>,
+    data: Option<BTreeMap<Cow<'a, str>, Option<&'a RawValue>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     kind: Option<&'a str>,
     #[serde(default, skip_serializing_if = "none_or_empty_vec")]
@@ -1503,7 +1503,7 @@ impl SpanKafkaMessage<'_> {
             };
 
             // TODO: Should a a tag supersede an existing value?
-            data.insert(key, Some(value));
+            data.insert(Cow::Owned(key), Some(value));
         }
     }
 }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1420,7 +1420,7 @@ struct SpanKafkaMessage<'a> {
     #[serde(default)]
     is_remote: bool,
 
-    #[serde(default, skip_serializing_if = "none_or_empty_map", borrow)]
+    #[serde(skip_serializing_if = "none_or_empty_map", borrow)]
     data: Option<BTreeMap<Cow<'a, str>, Option<&'a RawValue>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     kind: Option<&'a str>,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -121,6 +121,19 @@ def test_span_extraction(
     child_span = spans_consumer.get_span()
     del child_span["received"]
     assert child_span == {
+        "data": {  # Backfilled from `sentry_tags`
+            "sentry.category": "http",
+            "sentry.normalized_description": "GET *",
+            "sentry.group": "37e3d9fab1ae9162",
+            "sentry.op": "http",
+            "sentry.platform": "other",
+            "sentry.sdk.name": "raven-node",
+            "sentry.sdk.version": "2.6.3",
+            "sentry.status": "ok",
+            "sentry.trace.status": "ok",
+            "sentry.transaction": "hi",
+            "sentry.transaction.op": "hi",
+        },
         "description": "GET /api/0/organizations/?member=1",
         "duration_ms": int(duration.total_seconds() * 1e3),
         "event_id": "cbf6960622e14a45abc1f03b2055b186",
@@ -179,6 +192,13 @@ def test_span_extraction(
             "sentry.sdk.name": "raven-node",
             "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
+            # Backfilled from `sentry_tags`:
+            "sentry.op": "hi",
+            "sentry.platform": "other",
+            "sentry.status": "ok",
+            "sentry.trace.status": "ok",
+            "sentry.transaction": "hi",
+            "sentry.transaction.op": "hi",
         },
         "description": "hi",
         "duration_ms": duration_ms,
@@ -747,6 +767,10 @@ def test_span_ingestion(
                 "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/111.0.0.0 Safari/537.36",
+                # Backfilled from `sentry_tags`:
+                "sentry.op": "my 1st otel span",
+                "sentry.browser.name": "Chrome",
+                "sentry.status": "unknown",
             },
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -785,6 +809,10 @@ def test_span_ingestion(
                 "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/111.0.0.0 Safari/537.36",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Chrome",
+                "sentry.op": "my 1st v2 span",
+                "sentry.status": "unknown",
             },
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -821,6 +849,14 @@ def test_span_ingestion(
                 "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/111.0.0.0 Safari/537.36",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Chrome",
+                "sentry.category": "resource",
+                "sentry.normalized_description": "https://example.com/*/blah.js",
+                "sentry.domain": "example.com",
+                "sentry.file_extension": "js",
+                "sentry.group": "8a97a9e43588e2bd",
+                "sentry.op": "resource.script",
             },
             "description": "https://example.com/p/blah.js",
             "duration_ms": 1500,
@@ -865,6 +901,15 @@ def test_span_ingestion(
                 "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/111.0.0.0 Safari/537.36",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Chrome",
+                "sentry.category": "resource",
+                "sentry.normalized_description": "https://example.com/*/blah.js",
+                "sentry.domain": "example.com",
+                "sentry.file_extension": "js",
+                "sentry.group": "8a97a9e43588e2bd",
+                "sentry.op": "resource.script",
+                "sentry.status": "ok",
             },
             "description": "https://example.com/p/blah.js",
             "duration_ms": 1500,
@@ -908,6 +953,9 @@ def test_span_ingestion(
                 "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/111.0.0.0 Safari/537.36",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Chrome",
+                "sentry.op": "default",
             },
             "description": r"test \" with \" escaped \" chars",
             "duration_ms": 1500,
@@ -931,6 +979,10 @@ def test_span_ingestion(
                 "client.address": "127.0.0.1",
                 "sentry.name": "my 2nd OTel span",
                 "user_agent.original": "python-requests/2.32.2",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Python Requests",
+                "sentry.op": "my 2nd otel span",
+                "sentry.status": "unknown",
             },
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -969,6 +1021,9 @@ def test_span_ingestion(
                 "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/111.0.0.0 Safari/537.36",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Chrome",
+                "sentry.op": "default",
             },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -995,6 +1050,11 @@ def test_span_ingestion(
                 "sentry.name": "my 3rd protobuf OTel span",
                 "ui.component_name": "MyComponent",
                 "user_agent.original": "python-requests/2.32.2",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Python Requests",
+                "sentry.op": "my 3rd protobuf otel span",
+                "sentry.category": "ui",
+                "sentry.status": "unknown",
             },
             "duration_ms": 500,
             "exclusive_time_ms": 500.0,
@@ -1609,6 +1669,9 @@ def test_span_ingestion_with_performance_scores(
                 "browser.name": "Python Requests",
                 "client.address": "127.0.0.1",
                 "user_agent.original": "python-requests/2.32.2",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Python Requests",
+                "sentry.op": "ui.interaction.click",
             },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -1676,6 +1739,12 @@ def test_span_ingestion_with_performance_scores(
                 "sentry.segment.name": "/page/with/click/interaction/*/*",
                 "user": "[email]",
                 "user_agent.original": "python-requests/2.32.2",
+                # Backfilled from `sentry_tags`:
+                "sentry.browser.name": "Python Requests",
+                "sentry.op": "ui.interaction.click",
+                "sentry.transaction": "/page/with/click/interaction/*/*",
+                "sentry.replay_id": "8477286c8e5148b386b71ade38374d58",
+                "sentry.user": "[email]",
             },
             "duration_ms": 1500,
             "exclusive_time_ms": 345.0,
@@ -2402,6 +2471,24 @@ def test_scrubs_ip_addresses(
                 },
             }
         },
+        "data": {  # Backfilled from `sentry_tags`
+            "sentry.category": "http",
+            "sentry.normalized_description": "GET *",
+            "sentry.group": "37e3d9fab1ae9162",
+            "sentry.op": "http",
+            "sentry.platform": "other",
+            "sentry.sdk.name": "raven-node",
+            "sentry.sdk.version": "2.6.3",
+            "sentry.status": "ok",
+            "sentry.trace.status": "unknown",
+            "sentry.transaction": "hi",
+            "sentry.transaction.op": "hi",
+            "sentry.user": "id:unique_id",
+            "sentry.user.email": "[email]",
+            "sentry.user.id": "unique_id",
+            "sentry.user.ip": "127.0.0.1",
+            "sentry.user.username": "my_user",
+        },
         "description": "GET /api/0/organizations/?member=1",
         "duration_ms": int(duration.total_seconds() * 1e3),
         "event_id": "cbf6960622e14a45abc1f03b2055b186",
@@ -2440,6 +2527,7 @@ def test_scrubs_ip_addresses(
     }
     if scrub_ip_addresses:
         del expected["sentry_tags"]["user.ip"]
+        del expected["data"]["sentry.user.ip"]
     else:
         del expected["_meta"]["sentry_tags"]["user.ip"]
     assert child_span == expected
@@ -2461,6 +2549,18 @@ def test_scrubs_ip_addresses(
             "sentry.sdk.name": "raven-node",
             "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
+            # Backfilled from `sentry_tags`:
+            "sentry.op": "hi",
+            "sentry.platform": "other",
+            "sentry.status": "unknown",
+            "sentry.trace.status": "unknown",
+            "sentry.transaction": "hi",
+            "sentry.transaction.op": "hi",
+            "sentry.user": "id:unique_id",
+            "sentry.user.email": "[email]",
+            "sentry.user.id": "unique_id",
+            "sentry.user.ip": "127.0.0.1",
+            "sentry.user.username": "my_user",
         },
         "description": "hi",
         "duration_ms": duration_ms,
@@ -2495,6 +2595,7 @@ def test_scrubs_ip_addresses(
     }
     if scrub_ip_addresses:
         del expected["sentry_tags"]["user.ip"]
+        del expected["data"]["sentry.user.ip"]
     assert child_span == expected
 
     spans_consumer.assert_empty()


### PR DESCRIPTION
This populates `data` from `sentry_tags` for spans in `StoreService::produce_span`. This logic already exists in Snuba: https://github.com/getsentry/snuba/blob/4cf53a83cc5051551612b3ae8a5556228588f731/rust_snuba/src/processors/eap_items_span.rs#L153-L162.

This makes it necessary to parse `SpanKafkaMessage::data` as a `BTreeMap` instead of a `RawValue` because otherwise it can't be modified.

There is still an open question about what should happen if a key that would be inserted into `data` based on a tag is already present. Right now I'm overwriting it, but it would be simple enough not to.

Ref #4797. Ref RELAY-83.

#skip-changelog