### PR TITLE
ref: Introduce `Attributes` struct

### DIFF
--- a/relay-event-normalization/src/normalize/nel.rs
+++ b/relay-event-normalization/src/normalize/nel.rs
@@ -2,9 +2,9 @@
 
 use chrono::{DateTime, Duration, Utc};
 use relay_event_schema::protocol::{
-    Attribute, AttributeValue, NetworkReportRaw, OurLog, OurLogLevel, Timestamp, TraceId,
+    Attributes, NetworkReportRaw, OurLog, OurLogLevel, Timestamp, TraceId,
 };
-use relay_protocol::{Annotated, Object};
+use relay_protocol::Annotated;
 
 /// Creates a [`OurLog`] from the provided [`NetworkReportRaw`].
 pub fn create_log(nel: Annotated<NetworkReportRaw>, received_at: DateTime<Utc>) -> Option<OurLog> {
@@ -30,18 +30,12 @@ pub fn create_log(nel: Annotated<NetworkReportRaw>, received_at: DateTime<Utc>) 
         .checked_sub_signed(Duration::milliseconds(*nel.age.value().unwrap_or(&0)))
         .unwrap_or(received_at);
 
-    let mut attributes: Object<Attribute> = Default::default();
+    let mut attributes: Attributes = Default::default();
 
     macro_rules! add_attribute {
         ($name:literal, $value:expr) => {{
             if let Some(value) = $value.into_value() {
-                attributes.insert(
-                    $name.to_owned(),
-                    Annotated::new(Attribute {
-                        value: AttributeValue::from(value),
-                        other: Default::default(),
-                    }),
-                );
+                attributes.insert($name.to_owned(), value);
             }
         }};
     }

--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -1,5 +1,5 @@
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, SkipSerialization, Value};
-use std::fmt;
+use std::{borrow::Borrow, fmt};
 
 use crate::processor::ProcessValue;
 
@@ -157,5 +157,84 @@ impl IntoValue for AttributeType {
         S: serde::Serializer,
     {
         serde::ser::Serialize::serialize(self.as_str(), s)
+    }
+}
+
+/// Wrapper struct around a collection of attributes with some convenience methods.
+#[derive(Debug, Clone, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+pub struct Attributes(Object<Attribute>);
+
+impl Attributes {
+    /// Creates an empty collection of attributes.
+    pub fn new() -> Self {
+        Self(Object::new())
+    }
+
+    /// Returns the value of the attribute with the given key.
+    pub fn get_value<Q>(&self, key: &Q) -> Option<&Value>
+    where
+        String: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.get_attribute(key)?.value.value.value()
+    }
+
+    /// Returns the attribute with the given key.
+    pub fn get_attribute<Q>(&self, key: &Q) -> Option<&Attribute>
+    where
+        String: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.0.get(key)?.value()
+    }
+
+    /// Inserts an attribute with the given value into this collection.
+    pub fn insert<V: Into<AttributeValue>>(&mut self, key: String, value: V) {
+        fn inner(slf: &mut Attributes, key: String, value: AttributeValue) {
+            let attribute = Annotated::new(Attribute {
+                value,
+                other: Default::default(),
+            });
+            slf.insert_raw(key, attribute);
+        }
+        let value = value.into();
+        inner(self, key, value);
+    }
+
+    /// Inserts an annotated attribute into this collection.
+    pub fn insert_raw(&mut self, key: String, attribute: Annotated<Attribute>) {
+        self.0.insert(key, attribute);
+    }
+
+    /// Checks whether this collection contains an attribute with the given key.
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        String: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.0.contains_key(key)
+    }
+
+    /// Iterates mutably over this collection's attribute keys and values
+    pub fn iter_mut(
+        &mut self,
+    ) -> std::collections::btree_map::IterMut<String, Annotated<Attribute>> {
+        self.0.iter_mut()
+    }
+}
+
+impl IntoIterator for Attributes {
+    type Item = (String, Annotated<Attribute>);
+
+    type IntoIter = std::collections::btree_map::IntoIter<String, Annotated<Attribute>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl FromIterator<(String, Annotated<Attribute>)> for Attributes {
+    fn from_iter<T: IntoIterator<Item = (String, Annotated<Attribute>)>>(iter: T) -> Self {
+        Self(Object::from_iter(iter))
     }
 }

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -3,10 +3,10 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 
 use crate::OtelLog;
 use relay_common::time::UnixTimestamp;
-use relay_event_schema::protocol::datetime_to_timestamp;
 use relay_event_schema::protocol::{
     Attribute, AttributeType, OurLog, OurLogLevel, SpanId, Timestamp, TraceId,
 };
+use relay_event_schema::protocol::{Attributes, datetime_to_timestamp};
 use relay_protocol::{Annotated, Error, Object, Value};
 
 fn otel_value_to_log_attribute(value: OtelValue) -> Option<Attribute> {
@@ -50,67 +50,28 @@ pub fn otel_to_sentry_log(otel_log: OtelLog, received_at: DateTime<Utc>) -> Resu
         .timestamp_nanos_opt()
         .unwrap_or_else(|| UnixTimestamp::now().as_nanos() as i64);
 
-    let mut attribute_data = Object::new();
+    let mut attribute_data = Attributes::default();
 
-    attribute_data.insert(
-        "sentry.severity_text".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(severity_text.clone()),
-        )),
-    );
-    attribute_data.insert(
-        "sentry.severity_number".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::Integer,
-            Value::I64(severity_number as i64),
-        )),
-    );
+    attribute_data.insert("sentry.severity_text".to_owned(), severity_text.clone());
+    attribute_data.insert("sentry.severity_number".to_owned(), severity_number as i64);
     attribute_data.insert(
         "sentry.timestamp_nanos".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(time_unix_nano.to_string()),
-        )),
+        time_unix_nano.to_string(),
     );
