### PR TITLE
feat(ai): Fallback attribute for model name for cost calculation

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2348,6 +2348,20 @@ mod tests {
                             "gen_ai.usage.output_tokens": 2000,
                             "gen_ai.request.model": "gpt4-21-04"
                         }
+                    },
+                    {
+                        "timestamp": 1702474614.0175,
+                        "start_timestamp": 1702474613.0175,
+                        "description": "OpenAI ",
+                        "op": "gen_ai.chat_completions.openai",
+                        "span_id": "ac01bd820a083e63",
+                        "parent_span_id": "a1e13f3f06239d69",
+                        "trace_id": "922dda2462ea4ac2b6a4b339bee90863",
+                        "data": {
+                            "gen_ai.usage.input_tokens": 1000,
+                            "gen_ai.usage.output_tokens": 2000,
+                            "gen_ai.response.model": "gpt4-21-04"
+                        }
                     }
                 ]
             }
@@ -2387,7 +2401,7 @@ mod tests {
         );
 
         let spans = event.value().unwrap().spans.value().unwrap();
-        assert_eq!(spans.len(), 2);
+        assert_eq!(spans.len(), 3);
         let first_span_data = spans
             .first()
             .and_then(|span| span.value())
@@ -2416,6 +2430,16 @@ mod tests {
         assert_eq!(
             second_span_data.and_then(|data| data.gen_ai_response_tokens_per_second.value()),
             Some(&Value::F64(2000.0))
+        );
+
+        // Cost calculation when there is only gen_ai.response.model present
+        let third_span_data = spans
+            .get(2)
+            .and_then(|span| span.value())
+            .and_then(|span| span.data.value());
+        assert_eq!(
+            third_span_data.and_then(|data| data.gen_ai_usage_total_cost.value()),
+            Some(&Value::F64(190.0))
         );
     }
 

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -125,6 +125,11 @@ pub fn extract_ai_data(span: &mut Span, ai_model_costs: &ModelCosts) {
         // xxx (vgrozdanic): temporal fallback to legacy field, until we fix
         // sentry conventions and standardize what SDKs send
         .or_else(|| data.ai_model_id.value().and_then(|val| val.as_str()))
+        .or_else(|| {
+            data.gen_ai_response_model
+                .value()
+                .and_then(|val| val.as_str())
+        })
     {
         if let Some(total_cost) =
             calculate_ai_model_cost(ai_model_costs.cost_per_token(model_id), data)


### PR DESCRIPTION
Some SDKs are only sending `gen_ai.response.model` instead of `gen_ai.request.model` (or both), so this is additional fallback for those cases.

Currently Vercel AI SDK is the only SDK that does this, but Abhi has already started working on upstream changes, so hopefully this will soon be removed, and this whole logic will be updated.

At the moment, it's a huge mess what each SDK reports, as some reports only `gen_ai.request.model` attribute, and some only `gen_ai.response.model` attribute, but our SDK team is working hard to standardize this.

#skip-changelog