### PR TITLE
ref(relay): Enable str_to_string clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ strip = true
 dbg_macro = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
+str_to_string = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sentry)'] }

--- a/relay-cabi/src/glob.rs
+++ b/relay-cabi/src/glob.rs
@@ -98,7 +98,7 @@ fn glob_match_bytes(value: &[u8], pat: &str, options: GlobOptions) -> bool {
             pat.replace('\\', "/"),
         )
     } else {
-        (Cow::Borrowed(value), pat.to_string())
+        (Cow::Borrowed(value), pat.to_owned())
     };
     let key = (options, pat);
     let mut cache = GLOB_CACHE.lock().unwrap_or_else(PoisonError::into_inner);

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -160,7 +160,7 @@ impl Limiter for RedisSetLimiter {
                 continue;
             }
 
-            let id = &state.id().to_string();
+            let id = &state.id().to_owned();
             let scopes = num_scopes_tag(&state);
             let results = metric!(
                 timer(CardinalityLimiterTimers::Redis),

--- a/relay-config/src/upstream.rs
+++ b/relay-config/src/upstream.rs
@@ -146,7 +146,7 @@ impl FromStr for UpstreamDescriptor<'static> {
 
         Ok(UpstreamDescriptor {
             host: match url.host_str() {
-                Some(host) => Cow::Owned(host.to_string()),
+                Some(host) => Cow::Owned(host.to_owned()),
                 None => return Err(UpstreamParseError::NoHost),
             },
             port: url.port().unwrap_or_else(|| scheme.default_port()),

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -604,7 +604,7 @@ fn normalize_dist(distribution: &mut Annotated<String>) {
             meta.add_error(Error::new(ErrorKind::ValueTooLong));
             return Err(ProcessingAction::DeleteValueSoft);
         } else if trimmed != dist {
-            *dist = trimmed.to_string();
+            *dist = trimmed.to_owned();
         }
         Ok(())
     });
@@ -808,7 +808,7 @@ fn normalize_exception(exception: &mut Annotated<Exception>) {
             if let Some(value_str) = exception.value.value_mut() {
                 let new_values = regex
                     .captures(value_str)
-                    .map(|cap| (cap[1].to_string(), cap[2].trim().to_string().into()));
+                    .map(|cap| (cap[1].to_string(), cap[2].trim().to_owned().into()));
 
                 if let Some((new_type, new_value)) = new_values {
                     exception.ty.set_value(Some(new_type));
@@ -1245,7 +1245,7 @@ fn shorten_logger(logger: String, meta: &mut Meta) -> String {
                 });
             }
             meta.set_original_length(Some(original_len));
-            return trimmed.to_string();
+            return trimmed.to_owned();
         };
     }
 