-    attribute_data.insert(
-        "sentry.timestamp_precise".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::Integer,
-            Value::I64(time_unix_nano as i64),
-        )),
-    );
+    attribute_data.insert("sentry.timestamp_precise".to_owned(), time_unix_nano as i64);
     attribute_data.insert(
         "sentry.observed_timestamp_nanos".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(received_at_nanos.to_string()),
-        )),
+        received_at_nanos.to_string(),
     );
-    attribute_data.insert(
-        "sentry.trace_flags".to_owned(),
-        Annotated::new(Attribute::new(AttributeType::Integer, Value::I64(0))),
-    );
-    attribute_data.insert(
-        "sentry.body".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(body.clone()),
-        )),
-    );
-    attribute_data.insert(
-        "sentry.span_id".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(span_id.to_string()),
-        )),
-    );
+    attribute_data.insert("sentry.trace_flags".to_owned(), 0);
+    attribute_data.insert("sentry.body".to_owned(), body.clone());
+    attribute_data.insert("sentry.span_id".to_owned(), span_id.to_string());
 
     for attribute in attributes.into_iter() {
         if let Some(value) = attribute.value.and_then(|v| v.value) {
             let key = attribute.key;
             if let Some(v) = otel_value_to_log_attribute(value) {
-                attribute_data.insert(key, Annotated::new(v));
+                attribute_data.insert_raw(key, Annotated::new(v));
             }
         }
     }
@@ -170,67 +131,33 @@ pub fn ourlog_merge_otel(ourlog: &mut Annotated<OurLog>, received_at: DateTime<U
 
     attributes.insert(
         "sentry.severity_text".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(
-                ourlog_value
-                    .level
-                    .value()
-                    .map(|level| level.to_string())
-                    .unwrap_or_else(|| "info".to_owned()),
-            ),
-        )),
+        ourlog_value
+            .level
+            .value()
+            .map(|level| level.to_string())
+            .unwrap_or_else(|| "info".to_owned()),
     );
     attributes.insert(
         "sentry.severity_number".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::Integer,
-            Value::I64(level_to_otel_severity_number(
-                ourlog_value.level.value().cloned(),
-            )),
-        )),
+        level_to_otel_severity_number(ourlog_value.level.value().cloned()),
     );
     attributes.insert(
         "sentry.timestamp_nanos".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(timestamp_nanos.to_string()),
-        )),
+        timestamp_nanos.to_string(),
     );
