### PR TITLE
feat: Introduce DeepValue trait

### DIFF
--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -1,4 +1,6 @@
-use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, SkipSerialization, Value};
+use relay_protocol::{
+    Annotated, DeepValue, Empty, FromValue, IntoValue, Object, SkipSerialization, Value,
+};
 use std::fmt;
 
 use crate::processor::ProcessValue;
@@ -157,5 +159,15 @@ impl IntoValue for AttributeType {
         S: serde::Serializer,
     {
         serde::ser::Serialize::serialize(self.as_str(), s)
+    }
+}
+
+impl DeepValue for Attribute {
+    fn deep_value_ref(&self) -> Option<&Value> {
+        self.value.value.value()
+    }
+
+    fn deep_value(self) -> Option<Value> {
+        self.value.value.into_value()
     }
 }

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::DeepValue;
 use crate::meta::{Error, Meta};
 use crate::traits::{Empty, FromValue, IntoValue, SkipSerialization};
 use crate::value::{Map, Value};
@@ -410,5 +411,15 @@ impl<T> From<Option<T>> for Annotated<T> {
 impl<T> Default for Annotated<T> {
     fn default() -> Annotated<T> {
         Annotated::empty()
+    }
+}
+
+impl<T: DeepValue> DeepValue for Annotated<T> {
+    fn deep_value_ref(&self) -> Option<&Value> {
+        self.value()?.deep_value_ref()
+    }
+
+    fn deep_value(self) -> Option<Value> {
+        self.into_value()?.deep_value()
     }
 }

--- a/relay-protocol/src/traits.rs
+++ b/relay-protocol/src/traits.rs
@@ -329,3 +329,11 @@ pub trait Getter {
         None
     }
 }
+
+/// Helper trait for retrieving `Value`s from deeply nested structures.
+pub trait DeepValue {
+    /// Returns the contained `Value`.
+    fn deep_value(self) -> Option<Value>;
+    /// Returns a reference to the contained `Value`.
+    fn deep_value_ref(&self) -> Option<&Value>;
+}


### PR DESCRIPTION
We have some unfortunate chains of `value` calls specifically when dealing with `Annotated<Attribute>` (viz. the changes to `v2_to_v1.rs`). This introduces a helper trait `DeepValue` for cases like this, where we want to dig a `Value` out of a deeply nested structure.

#skip-changelog