@@ -2101,7 +2101,7 @@ mod tests {
         let max_name_and_unit_len = Some(30);
 
         let mut measurements: BTreeMap<String, Annotated<Measurement>> = Object::new();
-        measurements.insert(name.to_string(), Annotated::new(measurement));
+        measurements.insert(name.to_owned(), Annotated::new(measurement));
 
         let mut measurements = Measurements(measurements);
         let mut meta = Meta::default();
@@ -4289,7 +4289,7 @@ mod tests {
     #[test]
     fn test_json_value() {
         let mut exception = Annotated::new(Exception {
-            value: Annotated::new(r#"{"unauthorized":true}"#.to_string().into()),
+            value: Annotated::new(r#"{"unauthorized":true}"#.to_owned().into()),
             ..Exception::default()
         });
 

--- a/relay-event-normalization/src/event_error.rs
+++ b/relay-event-normalization/src/event_error.rs
@@ -33,7 +33,7 @@ impl Processor for EmitEventErrors {
                 value: Annotated::from(original_value.take()),
                 other: error
                     .data()
-                    .map(|(k, v)| (k.to_string(), Annotated::from(v.clone())))
+                    .map(|(k, v)| (k.to_owned(), Annotated::from(v.clone())))
                     .collect(),
             });
         }

--- a/relay-event-normalization/src/mechanism.rs
+++ b/relay-event-normalization/src/mechanism.rs
@@ -609,7 +609,7 @@ pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) {
             if cerror.name.value().is_none() {
                 if let Some(errno) = cerror.number.value() {
                     if let Some(name) = get_errno_name(*errno, os_hint) {
-                        cerror.name = Annotated::new(name.to_string());
+                        cerror.name = Annotated::new(name.to_owned());
                     }
                 }
             }
@@ -626,7 +626,7 @@ pub fn normalize_mechanism(mechanism: &mut Mechanism, os_hint: Option<OsHint>) {
                 if os_hint == OsHint::Darwin && signal.code_name.value().is_none() {
                     if let Some(code) = signal.code.value() {
                         if let Some(code_name) = get_signal_code_name(*signo, *code) {
-                            signal.code_name = Annotated::new(code_name.to_string());
+                            signal.code_name = Annotated::new(code_name.to_owned());
                         }
                     }
                 }

--- a/relay-event-normalization/src/normalize/breakdowns.rs
+++ b/relay-event-normalization/src/normalize/breakdowns.rs
@@ -348,7 +348,7 @@ mod tests {
             let mut config = HashMap::new();
 
             let span_ops_config = BreakdownConfig::SpanOperations(SpanOperationsConfig {
-                matches: vec!["http".to_owned(), "db".to_string()],
+                matches: vec!["http".to_owned(), "db".to_owned()],
             });
 
             config.insert("span_ops".to_owned(), span_ops_config.clone());

--- a/relay-event-normalization/src/normalize/contexts.rs
+++ b/relay-event-normalization/src/normalize/contexts.rs
@@ -94,10 +94,10 @@ fn normalize_runtime_context(runtime: &mut RuntimeContext) {
     if runtime.name.value().is_empty() && runtime.version.value().is_empty() {
         if let Some(raw_description) = runtime.raw_description.as_str() {
             if let Some(captures) = RUNTIME_DOTNET_REGEX.captures(raw_description) {
-                runtime.name = captures.name("name").map(|m| m.as_str().to_string()).into();
+                runtime.name = captures.name("name").map(|m| m.as_str().to_owned()).into();
                 runtime.version = captures
                     .name("version")
-                    .map(|m| m.as_str().to_string())
+                    .map(|m| m.as_str().to_owned())
                     .into();
             }
         }
@@ -200,62 +200,62 @@ fn normalize_os_context(os: &mut OsContext) {
     if let Some(raw_description) = os.raw_description.as_str() {
         if let Some((version, build_number)) = get_windows_version(raw_description) {
             os.name = "Windows".to_owned().into();
-            os.version = version.to_string().into();
+            os.version = version.to_owned().into();
             if os.build.is_empty() {
                 // Keep raw version as build
-                os.build.set_value(Some(build_number.to_string().into()));
+                os.build.set_value(Some(build_number.to_owned().into()));
             }
         } else if let Some(captures) = OS_MACOS_REGEX.captures(raw_description) {
             os.name = "macOS".to_owned().into();
             os.version = captures
                 .name("version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
             os.build = captures
                 .name("build")
-                .map(|m| m.as_str().to_string().into())
+                .map(|m| m.as_str().to_owned().into())
                 .into();
         } else if let Some(captures) = OS_IOS_REGEX.captures(raw_description) {
             os.name = "iOS".to_owned().into();
             os.version = captures
                 .name("version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
             os.build = captures
                 .name("build")
-                .map(|m| m.as_str().to_string().into())
+                .map(|m| m.as_str().to_owned().into())
                 .into();
         } else if let Some(captures) = OS_IPADOS_REGEX.captures(raw_description) {
             os.name = "iPadOS".to_owned().into();
             os.version = captures
                 .name("version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
             os.build = captures
                 .name("build")
-                .map(|m| m.as_str().to_string().into())
+                .map(|m| m.as_str().to_owned().into())
                 .into();
         } else if let Some(captures) = OS_LINUX_DISTRO_UNAME_REGEX.captures(raw_description) {
-            os.name = captures.name("name").map(|m| m.as_str().to_string()).into();
+            os.name = captures.name("name").map(|m| m.as_str().to_owned()).into();
             os.version = captures
                 .name("version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
             os.kernel_version = captures
                 .name("kernel_version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
         } else if let Some(captures) = OS_UNAME_REGEX.captures(raw_description) {
-            os.name = captures.name("name").map(|m| m.as_str().to_string()).into();
+            os.name = captures.name("name").map(|m| m.as_str().to_owned()).into();
             os.kernel_version = captures
                 .name("kernel_version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
         } else if let Some(captures) = OS_ANDROID_REGEX.captures(raw_description) {
             os.name = "Android".to_owned().into();
             os.version = captures
                 .name("version")
-                .map(|m| m.as_str().to_string())
+                .map(|m| m.as_str().to_owned())
                 .into();
         } else if raw_description == "Nintendo Switch" {
             os.name = "Nintendo OS".to_owned().into();
@@ -302,13 +302,13 @@ fn normalize_response_data(response: &mut ResponseContext) {
         // Retain meta data on the body (e.g. trimming annotations) but remove anything on the
         // inferred content type.
         response.data.set_value(Some(parsed_data));
-        response.inferred_content_type = Annotated::from(content_type.to_string());
+        response.inferred_content_type = Annotated::from(content_type.to_owned());
     } else {
         response.inferred_content_type = response
             .headers
             .value()
             .and_then(|headers| headers.get_header("Content-Type"))
-            .map(|value| value.split(';').next().unwrap_or(value).to_string())
+            .map(|value| value.split(';').next().unwrap_or(value).to_owned())
             .into();
     }
 }
@@ -451,7 +451,7 @@ mod tests {
         // Environment.OSVersion on Windows 7 (CoreCLR 1.0+, .NET Framework 1.1+, Mono 1+)
         let mut os = OsContext {
             raw_description: "Microsoft Windows NT 6.1.7601 Service Pack 1"
-                .to_string()
+                .to_owned()
                 .into(),
             ..OsContext::default()
         };
@@ -574,7 +574,7 @@ mod tests {
         // RuntimeInformation.OSDescription on CentOS 7 (CoreCLR 2.0+, Mono 5.4+)
         let mut os = OsContext {
             raw_description: "Linux 3.10.0-693.21.1.el7.x86_64 #1 SMP Wed Mar 7 19:03:37 UTC 2018"
-                .to_string()
+                .to_owned()
                 .into(),
             ..OsContext::default()
         };
@@ -590,7 +590,7 @@ mod tests {
         // (CoreCLR 2.0+, Mono 5.4+)
         let mut os = OsContext {
             raw_description: "Linux 4.4.0-43-Microsoft #1-Microsoft Wed Dec 31 14:42:53 PST 2014"
-                .to_string()
+                .to_owned()
                 .into(),
             ..OsContext::default()
         };
@@ -716,7 +716,7 @@ mod tests {
     fn test_unity_android_os() {
         let mut os = OsContext {
             raw_description: "Android OS 11 / API-30 (RP1A.201005.001/2107031736)"
-                .to_string()
+                .to_owned()
                 .into(),
             ..OsContext::default()
         };
@@ -763,7 +763,7 @@ mod tests {
     fn test_android_4_4_2() {
         let mut os = OsContext {
             raw_description: "Android OS 4.4.2 / API-19 (KOT49H/A536_S186_150813_ROW)"
-                .to_string()
+                .to_owned()
                 .into(),
             ..OsContext::default()
         };
@@ -776,7 +776,7 @@ mod tests {
     #[test]
     fn test_infer_json() {
         let mut response = ResponseContext {
-            data: Annotated::from(Value::String(r#"{"foo":"bar"}"#.to_string())),
+            data: Annotated::from(Value::String(r#"{"foo":"bar"}"#.to_owned())),
             ..ResponseContext::default()
         };
 
@@ -797,7 +797,7 @@ mod tests {
     #[test]
     fn test_broken_json_with_fallback() {
         let mut response = ResponseContext {
-            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_string())),
+            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_owned())),
             headers: Annotated::from(Headers(PairList(vec![Annotated::new((
                 Annotated::new("Content-Type".to_owned().into()),
                 Annotated::new("text/plain; encoding=utf-8".to_owned().into()),
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     fn test_broken_json_without_fallback() {
         let mut response = ResponseContext {
-            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_string())),
+            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_owned())),
             ..ResponseContext::default()
         };
 

--- a/relay-event-normalization/src/normalize/request.rs
+++ b/relay-event-normalization/src/normalize/request.rs
@@ -58,7 +58,7 @@ fn normalize_url(request: &mut Request) {
             if let Some(fragment_index) = url_string.find('#') {
                 let fragment = &url_string[fragment_index + 1..];
                 if !fragment.is_empty() && request.fragment.value().is_none() {
-                    request.fragment.set_value(Some(fragment.to_string()));
+                    request.fragment.set_value(Some(fragment.to_owned()));
                 }
                 url_string.truncate(fragment_index);
             }
@@ -151,13 +151,13 @@ fn normalize_data(request: &mut Request) {
         // Retain meta data on the body (e.g. trimming annotations) but remove anything on the
         // inferred content type.
         request.data.set_value(Some(parsed_data));
-        request.inferred_content_type = Annotated::from(content_type.to_string());
+        request.inferred_content_type = Annotated::from(content_type.to_owned());
     } else {
         request.inferred_content_type = request
             .headers
             .value()
             .and_then(|headers| headers.get_header("Content-Type"))
-            .map(|value| value.split(';').next().unwrap_or(value).to_string())
+            .map(|value| value.split(';').next().unwrap_or(value).to_owned())
             .into();
     }
 }
@@ -439,7 +439,7 @@ mod tests {
     #[test]
     fn test_infer_json() {
         let mut request = Request {
-            data: Annotated::from(Value::String(r#"{"foo":"bar"}"#.to_string())),
+            data: Annotated::from(Value::String(r#"{"foo":"bar"}"#.to_owned())),
             ..Request::default()
         };
 
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn test_broken_json_with_fallback() {
         let mut request = Request {
-            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_string())),
+            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_owned())),
             headers: Annotated::from(Headers(PairList(vec![Annotated::new((
                 Annotated::new("Content-Type".to_owned().into()),
                 Annotated::new("text/plain; encoding=utf-8".to_owned().into()),
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn test_broken_json_without_fallback() {
         let mut request = Request {
-            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_string())),
+            data: Annotated::from(Value::String(r#"{"foo":"b"#.to_owned())),
             ..Request::default()
         };
 
@@ -488,7 +488,7 @@ mod tests {
     #[test]
     fn test_infer_url_encoded() {
         let mut request = Request {
-            data: Annotated::from(Value::String(r#"foo=bar"#.to_string())),
+            data: Annotated::from(Value::String(r#"foo=bar"#.to_owned())),
             ..Request::default()
         };
 

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -474,7 +474,7 @@ mod tests {
             )),
             Annotated::new((
                 Annotated::new("UsEr-AgeNT".to_owned().into()),
-                Annotated::new(user_agent.to_string().into()),
+                Annotated::new(user_agent.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("WWW-Authenticate".to_owned().into()),
@@ -726,7 +726,7 @@ mod tests {
         let headers = Headers([
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#""Mozilla/5.0 (Linux; Android 11; foo g31(w)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36""#.to_string().into()),
+                Annotated::new(r#""Mozilla/5.0 (Linux; Android 11; foo g31(w)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36""#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("invalid header".to_owned().into()),
@@ -742,7 +742,7 @@ mod tests {
         let headers = Headers([
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#""Mozilla/5.0 (Linux; Android 11; foo g31(w)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36""#.to_string().into()),
+                Annotated::new(r#""Mozilla/5.0 (Linux; Android 11; foo g31(w)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36""#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA-MODEL".to_owned().into()),
@@ -816,11 +816,11 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA".to_owned().into()),
-                Annotated::new(r#"Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"#.to_string().into()),
+                Annotated::new(r#"Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"#.to_owned().into()),
             )),
         ];
             PairList(headers)
@@ -847,7 +847,7 @@ mod tests {
                 Annotated::new(
                     // browser field missing
                     r#"Not_A Brand";v="99", " ";v="109", "Chromium";v="109"#
-                        .to_string()
+                        .to_owned()
                         .into(),
                 ),
             ))];
@@ -865,11 +865,11 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA".to_owned().into()),
-                Annotated::new(r#"Not_A Brand";v="99", "weird browser";v="109", "Chromium";v="109"#.to_string().into()),
+                Annotated::new(r#"Not_A Brand";v="99", "weird browser";v="109", "Chromium";v="109"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA-FULL-VERSION".to_owned().into()),
@@ -898,11 +898,11 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA".to_owned().into()),
-                Annotated::new(r#"Not_A Brand";v="99", "Chromium";v="108"#.to_string().into()), // no browser field here
+                Annotated::new(r#"Not_A Brand";v="99", "Chromium";v="108"#.to_owned().into()), // no browser field here
             )),
         ];
             PairList(headers)
@@ -946,11 +946,11 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA-PLATFORM".to_owned().into()),
-                Annotated::new(r#"macOS"#.to_string().into()), // no browser field here
+                Annotated::new(r#"macOS"#.to_owned().into()), // no browser field here
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA-PLATFORM-VERSION".to_owned().into()),
@@ -984,7 +984,7 @@ mod tests {
         let headers = Headers({
             let headers = vec![Annotated::new((
                 Annotated::new("SEC-CH-UA-PLATFORM".to_owned().into()),
-                Annotated::new(r#""#.to_string().into()),
+                Annotated::new(r#""#.to_owned().into()),
             ))];
             PairList(headers)
         });
@@ -1000,7 +1000,7 @@ mod tests {
             let headers = vec![
                 Annotated::new((
                     Annotated::new("SEC-CH-UA-PLATFORM".to_owned().into()),
-                    Annotated::new(r#"macOs"#.to_string().into()),
+                    Annotated::new(r#"macOs"#.to_owned().into()),
                 )),
                 Annotated::new((
                     Annotated::new("SEC-CH-UA-PLATFORM-VERSION".to_owned().into()),
@@ -1021,11 +1021,11 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("invalid header".to_owned().into()),
-                Annotated::new(r#"macOS"#.to_string().into()),
+                Annotated::new(r#"macOS"#.to_owned().into()),
             )),
             Annotated::new((
                 Annotated::new("SEC-CH-UA-PLATFORM-VERSION".to_owned().into()),
@@ -1060,7 +1060,7 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
         ];
             PairList(headers)
@@ -1078,7 +1078,7 @@ mod tests {
             let headers = vec![
             Annotated::new((
                 Annotated::new("user-agent".to_owned().into()),
-                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_string().into()),
+                Annotated::new(r#"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"#.to_owned().into()),
             )),
         ];
             PairList(headers)

--- a/relay-event-schema/src/protocol/clientsdk.rs
+++ b/relay-event-schema/src/protocol/clientsdk.rs
@@ -134,7 +134,7 @@ impl FromValue for AutoInferSetting {
 
 impl IntoValue for AutoInferSetting {
     fn into_value(self) -> Value {
-        Value::String(self.as_str().to_string())
+        Value::String(self.as_str().to_owned())
     }
 
     fn serialize_payload<S>(&self, s: S, _: SkipSerialization) -> Result<S::Ok, S::Error>

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -899,7 +899,7 @@ mod tests {
             logger: Annotated::new("mylogger".to_owned()),
             modules: {
                 let mut map = Map::new();
-                map.insert("mymodule".to_owned(), Annotated::new("1.0.0".to_string()));
+                map.insert("mymodule".to_owned(), Annotated::new("1.0.0".to_owned()));
                 Annotated::new(map)
             },
             platform: Annotated::new("myplatform".to_owned()),

--- a/relay-event-schema/src/protocol/exception.rs
+++ b/relay-event-schema/src/protocol/exception.rs
@@ -147,7 +147,7 @@ mod tests {
         let output = r#"{"value":"{\"unauthorized\":true}"}"#;
 
         let exception = Annotated::new(Exception {
-            value: Annotated::new(r#"{"unauthorized":true}"#.to_string().into()),
+            value: Annotated::new(r#"{"unauthorized":true}"#.to_owned().into()),
             ..Default::default()
         });
 

--- a/relay-event-schema/src/protocol/fingerprint.rs
+++ b/relay-event-schema/src/protocol/fingerprint.rs
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn test_fingerprint_bool() {
         assert_eq!(
-            Annotated::new(vec!["True".to_owned(), "False".to_string()].into()),
+            Annotated::new(vec!["True".to_owned(), "False".to_owned()].into()),
             Annotated::<Fingerprint>::from_json("[true, false]").unwrap()
         );
     }
@@ -198,7 +198,7 @@ mod tests {
     fn test_fingerprint_invalid_fallback() {
         // XXX: review, this was changed after refactor
         assert_eq!(
-            Annotated::new(Fingerprint(vec!["a".to_owned(), "d".to_string()])),
+            Annotated::new(Fingerprint(vec!["a".to_owned(), "d".to_owned()])),
             Annotated::<Fingerprint>::from_json("[\"a\", null, \"d\"]").unwrap()
         );
     }

--- a/relay-event-schema/src/protocol/request.rs
+++ b/relay-event-schema/src/protocol/request.rs
@@ -27,8 +27,8 @@ impl Cookies {
     fn parse_cookie(string: &str) -> Result<CookieEntry, Error> {
         match Cookie::parse_encoded(string) {
             Ok(cookie) => Ok(Annotated::from((
-                cookie.name().to_string().into(),
-                cookie.value().to_string().into(),
+                cookie.name().to_owned().into(),
+                cookie.value().to_owned().into(),
             ))),
             Err(error) => Err(Error::invalid(error)),
         }
@@ -751,7 +751,7 @@ mod tests {
             vec![
                 Annotated::new((
                     Annotated::new("baz".to_owned()),
-                    Annotated::new(r#"{"a":42}"#.to_string().into()),
+                    Annotated::new(r#"{"a":42}"#.to_owned().into()),
                 )),
                 Annotated::new((
                     Annotated::new("foo".to_owned()),

--- a/relay-event-schema/src/protocol/stacktrace.rs
+++ b/relay-event-schema/src/protocol/stacktrace.rs
@@ -419,7 +419,7 @@ impl FromStr for InstructionAddrAdjustment {
             "all_but_first" => Ok(Self::AllButFirst),
             "all" => Ok(Self::All),
             "none" => Ok(Self::None),
-            s => Ok(Self::Unknown(s.to_string())),
+            s => Ok(Self::Unknown(s.to_owned())),
         }
     }
 }
@@ -780,9 +780,9 @@ mod tests {
         let frame = Annotated::new(Frame {
             vars: Annotated::new({
                 let mut vars = Object::new();
-                vars.insert("0".to_owned(), Annotated::new("foo".to_string().into()));
-                vars.insert("1".to_owned(), Annotated::new("bar".to_string().into()));
-                vars.insert("2".to_owned(), Annotated::new("baz".to_string().into()));
+                vars.insert("0".to_owned(), Annotated::new("foo".to_owned().into()));
+                vars.insert("1".to_owned(), Annotated::new("bar".to_owned().into()));
+                vars.insert("2".to_owned(), Annotated::new("baz".to_owned().into()));
                 vars.insert("3".to_owned(), Annotated::empty());
                 vars.into()
             }),

--- a/relay-event-schema/src/protocol/tags.rs
+++ b/relay-event-schema/src/protocol/tags.rs
@@ -35,8 +35,8 @@ impl FromValue for TagEntry {
         type TagTuple = (Annotated<LenientString>, Annotated<LenientString>);
         TagTuple::from_value(value).map_value(|(key, value)| {
             TagEntry(
-                key.map_value(|x| x.into_inner().replace(' ', "-").trim().to_string()),
-                value.map_value(|x| x.into_inner().trim().to_string()),
+                key.map_value(|x| x.into_inner().replace(' ', "-").trim().to_owned()),
+                value.map_value(|x| x.into_inner().trim().to_owned()),
             )
         })
     }

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -190,7 +190,7 @@ mod tests {
 
     fn get_event_with_exception_value(val: &str) -> Event {
         let ex = Exception {
-            value: Annotated::from(JsonLenientString::from(val.to_string())),
+            value: Annotated::from(JsonLenientString::from(val.to_owned())),
             ..Exception::default()
         };
 

--- a/relay-filter/src/client_ips.rs
+++ b/relay-filter/src/client_ips.rs
@@ -103,7 +103,7 @@ mod tests {
         for &(ip_addr, blacklisted_ips, expected) in examples {
             let ip_addr = ip_addr.parse::<IpAddr>().ok();
             let config = ClientIpsFilterConfig {
-                blacklisted_ips: blacklisted_ips.iter().map(|&ip| ip.to_string()).collect(),
+                blacklisted_ips: blacklisted_ips.iter().map(|&ip| ip.to_owned()).collect(),
             };
 
             let actual = should_filter(ip_addr, &config) != Ok(());

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -100,7 +100,7 @@ impl<'a> TryFrom<&'a str> for FilterStatKey {
             "web-crawlers" => FilterStatKey::WebCrawlers,
             "invalid-csp" => FilterStatKey::InvalidCsp,
             "filtered-transaction" => FilterStatKey::FilteredTransactions,
-            other => FilterStatKey::GenericFilter(other.to_string()),
+            other => FilterStatKey::GenericFilter(other.to_owned()),
         })
     }
 }

--- a/relay-filter/src/csp.rs
+++ b/relay-filter/src/csp.rs
@@ -180,7 +180,7 @@ mod tests {
         fn annotated_string_or_none(val: Option<&str>) -> Annotated<String> {
             match val {
                 None => Annotated::empty(),
-                Some(val) => Annotated::from(val.to_string()),
+                Some(val) => Annotated::from(val.to_owned()),
             }
         }
         Event {
@@ -245,9 +245,9 @@ mod tests {
             assert_eq!(
                 (actual.scheme, actual.domain, actual.port),
                 (
-                    scheme.map(|x| x.to_string()),
-                    domain.map(|x| x.to_string()),
-                    port.map(|x| x.to_string())
+                    scheme.map(|x| x.to_owned()),
+                    domain.map(|x| x.to_owned()),
+                    port.map(|x| x.to_owned())
                 )
             );
         }
@@ -312,9 +312,9 @@ mod tests {
             assert_eq!(
                 (actual.scheme, actual.domain, actual.port),
                 (
-                    scheme.map(|x| x.to_string()),
-                    domain.map(|x| x.to_string()),
-                    port.map(|x| x.to_string())
+                    scheme.map(|x| x.to_owned()),
+                    domain.map(|x| x.to_owned()),
+                    port.map(|x| x.to_owned())
                 )
             );
         }

--- a/relay-filter/src/error_messages.rs
+++ b/relay-filter/src/error_messages.rs
@@ -151,7 +151,7 @@ mod tests {
                         ..Default::default()
                     })])),
                     logentry: Annotated::new(LogEntry {
-                        formatted: Annotated::new(logentry_formatted.to_string().into()),
+                        formatted: Annotated::new(logentry_formatted.to_owned().into()),
                         ..Default::default()
                     }),
                     ..Default::default()

--- a/relay-filter/src/localhost.rs
+++ b/relay-filter/src/localhost.rs
@@ -73,7 +73,7 @@ mod tests {
     fn get_event_with_ip_addr(val: &str) -> Event {
         Event {
             user: Annotated::from(User {
-                ip_address: Annotated::from(IpAddr(val.to_string())),
+                ip_address: Annotated::from(IpAddr(val.to_owned())),
                 ..User::default()
             }),
             ..Event::default()
@@ -93,7 +93,7 @@ mod tests {
     fn get_event_with_url(val: &str) -> Event {
         Event {
             request: Annotated::from(Request {
-                url: Annotated::from(val.to_string()),
+                url: Annotated::from(val.to_owned()),
                 ..Request::default()
             }),
             ..Event::default()

--- a/relay-filter/src/releases.rs
+++ b/relay-filter/src/releases.rs
@@ -29,7 +29,7 @@ mod tests {
 
     fn get_event_for_release(release: &str) -> Event {
         Event {
-            release: Annotated::from(LenientString::from(release.to_string())),
+            release: Annotated::from(LenientString::from(release.to_owned())),
             ..Event::default()
         }
     }
@@ -37,7 +37,7 @@ mod tests {
     fn get_span_for_release(release: &str) -> Span {
         Span {
             data: Annotated::new(SpanData {
-                release: Annotated::from(LenientString::from(release.to_string())),
+                release: Annotated::from(LenientString::from(release.to_owned())),
                 ..Default::default()
             }),
             ..Default::default()

--- a/relay-filter/src/testutils.rs
+++ b/relay-filter/src/testutils.rs
@@ -7,7 +7,7 @@ use relay_protocol::Annotated;
 pub fn get_event_with_user_agent(user_agent: &str) -> Event {
     let headers = vec![Annotated::new((
         Annotated::new("UsEr-AgeNT".to_owned().into()),
-        Annotated::new(user_agent.to_string().into()),
+        Annotated::new(user_agent.to_owned().into()),
     ))];
 
     Event {

--- a/relay-filter/src/transaction_name.rs
+++ b/relay-filter/src/transaction_name.rs
@@ -52,7 +52,7 @@ mod tests {
             "*/ping",
             "*/up",
         ]
-        .map(|val| val.to_string())
+        .map(|val| val.to_owned())
         .to_vec();
 
         IgnoreTransactionsFilterConfig {

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -127,7 +127,7 @@ impl Producer {
 
         for topic in metadata.topics() {
             if let Some(error) = topic.error() {
-                return Err(ClientError::TopicError(topic.name().to_string(), error));
+                return Err(ClientError::TopicError(topic.name().to_owned(), error));
             }
         }
 
@@ -247,11 +247,8 @@ impl KafkaClientBuilder {
         let config_name = config_name.map(str::to_string);
 
         if let Some(producer) = self.reused_producers.get(&config_name) {
-            let producer = Producer::new(
-                (*topic_name).to_string(),
-                Arc::clone(producer),
-                rate_limiter,
-            );
+            let producer =
+                Producer::new((*topic_name).to_owned(), Arc::clone(producer), rate_limiter);
             if validate_topic {
                 producer.validate_topic()?;
             }
@@ -272,7 +269,7 @@ impl KafkaClientBuilder {
         self.reused_producers
             .insert(config_name, Arc::clone(&producer));
 
-        let producer = Producer::new((*topic_name).to_string(), producer, rate_limiter);
+        let producer = Producer::new((*topic_name).to_owned(), producer, rate_limiter);
         if validate_topic {
             producer.validate_topic()?;
         }

--- a/relay-prosperoconv/Cargo.toml
+++ b/relay-prosperoconv/Cargo.toml
@@ -8,10 +8,8 @@ edition = "2024"
 license-file = "../LICENSE.md"
 publish = false
 
-
-[lints]
-workspace = true
-
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sentry)'] }
 
 [dependencies]
 anyhow = "1.0.69"

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -227,7 +227,7 @@ impl From<f64> for Value {
 
 impl<'a> From<&'a str> for Value {
     fn from(value: &'a str) -> Self {
-        Value::String(value.to_string())
+        Value::String(value.to_owned())
     }
 }
 

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -124,7 +124,7 @@ impl<'a> RedisQuota<'a> {
         OwnedRedisQuota {
             quota: self.quota.clone(),
             scoping: self.scoping,
-            prefix: self.prefix.to_string(),
+            prefix: self.prefix.to_owned(),
             window: self.window,
             timestamp: self.timestamp,
         }

--- a/relay-server/src/metrics_extraction/sessions/mod.rs
+++ b/relay-server/src/metrics_extraction/sessions/mod.rs
@@ -45,7 +45,7 @@ pub fn extract_session_metrics<T: SessionLike>(
     let common_tags = CommonTags {
         release: attributes.release.clone(),
         environment: attributes.environment.clone(),
-        sdk: client.map(|s| s.to_string()),
+        sdk: client.map(|s| s.to_owned()),
     };
 
     // Always capture with "init" tag for the first session update of a session. This is used

--- a/relay-server/src/metrics_extraction/transactions/mod.rs
+++ b/relay-server/src/metrics_extraction/transactions/mod.rs
@@ -146,13 +146,13 @@ fn extract_light_transaction_tags(tags: &CommonTags) -> LightTransactionTags {
 fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> CommonTags {
     let mut tags = BTreeMap::new();
     if let Some(release) = event.release.as_str() {
-        tags.insert(CommonTag::Release, release.to_string());
+        tags.insert(CommonTag::Release, release.to_owned());
     }
     if let Some(dist) = event.dist.value() {
         tags.insert(CommonTag::Dist, dist.to_string());
     }
     if let Some(environment) = event.environment.as_str() {
-        tags.insert(CommonTag::Environment, environment.to_string());
+        tags.insert(CommonTag::Environment, environment.to_owned());
     }
     if let Some(transaction_name) = get_transaction_name(event) {
         tags.insert(CommonTag::Transaction, transaction_name);
@@ -167,7 +167,7 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
         _ => "other",
     };
 
-    tags.insert(CommonTag::Platform, platform.to_string());
+    tags.insert(CommonTag::Platform, platform.to_owned());
 
     if let Some(trace_context) = event.context::<TraceContext>() {
         // We assume that the trace context status is automatically set to unknown inside of the
@@ -226,7 +226,7 @@ fn extract_universal_tags(event: &Event, config: &TransactionMetricsConfig) -> C
                     let (key, value) = entry.as_pair();
                     if let (Some(key), Some(value)) = (key.as_str(), value.as_str()) {
                         if custom_tags.contains(key) {
-                            tags.insert(CommonTag::Custom(key.to_string()), value.to_string());
+                            tags.insert(CommonTag::Custom(key.to_owned()), value.to_owned());
                         }
                     }
                 }
@@ -409,7 +409,7 @@ impl TransactionExtractor<'_> {
             if let Some(transaction_from_dsc) = self.transaction_from_dsc {
                 universal_tags
                     .0
-                    .insert(CommonTag::Transaction, transaction_from_dsc.to_string());
+                    .insert(CommonTag::Transaction, transaction_from_dsc.to_owned());
             }
 
             TransactionCPRTags {

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -304,8 +304,8 @@ mod tests {
         Event {
             id: Annotated::new(EventId::new()),
             ty: Annotated::new(event_type),
-            transaction: Annotated::new(transaction.to_string()),
-            release: Annotated::new(LenientString(release.to_string())),
+            transaction: Annotated::new(transaction.to_owned()),
+            release: Annotated::new(LenientString(release.to_owned())),
             ..Event::default()
         }
     }

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -715,7 +715,7 @@ mod tests {
 
         for (date, message) in breadcrumbs {
             let mut breadcrumb = BTreeMap::new();
-            breadcrumb.insert("message", (*message).to_string());
+            breadcrumb.insert("message", (*message).to_owned());
             if let Some(date) = date {
                 breadcrumb.insert("timestamp", date.to_rfc3339());
             }

--- a/relay-server/src/utils/api.rs
+++ b/relay-server/src/utils/api.rs
@@ -35,7 +35,7 @@ impl ApiErrorResponse {
     /// Creates an error response with a detail message
     pub fn with_detail<S: AsRef<str>>(s: S) -> ApiErrorResponse {
         ApiErrorResponse {
-            detail: Some(s.as_ref().to_string()),
+            detail: Some(s.as_ref().to_owned()),
             causes: Vec::new(),
             relay: RelayErrorAction::None,
         }

--- a/relay-server/src/utils/dynamic_sampling.rs
+++ b/relay-server/src/utils/dynamic_sampling.rs
@@ -140,8 +140,8 @@ mod tests {
         Event {
             id: Annotated::new(EventId::new()),
             ty: Annotated::new(event_type),
-            transaction: Annotated::new(transaction.to_string()),
-            release: Annotated::new(LenientString(release.to_string())),
+            transaction: Annotated::new(transaction.to_owned()),
+            release: Annotated::new(LenientString(release.to_owned())),
             ..Event::default()
         }
     }
@@ -158,9 +158,9 @@ mod tests {
         DynamicSamplingContext {
             trace_id: "67e5504410b1426f9247bb680e5fe0c8".parse().unwrap(),
             public_key: "12345678901234567890123456789012".parse().unwrap(),
-            release: release.map(|value| value.to_string()),
-            environment: environment.map(|value| value.to_string()),
-            transaction: transaction.map(|value| value.to_string()),
+            release: release.map(|value| value.to_owned()),
+            environment: environment.map(|value| value.to_owned()),
+            transaction: transaction.map(|value| value.to_owned()),
             sample_rate,
             user: Default::default(),
             other: Default::default(),

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -63,10 +63,10 @@ fn write_native_placeholder(event: &mut Event, placeholder: NativePlaceholder) {
     exceptions.clear(); // clear previous errors if any
 
     exceptions.push(Annotated::new(Exception {
-        ty: Annotated::new(placeholder.exception_type.to_string()),
-        value: Annotated::new(JsonLenientString(placeholder.exception_value.to_string())),
+        ty: Annotated::new(placeholder.exception_type.to_owned()),
+        value: Annotated::new(JsonLenientString(placeholder.exception_value.to_owned())),
         mechanism: Annotated::new(Mechanism {
-            ty: Annotated::from(placeholder.mechanism_type.to_string()),
+            ty: Annotated::from(placeholder.mechanism_type.to_owned()),
             handled: Annotated::from(false),
             synthetic: Annotated::from(true),
             ..Mechanism::default()

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -34,7 +34,7 @@ where
         return f(event);
     }
 
-    let old_source = transaction_source_tag(inner).to_string();
+    let old_source = transaction_source_tag(inner).to_owned();
     let old_remarks = inner.transaction.meta().iter_remarks().count();
 
     let res = f(event);

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -110,7 +110,7 @@ fn merge_unreal_user_info(event: &mut Event, user_info: &str) {
         let tags = event.tags.value_mut().get_or_insert_with(Tags::default);
         tags.push(Annotated::new(TagEntry(
             Annotated::new("epic_account_id".to_owned()),
-            Annotated::new(epic_account_id.to_string()),
+            Annotated::new(epic_account_id.to_owned()),
         )));
     }
 
@@ -118,7 +118,7 @@ fn merge_unreal_user_info(event: &mut Event, user_info: &str) {
         let tags = event.tags.value_mut().get_or_insert_with(Tags::default);
         tags.push(Annotated::new(TagEntry::from_pair((
             Annotated::new("machine_id".to_owned()),
-            Annotated::new(machine_id.to_string()),
+            Annotated::new(machine_id.to_owned()),
         ))));
     }
 }

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -343,7 +343,7 @@ pub fn generate_completions(matches: &ArgMatches) -> Result<()> {
     };
 
     let mut app = make_app();
-    let name = app.get_name().to_string();
+    let name = app.get_name().to_owned();
     clap_complete::generate(shell, &mut app, name, &mut io::stdout());
 
     Ok(())


### PR DESCRIPTION
Regex beats Cursor, Clippy beats Regex.

Enables the [`str_to_string`](https://rust-lang.github.io/rust-clippy/master/#str_to_string) clippy lint on the workspace and one run of `clippy --fix`.

#skip-changelog