-    attributes.insert(
-        "sentry.timestamp_precise".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::Integer,
-            Value::I64(timestamp_nanos),
-        )),
-    );
+    attributes.insert("sentry.timestamp_precise".to_owned(), timestamp_nanos);
     attributes.insert(
         "sentry.observed_timestamp_nanos".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(received_at_nanos.to_string()),
-        )),
+        received_at_nanos.to_string(),
     );
-    attributes.insert(
-        "sentry.trace_flags".to_owned(),
-        Annotated::new(Attribute::new(AttributeType::Integer, Value::I64(0))),
-    );
+    attributes.insert("sentry.trace_flags".to_owned(), 0);
     attributes.insert(
         "sentry.body".to_owned(),
-        Annotated::new(Attribute::new(
-            AttributeType::String,
-            Value::String(ourlog_value.body.value().cloned().unwrap_or_default()),
-        )),
+        ourlog_value.body.value().cloned().unwrap_or_default(),
     );
 
     if let Some(span_id) = ourlog_value.span_id.value() {
-        attributes.insert(
-            "sentry.span_id".to_owned(),
-            Annotated::new(Attribute::new(
-                AttributeType::String,
-                Value::String(span_id.to_string()),
-            )),
-        );
+        attributes.insert("sentry.span_id".to_owned(), span_id.to_string());
     }
 }
 
@@ -399,10 +326,13 @@ mod tests {
         assert_eq!(
             annotated_log
                 .value()
-                .and_then(|v| v.attribute("db.statement"))
                 .unwrap()
+                .attributes
                 .value()
-                .and_then(|v| v.as_str()),
+                .unwrap()
+                .get_value("db.statement")
+                .unwrap()
+                .as_str(),
             Some("SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s")
         );
     }
@@ -428,9 +358,15 @@ mod tests {
                 .unwrap();
 
         let observed_timestamp = our_log
-            .attribute("sentry.observed_timestamp_nanos")
-            .and_then(|value| value.as_str().and_then(|s| s.parse::<u64>().ok()))
-            .unwrap_or(0);
+            .attributes
+            .value()
+            .unwrap()
+            .get_value("sentry.observed_timestamp_nanos")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .parse::<u64>()
+            .unwrap();
 
         assert_eq!(observed_timestamp, 946684800000000000);
     }
@@ -456,9 +392,15 @@ mod tests {
                 .unwrap();
 
         let observed_timestamp = our_log
-            .attribute("sentry.observed_timestamp_nanos")
-            .and_then(|value| value.as_str().and_then(|s| s.parse::<u64>().ok()))
-            .unwrap_or(0);
+            .attributes
+            .value()
+            .unwrap()
+            .get_value("sentry.observed_timestamp_nanos")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .parse::<u64>()
+            .unwrap();
 
         assert_ne!(observed_timestamp, 1544712660300000000);
     }
@@ -485,81 +427,51 @@ mod tests {
             DateTime::from_timestamp_nanos(946684800000000000),
         );
 
