### PR TITLE
ci: Run CI also in merge queues

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,7 @@ name: "Changelog"
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+  merge_group:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
   # Run actions on PRs, but only deploy on master
   pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -9,6 +9,7 @@ on:
 
   pull_request:
     branches: [master]
+  merge_group:
 
 jobs:
   enforce-license-compliance:

--- a/.github/workflows/validate-pipelines.yml
+++ b/.github/workflows/validate-pipelines.yml
@@ -7,6 +7,7 @@ on:
       - test/pipeline-*
 
   pull_request:
+  merge_group:
 
 jobs:
     files-changed:


### PR DESCRIPTION
This is required in order to be able to enable merge queues, the required checks need to run.

#skip-changelog