### PR TITLE
feat(profiling): strip out profiler_id from profile context for short transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Set default sdk name for playstation crashes. ([#4802](https://github.com/getsentry/relay/pull/4802))
 - Skip large attachments on playstation crashes. ([#4793](https://github.com/getsentry/relay/pull/4793))
 - Use the received timestamp as observed nanos for logs. ([#4810](https://github.com/getsentry/relay/pull/4810))
+- Strip out profiler_id from profile context for short transactions. ([#4818](https://github.com/getsentry/relay/pull/4818))
 
 ## 25.5.1
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1732,6 +1732,8 @@ impl EnvelopeProcessorService {
         // We take the main event out of the result.
         let mut event = extraction_result.event;
 
+        profile::scrub_profiler_id(&mut event);
+
         relay_cogs::with!(cogs, "profile_filter", {
             let profile_id = profile::filter(
                 managed_envelope,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1732,8 +1732,6 @@ impl EnvelopeProcessorService {
         // We take the main event out of the result.
         let mut event = extraction_result.event;
 
-        profile::scrub_profiler_id(&mut event);
-
         relay_cogs::with!(cogs, "profile_filter", {
             let profile_id = profile::filter(
                 managed_envelope,
@@ -1881,6 +1879,7 @@ impl EnvelopeProcessorService {
                 project_info.clone(),
             );
             profile::transfer_id(&mut event, profile_id);
+            profile::scrub_profiler_id(&mut event);
 
             // Always extract metrics in processing Relays for sampled items.
             event_metrics_extracted = self.extract_transaction_metrics(

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -95,6 +95,9 @@ pub fn transfer_id(event: &mut Annotated<Event>, profile_id: Option<ProfileId>) 
 }
 
 /// Strip out the profiler_id from the transaction's profile context if the transaction lasts less than 20ms.
+///
+/// This is necessary because if the transaction lasts less than 20ms, we know that the respective
+/// profile data won't have enough samples to be of any use, hence we "unlink" the profile from the transaction.
 pub fn scrub_profiler_id(event: &mut Annotated<Event>) {
     let Some(event) = event.value_mut() else {
         return;

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -9,7 +9,9 @@ use relay_config::Config;
 use relay_event_schema::protocol::{Contexts, Event, ProfileContext};
 use relay_filter::ProjectFiltersConfig;
 use relay_profiling::{ProfileError, ProfileId};
-use relay_protocol::{Annotated, Getter, Remark, RemarkType};
+use relay_protocol::Annotated;
+#[cfg(feature = "processing")]
+use relay_protocol::{Getter, Remark, RemarkType};
 
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::services::outcome::{DiscardReason, Outcome};
@@ -98,6 +100,7 @@ pub fn transfer_id(event: &mut Annotated<Event>, profile_id: Option<ProfileId>) 
 ///
 /// This is necessary because if the transaction lasts less than 20ms, we know that the respective
 /// profile data won't have enough samples to be of any use, hence we "unlink" the profile from the transaction.
+#[cfg(feature = "processing")]
 pub fn scrub_profiler_id(event: &mut Annotated<Event>) {
     let Some(event) = event.value_mut() else {
         return;
@@ -206,8 +209,10 @@ fn expand_profile(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "processing")]
     use chrono::{Duration, TimeZone, Utc};
     use std::sync::Arc;
+    #[cfg(feature = "processing")]
     use uuid::Uuid;
 
     #[cfg(feature = "processing")]
@@ -216,6 +221,7 @@ mod tests {
     #[cfg(not(feature = "processing"))]
     use relay_dynamic_config::Feature;
     use relay_event_schema::protocol::EventId;
+    #[cfg(feature = "processing")]
     use relay_protocol::get_value;
     use relay_sampling::evaluation::ReservoirCounters;
     use relay_system::Addr;

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -98,7 +98,7 @@ pub fn transfer_id(event: &mut Annotated<Event>, profile_id: Option<ProfileId>) 
 
 /// Strip out the profiler_id from the transaction's profile context if the transaction lasts less than 20ms.
 ///
-/// This is necessary because if the transaction lasts less than 20ms, we know that the respective
+/// This is necessary because if the transaction lasts less than 19.8ms, we know that the respective
 /// profile data won't have enough samples to be of any use, hence we "unlink" the profile from the transaction.
 #[cfg(feature = "processing")]
 pub fn scrub_profiler_id(event: &mut Annotated<Event>) {
@@ -109,7 +109,7 @@ pub fn scrub_profiler_id(event: &mut Annotated<Event>) {
         .get_value("event.duration")
         .and_then(|duration| duration.as_f64());
 
-    if !transaction_duration.is_some_and(|duration| duration < 20f64) {
+    if !transaction_duration.is_some_and(|duration| duration < 19.8) {
         return;
     }
     if let Some(contexts) = event.contexts.value_mut().as_mut() {

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -216,6 +216,7 @@ mod tests {
     #[cfg(not(feature = "processing"))]
     use relay_dynamic_config::Feature;
     use relay_event_schema::protocol::EventId;
+    use relay_protocol::get_value;
     use relay_sampling::evaluation::ReservoirCounters;
     use relay_system::Addr;
 
@@ -677,14 +678,10 @@ mod tests {
 
         scrub_profiler_id(&mut event);
 
-        let profile_context = event
-            .value()
-            .expect("missing event")
-            .contexts
-            .value()
-            .expect("missing contexts")
+        let profile_context = get_value!(event.contexts)
+            .unwrap()
             .get::<ProfileContext>()
-            .expect("missing profile context");
+            .unwrap();
 
         assert!(
             profile_context
@@ -724,14 +721,10 @@ mod tests {
 
         scrub_profiler_id(&mut event);
 
-        let profile_context = event
-            .value()
-            .expect("missing event")
-            .contexts
-            .value()
-            .expect("missing contexts")
+        let profile_context = get_value!(event.contexts)
+            .unwrap()
             .get::<ProfileContext>()
-            .expect("missing profile context");
+            .unwrap();
 
         assert!(
             !profile_context

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -206,7 +206,9 @@ fn expand_profile(
 
 #[cfg(test)]
 mod tests {
+    use chrono::{Duration, TimeZone, Utc};
     use std::sync::Arc;
+    use uuid::Uuid;
 
     #[cfg(feature = "processing")]
     use insta::assert_debug_snapshot;
@@ -650,9 +652,6 @@ mod tests {
     #[cfg(feature = "processing")]
     #[test]
     fn test_scrub_profiler_id_should_be_stripped() {
-        use chrono::{Duration, TimeZone, Utc};
-        use uuid::Uuid;
-
         let mut contexts = Contexts::new();
         contexts.add(ProfileContext {
             profiler_id: Annotated::new(EventId(
@@ -692,19 +691,14 @@ mod tests {
                 .profiler_id
                 .meta()
                 .iter_remarks()
-                .any(
-                    |remark| remark.rule_id == "transaction_duration".to_string()
-                        && remark.ty == RemarkType::Removed
-                )
+                .any(|remark| remark.rule_id == *"transaction_duration"
+                    && remark.ty == RemarkType::Removed)
         )
     }
 
     #[cfg(feature = "processing")]
     #[test]
     fn test_scrub_profiler_id_should_not_be_stripped() {
-        use chrono::{Duration, TimeZone, Utc};
-        use uuid::Uuid;
-
         let mut contexts = Contexts::new();
         contexts.add(ProfileContext {
             profiler_id: Annotated::new(EventId(
@@ -744,10 +738,8 @@ mod tests {
                 .profiler_id
                 .meta()
                 .iter_remarks()
-                .any(
-                    |remark| remark.rule_id == "transaction_duration".to_string()
-                        && remark.ty == RemarkType::Removed
-                )
+                .any(|remark| remark.rule_id == *"transaction_duration"
+                    && remark.ty == RemarkType::Removed)
         )
     }
 }

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -94,6 +94,7 @@ pub fn transfer_id(event: &mut Annotated<Event>, profile_id: Option<ProfileId>) 
     }
 }
 
+/// Strip out the profiler_id from the transaction's profile context if the transaction lasts less than 20ms.
 pub fn scrub_profiler_id(event: &mut Annotated<Event>) {
     let Some(event) = event.value_mut() else {
         return;


### PR DESCRIPTION
For continuous profiles, we want to make sure that, in case the transaction duration is `< 20 ms`, the `profiler_id` field in the `profile context` is stripped out.

The reason for this is that in that case, we know we wouldn't have enough "samples" (100hz freq.) and the profile data associated with it would be unusable.