### PR TITLE
feat(ai): Conditionally set `total_cost` and `total_tokens` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Derive a `sentry.description` attribute for V2 spans ([#4832](https://github.com/getsentry/relay/pull/4832))
 - Consider `gen_ai` also as AI span op prefix. ([#4859](https://github.com/getsentry/relay/pull/4859))
 - Change pii scrubbing on some AI attributes to optional ([#4860](https://github.com/getsentry/relay/pull/4860))
+- Conditionally set `total_cost` and `total_tokens` attributes on AI spans. ([#4868](https://github.com/getsentry/relay/pull/4868))
 
 ## 25.6.1
 

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -26,7 +26,7 @@ fn calculate_ai_model_cost(model_cost: Option<ModelCostV2>, data: &SpanData) -> 
         .value()
         .and_then(Value::as_f64);
 
-    if input_tokens_used.is_none() || output_tokens_used.is_none() {
+    if input_tokens_used.is_none() && output_tokens_used.is_none() {
         return None;
     }
 
@@ -79,8 +79,8 @@ pub fn map_ai_measurements_to_data(span: &mut Span) {
             .value()
             .and_then(Value::as_f64);
 
-        if input_tokens.is_none() || output_tokens.is_none() {
-            // don't set total_tokens if there are no input or output tokens
+        if input_tokens.is_none() && output_tokens.is_none() {
+            // don't set total_tokens if there are no input nor output tokens
             return;
         }
 


### PR DESCRIPTION
Currently we always set `total_cost` and `total_tokens` attributes on every AI span, even if `input_tokens` or `output_tokens` are not present.

At the moment, that is not the behavior we want, since for example we have spans that are just invoking agent and it has no cost nor any tokens are used, so setting this attributes is wrong.

This also shows up then in UI and additionally confusing users