### PR TITLE
ref(server): Make the ourlog header a part of the item container

### DIFF
--- a/relay-event-schema/src/protocol/ourlog.rs
+++ b/relay-event-schema/src/protocol/ourlog.rs
@@ -1,7 +1,8 @@
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, SkipSerialization, Value};
+use std::collections::BTreeMap;
 use std::fmt::{self, Display};
 
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::processor::ProcessValue;
 use crate::protocol::{Attributes, SpanId, Timestamp, TraceId};
@@ -33,15 +34,6 @@ pub struct OurLog {
     #[metastructure(pii = "true", trim = false)]
     pub attributes: Annotated<Attributes>,
 
-    /// Relay internal metadata associated with the log item.
-    ///
-    /// Temporary solution until Relay has a better mechanism to transport metadata with an item
-    /// contained in an item container.
-    ///
-    /// See: <https://github.com/getsentry/relay/issues/4881>.
-    #[metastructure(pii = "false", trim = false)]
-    pub __headers: Annotated<OurLogHeaders>,
-
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = true, pii = "maybe")]
     pub other: Object<Value>,
@@ -51,13 +43,17 @@ pub struct OurLog {
 ///
 /// This metadata is purely an internal protocol extension used by Relay,
 /// no one except Relay should be sending this data, nor should anyone except Relay rely on it.
-#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
-pub struct OurLogHeaders {
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct OurLogHeader {
     /// Original (calculated) size of the log item when it was first received by a Relay.
     ///
     /// If this value exists, Relay uses it as quantity for all outcomes emitted to the
     /// log byte data category.
-    pub byte_size: Annotated<u64>,
+    pub byte_size: Option<u64>,
+
+    /// Forward compatibility for additional headers.
+    #[serde(flatten)]
+    pub other: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -103,7 +103,6 @@ pub fn otel_to_sentry_log(otel_log: OtelLog, received_at: DateTime<Utc>) -> Resu
         level: Annotated::new(level),
         attributes: Annotated::new(attribute_data),
         body: Annotated::new(body),
-        __headers: Annotated::empty(),
         other: Object::default(),
     };
 

--- a/relay-ourlogs/src/size.rs
+++ b/relay-ourlogs/src/size.rs
@@ -15,6 +15,7 @@ use relay_protocol::{Annotated, Value};
 /// Complex types like objects and arrays are counted as the sum of all contained simple data types.
 ///
 /// Considered for the size of a log are all attribute keys, values and the log message body.
+/// An empty log (no message, no attributes) is counted as 1 byte.
 ///
 /// The byte size should only be calculated once before any processing, enrichment and other
 /// modifications done by Relay.
@@ -31,7 +32,7 @@ pub fn calculate_size(log: &OurLog) -> u64 {
             .sum::<usize>();
     }
 
-    u64::try_from(total_size).unwrap_or(u64::MAX)
+    u64::try_from(total_size).unwrap_or(u64::MAX).max(1)
 }
 
 /// Calculates the size of a single attribute.
@@ -295,5 +296,10 @@ mod tests {
             }
         }"#
         );
+    }
+
+    #[test]
+    fn test_calculate_size_empty_log_is_1byte() {
+        assert_calculated_size_of!(1, r#"{}"#);
     }
 }

--- a/relay-server/src/envelope/container.rs
+++ b/relay-server/src/envelope/container.rs
@@ -1,12 +1,11 @@
-use std::marker::PhantomData;
+use std::collections::BTreeMap;
 
 use bytes::BufMut;
 use relay_protocol::{
     Annotated, DeserializableAnnotated, FromValue, IntoValue, SerializableAnnotated,
 };
-use serde::ser::SerializeSeq;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize, de, ser};
-use smallvec::SmallVec;
 
 use crate::envelope::{ContentType, Item, ItemType};
 
