### PR TITLE
feat(spans): Backfill data from tags

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1480,10 +1480,15 @@ struct SpanKafkaMessage<'a> {
 }
 
 impl SpanKafkaMessage<'_> {
-    /// Backfills `data` based on `sentry_tags`.
+    /// Backfills `data` based on `sentry_tags` and `tags`.
     ///
-    /// Every item in `sentry_tags` is copied to `data`, with the key prefixed with `sentry.`.
-    /// The only exception is the `description` tag, which is copied as `sentry.normalized_description`.
+    /// * Every item in `sentry_tags` is copied to `data`, with the key prefixed with `sentry.`.
+    ///   The only exception is the `description` tag, which is copied as `sentry.normalized_description`.
+    ///
+    /// * Every item in `tags` is copied to `data` verbatim, with the exception of `description`, which
+    ///   is copied as `sentry.normalized_description`.
+    ///
+    /// Items in `tags` take precedence over those in `sentry_tags`.
     fn backfill_data(&mut self) {
         let data = self.data.get_or_insert_default();
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1454,8 +1454,8 @@ struct SpanKafkaMessage<'a> {
     #[serde(borrow)]
     sentry_tags: Option<BTreeMap<&'a str, Option<&'a RawValue>>>,
     span_id: &'a str,
-    #[serde(default, skip_serializing_if = "none_or_empty_object")]
-    tags: Option<&'a RawValue>,
+    #[serde(skip_serializing_if = "none_or_empty_map", borrow)]
+    tags: Option<BTreeMap<&'a str, Option<&'a RawValue>>>,
     trace_id: EventId,
 
     #[serde(default)]
@@ -1485,24 +1485,38 @@ impl SpanKafkaMessage<'_> {
     /// Every item in `sentry_tags` is copied to `data`, with the key prefixed with `sentry.`.
     /// The only exception is the `description` tag, which is copied as `sentry.normalized_description`.
     fn backfill_data(&mut self) {
-        let Some(sentry_tags) = self.sentry_tags.as_ref() else {
-            return;
-        };
-
         let data = self.data.get_or_insert_default();
 
-        for (key, value) in sentry_tags {
-            let Some(value) = value else {
-                continue;
-            };
+        if let Some(sentry_tags) = &self.sentry_tags {
+            for (key, value) in sentry_tags {
+                let Some(value) = value else {
+                    continue;
+                };
 
-            let key = if *key == "description" {
-                "sentry.normalized_description".to_owned()
-            } else {
-                format!("sentry.{key}")
-            };
+                let key = if *key == "description" {
+                    "sentry.normalized_description".to_owned()
+                } else {
+                    format!("sentry.{key}")
+                };
 
-            data.insert(Cow::Owned(key), Some(value));
+                data.insert(Cow::Owned(key), Some(value));
+            }
+        }
+
+        if let Some(tags) = &self.tags {
+            for (key, value) in tags {
+                let Some(value) = value else {
+                    continue;
+                };
+
+                let key = if *key == "description" {
+                    "sentry.normalized_description"
+                } else {
+                    key
+                };
+
+                data.insert(Cow::Borrowed(key), Some(value));
+            }
         }
     }
 }

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -2449,6 +2449,9 @@ def test_scrubs_ip_addresses(
             "span_id": "bbbbbbbbbbbbbbbb",
             "start_timestamp": start.isoformat(),
             "status": "success",
+            "tags": {
+                "extra_info": "added by user",
+            },
             "timestamp": end.isoformat(),
             "trace_id": "ff62a8b040f340bda5d830223def1d81",
         },
@@ -2471,7 +2474,8 @@ def test_scrubs_ip_addresses(
                 },
             }
         },
-        "data": {  # Backfilled from `sentry_tags`
+        "data": {
+            # Backfilled from `sentry_tags`
             "sentry.category": "http",
             "sentry.normalized_description": "GET *",
             "sentry.group": "37e3d9fab1ae9162",
@@ -2488,6 +2492,8 @@ def test_scrubs_ip_addresses(
             "sentry.user.id": "unique_id",
             "sentry.user.ip": "127.0.0.1",
             "sentry.user.username": "my_user",
+            # Backfilled from `tags`
+            "extra_info": "added by user",
         },
         "description": "GET /api/0/organizations/?member=1",
         "duration_ms": int(duration.total_seconds() * 1e3),
@@ -2518,6 +2524,9 @@ def test_scrubs_ip_addresses(
             "user.id": "unique_id",
             "user.ip": "127.0.0.1",
             "user.username": "my_user",
+        },
+        "tags": {
+            "extra_info": "added by user",
         },
         "span_id": "bbbbbbbbbbbbbbbb",
         "start_timestamp_ms": int(start.timestamp() * 1e3),


### PR DESCRIPTION
Continuing on from #4803, this populates `data` from `tags` for spans in `StoreService::produce_span`. The logic is based on https://github.com/getsentry/snuba/blob/4cf53a83cc5051551612b3ae8a5556228588f731/rust_snuba/src/processors/eap_items_span.rs#L164-L173.

Ref https://github.com/getsentry/relay/issues/4797. Ref RELAY-83.

#skip-changelog