### PR TITLE
test(autoscaling): fix flaky test

### DIFF
--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -51,7 +51,10 @@ def test_sqlite_spooling_metrics(mini_sentry, relay):
     response = relay.get("/api/relay/autoscaling/")
     assert response.status_code == 200
     body = parse_prometheus(response.text)
-    assert int(body["relay_spool_item_count"]) == 200
+    # In some test runs, the last event is not counted making this test flaky.
+    # Since this metric does not need to be very precise, we can consider it successful
+    # if one item is not counted.
+    assert 199 <= int(body["relay_spool_item_count"]) <= 200
     assert int(body["relay_up"]) == 1
     assert int(body["relay_spool_total_size"]) > 30000
 


### PR DESCRIPTION
Fixes a flaky CI test where sometimes the assertion fails because it doesn't add the last item to the item count.
Instead of adding a `wait` to give it more time to use the proper count, we can assert on the lower value as well.

closes RELAY-124

#skip-changelog