### PR TITLE
Rename AI agents legacy attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `gen_ai.response.tokens_per_second` span attribute on AI spans. ([#4883](https://github.com/getsentry/relay/pull/4883))
 - Add support for playstation data requests. ([#4870](https://github.com/getsentry/relay/pull/4870))
 - Expand the NEL attributes & others. ([#4874](https://github.com/getsentry/relay/pull/4874))
+- Normalize legacy AI agents attributes to OTel compatible names. ([#4916](https://github.com/getsentry/relay/pull/4916))
 
 ## 25.6.2
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -469,7 +469,8 @@ pub struct SpanData {
     /// The input tokens used by an LLM call (usually cheaper than output tokens)
     #[metastructure(
         field = "gen_ai.usage.input_tokens",
-        legacy_alias = "ai.prompt_tokens.used"
+        legacy_alias = "ai.prompt_tokens.used",
+        legacy_alias = "gen_ai.usage.prompt_tokens"
     )]
     pub gen_ai_usage_input_tokens: Annotated<Value>,
 
@@ -481,7 +482,8 @@ pub struct SpanData {
     /// The output tokens used by an LLM call (the ones the LLM actually generated)
     #[metastructure(
         field = "gen_ai.usage.output_tokens",
-        legacy_alias = "ai.completion_tokens.used"
+        legacy_alias = "ai.completion_tokens.used",
+        legacy_alias = "gen_ai.usage.completion_tokens"
     )]
     pub gen_ai_usage_output_tokens: Annotated<Value>,
 


### PR DESCRIPTION
Renaming from legacy name to correct current name:

- `gen_ai.usage.prompt_tokens` -> `gen_ai.usage.input_tokens`
- `gen_ai.usage.completion_tokens` -> `gen_ai.usage.output_tokens`

We checked, those attributes are not used by customers in dashboards, alerts or saved queries and can be safely renamed. 