### PR TITLE
ci(deploy): Temporarily disable deploy CI checks

### DIFF
--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/githubactions/checkruns.py \
-    getsentry/relay \
-    "${GO_REVISION_RELAY_REPO}" \
-    "Integration Tests" \
-    "Test All Features (ubuntu-latest)" \
-    "Publish Relay to Internal AR (relay)" \
-    "Publish Relay to Internal AR (relay-pop)" \
-    "Upload build artifacts to gocd (relay, linux/amd64)" \
-    "Upload build artifacts to gocd (relay, linux/arm64)" \
-    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
-    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \
+echo 'Temporarily disabled because of: https://github.com/getsentry/devinfra-deployment-service/pull/695'
+
+# /devinfra/scripts/checks/githubactions/checkruns.py \
+#     getsentry/relay \
+#     "${GO_REVISION_RELAY_REPO}" \
+#     "Integration Tests" \
+#     "Test All Features (ubuntu-latest)" \
+#     "Publish Relay to Internal AR (relay)" \
+#     "Publish Relay to Internal AR (relay-pop)" \
+#     "Upload build artifacts to gocd (relay, linux/amd64)" \
+#     "Upload build artifacts to gocd (relay, linux/arm64)" \
+#     "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
+#     "Upload build artifacts to gocd (relay-pop, linux/arm64)" \


### PR DESCRIPTION
Due to https://github.com/getsentry/devinfra-deployment-service/pull/695 the check script currently doesn't handle merge queues correctly.

To unblock deployments, temporarily disable the checks until this is fixed.

The checks are still not optional, the merge queue enforces these checks to succeed before merging.

#skip-changelog