### PR TITLE
test(insta): Update all insta snapshots

### DIFF
--- a/relay-config/src/redis.rs
+++ b/relay-config/src/redis.rs
@@ -396,7 +396,7 @@ quotas:
             },
         });
 
-        assert_json_snapshot!(config, @r#"
+        assert_json_snapshot!(config, @r###"
         {
           "server": "redis://127.0.0.1:6379",
           "max_connections": 42,
@@ -405,7 +405,7 @@ quotas:
           "recycle_timeout": 2,
           "recycle_check_frequency": 100
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -418,7 +418,7 @@ quotas:
             },
         }));
 
-        assert_json_snapshot!(configs, @r#"
+        assert_json_snapshot!(configs, @r###"
         {
           "server": "redis://127.0.0.1:6379",
           "max_connections": 42,
@@ -427,7 +427,7 @@ quotas:
           "recycle_timeout": 2,
           "recycle_check_frequency": 100
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -534,7 +534,7 @@ max_connections: 20
             },
         };
 
-        assert_json_snapshot!(config, @r#"
+        assert_json_snapshot!(config, @r###"
         {
           "cluster_nodes": [
             "redis://127.0.0.1:6379",
@@ -546,7 +546,7 @@ max_connections: 20
           "recycle_timeout": 2,
           "recycle_check_frequency": 100
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -562,7 +562,7 @@ max_connections: 20
             },
         });
 
-        assert_json_snapshot!(configs, @r#"
+        assert_json_snapshot!(configs, @r###"
         {
           "cluster_nodes": [
             "redis://127.0.0.1:6379",
@@ -574,7 +574,7 @@ max_connections: 20
           "recycle_timeout": 2,
           "recycle_check_frequency": 100
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -603,7 +603,7 @@ max_connections: 20
             }),
         };
 
-        assert_json_snapshot!(configs, @r#"
+        assert_json_snapshot!(configs, @r###"
         {
           "project_configs": {
             "server": "redis://127.0.0.1:6379",
@@ -632,6 +632,6 @@ max_connections: 20
             "recycle_check_frequency": 100
           }
         }
-        "#);
+        "###);
     }
 }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1671,7 +1671,7 @@ mod tests {
 
         normalize_event_measurements(&mut event, None, None);
 
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r#"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
         {
           "type": "transaction",
           "timestamp": 1619420405.0,
@@ -1707,7 +1707,7 @@ mod tests {
             },
           },
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1744,7 +1744,7 @@ mod tests {
         normalize_event_measurements(&mut event, Some(dynamic_measurement_config), None);
 
         // Only two custom measurements are retained, in alphabetic order (1 and 2)
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r#"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
         {
           "type": "transaction",
           "timestamp": 1619420405.0,
@@ -1784,7 +1784,7 @@ mod tests {
             },
           },
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1799,7 +1799,7 @@ mod tests {
         .unwrap()
         .into_value()
         .unwrap();
-        insta::assert_debug_snapshot!(measurements, @r#"
+        insta::assert_debug_snapshot!(measurements, @r###"
         Measurements(
             {
                 "fcp": Measurement {
@@ -1816,9 +1816,9 @@ mod tests {
                 },
             },
         )
-        "#);
+        "###);
         normalize_units(&mut measurements);
-        insta::assert_debug_snapshot!(measurements, @r#"
+        insta::assert_debug_snapshot!(measurements, @r###"
         Measurements(
             {
                 "fcp": Measurement {
@@ -1837,7 +1837,7 @@ mod tests {
                 },
             },
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -1932,7 +1932,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r#"
+        assert_debug_snapshot!(event.tags, @r###"
         Tags(
             PairList(
                 [
@@ -1943,7 +1943,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -1961,7 +1961,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r#"
+        assert_debug_snapshot!(event.tags, @r###"
         Tags(
             PairList(
                 [
@@ -1972,7 +1972,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -1992,7 +1992,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r#"
+        assert_debug_snapshot!(event.tags, @r###"
         Tags(
             PairList(
                 [
@@ -2003,7 +2003,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -2023,7 +2023,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r#"
+        assert_debug_snapshot!(event.tags, @r###"
         Tags(
             PairList(
                 [
@@ -2034,7 +2034,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -2054,7 +2054,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r#"
+        assert_debug_snapshot!(event.tags, @r###"
         Tags(
             PairList(
                 [
@@ -2065,7 +2065,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -2712,7 +2712,7 @@ mod tests {
             ..Default::default()
         };
         normalize_device_class(&mut event);
-        assert_debug_snapshot!(event.tags, @r#"
+        assert_debug_snapshot!(event.tags, @r###"
         Tags(
             PairList(
                 [
@@ -2723,7 +2723,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]
@@ -4630,7 +4630,7 @@ mod tests {
             .first()
             .unwrap();
 
-        assert_debug_snapshot!(exception.meta(), @r#"
+        assert_debug_snapshot!(exception.meta(), @r###"
         Meta {
             remarks: [],
             errors: [
@@ -4657,7 +4657,8 @@ mod tests {
                     },
                 ),
             ),
-        }"#);
+        }
+        "###);
     }
 
     #[test]
@@ -4709,7 +4710,7 @@ mod tests {
             .first()
             .unwrap()
             .meta();
-        assert_debug_snapshot!(debug_image_meta, @r#"
+        assert_debug_snapshot!(debug_image_meta, @r###"
         Meta {
             remarks: [],
             errors: [
@@ -4728,7 +4729,8 @@ mod tests {
                     {},
                 ),
             ),
-        }"#);
+        }
+        "###);
     }
 
     #[test]
@@ -4798,7 +4800,7 @@ mod tests {
         }"#;
         let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
         normalize_trace_context_tags(&mut event);
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r#"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
         {
           "type": "transaction",
           "timestamp": 2.0,
@@ -4839,7 +4841,7 @@ mod tests {
             },
           },
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -4870,7 +4872,7 @@ mod tests {
         }"#;
         let mut event = Annotated::<Event>::from_json(json).unwrap().0.unwrap();
         normalize_trace_context_tags(&mut event);
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r#"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(event)), {}, @r###"
         {
           "type": "transaction",
           "timestamp": 2.0,
@@ -4911,6 +4913,6 @@ mod tests {
             },
           },
         }
-        "#);
+        "###);
     }
 }

--- a/relay-event-normalization/src/mechanism.rs
+++ b/relay-event-normalization/src/mechanism.rs
@@ -989,12 +989,12 @@ mod tests {
         };
 
         normalize_mechanism(&mut good_mechanism, None);
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(good_mechanism)), @r#"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(good_mechanism)), @r###"
         {
           "type": "generic",
           "help_link": "https://example.com/",
         }
-        "#);
+        "###);
 
         let mut bad_mechanism = Mechanism {
             ty: Annotated::new("generic".to_owned()),
@@ -1003,7 +1003,7 @@ mod tests {
         };
 
         normalize_mechanism(&mut bad_mechanism, None);
-        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(bad_mechanism)), @r#"
+        insta::assert_ron_snapshot!(SerializableAnnotated(&Annotated::new(bad_mechanism)), @r###"
         {
           "type": "generic",
           "help_link": (),
@@ -1023,6 +1023,6 @@ mod tests {
             },
           },
         }
-        "#);
+        "###);
     }
 }

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -418,7 +418,7 @@ mod tests {
     fn test_model_cost_config_v1() {
         let original = r#"{"version":1,"costs":[{"modelId":"babbage-002.ft","forCompletion":false,"costPer1kTokens":0.0016}]}"#;
         let deserialized: ModelCosts = serde_json::from_str(original).unwrap();
-        assert_debug_snapshot!(deserialized, @r#"
+        assert_debug_snapshot!(deserialized, @r###"
         ModelCosts {
             version: 1,
             costs: [
@@ -430,7 +430,7 @@ mod tests {
             ],
             models: {},
         }
-        "#);
+        "###);
 
         let serialized = serde_json::to_string(&deserialized).unwrap();
         assert_eq!(&serialized, original);
@@ -1373,7 +1373,7 @@ mod tests {
             ".event_id" => "[event-id]",
             ".received" => "[received]",
             ".timestamp" => "[timestamp]"
-        }, @r#"
+        }, @r###"
         {
           "event_id": "[event-id]",
           "level": "error",
@@ -1389,7 +1389,7 @@ mod tests {
             "id": "legacy:1234-12-12",
           },
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1413,7 +1413,7 @@ mod tests {
 
         normalize_event(&mut event, &NormalizationConfig::default());
 
-        assert_json_snapshot!(SerializableAnnotated(&event), {".received" => "[received]"}, @r#"
+        assert_json_snapshot!(SerializableAnnotated(&event), {".received" => "[received]"}, @r###"
         {
           "event_id": "74ad1301f4df489ead37d757295442b1",
           "level": "error",
@@ -1444,7 +1444,8 @@ mod tests {
               }
             }
           }
-        }"#)
+        }
+        "###)
     }
 
     #[test]
@@ -1473,32 +1474,32 @@ mod tests {
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
         ".event_id" => "[event-id]",
-    }, @r#"
-    {
-      "event_id": "[event-id]",
-      "level": "error",
-      "type": "default",
-      "logger": "",
-      "platform": "other",
-      "timestamp": 946857600.0,
-      "received": 946857600.0,
-      "_meta": {
-        "timestamp": {
-          "": Meta(Some(MetaInner(
-            err: [
-              [
-                "future_timestamp",
-                {
-                  "sdk_time": "2000-01-03T00:02:00+00:00",
-                  "server_time": "2000-01-03T00:00:00+00:00",
-                },
-              ],
-            ],
-          ))),
-        },
-      },
-    }
-    "#);
+    }, @r###"
+        {
+          "event_id": "[event-id]",
+          "level": "error",
+          "type": "default",
+          "logger": "",
+          "platform": "other",
+          "timestamp": 946857600.0,
+          "received": 946857600.0,
+          "_meta": {
+            "timestamp": {
+              "": Meta(Some(MetaInner(
+                err: [
+                  [
+                    "future_timestamp",
+                    {
+                      "sdk_time": "2000-01-03T00:02:00+00:00",
+                      "server_time": "2000-01-03T00:00:00+00:00",
+                    },
+                  ],
+                ],
+              ))),
+            },
+          },
+        }
+        "###);
     }
 
     #[test]
@@ -1527,32 +1528,32 @@ mod tests {
 
         insta::assert_ron_snapshot!(SerializableAnnotated(&event), {
         ".event_id" => "[event-id]",
-    }, @r#"
-    {
-      "event_id": "[event-id]",
-      "level": "error",
-      "type": "default",
-      "logger": "",
-      "platform": "other",
-      "timestamp": 952041600.0,
-      "received": 952041600.0,
-      "_meta": {
-        "timestamp": {
-          "": Meta(Some(MetaInner(
-            err: [
-              [
-                "past_timestamp",
-                {
-                  "sdk_time": "2000-01-03T00:00:00+00:00",
-                  "server_time": "2000-03-03T00:00:00+00:00",
-                },
-              ],
-            ],
-          ))),
-        },
-      },
-    }
-    "#);
+    }, @r###"
+        {
+          "event_id": "[event-id]",
+          "level": "error",
+          "type": "default",
+          "logger": "",
+          "platform": "other",
+          "timestamp": 952041600.0,
+          "received": 952041600.0,
+          "_meta": {
+            "timestamp": {
+              "": Meta(Some(MetaInner(
+                err: [
+                  [
+                    "past_timestamp",
+                    {
+                      "sdk_time": "2000-01-03T00:00:00+00:00",
+                      "server_time": "2000-03-03T00:00:00+00:00",
+                    },
+                  ],
+                ],
+              ))),
+            },
+          },
+        }
+        "###);
     }
 
     #[test]
@@ -1896,7 +1897,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(event.value().unwrap().tags, @r#"
+        assert_debug_snapshot!(event.value().unwrap().tags, @r###"
         Tags(
             PairList(
                 [
@@ -1907,7 +1908,7 @@ mod tests {
                 ],
             ),
         )
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_empty.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_empty.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_exact_length.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_exact_length.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_short_no_trimming.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_short_no_trimming.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_too_long_single_word.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_too_long_single_word.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_trimmed.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_trimmed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_word_leading_dots.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_word_leading_dots.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_word_trimmed_at_max.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_word_trimmed_at_max.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_word_trimmed_before_max.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__tests__normalize_logger_word_trimmed_before_max.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/normalize.rs
+source: relay-event-normalization/src/normalize/mod.rs
 expression: event
 ---
 {

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -2017,7 +2017,7 @@ LIMIT 1
             tags.get_value("ai_pipeline_group").unwrap().as_str(),
             Some("68e6cafc5b68d276")
         );
-        assert_json_snapshot!(SerializableAnnotated(&span.data), @r#"
+        assert_json_snapshot!(SerializableAnnotated(&span.data), @r###"
         {
           "gen_ai.usage.total_tokens": 300,
           "gen_ai.usage.input_tokens": 100,
@@ -2025,7 +2025,7 @@ LIMIT 1
           "ai.pipeline.name": "My AI pipeline",
           "ai.streaming": true
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -2076,7 +2076,7 @@ LIMIT 1
             tags.get_value("ai_pipeline_group").unwrap().as_str(),
             Some("68e6cafc5b68d276")
         );
-        assert_json_snapshot!(SerializableAnnotated(&span.data), @r#"
+        assert_json_snapshot!(SerializableAnnotated(&span.data), @r###"
         {
           "gen_ai.usage.total_tokens": 300,
           "gen_ai.usage.input_tokens": 100,
@@ -2084,7 +2084,7 @@ LIMIT 1
           "ai.pipeline.name": "My AI pipeline",
           "ai.streaming": true
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/user_agent.rs
+++ b/relay-event-normalization/src/normalize/user_agent.rs
@@ -550,7 +550,7 @@ mod tests {
 
         let mut event = get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "browser": {
             "name": "Chrome Mobile",
@@ -558,7 +558,7 @@ mod tests {
             "type": "browser"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -567,7 +567,7 @@ mod tests {
 
         let mut event = get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "client_os": {
             "name": "Windows",
@@ -575,7 +575,7 @@ mod tests {
             "type": "os"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -583,7 +583,7 @@ mod tests {
         let ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) - (-)";
         let mut event = get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "browser": {
             "name": "Mobile Safari UI/WKWebView",
@@ -601,7 +601,7 @@ mod tests {
             "type": "device"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -609,7 +609,7 @@ mod tests {
         let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) - (-)";
         let mut event = get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "client_os": {
             "name": "Mac OS X",
@@ -623,7 +623,7 @@ mod tests {
             "type": "device"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -632,7 +632,7 @@ mod tests {
 
         let mut event = get_event_with_user_agent(ua);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "device": {
             "family": "Samsung Galaxy Nexus",
@@ -641,14 +641,14 @@ mod tests {
             "type": "device"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
     fn test_all_contexts() {
         let mut event = get_event_with_user_agent(GOOD_UA);
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "browser": {
             "name": "Chrome Mobile",
@@ -667,7 +667,7 @@ mod tests {
             "type": "device"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -694,7 +694,7 @@ mod tests {
         event.contexts = Annotated::new(contexts);
 
         normalize_user_agent(&mut event);
-        assert_annotated_snapshot!(event.contexts, @r#"
+        assert_annotated_snapshot!(event.contexts, @r###"
         {
           "browser": {
             "name": "BR_FAMILY",
@@ -718,7 +718,7 @@ mod tests {
             "type": "os"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-event-normalization/src/replay.rs
+++ b/relay-event-normalization/src/replay.rs
@@ -486,26 +486,28 @@ mod tests {
         let mut replay = Annotated::<Replay>::from_json(json.as_str()).unwrap();
 
         normalize(&mut replay, None, RawUserAgentInfo::default(), None);
-        assert_annotated_snapshot!(replay, @r#"{
-  "platform": "other",
-  "dist": "0000000000000000000000000000000000000000000000000000000000000...",
-  "type": "replay_event",
-  "_meta": {
-    "dist": {
-      "": {
-        "rem": [
-          [
-            "!limit",
-            "s",
-            61,
-            64
-          ]
-        ],
-        "len": 100
-      }
-    }
-  }
-}"#);
+        assert_annotated_snapshot!(replay, @r###"
+        {
+          "platform": "other",
+          "dist": "0000000000000000000000000000000000000000000000000000000000000...",
+          "type": "replay_event",
+          "_meta": {
+            "dist": {
+              "": {
+                "rem": [
+                  [
+                    "!limit",
+                    "s",
+                    61,
+                    64
+                  ]
+                ],
+                "len": 100
+              }
+            }
+          }
+        }
+        "###);
     }
 
     #[test]

--- a/relay-event-normalization/src/snapshots/relay_event_normalization__trimming__tests__databag_array_stripping.snap
+++ b/relay-event-normalization/src/snapshots/relay_event_normalization__trimming__tests__databag_array_stripping.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/store/trimming.rs
+source: relay-event-normalization/src/trimming.rs
 expression: stripped_extra
 ---
 {

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -662,7 +662,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_annotated_snapshot!(event, @r#"
+        assert_annotated_snapshot!(event, @r###"
         {
           "type": "transaction",
           "transaction": "/",
@@ -689,7 +689,7 @@ mod tests {
             }
           ]
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -833,28 +833,30 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                5,
-                45,
-            ),
-        ),
-    },
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                51,
-                54,
-            ),
-        ),
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        5,
+                        45,
+                    ),
+                ),
+            },
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        51,
+                        54,
+                    ),
+                ),
+            },
+        ]
+        "###);
     }
 
     /// When no identifiers are scrubbed, we should not set an original value in _meta.
@@ -994,23 +996,25 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                22,
-                25,
-            ),
-        ),
-    },
-    Remark {
-        ty: Substituted,
-        rule_id: "/foo/*/user/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        22,
+                        25,
+                    ),
+                ),
+            },
+            Remark {
+                ty: Substituted,
+                rule_id: "/foo/*/user/*/**",
+                range: None,
+            },
+        ]
+        "###);
     }
 
     #[test]
@@ -1075,23 +1079,25 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                22,
-                25,
-            ),
-        ),
-    },
-    Remark {
-        ty: Substituted,
-        rule_id: "/foo/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        22,
+                        25,
+                    ),
+                ),
+            },
+            Remark {
+                ty: Substituted,
+                rule_id: "/foo/*/**",
+                range: None,
+            },
+        ]
+        "###);
     }
 
     #[test]
@@ -1140,23 +1146,25 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                22,
-                25,
-            ),
-        ),
-    },
-    Remark {
-        ty: Substituted,
-        rule_id: "/foo/*/user/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        22,
+                        25,
+                    ),
+                ),
+            },
+            Remark {
+                ty: Substituted,
+                rule_id: "/foo/*/user/*/**",
+                range: None,
+            },
+        ]
+        "###);
 
         assert_eq!(
             get_value!(event.transaction_info.source!).as_str(),
@@ -1177,23 +1185,25 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                22,
-                25,
-            ),
-        ),
-    },
-    Remark {
-        ty: Substituted,
-        rule_id: "/foo/*/user/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        22,
+                        25,
+                    ),
+                ),
+            },
+            Remark {
+                ty: Substituted,
+                rule_id: "/foo/*/user/*/**",
+                range: None,
+            },
+        ]
+        "###);
 
         assert_eq!(
             get_value!(event.transaction_info.source!).as_str(),
@@ -1323,13 +1333,15 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "/user/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "/user/*/**",
+                range: None,
+            },
+        ]
+        "###);
 
         assert_eq!(
             get_value!(event.transaction_info.source!).as_str(),
@@ -1399,13 +1411,15 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "/foo/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "/foo/*/**",
+                range: None,
+            },
+        ]
+        "###);
 
         assert_eq!(
             get_value!(event.transaction_info.source!).as_str(),
@@ -1610,18 +1624,20 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                21,
-                31,
-            ),
-        ),
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        21,
+                        31,
+                    ),
+                ),
+            },
+        ]
+        "###);
         assert_eq!(
             get_value!(event.transaction_info.source!).as_str(),
             "sanitized"
@@ -1676,23 +1692,25 @@ mod tests {
             .meta()
             .iter_remarks()
             .collect_vec();
-        assert_debug_snapshot!(remarks, @r#"[
-    Remark {
-        ty: Substituted,
-        rule_id: "int",
-        range: Some(
-            (
-                21,
-                31,
-            ),
-        ),
-    },
-    Remark {
-        ty: Substituted,
-        rule_id: "/remains/*/**",
-        range: None,
-    },
-]"#);
+        assert_debug_snapshot!(remarks, @r###"
+        [
+            Remark {
+                ty: Substituted,
+                rule_id: "int",
+                range: Some(
+                    (
+                        21,
+                        31,
+                    ),
+                ),
+            },
+            Remark {
+                ty: Substituted,
+                rule_id: "/remains/*/**",
+                range: None,
+            },
+        ]
+        "###);
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -1311,7 +1311,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
 
-        assert_annotated_snapshot!(Annotated::new(event), @r#"
+        assert_annotated_snapshot!(Annotated::new(event), @r###"
         {
           "culprit": "",
           "logentry": {
@@ -1337,7 +1337,7 @@ mod tests {
             "violated_directive": ""
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1477,7 +1477,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src http://cdn.example.com""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src http://cdn.example.com""###);
     }
 
     #[test]
@@ -1492,7 +1492,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src cdn.example.com""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src cdn.example.com""###);
     }
 
     #[test]
@@ -1507,7 +1507,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src cdn.example.com""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src cdn.example.com""###);
     }
 
     #[test]
@@ -1522,7 +1522,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src https://cdn.example.com""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src https://cdn.example.com""###);
     }
 
     #[test]
@@ -1537,7 +1537,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src 'self'""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src 'self'""###);
     }
 
     #[test]
@@ -1552,7 +1552,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src http://example2.com 'self'""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src http://example2.com 'self'""###);
     }
 
     #[test]
@@ -1567,7 +1567,7 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.culprit, @r#""style-src example2.com""#);
+        insta::assert_debug_snapshot!(event.culprit, @r###""style-src example2.com""###);
     }
 
     #[test]
@@ -1620,7 +1620,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'image' from 'google.com'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'image' from 'google.com'""###);
     }
 
     #[test]
@@ -1636,7 +1636,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked inline 'style'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked inline 'style'""###);
     }
 
     #[test]
@@ -1653,7 +1653,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked unsafe inline 'script'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked unsafe inline 'script'""###);
     }
 
     #[test]
@@ -1670,7 +1670,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked unsafe eval() 'script'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked unsafe eval() 'script'""###);
     }
 
     #[test]
@@ -1687,7 +1687,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked unsafe (eval() or inline) 'script'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked unsafe (eval() or inline) 'script'""###);
     }
 
     #[test]
@@ -1703,7 +1703,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'script' from 'data:'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'script' from 'data:'""###);
     }
 
     #[test]
@@ -1719,7 +1719,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'script' from 'data:'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'script' from 'data:'""###);
     }
 
     #[test]
@@ -1735,7 +1735,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'style' from 'fonts.google.com'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'style' from 'fonts.google.com'""###);
     }
 
     #[test]
@@ -1751,7 +1751,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'script' from 'cdn.ajaxapis.com'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'script' from 'cdn.ajaxapis.com'""###);
     }
 
     #[test]
@@ -1767,7 +1767,7 @@ mod tests {
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
         let message = &event.logentry.value().unwrap().formatted;
-        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r#""Blocked 'style' from 'notlocalhost:8000'""#);
+        insta::assert_debug_snapshot!(message.as_str().unwrap(), @r###""Blocked 'style' from 'notlocalhost:8000'""###);
     }
 
     #[test]
@@ -1796,7 +1796,7 @@ mod tests {
 
         let mut event = Event::default();
         ExpectCt::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        assert_annotated_snapshot!(Annotated::new(event), @r#"
+        assert_annotated_snapshot!(Annotated::new(event), @r###"
         {
           "culprit": "www.example.com",
           "logentry": {
@@ -1839,7 +1839,7 @@ mod tests {
             "test_report": false
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1871,7 +1871,7 @@ mod tests {
 
         let mut event = Event::default();
         ExpectStaple::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        assert_annotated_snapshot!(Annotated::new(event), @r#"
+        assert_annotated_snapshot!(Annotated::new(event), @r###"
         {
           "culprit": "www.example.com",
           "logentry": {
@@ -1913,7 +1913,7 @@ mod tests {
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1931,7 +1931,7 @@ mod tests {
 
         let mut event = Event::default();
         Hpkp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        assert_annotated_snapshot!(Annotated::new(event), @r#"
+        assert_annotated_snapshot!(Annotated::new(event), @r###"
         {
           "logentry": {
             "formatted": "Public key pinning validation failed for 'example.com'"
@@ -1970,7 +1970,7 @@ mod tests {
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -660,7 +660,7 @@ mod tests {
             },
         };
 
-        insta::assert_json_snapshot!(filters_config, @r#"
+        insta::assert_json_snapshot!(filters_config, @r###"
         {
           "browserExtensions": {
             "isEnabled": true
@@ -719,7 +719,7 @@ mod tests {
             ]
           }
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-metrics/src/bucket.rs
+++ b/relay-metrics/src/bucket.rs
@@ -1178,12 +1178,12 @@ mod tests {
         let s = "transactions/foo:17.5|d|#foo,bar:baz";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Bucket::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric.tags, @r#"
-            {
-                "bar": "baz",
-                "foo": "",
-            }
-            "#);
+        insta::assert_debug_snapshot!(metric.tags, @r###"
+        {
+            "bar": "baz",
+            "foo": "",
+        }
+        "###);
     }
 
     #[test]
@@ -1191,11 +1191,11 @@ mod tests {
         let s = "transactions/foo:17.5|d|#foo:😅\\u{2c}🚀";
         let timestamp = UnixTimestamp::from_secs(4711);
         let metric = Bucket::parse(s.as_bytes(), timestamp).unwrap();
-        insta::assert_debug_snapshot!(metric.tags, @r#"
-            {
-                "foo": "😅,🚀",
-            }
-            "#);
+        insta::assert_debug_snapshot!(metric.tags, @r###"
+        {
+            "foo": "😅,🚀",
+        }
+        "###);
     }
 
     #[test]

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -841,13 +841,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let pii_config = simple_enabled_pii_config();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
-        assert_annotated_snapshot!(data, @r#"
+        assert_annotated_snapshot!(data, @r###"
         {
           "extra": {
             "foo": "1453843029218310"
           }
         }
-        "#);
+        "###);
     }
 
     macro_rules! sanitize_url_test {
@@ -943,13 +943,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(data, @r#"
+        assert_annotated_snapshot!(data, @r###"
         {
           "extra": {
             "foo": 1
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1110,13 +1110,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(data, @r#"
+        assert_annotated_snapshot!(data, @r###"
         {
           "extra": {
             "foobar": "123-45-6789"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1138,13 +1138,13 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        assert_annotated_snapshot!(data, @r#"
+        assert_annotated_snapshot!(data, @r###"
         {
           "extra": {
             "foobar": "xxx"
           }
         }
-        "#);
+        "###);
     }
 
     macro_rules! should_have_mysql_pwd_as_a_default_test {

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -1745,22 +1745,24 @@ mod tests {
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
 
         let params = get_value!(event.logentry.params!);
-        assert_debug_snapshot!(params, @r#"Array(
-    [
-        Meta {
-            remarks: [
-                Remark {
-                    ty: Removed,
-                    rule_id: "@anything:remove",
-                    range: None,
+        assert_debug_snapshot!(params, @r###"
+        Array(
+            [
+                Meta {
+                    remarks: [
+                        Remark {
+                            ty: Removed,
+                            rule_id: "@anything:remove",
+                            range: None,
+                        },
+                    ],
+                    errors: [],
+                    original_length: None,
+                    original_value: None,
                 },
             ],
-            errors: [],
-            original_length: None,
-            original_value: None,
-        },
-    ],
-)"#);
+        )
+        "###);
     }
 
     #[test]
@@ -1848,47 +1850,47 @@ mod tests {
 
             let vars = get_value!(event.exceptions.values[0].stacktrace.frames[0].vars).unwrap();
 
-            allow_duplicates!(assert_debug_snapshot!(vars, @r#"
-        FrameVars(
-            {
-                "headers": Array(
-                    [
-                        Array(
-                            [
-                                String(
-                                    "authorization",
-                                ),
-                                Annotated(
-                                    String(
-                                        "[Filtered]",
-                                    ),
-                                    Meta {
-                                        remarks: [
-                                            Remark {
-                                                ty: Substituted,
-                                                rule_id: "@anything:replace",
-                                                range: Some(
-                                                    (
-                                                        0,
-                                                        10,
-                                                    ),
-                                                ),
-                                            },
-                                        ],
-                                        errors: [],
-                                        original_length: Some(
-                                            13,
-                                        ),
-                                        original_value: None,
-                                    },
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            },
-        )
-        "#));
+            allow_duplicates!(assert_debug_snapshot!(vars, @r###"
+                              FrameVars(
+                                  {
+                                      "headers": Array(
+                                          [
+                                              Array(
+                                                  [
+                                                      String(
+                                                          "authorization",
+                                                      ),
+                                                      Annotated(
+                                                          String(
+                                                              "[Filtered]",
+                                                          ),
+                                                          Meta {
+                                                              remarks: [
+                                                                  Remark {
+                                                                      ty: Substituted,
+                                                                      rule_id: "@anything:replace",
+                                                                      range: Some(
+                                                                          (
+                                                                              0,
+                                                                              10,
+                                                                          ),
+                                                                      ),
+                                                                  },
+                                                              ],
+                                                              errors: [],
+                                                              original_length: Some(
+                                                                  13,
+                                                              ),
+                                                              original_value: None,
+                                                          },
+                                                      ),
+                                                  ],
+                                              ),
+                                          ],
+                                      ),
+                                  },
+                              )
+                              "###));
         }
     }
 

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__authorization_scrubbing.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__authorization_scrubbing.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__breadcrumb_message-2.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__breadcrumb_message-2.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__contexts.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__contexts.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__csp_blocked_uri.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__csp_blocked_uri.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__debug_meta_files_not_strippable.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__debug_meta_files_not_strippable.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_encrypted_private_key.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_encrypted_private_key.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_private_key.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_private_key.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_public_key.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_public_key.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_rsa_private_key.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_rsa_private_key.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_social_security_number.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__does_sanitize_social_security_number.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__doesnt_scrub_not_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__doesnt_scrub_not_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__event_message_not_strippable.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__event_message_not_strippable.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__exclude_fields_on_field_name.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__exclude_fields_on_field_name.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__explicit_fields.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__explicit_fields.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__explicit_fields_case_insensitive.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__explicit_fields_case_insensitive.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__extra.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__extra.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__http.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__http.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__http_remote_addr_stripped.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__http_remote_addr_stripped.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__no_scrub_object_with_safe_fields.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__no_scrub_object_with_safe_fields.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__odd_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__odd_keys.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_pairlist.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_pairlist.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_pairlist_with_partials.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_pairlist_with_partials.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_string.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_string.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_string_with_partials.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__querystring_as_string_with_partials.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__safe_fields_for_token.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__safe_fields_for_token.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_additional_sensitive_fields.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_additional_sensitive_fields.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_amex.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_amex.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_discover.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_discover.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_mastercard.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_mastercard.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_visa.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_visa.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_within_value_1.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_within_value_1.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_within_value_2.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_credit_card_within_value_2.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_http_body.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_http_body.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data.value().unwrap().request
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_1.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_1.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_2.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_2.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_3.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_3.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_4.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_4.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_5.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_5.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_6.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_6.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_7.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_url_7.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__scrub_object.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__scrub_object.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sensitive_cookies.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sensitive_cookies.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__should_have_mysql_pwd_as_a_default_1.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__should_have_mysql_pwd_as_a_default_1.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__should_have_mysql_pwd_as_a_default_2.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__should_have_mysql_pwd_as_a_default_2.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__stacktrace.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__stacktrace.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__stacktrace_paths_not_strippable.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__stacktrace_paths_not_strippable.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__user.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__user.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/convert.rs
+source: relay-pii/src/convert.rs
 expression: data
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__anything_hash_on_container.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__anything_hash_on_container.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__anything_hash_on_string.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__anything_hash_on_string.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__basic_stripping.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__basic_stripping.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__debugmeta_path_not_addressible_with_wildcard_selector.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__debugmeta_path_not_addressible_with_wildcard_selector.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__hash_debugmeta_path.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__hash_debugmeta_path.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__no_field_upsert.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__no_field_upsert.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__quoted_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__quoted_keys.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__redact_containers.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__redact_containers.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__redact_custom_pattern.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__redact_custom_pattern.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__remove_debugmeta_path.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__remove_debugmeta_path.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__replace_debugmeta_path.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__replace_debugmeta_path.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: event
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_http_not_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_http_not_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: breadcrumb
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_http_objects_are_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_http_objects_are_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: breadcrumb
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_http_strings_are_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_http_strings_are_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: breadcrumb
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_untyped_props_are_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_breadcrumb_data_untyped_props_are_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: breadcrumb
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_http_not_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_http_not_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: span
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_http_objects_are_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_http_objects_are_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: span
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_http_strings_are_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_http_strings_are_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: span
 ---
 {

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_untyped_props_are_scrubbed.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__scrub_span_data_untyped_props_are_scrubbed.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/pii/processor.rs
+source: relay-pii/src/processor.rs
 expression: span
 ---
 {

--- a/relay-sampling/src/dsc.rs
+++ b/relay-sampling/src/dsc.rs
@@ -315,7 +315,7 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r#"
+        insta::assert_ron_snapshot!(dsc, @r###"
         {
           "trace_id": "b1e2a9dc9b8e4cd0af0e80e6b83b56e6",
           "public_key": "abd0f232775f45feab79864e580d160b",
@@ -325,7 +325,7 @@ mod tests {
           "user_id": "hello",
           "replay_id": None,
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -339,7 +339,7 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r#"
+        insta::assert_ron_snapshot!(dsc, @r###"
         {
           "trace_id": "67e5504410b1426f9247bb680e5fe0c8",
           "public_key": "abd0f232775f45feab79864e580d160b",
@@ -350,7 +350,7 @@ mod tests {
           "user_id": "hello",
           "replay_id": None,
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -364,7 +364,7 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r#"
+        insta::assert_ron_snapshot!(dsc, @r###"
         {
           "trace_id": "67e5504410b1426f9247bb680e5fe0c8",
           "public_key": "abd0f232775f45feab79864e580d160b",
@@ -375,7 +375,7 @@ mod tests {
           "user_id": "hello",
           "replay_id": None,
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -402,18 +402,18 @@ mod tests {
         }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r#"
-            {
-              "trace_id": "67e5504410b1426f9247bb680e5fe0c8",
-              "public_key": "abd0f232775f45feab79864e580d160b",
-              "release": None,
-              "environment": None,
-              "transaction": None,
-              "sample_rate": "0.1",
-              "user_id": "hello",
-              "replay_id": None,
-            }
-        "#);
+        insta::assert_ron_snapshot!(dsc, @r###"
+        {
+          "trace_id": "67e5504410b1426f9247bb680e5fe0c8",
+          "public_key": "abd0f232775f45feab79864e580d160b",
+          "release": None,
+          "environment": None,
+          "transaction": None,
+          "sample_rate": "0.1",
+          "user_id": "hello",
+          "replay_id": None,
+        }
+        "###);
     }
 
     #[test]
@@ -427,18 +427,18 @@ mod tests {
             }
         "#;
         let dsc = serde_json::from_str::<DynamicSamplingContext>(json).unwrap();
-        insta::assert_ron_snapshot!(dsc, @r#"
-            {
-              "trace_id": "67e5504410b1426f9247bb680e5fe0c8",
-              "public_key": "abd0f232775f45feab79864e580d160b",
-              "release": None,
-              "environment": None,
-              "transaction": None,
-              "sample_rate": "1.0",
-              "user_id": "hello",
-              "replay_id": None,
-            }
-        "#);
+        insta::assert_ron_snapshot!(dsc, @r###"
+        {
+          "trace_id": "67e5504410b1426f9247bb680e5fe0c8",
+          "public_key": "abd0f232775f45feab79864e580d160b",
+          "release": None,
+          "environment": None,
+          "transaction": None,
+          "sample_rate": "1.0",
+          "user_id": "hello",
+          "replay_id": None,
+        }
+        "###);
     }
 
     #[test]

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -1064,8 +1064,7 @@ mod tests {
         envelope.serialize(&mut buffer).unwrap();
 
         let stringified = String::from_utf8_lossy(&buffer);
-        insta::assert_snapshot!(stringified, @r#"{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","client":"sentry/client","version":7,"origin":"http://origin/","remote_addr":"192.168.0.1","user_agent":"sentry/agent"}
-"#);
+        insta::assert_snapshot!(stringified, @r###"{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","client":"sentry/client","version":7,"origin":"http://origin/","remote_addr":"192.168.0.1","user_agent":"sentry/agent"}"###);
     }
 
     #[test]
@@ -1089,14 +1088,13 @@ mod tests {
         envelope.serialize(&mut buffer).unwrap();
 
         let stringified = String::from_utf8_lossy(&buffer);
-        insta::assert_snapshot!(stringified, @r#"
+        insta::assert_snapshot!(stringified, @r###"
         {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","client":"sentry/client","version":7,"origin":"http://origin/","remote_addr":"192.168.0.1","user_agent":"sentry/agent"}
         {"type":"event","length":41,"content_type":"application/json"}
         {"message":"hello world","level":"error"}
         {"type":"attachment","length":7,"content_type":"text/plain","filename":"application.log"}
         Hello
-
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -4167,7 +4167,7 @@ mod tests {
             .unwrap();
 
         let event = Annotated::<Event>::from_json_bytes(&event.payload()).unwrap();
-        insta::assert_debug_snapshot!(event.value().unwrap()._dsc, @r#"
+        insta::assert_debug_snapshot!(event.value().unwrap()._dsc, @r###"
         Object(
             {
                 "environment": ~,
@@ -4185,7 +4185,7 @@ mod tests {
                 "transaction": ~,
             },
         )
-        "#);
+        "###);
     }
 
     fn capture_test_event(transaction_name: &str, source: TransactionSource) -> Vec<String> {
@@ -4243,51 +4243,51 @@ mod tests {
     #[test]
     fn test_log_transaction_metrics_none() {
         let captures = capture_test_event("/nothing", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r#"
+        insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:none,source_out:sanitized,is_404:false",
         ]
-        "#);
+        "###);
     }
 
     #[test]
     fn test_log_transaction_metrics_rule() {
         let captures = capture_test_event("/foo/john/denver", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r#"
+        insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:rule,source_out:sanitized,is_404:false",
         ]
-        "#);
+        "###);
     }
 
     #[test]
     fn test_log_transaction_metrics_pattern() {
         let captures = capture_test_event("/something/12345", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r#"
+        insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:pattern,source_out:sanitized,is_404:false",
         ]
-        "#);
+        "###);
     }
 
     #[test]
     fn test_log_transaction_metrics_both() {
         let captures = capture_test_event("/foo/john/12345", TransactionSource::Url);
-        insta::assert_debug_snapshot!(captures, @r#"
+        insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:url,changes:both,source_out:sanitized,is_404:false",
         ]
-        "#);
+        "###);
     }
 
     #[test]
     fn test_log_transaction_metrics_no_match() {
         let captures = capture_test_event("/foo/john/12345", TransactionSource::Route);
-        insta::assert_debug_snapshot!(captures, @r#"
+        insta::assert_debug_snapshot!(captures, @r###"
         [
             "event.transaction_name_changes:1|c|#source_in:route,changes:none,source_out:route,is_404:false",
         ]
-        "#);
+        "###);
     }
 
     /// Confirms that the hardcoded value we use for the fixed length of the measurement MRI is

--- a/relay-server/src/utils/param_parser.rs
+++ b/relay-server/src/utils/param_parser.rs
@@ -168,33 +168,33 @@ mod tests {
 
         update_nested_value(&mut val, &["x", "y", "z"], "xx");
 
-        insta::assert_json_snapshot!(val, @r#"
-       ⋮{
-       ⋮  "x": {
-       ⋮    "y": {
-       ⋮      "z": "xx"
-       ⋮    }
-       ⋮  }
-       ⋮}
-        "#);
+        insta::assert_json_snapshot!(val, @r###"
+        {
+          "x": {
+            "y": {
+              "z": "xx"
+            }
+          }
+        }
+        "###);
 
         update_nested_value(&mut val, &["x", "y", "k"], "kk");
         update_nested_value(&mut val, &["w", ""], "w");
         update_nested_value(&mut val, &["z1"], "val1");
-        insta::assert_json_snapshot!(val, @r#"
-       ⋮{
-       ⋮  "w": {
-       ⋮    "": "w"
-       ⋮  },
-       ⋮  "x": {
-       ⋮    "y": {
-       ⋮      "k": "kk",
-       ⋮      "z": "xx"
-       ⋮    }
-       ⋮  },
-       ⋮  "z1": "val1"
-       ⋮}
-        "#);
+        insta::assert_json_snapshot!(val, @r###"
+        {
+          "w": {
+            "": "w"
+          },
+          "x": {
+            "y": {
+              "k": "kk",
+              "z": "xx"
+            }
+          },
+          "z1": "val1"
+        }
+        "###);
     }
 
     #[test]
@@ -218,22 +218,22 @@ mod tests {
         });
 
         merge_values(&mut original, modified);
-        insta::assert_json_snapshot!(original, @r#"
-       ⋮{
-       ⋮  "k1": "v1",
-       ⋮  "k2": {
-       ⋮    "k3": "v3",
-       ⋮    "k4": "v4",
-       ⋮    "k4-1": "v4-1"
-       ⋮  },
-       ⋮  "k5": [
-       ⋮    1,
-       ⋮    2,
-       ⋮    3
-       ⋮  ],
-       ⋮  "k6": "v6"
-       ⋮}
-        "#);
+        insta::assert_json_snapshot!(original, @r###"
+        {
+          "k1": "v1",
+          "k2": {
+            "k3": "v3",
+            "k4": "v4",
+            "k4-1": "v4-1"
+          },
+          "k5": [
+            1,
+            2,
+            3
+          ],
+          "k6": "v6"
+        }
+        "###);
     }
 
     #[test]

--- a/relay-server/tests/snapshots/test_fixtures__legacy_node_exception__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__legacy_node_exception__pii_stripping.snap
@@ -1,6 +1,6 @@
 ---
 source: relay-server/tests/test_fixtures.rs
-expression: SerializableAnnotated(&event)
+expression: SerializableAnnotated(& event)
 ---
 {
   "event_id": "c99bf5ef2eb447d59183ced79601b547",

--- a/relay-server/tests/snapshots/test_fixtures__legacy_python__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__legacy_python__pii_stripping.snap
@@ -1,6 +1,6 @@
 ---
 source: relay-server/tests/test_fixtures.rs
-expression: SerializableAnnotated(&event)
+expression: SerializableAnnotated(& event)
 ---
 {
   "event_id": "b308014887f5418c8f797159bfb6fc42",

--- a/relay-server/tests/snapshots/test_pii__reponse_context_pii.snap
+++ b/relay-server/tests/snapshots/test_pii__reponse_context_pii.snap
@@ -1,5 +1,5 @@
 ---
-source: relay-general/src/protocol/contexts/response.rs
+source: relay-server/tests/test_pii.rs
 expression: data
 ---
 {

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -520,7 +520,7 @@ mod tests {
             }
           }
         }
-"###);
+        "###);
     }
 
     /// Intended to be synced with `relay-event-schema::protocol::span::convert::tests::roundtrip`.
@@ -743,7 +743,7 @@ mod tests {
           "links": [],
           "attributes": {}
         }
-"###);
+        "###);
     }
 
     #[test]
@@ -770,7 +770,7 @@ mod tests {
           "links": [],
           "attributes": {}
         }
-"###);
+        "###);
     }
 
     #[test]
@@ -797,7 +797,7 @@ mod tests {
           "links": [],
           "attributes": {}
         }
-"###);
+        "###);
     }
 
     #[test]

--- a/tools/document-metrics/src/main.rs
+++ b/tools/document-metrics/src/main.rs
@@ -330,7 +330,7 @@ mod tests {
         "#;
 
         let metrics = parse_metrics(source)?;
-        insta::assert_debug_snapshot!(metrics, @r#"
+        insta::assert_debug_snapshot!(metrics, @r###"
         [
             Metric {
                 ty: Set,
@@ -364,7 +364,7 @@ mod tests {
                 features: [],
             },
         ]
-        "#);
+        "###);
 
         Ok(())
     }


### PR DESCRIPTION
Just a `cargo insta test --workspace --all-features --force-update-snapshots` and manually accepting all changed snapshots.

#skip-changelog