@@ -54,10 +53,109 @@ pub trait ContainerItem: FromValue + IntoValue {
     const ITEM_TYPE: ItemType;
     /// The expected content type of the container for this type.
     const CONTENT_TYPE: ContentType;
+
+    /// Header associated with the item.
+    ///
+    /// The header will be automatically serialized and de-serialized by the [`ItemContainer`].
+    /// All headers must be de-serialized from and into an object keyed with a string.
+    ///
+    /// To ensure compatibility, Relay should almost always make sure each header is optional
+    /// or has a default defined.
+    ///
+    /// Use [`NoHeader`] when there are no explicit headers defined.
+    type Header: DeserializeOwned + Serialize + std::fmt::Debug;
+}
+
+/// A header implementation for [`container items`](ContainerItem) which currently do not have any
+/// headers defined.
+///
+/// The implementation makes sure headers are forward compatible and passed a long.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct NoHeader(BTreeMap<String, relay_protocol::Value>);
+
+#[derive(Debug)]
+pub struct WithHeader<T: ContainerItem> {
+    /// Optionally associated header with the item/value.
+    pub header: Option<T::Header>,
+    /// The value contained in a item container.
+    pub value: Annotated<T>,
+}
+
+impl<T: ContainerItem> WithHeader<T> {
+    /// Creates a [`Self`] from just a value with no associated header.
+    ///
+    /// This should only be used when creating new items, in most cases existing headers should be
+    /// respected and explicitly handled and passed along.
+    pub fn just(value: Annotated<T>) -> Self {
+        Self {
+            header: None,
+            value,
+        }
+    }
+}
+
+impl<T: ContainerItem> std::ops::Deref for WithHeader<T> {
+    type Target = Annotated<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T: ContainerItem> std::ops::DerefMut for WithHeader<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<'de, T: ContainerItem> Deserialize<'de> for WithHeader<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(bound(deserialize = "T: ContainerItem"))]
+        struct Inner<T: ContainerItem> {
+            #[serde(rename = "__header")]
+            header: Option<T::Header>,
+            #[serde(flatten)]
+            value: DeserializableAnnotated<T>,
+        }
+
+        let Inner { header, value } = Inner::<T>::deserialize(deserializer)?;
+        Ok(Self {
+            header,
+            value: value.0,
+        })
+    }
+}
+
+impl<T: ContainerItem> Serialize for WithHeader<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(bound(serialize = "T: ContainerItem"))]
+        struct Inner<'a, T: ContainerItem> {
+            #[serde(rename = "__header", skip_serializing_if = "Option::is_none")]
+            header: Option<&'a T::Header>,
+            #[serde(flatten)]
+            value: SerializableAnnotated<'a, T>,
+        }
+
+        let inner = Inner {
+            header: self.header.as_ref(),
+            value: SerializableAnnotated(&self.value),
+        };
+
+        inner.serialize(serializer)
+    }
 }
 
 /// A list of items in an item container.
-pub type ContainerItems<T> = SmallVec<[Annotated<T>; 3]>;
+pub type ContainerItems<T> = Vec<WithHeader<T>>;
 
 /// A container for multiple homogeneous envelope items.
 ///
@@ -72,20 +170,18 @@ pub type ContainerItems<T> = SmallVec<[Annotated<T>; 3]>;
 /// An item container does not have a special [`super::ItemType`], but is identified by the
 /// content type of the item.
 #[derive(Debug)]
