### PR TITLE
Reapply "fix(unreal): Fix unreal crash reporter OS names, improve os name parsing"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- OS name parsing of Unreal crash reports. ([#4854](https://github.com/getsentry/relay/pull/4854))
+
 **Internal**:
 
 - Forward logs to Kafka directly instead of serialized as envelope. ([#4875](https://github.com/getsentry/relay/pull/4875))

--- a/relay-event-normalization/src/normalize/contexts.rs
+++ b/relay-event-normalization/src/normalize/contexts.rs
@@ -11,7 +11,7 @@ use relay_protocol::{Annotated, Empty, Value};
 
 /// Environment.OSVersion (GetVersionEx) or RuntimeInformation.OSDescription on Windows
 static OS_WINDOWS_REGEX1: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(Microsoft )?Windows (NT )?(?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$")
+    Regex::new(r"^(Microsoft\s+)?Windows\s+(NT\s+)?(?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$")
         .unwrap()
 });
 static OS_WINDOWS_REGEX2: Lazy<Regex> = Lazy::new(|| {
@@ -179,6 +179,28 @@ fn get_windows_version(description: &str) -> Option<(&str, &str)> {
     Some((version_name, build_number_str))
 }
 
+/// Simple marketing names in the form `<OS> <version>`.
+fn get_marketing_name(description: &str) -> Option<(&str, &str)> {
+    let (name, version) = description.split_once(' ')?;
+    let name = name.trim();
+    let version = version.trim();
+
+    // Validate if it looks like a reasonable name.
+    if name.bytes().any(|c| !c.is_ascii_alphabetic()) {
+        return None;
+    }
+
+    // Validate if it looks like a reasonable version.
+    if version
+        .bytes()
+        .any(|c| !matches!(c, b'0'..=b'9' | b'.' | b'-'))
+    {
+        return None;
+    }
+
+    Some((name, version))
+}
+
 #[allow(dead_code)]
 /// Returns the API version of an Android description.
 ///
@@ -221,19 +243,11 @@ fn normalize_os_context(os: &mut OsContext) {
                 .name("version")
                 .map(|m| m.as_str().to_owned())
                 .into();
-            os.build = captures
-                .name("build")
-                .map(|m| m.as_str().to_owned().into())
-                .into();
         } else if let Some(captures) = OS_IPADOS_REGEX.captures(raw_description) {
             os.name = "iPadOS".to_owned().into();
             os.version = captures
                 .name("version")
                 .map(|m| m.as_str().to_owned())
-                .into();
-            os.build = captures
-                .name("build")
-                .map(|m| m.as_str().to_owned().into())
                 .into();
         } else if let Some(captures) = OS_LINUX_DISTRO_UNAME_REGEX.captures(raw_description) {
             os.name = captures.name("name").map(|m| m.as_str().to_owned()).into();
@@ -259,6 +273,9 @@ fn normalize_os_context(os: &mut OsContext) {
                 .into();
         } else if raw_description == "Nintendo Switch" {
             os.name = "Nintendo OS".to_owned().into();
+        } else if let Some((name, version)) = get_marketing_name(raw_description) {
+            os.name = name.to_owned().into();
+            os.version = version.to_owned().into();
         }
     }
 
@@ -730,6 +747,17 @@ mod tests {
     fn test_unity_android_api_version() {
         let description = "Android OS 11 / API-30 (RP1A.201005.001/2107031736)";
         assert_eq!(Some("30"), get_android_api_version(description));
+    }
+
+    #[test]
+    fn test_unreal_windows_os() {
+        let mut os = OsContext {
+            raw_description: "Windows 10".to_owned().into(),
+            ..OsContext::default()
+        };
+        normalize_os_context(&mut os);
+        assert_eq!(Some("Windows"), os.name.as_str());
+        assert_eq!(Some("10"), os.version.as_str());
     }
 
     #[test]

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context.snap
@@ -24,7 +24,7 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "type": "gpu"
     },
     "os": {
-      "name": "Windows 10",
+      "raw_description": "Windows 10",
       "type": "os"
     },
     "unreal": {

--- a/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
+++ b/relay-server/src/utils/snapshots/relay_server__utils__unreal__tests__merge_unreal_context_event.snap
@@ -20,7 +20,7 @@ expression: "Annotated::new(event).to_json_pretty().unwrap()"
       "type": "gpu"
     },
     "os": {
-      "name": "Windows 10",
+      "raw_description": "Windows 10",
       "type": "os"
     },
     "unreal": {

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -238,7 +238,7 @@ fn merge_unreal_context(event: &mut Event, context: Unreal4Context) {
     // OS information is likely overwritten by Minidump processing later.
     if let Some(os_major) = runtime_props.misc_os_version_major.take() {
         let os_context = contexts.get_or_default::<OsContext>();
-        os_context.name = Annotated::new(os_major);
+        os_context.raw_description = Annotated::new(os_major);
     }
 
     // See https://github.com/EpicGames/UnrealEngine/blob/5.3.2-release/Engine/Source/Runtime/RHI/Private/DynamicRHI.cpp#L368-L376


### PR DESCRIPTION
This reverts commit 46bdd96920084a6558229f4f94731fd10c354529.

Re-apply of #4854, now with disabled Sentry tests (snapshots outdated).

Disabled here: https://github.com/getsentry/sentry/pull/94767


#skip-changelog