### PR TITLE
chore(relay): Remove stale comment about `span.name`

### DIFF
--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -99,10 +99,8 @@ pub fn span_v2_to_span_v1(span_v2: SpanV2) -> SpanV1 {
         }
     }
 
-    // Note: This writes the incoming `name` field to a the `sentry.name` attribute. This creates a
-    // bit of duplication, since the attribute `sentry.name` will have the same value as the `op`
-    // field. This duplication is temporary, since we will soon generate a proper `op` field that will
-    // be different from the name.
+    // Write the incoming `name` field to a the `sentry.name` attribute, since the V1
+    // Span schema doesn't have a top-level `name` field.
     if let Some(name) = name.value() {
         data.insert(
             "sentry.name".to_owned(),


### PR DESCRIPTION
As of https://github.com/getsentry/relay/pull/4796, the `op` field on `SpanV1` does _not_ contain the name, it contains the op! So, this comment is no longer true, there's no duplication.

#skip-changelog
