### PR TITLE
fix(relay): do not infer geo information if already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - OS name parsing of Unreal crash reports. ([#4854](https://github.com/getsentry/relay/pull/4854))
+- Do not overwrite geo information if already set. ([#4888](https://github.com/getsentry/relay/pull/4888))
 
 **Internal**:
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -514,6 +514,10 @@ pub fn normalize_user_geoinfo(
     ip_addr: Option<&IpAddr>,
 ) {
     let user = user.value_mut().get_or_insert_with(User::default);
+    // The event was already populated with geo information so we don't have to do anything.
+    if user.geo.value().is_some() {
+        return;
+    }
     if let Some(ip_address) = user
         .ip_address
         .value()

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -428,7 +428,40 @@ def test_geo_inferred_without_user_ip(
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected_ip
     # Geo is always present
-    assert event["user"]["geo"] is not None
+    assert event["user"]["geo"] == {
+        "city": "Boxford",
+        "country_code": "GB",
+        "region": "United Kingdom",
+        "subdivision": "England",
+    }
+
+
+@pytest.mark.parametrize(
+    "scrub_ip_addresses, expected_ip", [(True, None), (False, "2.125.160.216")]
+)
+def test_geo_is_not_overwritten(mini_sentry, relay, scrub_ip_addresses, expected_ip):
+    project_id = 42
+    relay = relay(
+        mini_sentry,
+        options={"geoip": {"path": "tests/fixtures/GeoIP2-Enterprise-Test.mmdb"}},
+    )
+
+    config = mini_sentry.add_basic_project_config(project_id)
+    config["config"].setdefault("datascrubbingSettings", {})[
+        "scrubIpAddresses"
+    ] = scrub_ip_addresses
+
+    relay.send_event(
+        project_id,
+        {"user": {"ip_address": "{{auto}}", "geo": {"city": "CoolCity"}}},
+        headers={"X-Forwarded-For": "2.125.160.216"},
+    )
+
+    envelope = mini_sentry.captured_events.get(timeout=1)
+    event = envelope.get_event()
+    assert event.get("user", {}).get("ip_address", None) == expected_ip
+    # Geo is always present
+    assert event["user"]["geo"] == {"city": "CoolCity"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes a bug where relay would overwrite geo information even if data was already provided