### PR TITLE
ref(global-config): Remove deprecated fields

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -207,24 +207,6 @@ pub struct Options {
     )]
     pub drop_transaction_attachments: bool,
 
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(
-        rename = "profiling.profile_metrics.unsampled_profiles.platforms",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "Vec::is_empty"
-    )]
-    pub deprecated1: Vec<String>,
-
-    /// Deprecated, still forwarded for older downstream Relays.
-    #[doc(hidden)]
-    #[serde(
-        rename = "profiling.profile_metrics.unsampled_profiles.sample_rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub deprecated2: f32,
-
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,


### PR DESCRIPTION
Deprecated/Removed options are still forwarded and these options have been deprecated for > 10 months.

#skip-changelog