### PR TITLE
feat(unreal): Preserve values from the incoming event object over properties pulled from the Unreal context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**:
 
+- Preserve user specified event values in Unreal crash reports. ([#4882](https://github.com/getsentry/relay/pull/4882))
 - OS name parsing of Unreal crash reports. ([#4854](https://github.com/getsentry/relay/pull/4854))
 
 **Internal**:


### PR DESCRIPTION
This PR modifies how values coming from the Unreal-generated "crash context" are merged into the event object deserialized from the `__sentry` property. With this change, properties of the event are only written if they are not empty, to avoid overriding values that were set manually from the client SDK. This should help with issues such as #4834 by allowing clients to explicitly set the value of the `os.name` context and not have it be overwritten by the `OsVersion` emitted by Unreal. I've added an additional test case to verify that values set in the incoming event are properly preserved, but even though I didn't have to modify any existing test case I think this might be a breaking change since values that were explicitly set from the SDK will now be preserved.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