-        insta::assert_debug_snapshot!(merged_log, @r###"
-        OurLog {
-            timestamp: Timestamp(
-                2000-01-01T00:00:00Z,
-            ),
-            trace_id: TraceId("5b8efff798038103d269b633813fc60c"),
-            span_id: SpanId("eee19b7ec3c1b174"),
-            level: Info,
-            body: "Example log record",
-            attributes: {
-                "foo": Attribute {
-                    value: String(
-                        "9",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.body": Attribute {
-                    value: String(
-                        "Example log record",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.observed_timestamp_nanos": Attribute {
-                    value: String(
-                        "946684800000000000",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.severity_number": Attribute {
-                    value: I64(
-                        9,
-                    ),
-                    type: Integer,
-                    other: {},
-                },
-                "sentry.severity_text": Attribute {
-                    value: String(
-                        "info",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.span_id": Attribute {
-                    value: String(
-                        "eee19b7ec3c1b174",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.timestamp_nanos": Attribute {
-                    value: String(
-                        "946684800000000000",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.timestamp_precise": Attribute {
-                    value: I64(
-                        946684800000000000,
-                    ),
-                    type: Integer,
-                    other: {},
-                },
-                "sentry.trace_flags": Attribute {
-                    value: I64(
-                        0,
-                    ),
-                    type: Integer,
-                    other: {},
-                },
+        insta::assert_json_snapshot!(SerializableAnnotated(&merged_log), @r###"
+        {
+          "timestamp": 946684800.0,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "span_id": "eee19b7ec3c1b174",
+          "level": "info",
+          "body": "Example log record",
+          "attributes": {
+            "foo": {
+              "type": "string",
+              "value": "9"
             },
-            other: {},
+            "sentry.body": {
+              "type": "string",
+              "value": "Example log record"
+            },
+            "sentry.observed_timestamp_nanos": {
+              "type": "string",
+              "value": "946684800000000000"
+            },
+            "sentry.severity_number": {
+              "type": "integer",
+              "value": 9
+            },
+            "sentry.severity_text": {
+              "type": "string",
+              "value": "info"
+            },
+            "sentry.span_id": {
+              "type": "string",
+              "value": "eee19b7ec3c1b174"
+            },
+            "sentry.timestamp_nanos": {
+              "type": "string",
+              "value": "946684800000000000"
+            },
+            "sentry.timestamp_precise": {
+              "type": "integer",
+              "value": 946684800000000000
+            },
+            "sentry.trace_flags": {
+              "type": "integer",
+              "value": 0
+            }
+          }
         }
         "###);
     }
@@ -591,9 +503,7 @@ mod tests {
                 .attributes
                 .value()
                 .unwrap()
-                .get("sentry.severity_number")
-                .unwrap()
-                .value()
+                .get_attribute("sentry.severity_number")
                 .unwrap(),
             &Attribute::new(AttributeType::Integer, Value::I64(0)),
         );
@@ -602,14 +512,8 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn ourlog_merge_otel_log_with_timestamp() {
-        let mut attributes = Object::new();
-        attributes.insert(
-            "foo".to_owned(),
-            Annotated::new(Attribute::new(
-                AttributeType::String,
-                Value::String("9".to_owned()),
-            )),
-        );
+        let mut attributes = Attributes::new();
+        attributes.insert("foo".to_owned(), "9".to_owned());
         let datetime = Utc.with_ymd_and_hms(2021, 11, 29, 0, 0, 0).unwrap();
         let mut ourlog = Annotated::new(OurLog {
             timestamp: Annotated::new(Timestamp(datetime)),
@@ -622,77 +526,6 @@ mod tests {
             &mut ourlog,
             DateTime::from_timestamp_nanos(946684800000000000),
         );
-
-        insta::assert_debug_snapshot!(ourlog, @r###"
-        OurLog {
-            timestamp: Timestamp(
-                2021-11-29T00:00:00Z,
-            ),
-            trace_id: ~,
-            span_id: ~,
-            level: ~,
-            body: "somebody",
-            attributes: {
-                "foo": Attribute {
-                    value: String(
-                        "9",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.body": Attribute {
-                    value: String(
-                        "somebody",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.observed_timestamp_nanos": Attribute {
-                    value: String(
-                        "946684800000000000",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.severity_number": Attribute {
-                    value: I64(
-                        0,
-                    ),
-                    type: Integer,
-                    other: {},
-                },
-                "sentry.severity_text": Attribute {
-                    value: String(
-                        "info",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.timestamp_nanos": Attribute {
-                    value: String(
-                        "1638144000000000000",
-                    ),
-                    type: String,
-                    other: {},
-                },
-                "sentry.timestamp_precise": Attribute {
-                    value: I64(
-                        1638144000000000000,
-                    ),
-                    type: Integer,
-                    other: {},
-                },
-                "sentry.trace_flags": Attribute {
-                    value: I64(
-                        0,
-                    ),
-                    type: Integer,
-                    other: {},
-                },
-            },
-            other: {},
-        }
-        "###);
 
         insta::assert_json_snapshot!(SerializableAnnotated(&ourlog), @r###"
         {

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -360,12 +360,13 @@ mod tests {
         let observed_timestamp = our_log
             .attributes
             .value()
-            .unwrap()
-            .get_value("sentry.observed_timestamp_nanos")
-            .unwrap()
-            .as_str()
-            .unwrap()
-            .parse::<u64>()
+            .and_then(|attrs| {
+                attrs
+                    .get_value("sentry.observed_timestamp_nanos")?
+                    .as_str()?
+                    .parse::<u64>()
+                    .ok()
+            })
             .unwrap();
 
         assert_eq!(observed_timestamp, 946684800000000000);
@@ -394,12 +395,13 @@ mod tests {
         let observed_timestamp = our_log
             .attributes
             .value()
-            .unwrap()
-            .get_value("sentry.observed_timestamp_nanos")
-            .unwrap()
-            .as_str()
-            .unwrap()
-            .parse::<u64>()
+            .and_then(|attrs| {
+                attrs
+                    .get_value("sentry.observed_timestamp_nanos")?
+                    .as_str()?
+                    .parse::<u64>()
+                    .ok()
+            })
             .unwrap();
 
         assert_ne!(observed_timestamp, 1544712660300000000);

--- a/relay-server/src/services/processor/ourlog/processing.rs
+++ b/relay-server/src/services/processor/ourlog/processing.rs
@@ -10,7 +10,7 @@ use relay_event_normalization::{
     ClientHints, FromUserAgentInfo, RawUserAgentInfo, SchemaProcessor,
 };
 use relay_event_schema::processor::{ProcessingState, process_value};
-use relay_event_schema::protocol::{Attribute, AttributeType, BrowserContext, OurLog};
+use relay_event_schema::protocol::{AttributeType, BrowserContext, OurLog};
 use relay_ourlogs::OtelLog;
 use relay_pii::PiiProcessor;
 use relay_protocol::{Annotated, ErrorKind, Value};
@@ -154,25 +154,13 @@ fn populate_ua_fields(log: &mut OurLog, user_agent: Option<&str>, client_hints: 
     }) {
         if !attributes.contains_key("sentry.browser.name") {
             if let Some(name) = context.name.value() {
-                attributes.insert(
-                    "sentry.browser.name".to_owned(),
-                    Annotated::new(Attribute::new(
-                        AttributeType::String,
-                        Value::String(name.to_owned()),
-                    )),
-                );
+                attributes.insert("sentry.browser.name".to_owned(), name.to_owned());
             }
         }
 
         if !attributes.contains_key("sentry.browser.version") {
             if let Some(version) = context.version.value() {
-                attributes.insert(
-                    "sentry.browser.version".to_owned(),
-                    Annotated::new(Attribute::new(
-                        AttributeType::String,
-                        Value::String(version.to_owned()),
-                    )),
-                );
+                attributes.insert("sentry.browser.version".to_owned(), version.to_owned());
             }
         }
     }
@@ -502,24 +490,12 @@ mod tests {
 
         let attributes = log.attributes.value().unwrap();
         assert_eq!(
-            attributes
-                .get("sentry.browser.name")
-                .unwrap()
-                .value()
-                .unwrap()
-                .value
-                .value,
-            Value::String("Chrome".to_owned()).into(),
+            attributes.get_value("sentry.browser.name").unwrap(),
+            &Value::String("Chrome".to_owned()),
         );
         assert_eq!(
-            attributes
-                .get("sentry.browser.version")
-                .unwrap()
-                .value()
-                .unwrap()
-                .value
-                .value,
-            Value::String("131.0.0".to_owned()).into(),
+            attributes.get_value("sentry.browser.version").unwrap(),
+            &Value::String("131.0.0".to_owned()),
         );
     }
 }

--- a/relay-server/src/services/processor/ourlog/processing.rs
+++ b/relay-server/src/services/processor/ourlog/processing.rs
@@ -234,6 +234,8 @@ fn process_attribute_types(ourlog: &mut OurLog) {
 
 #[cfg(test)]
 mod tests {
+    use relay_protocol::SerializableAnnotated;
+
     use super::*;
 
     #[test]
@@ -305,174 +307,103 @@ mod tests {
             process_attribute_types(log);
         }
 
-        insta::assert_debug_snapshot!(data.value().unwrap().attributes, @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&data.value().unwrap().attributes), @r###"
         {
-            "double_with_i64": Attribute {
-                value: I64(
-                    -42,
-                ),
-                type: Double,
-                other: {},
-            },
-            "invalid_int_from_invalid_string": Meta {
-                remarks: [],
-                errors: [
-                    Error {
-                        kind: InvalidData,
-                        data: {},
-                    },
+          "double_with_i64": {
+            "type": "double",
+            "value": -42
+          },
+          "invalid_int_from_invalid_string": null,
+          "missing_type": null,
+          "missing_value": null,
+          "unknown_type": null,
+          "valid_bool": {
+            "type": "boolean",
+            "value": true
+          },
+          "valid_double": {
+            "type": "double",
+            "value": 42.5
+          },
+          "valid_double_with_u64": {
+            "type": "double",
+            "value": 42
+          },
+          "valid_int_from_string": null,
+          "valid_int_i64": {
+            "type": "integer",
+            "value": -42
+          },
+          "valid_int_u64": {
+            "type": "integer",
+            "value": 42
+          },
+          "valid_string": {
+            "type": "string",
+            "value": "test"
+          },
+          "valid_string_with_other": {
+            "type": "string",
+            "value": "test",
+            "some_other_field": "some_other_value"
+          },
+          "_meta": {
+            "invalid_int_from_invalid_string": {
+              "": {
+                "err": [
+                  "invalid_data"
                 ],
-                original_length: None,
-                original_value: Some(
-                    Object(
-                        {
-                            "type": String(
-                                "integer",
-                            ),
-                            "value": String(
-                                "abc",
-                            ),
-                        },
-                    ),
-                ),
+                "val": {
+                  "type": "integer",
+                  "value": "abc"
+                }
+              }
             },
-            "missing_type": Meta {
-                remarks: [],
-                errors: [
-                    Error {
-                        kind: MissingAttribute,
-                        data: {},
-                    },
+            "missing_type": {
+              "": {
+                "err": [
+                  "missing_attribute"
                 ],
-                original_length: None,
-                original_value: Some(
-                    Object(
-                        {
-                            "type": ~,
-                            "value": String(
-                                "value with missing type",
-                            ),
-                        },
-                    ),
-                ),
+                "val": {
+                  "type": null,
+                  "value": "value with missing type"
+                }
+              }
             },
-            "missing_value": Meta {
-                remarks: [],
-                errors: [
-                    Error {
-                        kind: MissingAttribute,
-                        data: {},
-                    },
+            "missing_value": {
+              "": {
+                "err": [
+                  "missing_attribute"
                 ],
-                original_length: None,
-                original_value: Some(
-                    Object(
-                        {
-                            "type": String(
-                                "string",
-                            ),
-                            "value": ~,
-                        },
-                    ),
-                ),
+                "val": {
+                  "type": "string",
+                  "value": null
+                }
+              }
             },
-            "unknown_type": Meta {
-                remarks: [],
-                errors: [
-                    Error {
-                        kind: InvalidData,
-                        data: {},
-                    },
+            "unknown_type": {
+              "": {
+                "err": [
+                  "invalid_data"
                 ],
-                original_length: None,
-                original_value: Some(
-                    Object(
-                        {
-                            "type": String(
-                                "custom",
-                            ),
-                            "value": String(
-                                "test",
-                            ),
-                        },
-                    ),
-                ),
+                "val": {
+                  "type": "custom",
+                  "value": "test"
+                }
+              }
             },
-            "valid_bool": Attribute {
-                value: Bool(
-                    true,
-                ),
-                type: Boolean,
-                other: {},
-            },
-            "valid_double": Attribute {
-                value: F64(
-                    42.5,
-                ),
-                type: Double,
-                other: {},
-            },
-            "valid_double_with_u64": Attribute {
-                value: I64(
-                    42,
-                ),
-                type: Double,
-                other: {},
-            },
-            "valid_int_from_string": Meta {
-                remarks: [],
-                errors: [
-                    Error {
-                        kind: InvalidData,
-                        data: {},
-                    },
+            "valid_int_from_string": {
+              "": {
+                "err": [
+                  "invalid_data"
                 ],
-                original_length: None,
-                original_value: Some(
-                    Object(
-                        {
-                            "type": String(
-                                "integer",
-                            ),
-                            "value": String(
-                                "42",
-                            ),
-                        },
-                    ),
-                ),
-            },
-            "valid_int_i64": Attribute {
-                value: I64(
-                    -42,
-                ),
-                type: Integer,
-                other: {},
-            },
-            "valid_int_u64": Attribute {
-                value: I64(
-                    42,
-                ),
-                type: Integer,
-                other: {},
-            },
-            "valid_string": Attribute {
-                value: String(
-                    "test",
-                ),
-                type: String,
-                other: {},
-            },
-            "valid_string_with_other": Attribute {
-                value: String(
-                    "test",
-                ),
-                type: String,
-                other: {
-                    "some_other_field": String(
-                        "some_other_value",
-                    ),
-                },
-            },
+                "val": {
+                  "type": "integer",
+                  "value": "42"
+                }
+              }
+            }
+          }
         }
         "###);
     }

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -1,10 +1,8 @@
-use std::collections::BTreeMap;
-
 use chrono::{TimeZone, Utc};
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use opentelemetry_proto::tonic::trace::v1::span::Link as OtelLink;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind as OtelSpanKind;
-use relay_event_schema::protocol::{Attribute, AttributeType, SpanV2Kind};
+use relay_event_schema::protocol::{Attribute, AttributeType, Attributes, SpanV2Kind};
 use relay_protocol::ErrorKind;
 
 use crate::otel_trace::{
@@ -13,7 +11,7 @@ use crate::otel_trace::{
 use relay_event_schema::protocol::{
     SpanId, SpanV2 as SentrySpanV2, SpanV2Link, SpanV2Status, Timestamp, TraceId,
 };
-use relay_protocol::{Annotated, Error, Object, Value};
+use relay_protocol::{Annotated, Error, Value};
 
 /// Transform an OTEL span to a Sentry span V2.
 ///
@@ -54,7 +52,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> Result<SentrySpanV2, Error> {
         bytes => Some(SpanId::try_from(bytes)?),
     };
 
-    let mut sentry_attributes = Object::default();
+    let mut sentry_attributes = Attributes::new();
     let mut name = if name.is_empty() { None } else { Some(name) };
     let mut description = None;
     let mut http_method = None;
@@ -90,7 +88,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> Result<SentrySpanV2, Error> {
         }
 
         if let Some(v) = otel_value_to_attr(value) {
-            sentry_attributes.insert(key, Annotated::new(v));
+            sentry_attributes.insert_raw(key, Annotated::new(v));
         }
     }
 
@@ -100,13 +98,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> Result<SentrySpanV2, Error> {
 
     // Put the fixed up description back into the attributes
     if let Some(description) = description {
-        sentry_attributes.insert(
-            "sentry.description".into(),
-            Annotated::new(Attribute::new(
-                AttributeType::String,
-                Value::String(description),
-            )),
-        );
+        sentry_attributes.insert("sentry.description".into(), description);
     }
 
     let sentry_links: Vec<Annotated<SpanV2Link>> = links
@@ -194,7 +186,7 @@ fn otel_to_sentry_link(otel_link: OtelLink) -> Result<SpanV2Link, Error> {
     // <https://www.w3.org/TR/trace-context-2/#sampled-flag>
     const W3C_TRACE_CONTEXT_SAMPLED: u32 = 1 << 0;
 
-    let attributes = BTreeMap::from_iter(otel_link.attributes.into_iter().filter_map(|kv| {
+    let attributes = Attributes::from_iter(otel_link.attributes.into_iter().filter_map(|kv| {
         let value = kv.value?.value?;
         let attr_value = otel_value_to_attr(value)?;
         Some((kv.key, Annotated::new(attr_value)))

--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -257,9 +257,7 @@ fn derive_op_for_v2_span(span: &SpanV2) -> String {
     }
 
     if let Some(faas_trigger) = attributes
-        .get("faas.trigger")
-        .and_then(|faas_trigger| faas_trigger.value())
-        .and_then(|trigger_value| trigger_value.value.value.value())
+        .get_value("faas.trigger")
         .and_then(|v| v.as_str())
     {
         return faas_trigger.to_owned();


### PR DESCRIPTION
This struct reduces the amount of ceremony required to insert an attribute into a collection or get an attribute's value. I only added the methods I needed, there's probably more that could be added.

This PR also removes some redundant debug snapshots, or in one case, replaces it with a JSON snapshot.

#skip-changelog