### PR TITLE
fix(ai): Consider `gen_ai` valid op prefix for AI spans 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Take into account more types of tokens when doing AI cost calculation. ([#4840](https://github.com/getsentry/relay/pull/4840))
 - Use the `FiniteF64` type for measurements. ([#4828](https://github.com/getsentry/relay/pull/4828))
 - Derive a `sentry.description` attribute for V2 spans ([#4832](https://github.com/getsentry/relay/pull/4832))
+- Consider `gen_ai` also as AI span op prefix. ([#4859](https://github.com/getsentry/relay/pull/4859))
 
 ## 25.6.1
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -112,7 +112,7 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
 /// These metrics are added to [`crate::GlobalConfig`] by the service and enabled
 /// by project configs in sentry.
 pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMapping>)> {
-    let is_ai = RuleCondition::glob("span.op", "ai.*");
+    let is_ai = RuleCondition::glob("span.op", "ai.*") | RuleCondition::glob("span.op", "gen_ai.*");
 
     let is_db = RuleCondition::eq("span.sentry_tags.category", "db")
         & !RuleCondition::glob("span.op", DISABLED_DATABASES)

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -42,7 +42,7 @@ fn calculate_ai_model_cost(model_cost: Option<ModelCostV2>, data: &SpanData) -> 
 
 /// Maps AI-related measurements (legacy) to span data.
 pub fn map_ai_measurements_to_data(span: &mut Span) {
-    if !span.op.value().is_some_and(|op| op.starts_with("ai.")) {
+    if !is_ai_span(span) {
         return;
     };
 
@@ -86,7 +86,7 @@ pub fn map_ai_measurements_to_data(span: &mut Span) {
 
 /// Extract the gen_ai_usage_total_cost data into the span
 pub fn extract_ai_data(span: &mut Span, ai_model_costs: &ModelCosts) {
-    if !span.op.value().is_some_and(|op| op.starts_with("ai.")) {
+    if !is_ai_span(span) {
         return;
     }
 
@@ -122,4 +122,12 @@ pub fn enrich_ai_span_data(event: &mut Event, model_costs: Option<&ModelCosts>) 
             extract_ai_data(span, model_costs);
         }
     }
+}
+
+/// Returns true if the span is an AI span.
+/// AI spans are spans with op starting with "ai." (legacy) or "gen_ai." (new).
+pub fn is_ai_span(span: &Span) -> bool {
+    span.op
+        .value()
+        .is_some_and(|op| op.starts_with("ai.") || op.starts_with("gen_ai."))
 }


### PR DESCRIPTION
AI spans were the ones where `op` prefix was `ai.`, but that has recently changed, and now most of AI spans `op` starts with `gen_ai`.

This PR fixes that.