-pub struct ItemContainer<T> {
+pub struct ItemContainer<T: ContainerItem> {
     items: ContainerItems<T>,
 }
 
-impl<T> ItemContainer<T> {
+impl<T: ContainerItem> ItemContainer<T> {
     /// Returns all contained items.
     ///
     /// The container can be reconstructed using [`ItemContainer::from`].
     pub fn into_items(self) -> ContainerItems<T> {
         self.items
     }
-}
 
-impl<T: ContainerItem> ItemContainer<T> {
     /// Parses an [`ItemContainer`] from an envelope [`Item`].
     ///
     /// This function also validates metadata of the container, specifically the content type
@@ -146,147 +242,91 @@ impl<T: ContainerItem> ItemContainer<T> {
 
     fn deserialize<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
-        struct Layout<T> {
-            #[serde(bound(deserialize = "T: FromValue"))]
-            items: AnnotatedItems<T>,
+        #[serde(bound(deserialize = "T: ContainerItem"))]
+        struct Layout<T: ContainerItem> {
+            items: ContainerItems<T>,
         }
 
-        let Layout {
-            items: AnnotatedItems(items),
-        } = Layout::<T>::deserialize(deserializer)?;
+        let Layout { items } = Layout::<T>::deserialize(deserializer)?;
 
         Ok(Self { items })
     }
 
     fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         #[derive(Serialize)]
-        struct Layout<'a, T> {
-            #[serde(bound(serialize = "T: IntoValue"))]
-            items: AnnotatedItemsRef<'a, T>,
+        #[serde(bound(serialize = "T: ContainerItem"))]
+        struct Layout<'a, T: ContainerItem> {
+            items: &'a ContainerItems<T>,
         }
 
-        let layout = Layout {
-            items: AnnotatedItemsRef(&self.items),
-        };
-
+        let layout = Layout { items: &self.items };
         Serialize::serialize(&layout, serializer)
     }
 }
 
-impl<T> From<ContainerItems<T>> for ItemContainer<T> {
+impl<T: ContainerItem> From<ContainerItems<T>> for ItemContainer<T> {
     fn from(items: ContainerItems<T>) -> Self {
         Self { items }
-    }
-}
-
-impl<T> From<Vec<Annotated<T>>> for ItemContainer<T> {
-    fn from(items: Vec<Annotated<T>>) -> Self {
-        ContainerItems::from_vec(items).into()
     }
 }
 
 impl ContainerItem for relay_event_schema::protocol::OurLog {
     const ITEM_TYPE: ItemType = ItemType::Log;
     const CONTENT_TYPE: ContentType = ContentType::LogContainer;
+
+    type Header = relay_event_schema::protocol::OurLogHeader;
 }
 
 impl ContainerItem for relay_event_schema::protocol::SpanV2 {
     const ITEM_TYPE: ItemType = ItemType::Span;
     const CONTENT_TYPE: ContentType = ContentType::SpanV2Container;
-}
 
-/// (De-)Serializes a list of Annotated items with metadata.
-#[derive(Debug)]
-struct AnnotatedItems<T>(ContainerItems<T>);
-
-impl<'de, T> Deserialize<'de> for AnnotatedItems<T>
-where
-    T: FromValue,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct Visitor<T>(PhantomData<T>);
-
-        impl<'de, T> de::Visitor<'de> for Visitor<T>
-        where
-            T: FromValue,
-        {
-            type Value = AnnotatedItems<T>;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a list of envelope items")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: de::SeqAccess<'de>,
-            {
-                let mut items = ContainerItems::new();
-                if let Some(size) = seq.size_hint() {
-                    items.reserve_exact(size);
-                }
-
-                while let Some(DeserializableAnnotated(item)) = seq.next_element()? {
-                    items.push(item);
-                }
-
-                Ok(AnnotatedItems(items))
-            }
-        }
-
-        deserializer.deserialize_seq(Visitor(Default::default()))
-    }
-}
-
-struct AnnotatedItemsRef<'a, T>(&'a ContainerItems<T>);
-
-impl<T> Serialize for AnnotatedItemsRef<'_, T>
-where
-    T: IntoValue,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for item in self.0 {
-            seq.serialize_element(&SerializableAnnotated(item))?;
-        }
-        seq.end()
-    }
+    type Header = NoHeader;
 }
 
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
     use insta::assert_debug_snapshot;
-    use relay_protocol::Empty;
+    use relay_protocol::{Empty, Object, Value};
 
     use crate::envelope::ItemType;
 
     use super::*;
 
+    macro_rules! container {
+        ($header:literal, $($item:literal),*) => {
+            concat!($header, "\n", r#"{"items":["#, $($item),*, r#"]}"#).as_bytes()
+        }
+    }
+
     #[derive(Debug, Empty, IntoValue, FromValue)]
     struct TestLog {
         level: Annotated<String>,
         message: Annotated<String>,
+
+        #[metastructure(additional_properties)]
+        other: Object<Value>,
     }
+
     impl ContainerItem for TestLog {
         const ITEM_TYPE: ItemType = ItemType::Log;
         const CONTENT_TYPE: ContentType = ContentType::LogContainer;
+
+        type Header = NoHeader;
     }
 
     fn logs<'a>(logs: impl IntoIterator<Item = (&'a str, &'a str)>) -> ItemContainer<TestLog> {
-        let items: ContainerItems<_> = logs
+        let items = logs
             .into_iter()
             .map(|(level, message)| TestLog {
                 level: Annotated::new(level.to_owned()),
                 message: Annotated::new(message.to_owned()),
+                other: Default::default(),
             })
             .map(Annotated::new)
-            .collect();
+            .map(WithHeader::just)
+            .collect::<Vec<_>>();
 
         ItemContainer::from(items)
     }
