### PR TITLE
test(setup): Align socket options with Relay options

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,7 +46,7 @@ from .fixtures.processing import (  # noqa
 def random_port():
     def inner():
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         s.bind(("127.0.0.1", 0))
         s.listen(1)
         port = s.getsockname()[1]


### PR DESCRIPTION
Sometimes tests are failing with port in use, align what the integration tests do with Relays settings to hopefully prevent that.

#skip-changelog