### PR TITLE
ref(logs): Uses the received timestamp as observed nanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Consistently always emit session outcomes. ([#4798](https://github.com/getsentry/relay/pull/4798))
 - Set default sdk name for playstation crashes. ([#4802](https://github.com/getsentry/relay/pull/4802))
 - Skip large attachments on playstation crashes. ([#4793](https://github.com/getsentry/relay/pull/4793))
+- Use the received timestamp as observed nanos for logs. ([#4810](https://github.com/getsentry/relay/pull/4810))
 
 ## 25.5.1
 

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, TimeZone, Utc};
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
-use relay_common::time::UnixTimestamp;
 
 use crate::OtelLog;
+use relay_common::time::UnixTimestamp;
 use relay_event_schema::protocol::datetime_to_timestamp;
 use relay_event_schema::protocol::{
     Attribute, AttributeType, OurLog, OurLogLevel, SpanId, Timestamp, TraceId,

--- a/relay-server/src/services/processor/ourlog/processing.rs
+++ b/relay-server/src/services/processor/ourlog/processing.rs
@@ -41,11 +41,12 @@ pub fn process(
     }
 
     let normalize_config = NormalizeOurLogConfig::new(managed_envelope);
+    let received_at = managed_envelope.received_at();
 
     managed_envelope.retain_items(|item| {
         let mut logs = match item.ty() {
             ItemType::OtelLog => match serde_json::from_slice::<OtelLog>(&item.payload()) {
-                Ok(otel_log) => match relay_ourlogs::otel_to_sentry_log(otel_log) {
+                Ok(otel_log) => match relay_ourlogs::otel_to_sentry_log(otel_log, received_at) {
                     Ok(log) => ContainerItems::from_elem(Annotated::new(log), 1),
                     Err(err) => {
                         relay_log::debug!("failed to convert OTel Log to Sentry Log: {:?}", err);
@@ -62,7 +63,7 @@ pub fn process(
                 Ok(logs) => {
                     let mut logs = logs.into_items();
                     for log in logs.iter_mut() {
-                        relay_ourlogs::ourlog_merge_otel(log);
+                        relay_ourlogs::ourlog_merge_otel(log, received_at);
                     }
                     logs
                 }


### PR DESCRIPTION
Uses the received time instead of the current time for the observed timestamp.