@@ -308,11 +348,10 @@ mod tests {
 
     #[test]
     fn test_container_deserialize_invalid_item_count() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}
-{"items":[{"level":"info","message":"foobar"}]}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}"#,
+            r#"{"level":"info","message":"foobar"}"#
+        )))
         .unwrap();
 
         assert_eq!(item.item_count(), Some(2));
@@ -327,11 +366,10 @@ mod tests {
 
     #[test]
     fn test_container_deserialize_invalid_content_type() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"log","content_type":"application/json","item_count":1}
-{"items":[{"level":"info","message":"foobar"}]}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","content_type":"application/json","item_count":1}"#,
+            r#"{"level":"info","message":"foobar"},"#
+        )))
         .unwrap();
 
         assert_eq!(item.item_count(), Some(1));
@@ -346,11 +384,10 @@ mod tests {
 
     #[test]
     fn test_container_deserialize_invalid_item_type() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"span","content_type":"application/vnd.sentry.items.log+json","item_count":1}
-{"items":[{"level":"info","message":"foobar"}]}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"span","content_type":"application/vnd.sentry.items.log+json","item_count":1}"#,
+            r#"{"level":"info","message":"foobar"},"#
+        )))
         .unwrap();
 
         assert_eq!(item.item_count(), Some(1));
@@ -365,11 +402,10 @@ mod tests {
 
     #[test]
     fn test_container_deserialize_missing_content_type() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"log","item_count":1}
-{"items":[{"level":"info","message":"foobar"}]}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","item_count":1}"#,
+            r#"{"level":"info","message":"foobar"},"#
+        )))
         .unwrap();
 
         assert_eq!(item.item_count(), Some(1));
@@ -400,11 +436,10 @@ mod tests {
 
     #[test]
     fn test_container_deserialize_unexpected_type() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":1}
-{"items":{"level":"info","message":"foobar"}}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":1}"#,
+            r#"{"level":"info","message":"foobar"},"#
+        )))
         .unwrap();
 
         assert_eq!(item.item_count(), Some(1));
@@ -416,11 +451,11 @@ mod tests {
 
     #[test]
     fn test_container_deserialize_successful() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}
-{"items":[{"level":"info","message":"foobar"},{"level":"error","message":"ohno"}]}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}"#,
+            r#"{"level":"info","message":"foobar"},"#,
+            r#"{"level":"error","message":"ohno"}"#
+        )))
         .unwrap();
 
         assert_eq!(item.item_count(), Some(2));
