### PR TITLE
fix(profile-chunk): Do not infer profile chunk as the event category

### DIFF
--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -136,7 +136,7 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Span => None,
         ItemType::OtelSpan => None,
         ItemType::OtelTracesData => None,
-        ItemType::ProfileChunk => Some(DataCategory::ProfileChunk),
+        ItemType::ProfileChunk => None,
         ItemType::Unknown(_) => None,
     }
 }


### PR DESCRIPTION
Profile chunks are not events, this should've never been there.

#skip-changelog