### PR TITLE
fix(minidump): Re-add multipart size limit

### DIFF
--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -395,7 +395,10 @@ mod tests {
 
         let config = Config::default();
 
-        let multipart = ConstrainedMultipart(utils::multipart_from_request(request)?);
+        let multipart = ConstrainedMultipart(utils::multipart_from_request(
+            request,
+            multer::Constraints::new(),
+        )?);
         let items = multipart.items(infer_attachment_type, &config).await?;
 
         // we expect the multipart body to contain

--- a/relay-server/src/extractors/remote.rs
+++ b/relay-server/src/extractors/remote.rs
@@ -51,7 +51,7 @@ impl FromRequest<ServiceState> for Remote<Multipart<'static>> {
         request: Request,
         _state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        utils::multipart_from_request(request)
+        utils::multipart_from_request(request, multer::Constraints::new())
             .map(Remote)
             .map_err(Remote)
     }

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -298,22 +298,13 @@ impl FromRequest<ServiceState> for ConstrainedMultipart {
     type Rejection = Remote<multer::Error>;
 
     async fn from_request(request: Request, state: &ServiceState) -> Result<Self, Self::Rejection> {
-        let content_type = request
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        let boundary = multer::parse_boundary(content_type)?;
-
         // Still want to enforce multer limits here so that we avoid parsing large fields.
         let limits =
             multer::SizeLimit::new().whole_stream(state.config().max_attachments_size() as u64);
 
-        Ok(ConstrainedMultipart(Multipart::with_constraints(
-            request.into_body().into_data_stream(),
-            boundary,
-            multer::Constraints::new().size_limit(limits),
-        )))
+        multipart_from_request(request, multer::Constraints::new().size_limit(limits))
+            .map(Self)
+            .map_err(Remote)
     }
 }
 
@@ -339,7 +330,9 @@ impl FromRequest<ServiceState> for UnconstrainedMultipart {
         request: Request,
         _state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        multipart_from_request(request).map(Self).map_err(Remote)
+        multipart_from_request(request, multer::Constraints::new())
+            .map(Self)
+            .map_err(Remote)
     }
 }
 
@@ -353,7 +346,10 @@ impl UnconstrainedMultipart {
     }
 }
 
-pub fn multipart_from_request(request: Request) -> Result<Multipart<'static>, multer::Error> {
+pub fn multipart_from_request(
+    request: Request,
+    constraints: multer::Constraints,
+) -> Result<Multipart<'static>, multer::Error> {
     let content_type = request
         .headers()
         .get("content-type")
@@ -361,9 +357,10 @@ pub fn multipart_from_request(request: Request) -> Result<Multipart<'static>, mu
         .unwrap_or("");
     let boundary = multer::parse_boundary(content_type)?;
 
-    Ok(Multipart::new(
+    Ok(Multipart::with_constraints(
         request.into_body().into_data_stream(),
         boundary,
+        constraints,
     ))
 }
 


### PR DESCRIPTION
This limit was removed in  #4807 which caused the undesired side effect of large minidumps in a multipart form being read in their entirety, even if the combined size of the multipart is  too large. Re-adding this limit now makes it such that we don't even attempt the read if we already know that the form is too large.

#skip-changelog