### PR TITLE
ref(derive): Remove leftover expect

### DIFF
--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -189,7 +189,6 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
 
     Ok(s.gen_impl(quote! {
         #[automatically_derived]
-        #[expect(non_local_definitions, reason = "crate needs to be migrated to syn")]
         gen impl crate::processor::ProcessValue for @Self {
             fn value_type(&self) -> enumset::EnumSet<crate::processor::ValueType> {
                 match *self {


### PR DESCRIPTION
This was migrated to syn2 a while ago.

#skip-changelog