@@ -429,13 +464,21 @@ mod tests {
         assert_debug_snapshot!(container, @r###"
         ItemContainer {
             items: [
-                TestLog {
-                    level: "info",
-                    message: "foobar",
+                WithHeader {
+                    header: None,
+                    value: TestLog {
+                        level: "info",
+                        message: "foobar",
+                        other: {},
+                    },
                 },
-                TestLog {
-                    level: "error",
-                    message: "ohno",
+                WithHeader {
+                    header: None,
+                    value: TestLog {
+                        level: "error",
+                        message: "ohno",
+                        other: {},
+                    },
                 },
             ],
         }
@@ -444,11 +487,11 @@ mod tests {
 
     #[test]
     fn test_container_roundtrip() {
-        let (item, _) = Item::parse(Bytes::from_static(
-            br#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}
-{"items":[{"level":"info","message":"foobar"},{"level":"error","message":"ohno"}]}
-        "#,
-        ))
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}"#,
+            r#"{"level":"info","message":"foobar"},"#,
+            r#"{"level":"error","message":"ohno"}"#
+        )))
         .unwrap();
 
         let container = ItemContainer::<TestLog>::parse(&item).unwrap();
@@ -459,16 +502,90 @@ mod tests {
         assert_debug_snapshot!(container, @r###"
         ItemContainer {
             items: [
-                TestLog {
-                    level: "info",
-                    message: "foobar",
+                WithHeader {
+                    header: None,
+                    value: TestLog {
+                        level: "info",
+                        message: "foobar",
+                        other: {},
+                    },
                 },
-                TestLog {
-                    level: "error",
-                    message: "ohno",
+                WithHeader {
+                    header: None,
+                    value: TestLog {
+                        level: "error",
+                        message: "ohno",
+                        other: {},
+                    },
                 },
             ],
         }
         "###);
+    }
+
+    #[test]
+    fn test_container_with_headers() {
+        let (item, _) = Item::parse(Bytes::from_static(container!(
+            r#"{"type":"log","content_type":"application/vnd.sentry.items.log+json","item_count":2}"#,
+            r#"{"__header":{},"level":"info","message":"foobar"},"#,
+            r#"{"__header":{"foo":[1,"bar"]},"level":"error","message":"ohno"}"#
+        )))
+        .unwrap();
+
+        let container = ItemContainer::<TestLog>::parse(&item).unwrap();
+        let mut new_item = Item::new(ItemType::Log);
+        container.write_to(&mut new_item).unwrap();
+
+        let container = ItemContainer::<TestLog>::parse(&new_item).unwrap();
+        assert_debug_snapshot!(container, @r###"
+        ItemContainer {
+            items: [
+                WithHeader {
+                    header: Some(
+                        NoHeader(
+                            {},
+                        ),
+                    ),
+                    value: TestLog {
+                        level: "info",
+                        message: "foobar",
+                        other: {},
+                    },
+                },
+                WithHeader {
+                    header: Some(
+                        NoHeader(
+                            {
+                                "foo": Array(
+                                    [
+                                        I64(
+                                            1,
+                                        ),
+                                        String(
+                                            "bar",
+                                        ),
+                                    ],
+                                ),
+                            },
+                        ),
+                    ),
+                    value: TestLog {
+                        level: "error",
+                        message: "ohno",
+                        other: {},
+                    },
+                },
+            ],
+        }
+        "###);
+
+        let mut new_item = Item::new(ItemType::Log);
+        container.write_to(&mut new_item).unwrap();
+
+        // Make sure the headers serialize back in the original format.
+        //
+        // The test is engineered to have a matching serialization as the original test input,
+        // e.g. correct order of fields.
+        assert_eq!(new_item.payload(), item.payload());
     }
 }

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -1,9 +1,8 @@
 use relay_event_schema::protocol::OurLog;
-use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 use smallvec::SmallVec;
 
-use crate::envelope::Item;
+use crate::envelope::{Item, WithHeader};
 use crate::utils::EnvelopeSummary;
 use crate::{Envelope, processing};
 
@@ -76,7 +75,7 @@ impl Counted for Box<Envelope> {
     }
 }
 
-impl Counted for Annotated<OurLog> {
+impl Counted for WithHeader<OurLog> {
     fn quantities(&self) -> Quantities {
         smallvec::smallvec![
             (DataCategory::LogItem, 1),

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::OurLog;
 use relay_pii::PiiConfigError;
-use relay_protocol::Annotated;
 use relay_quotas::{DataCategory, RateLimits};
 
 use crate::Envelope;
-use crate::envelope::{ContainerWriteError, EnvelopeHeaders, Item, ItemContainer, ItemType, Items};
+use crate::envelope::{
+    ContainerItems, ContainerWriteError, EnvelopeHeaders, Item, ItemContainer, ItemType, Items,
+};
 use crate::managed::{
     Counted, Managed, ManagedEnvelope, ManagedResult as _, OutcomeError, Quantities,
 };
@@ -286,7 +287,7 @@ pub struct ExpandedLogs {
     #[cfg(feature = "processing")]
     retention: Option<u16>,
     /// Expanded and parsed logs.
-    logs: Vec<Annotated<OurLog>>,
+    logs: ContainerItems<OurLog>,
 }
 
 impl Counted for ExpandedLogs {

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -3,13 +3,13 @@ use relay_event_normalization::{
     ClientHints, FromUserAgentInfo as _, RawUserAgentInfo, SchemaProcessor,
 };
 use relay_event_schema::processor::{ProcessingState, process_value};
-use relay_event_schema::protocol::{AttributeType, BrowserContext, OurLog, OurLogHeaders};
+use relay_event_schema::protocol::{AttributeType, BrowserContext, OurLog, OurLogHeader};
 use relay_ourlogs::OtelLog;
 use relay_pii::PiiProcessor;
 use relay_protocol::{Annotated, ErrorKind, Value};
 use relay_quotas::DataCategory;
 
-use crate::envelope::{ContainerItems, Item, ItemContainer};
+use crate::envelope::{ContainerItems, Item, ItemContainer, WithHeader};
 use crate::extractors::RequestMeta;
 use crate::processing::logs::{Error, ExpandedLogs, Result, SerializedLogs};
 use crate::processing::{Context, Managed};
@@ -61,7 +61,7 @@ pub fn process(logs: &mut Managed<ExpandedLogs>, ctx: Context<'_>) {
     });
 }
 
-fn expand_otel_log(item: &Item, received_at: DateTime<Utc>) -> Result<Annotated<OurLog>> {
+fn expand_otel_log(item: &Item, received_at: DateTime<Utc>) -> Result<WithHeader<OurLog>> {
     let log = serde_json::from_slice::<OtelLog>(&item.payload()).map_err(|err| {
         relay_log::debug!("failed to parse OTel Log: {err}");
         Error::Invalid(DiscardReason::InvalidJson)
@@ -72,17 +72,20 @@ fn expand_otel_log(item: &Item, received_at: DateTime<Utc>) -> Result<Annotated<
         Error::Invalid(DiscardReason::InvalidLog)
     })?;
 
-    let mut log = Annotated::new(log);
-
     // The OTel log conversion already adds certain Sentry attributes which are included in the
     // cost here.
     //
     // As OTel logs are deprecated and to be removed, this is okay for now.
     //
-    // See: https://github.com/getsentry/relay/issues/4884
-    materialize_byte_size(&mut log);
-
-    Ok(log)
+    // See: <https://github.com/getsentry/relay/issues/4884>.
+    let byte_size = Some(relay_ourlogs::calculate_size(&log));
+    Ok(WithHeader {
+        value: Annotated::new(log),
+        header: Some(OurLogHeader {
+            byte_size,
+            other: Default::default(),
+        }),
+    })
 }
 
 fn expand_log_container(item: &Item, received_at: DateTime<Utc>) -> Result<ContainerItems<OurLog>> {
@@ -94,27 +97,23 @@ fn expand_log_container(item: &Item, received_at: DateTime<Utc>) -> Result<Conta
         .into_items();
 
     for log in &mut logs {
-        materialize_byte_size(log);
+        // Manifests the byte size of a log item into the log itself, before making any modifications.
+        //
+        // Relay later may deem certain attributes to be invalid and therefore drop or modify them,
+        // we still keep the original size.
+        if let Some(size) = log.value().map(relay_ourlogs::calculate_size) {
+            let header = log.header.get_or_insert_default();
+            // Unconditionally override the size of the log.
+            //
+            // Once there is processing of logs in other internal Relays, we will have to respect
+            // the value set by the header, if it is coming from an internal Relay.
+            header.byte_size = Some(size);
+        };
+
         relay_ourlogs::ourlog_merge_otel(log, received_at);
     }
 
     Ok(logs)
-}
-
-/// Manifests the byte size of a log item into the log itself.
-///
-/// Relay later may deem certain attributes to be invalid and therefor drop or modify them,
-/// we still keep the original size.
-///
-/// For details on the size calculation see: [`relay_ourlogs::calculate_size`].
-fn materialize_byte_size(log: &mut Annotated<OurLog>) {
-    let Some(log) = log.value_mut() else {
-        return;
-    };
-
-    log.__headers = Annotated::new(OurLogHeaders {
-        byte_size: Annotated::new(relay_ourlogs::calculate_size(log)),
-    });
 }
 
 fn process_log(log: &mut Annotated<OurLog>, meta: &RequestMeta, ctx: Context<'_>) -> Result<()> {

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -9,6 +9,7 @@ use sentry_protos::snuba::v1::{AnyValue, TraceItem, TraceItemType, any_value};
 use uuid::Uuid;
 
 use crate::constants::DEFAULT_EVENT_RETENTION;
+use crate::envelope::WithHeader;
 use crate::processing::Counted;
 use crate::processing::logs::{Error, Result};
 use crate::services::outcome::DiscardReason;
@@ -40,10 +41,10 @@ pub struct Context {
     pub retention: Option<u16>,
 }
 
-pub fn convert(log: Annotated<OurLog>, ctx: &Context) -> Result<StoreLog> {
+pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreLog> {
     let quantities = log.quantities();
 
-    let log = required!(log);
+    let log = required!(log.value);
     let timestamp = required!(log.timestamp);
     let attrs = log.attributes.0.unwrap_or_default();
 

--- a/relay-server/src/processing/logs/utils.rs
+++ b/relay-server/src/processing/logs/utils.rs
@@ -1,5 +1,6 @@
 use relay_event_schema::protocol::OurLog;
-use relay_protocol::Annotated;
+
+use crate::envelope::WithHeader;
 
 /// Returns the calculated size of a [`OurLog`].
 ///
@@ -7,14 +8,10 @@ use relay_protocol::Annotated;
 /// of the log, instead of calculating it.
 ///
 /// When compiled with debug assertion the function asserts the presence of a manifested byte size.
-pub fn get_calculated_byte_size(log: &Annotated<OurLog>) -> usize {
+pub fn get_calculated_byte_size(log: &WithHeader<OurLog>) -> usize {
     // Use the remembered byte size here, as this is the one Relay stored when initially
     // receiving the log item. This will not include any modifications done to the log.
-    let bytes = log
-        .value()
-        .and_then(|v| v.__headers.value())
-        .and_then(|v| v.byte_size.value())
-        .copied();
+    let bytes = log.header.as_ref().and_then(|header| header.byte_size);
 
     debug_assert!(
         bytes.is_some(),

--- a/relay-server/src/processing/logs/utils.rs
+++ b/relay-server/src/processing/logs/utils.rs
@@ -21,7 +21,7 @@ pub fn get_calculated_byte_size(log: &WithHeader<OurLog>) -> usize {
     // Only fall back to a calculated size, when there is nothing stored.
     // This should never happen, logs should have a size assigned to them immediately after
     // they have been expanded.
-    let bytes = bytes.unwrap_or_else(|| log.value().map_or(0, relay_ourlogs::calculate_size));
+    let bytes = bytes.unwrap_or_else(|| log.value().map_or(1, relay_ourlogs::calculate_size));
 
     usize::try_from(bytes).unwrap_or(usize::MAX)
 }

--- a/relay-server/src/services/processor/nel.rs
+++ b/relay-server/src/services/processor/nel.rs
@@ -2,7 +2,7 @@ use relay_event_normalization::nel;
 use relay_event_schema::protocol::{NetworkReportError, OurLog};
 use relay_protocol::Annotated;
 
-use crate::envelope::{ContainerItems, Item, ItemContainer, ItemType};
+use crate::envelope::{ContainerItems, Item, ItemContainer, ItemType, WithHeader};
 use crate::extractors::RequestMeta;
 use crate::managed::ManagedEnvelope;
 use crate::services::processor::ProcessingError;
@@ -15,7 +15,7 @@ pub fn convert_to_logs(envelope: &mut ManagedEnvelope) {
 
     for item in items {
         match log_from_nel_item(&item, envelope.meta()) {
-            Ok(Some(log)) => logs.push(log),
+            Ok(Some(log)) => logs.push(WithHeader::just(log)),
             Ok(None) => {}
             Err(error) => {
                 let mut payload = item.payload();

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -92,7 +92,7 @@ pub fn expand_v2_spans(
         };
 
         for span_v2 in spans_v2.into_items() {
-            let span_v1 = span_v2.map_value(relay_spans::span_v2_to_span_v1);
+            let span_v1 = span_v2.value.map_value(relay_spans::span_v2_to_span_v1);
             match span_v1.to_json() {
                 Ok(payload) => {
                     let mut new_item = Item::new(ItemType::Span);


### PR DESCRIPTION
Makes the `__header` added to the `OurLog` struct officially part of the item container parsing. Each item contained in an item container can have an optional header `__header`.

We might need some future bike-shedding on naming, currently it's named `WithHeader` and largely hidden behind the `ContainerItems` type alias. With some experimentation I was reasonably satisfied with the naming. I plan to explore in a follow-up PR to namespace all types just with the module, e.g. `ContainerItems<T> -> container::Items<T>`.

Closes: #4881

#skip-changelog