### PR TITLE
fix(spans): Filter measurements in store service

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1012,6 +1012,11 @@ impl StoreService {
             }
         };
 
+        // Discard measurements with empty `value`s.
+        if let Some(measurements) = &mut span.measurements {
+            measurements.retain(|_, v| v.as_ref().and_then(|v| v.value).is_some());
+        }
+
         span.backfill_data();
         span.duration_ms =
             ((span.end_timestamp_precise - span.start_timestamp_precise) * 1e3) as u32;


### PR DESCRIPTION
#4845 [removed](https://github.com/getsentry/relay/pull/4845/files#diff-d6c21d4aad387e798a96b09e540548dd6efd801a5ba9c08e5a4049857e1abe89L917-L920) a check that discarded infinite measurement values because measurements had been re-typed to `FiniteF64`. Unfortunately the removed check also discarded measurements with _empty_ values, and such measurements now made it through to Snuba. This reinstitutes the check for empty values.

#skip-changelog