### PR TITLE
ci(release): manually add transitive dependencies in `setup_requires`

### DIFF
--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -7,6 +7,9 @@ yum -y -q install gcc libffi-devel
 
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
 
+# Install cffi to prevent ModuleNotFoundError
+/opt/python/cp311-cp311/bin/pip install cffi
+
 # Build wheels
 /opt/python/cp311-cp311/bin/python setup.py bdist_wheel
 

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -7,9 +7,6 @@ yum -y -q install gcc libffi-devel
 
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
 
-# Install cffi to prevent ModuleNotFoundError
-/opt/python/cp311-cp311/bin/pip install cffi
-
 # Build wheels
 /opt/python/cp311-cp311/bin/python setup.py bdist_wheel
 

--- a/py/setup.py
+++ b/py/setup.py
@@ -114,8 +114,13 @@ setup(
     zip_safe=False,
     platforms="any",
     python_requires=">=3.10",
-    install_requires=["milksnake>=0.1.6", "cffi", "pycparser"],
-    setup_requires=["milksnake>=0.1.6", "cffi", "pycparser"],
+    install_requires=["milksnake>=0.1.6"],
+    # Specify transitive dependencies manually that are required for the build because
+    # they are not resolved properly since upgrading to python 3.11 in manylinux.
+    # milksnake -> cffi -> pycparser
+    # milksnake specifies cffi>=1.6.0 as dependency while cffi does not specify a
+    # minimum version for pycparser
+    setup_requires=["milksnake>=0.1.6", "cffi>=1.6.0", "pycparser"],
     milksnake_tasks=[build_native],
     cmdclass={"sdist": CustomSDist},  # type: ignore
 )

--- a/py/setup.py
+++ b/py/setup.py
@@ -114,8 +114,8 @@ setup(
     zip_safe=False,
     platforms="any",
     python_requires=">=3.10",
-    install_requires=["milksnake>=0.1.6"],
-    setup_requires=["milksnake>=0.1.6"],
+    install_requires=["milksnake>=0.1.6", "cffi", "pycparser"],
+    setup_requires=["milksnake>=0.1.6", "cffi", "pycparser"],
     milksnake_tasks=[build_native],
     cmdclass={"sdist": CustomSDist},  # type: ignore
 )


### PR DESCRIPTION
Upgrading from python 3.7 to 3.11 introduced a `ModuleNotFoundError` for `cffi`.

This is likely because transitive dependencies are not properly resolved. However, we can add those in `setup_requires` to ensure that the build is successful.

`milksnake >= 1.6.0` depends on `cffi >= 1.6.0` which depends on `pycparser` without specifying a particular version.

#skip-changelog
