### PR TITLE
ci(release): update python version used in manylinux

### DIFF
--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -8,7 +8,7 @@ yum -y -q install gcc libffi-devel
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
 
 # Build wheels
-/opt/python/cp37-cp37m/bin/python setup.py bdist_wheel
+/opt/python/cp311-cp311/bin/python setup.py bdist_wheel
 
 # Audit wheels
 for wheel in dist/*-linux_*.whl; do


### PR DESCRIPTION
Previously used CPython 3.7 has been removed from manylinux. This PR bumps the version to 3.11.
Relay uses 3.11 in integration tests and sentry uses 3.13.

#skip-changelog