### PR TITLE
ci(merge-queue): Don't re-run checks on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - master
       - release/**
       - release-library/**
 
@@ -19,6 +18,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RELAY_CARGO_ARGS: "--locked"
+  IS_MASTER: "${{ github.event_name == 'merge_group' }}"
 
 jobs:
   lint:
@@ -40,7 +40,7 @@ jobs:
           submodules: recursive
 
       - name: Setup SSH agent
-        if: ${{ env.SSH_PRIVATE_KEY != '' }}
+        if: env.SSH_PRIVATE_KEY != ''
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
@@ -130,7 +130,7 @@ jobs:
           submodules: recursive
 
       - name: Setup SSH agent
-        if: ${{ env.SSH_PRIVATE_KEY != '' }}
+        if: env.SSH_PRIVATE_KEY != ''
         # Windows needs an older versino of the ssh agent: https://github.com/webfactory/ssh-agent/pull/17
         uses: webfactory/ssh-agent@v0.7.0
         with:
@@ -184,7 +184,7 @@ jobs:
           submodules: recursive
 
       - name: Setup SSH agent
-        if: ${{ env.SSH_PRIVATE_KEY != '' }}
+        if: env.SSH_PRIVATE_KEY != ''
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
@@ -473,7 +473,7 @@ jobs:
           docker buildx build \
             --platform "${PLATFORMS}" \
             --tag "${DOCKER_IMAGE}:${REVISION}" \
-            $( [[ "${GITHUB_REF}" == "refs/heads/master" ]] && printf %s "--tag ${DOCKER_IMAGE}:nightly" ) \
+            $( [[ "${IS_MASTER}" == "true" ]] && printf %s "--tag ${DOCKER_IMAGE}:nightly" ) \
             --file Dockerfile.release \
             --push \
             .
@@ -557,7 +557,7 @@ jobs:
           docker buildx build \
             --platform "${PLATFORMS}" \
             --tag "${AR_DOCKER_IMAGE}:${REVISION}" \
-            $( [[ "${GITHUB_REF}" == "refs/heads/master" ]] && printf %s "--tag ${AR_DOCKER_IMAGE}:latest" ) \
+            $( [[ "${IS_MASTER}" == "true" ]] && printf %s "--tag ${AR_DOCKER_IMAGE}:latest" ) \
             --file Dockerfile.release \
             --push \
             .
@@ -572,7 +572,7 @@ jobs:
       matrix:
         image_name: ["relay"] # Don't publish relay-pop (for now)
 
-    if: ${{ (github.ref_name == 'master') }}
+    if: github.event_name == 'merge_group' 
 
     env:
       GHCR_DOCKER_IMAGE: "ghcr.io/getsentry/${{ matrix.image_name }}"
@@ -644,7 +644,7 @@ jobs:
         run: docker buildx imagetools create --tag "${AR_DOCKER_IMAGE}:${REVISION}" "${GHCR_DOCKER_IMAGE}:${REVISION}"
 
       - name: Copy Nightly from GHCR to AR
-        if: github.ref == 'refs/heads/master'
+        if: env.IS_MASTER == 'true'
         run: docker buildx imagetools create --tag "${AR_DOCKER_IMAGE}:nightly" "${GHCR_DOCKER_IMAGE}:nightly"
 
   gocd-artifacts:
@@ -772,7 +772,7 @@ jobs:
           key: ${{ github.job }}
 
       - name: Setup SSH agent
-        if: ${{ env.SSH_PRIVATE_KEY != '' }}
+        if: env.SSH_PRIVATE_KEY != ''
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
@@ -861,7 +861,7 @@ jobs:
   validate-devservices-config:
       runs-on: ubuntu-24.04
       needs: devservices-files-changed
-      if: ${{ needs.devservices-files-changed.outputs.devservices-files-changed == 'true' }}
+      if: needs.devservices-files-changed.outputs.devservices-files-changed == 'true'
       steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         name: Checkout repository


### PR DESCRIPTION
This might not work for all commits that are added not through the merge queue, but that would only be a new release, in which the pipeline should have already ran within the release branch.

#skip-changelog