### PR TITLE
feat(logs): Extract metadata into metadata trace item attributes

### DIFF
--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -13,6 +13,7 @@ mod geo;
 mod legacy;
 mod logentry;
 mod mechanism;
+mod meta_collect;
 mod normalize;
 mod regexes;
 mod remove_other;
@@ -29,6 +30,7 @@ pub mod replay;
 pub use event::{
     NormalizationConfig, normalize_event, normalize_measurements, normalize_performance_score,
 };
+pub use meta_collect::MetaCollectProcessor;
 pub use normalize::breakdowns::*;
 pub use normalize::*;
 pub use remove_other::RemoveOtherProcessor;

--- a/relay-event-normalization/src/meta_collect.rs
+++ b/relay-event-normalization/src/meta_collect.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use relay_event_schema::processor::{
+    ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor,
+};
+use relay_event_schema::protocol::Attribute;
+use relay_protocol::{Meta, MetaTree};
+
+/// A processor which collects and removes all metadata from an `Annotated` tree.
+#[derive(Debug, Default)]
+pub struct MetaCollectProcessor {
+    foo: HashMap<String, Meta>,
+    max_depth: usize,
+}
+
+impl MetaCollectProcessor {
+    /// Creates a new [`Self`].
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns all collected metadata keyed, by the path of the metadata within the original object.
+    pub fn into_inner(self) -> HashMap<String, Meta> {
+        self.foo
+    }
+}
+
+impl Processor for MetaCollectProcessor {
+    fn before_process<T: ProcessValue>(
+        &mut self,
+        value: Option<&T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        println!("before: {}", state.path());
+
+        Ok(())
+    }
+
+    fn process_attribute(
+        &mut self,
+        value: &mut Attribute,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        println!("attribute: {}", state.path());
+        value.process_child_values(self, state)
+    }
+
+    fn after_process<T: ProcessValue>(
+        &mut self,
+        _value: Option<&T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        println!("after: {}", state.path());
+
+        let meta = std::mem::take(meta);
+
+        if !meta.is_empty() {
+            self.foo.insert(state.path().to_string(), meta);
+        }
+
+        Ok(())
+    }
+}
+
+struct MetaTreeProcessor<'a> {
+    current: &'a mut MetaTree,
+}
+
+impl Processor for MetaTreeProcessor<'_> {
+    fn before_process<T: ProcessValue>(
+        &mut self,
+        value: Option<&T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        if let Some(value) = value {
+            value.process_child_values(processor, state);
+        }
+
+        Err(ProcessingAction::DeleteValueHard)
+    }
+
+    fn after_process<T: ProcessValue>(
+        &mut self,
+        value: Option<&T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+    }
+}

--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -114,6 +114,7 @@ pub trait Processor: Sized {
     process_method!(process_trace_context, crate::protocol::TraceContext);
     process_method!(process_native_image_path, crate::protocol::NativeImagePath);
     process_method!(process_contexts, crate::protocol::Contexts);
+    process_method!(process_attribute, crate::protocol::Attribute);
 
     fn process_other(
         &mut self,

--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -4,6 +4,7 @@ use std::{borrow::Borrow, fmt};
 use crate::processor::ProcessValue;
 
 #[derive(Clone, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+#[metastructure(process_func = "process_attribute")]
 pub struct Attribute {
     #[metastructure(flatten)]
     pub value: AttributeValue,

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -1,11 +1,13 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use chrono::{DateTime, Utc};
 use prost_types::Timestamp;
+use relay_event_schema::processor::{ProcessValue, ProcessingState, process_value};
 use relay_event_schema::protocol::{Attributes, OurLog};
 use relay_protocol::{Annotated, Value};
 use relay_quotas::Scoping;
 use sentry_protos::snuba::v1::{AnyValue, TraceItem, TraceItemType, any_value};
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::constants::DEFAULT_EVENT_RETENTION;
@@ -41,8 +43,10 @@ pub struct Context {
     pub retention: Option<u16>,
 }
 
-pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreLog> {
+pub fn convert(mut log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreLog> {
     let quantities = log.quantities();
+
+    let meta = collect_meta(&mut log.value);
 
     let log = required!(log.value);
     let timestamp = required!(log.timestamp);
@@ -57,7 +61,7 @@ pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreLog> {
         timestamp: Some(ts(timestamp.0)),
         trace_id: required!(log.trace_id).to_string(),
         item_id: Uuid::new_v7(timestamp.into()).as_bytes().to_vec(),
-        attributes: attributes(attrs),
+        attributes: attributes(meta, attrs),
         client_sample_rate: 1.0,
         server_sample_rate: 1.0,
     };
@@ -75,8 +79,58 @@ fn ts(dt: DateTime<Utc>) -> Timestamp {
     }
 }
 
-fn attributes(attributes: Attributes) -> HashMap<String, AnyValue> {
-    let mut result = HashMap::with_capacity(attributes.0.len());
+/// The schema of a 'metadata attribute' stored in EAP.
+///
+/// A metadata attribute is a regular attribute stored in EAP, but it carries metadata about fields
+/// of the original payload processed by Relay and other components.
+///
+/// It is also a place to store other, non-processing related, metadata on attributes, for example
+/// the `unit` of an attribute.
+///
+/// The attribute metadata itself is serialized as a JSON string.
+#[derive(Debug, Serialize)]
+struct AttributeMeta {
+    /// Meta as it was extracted from Relay's annotated model.
+    meta: relay_protocol::Meta,
+}
+
+/// Extracts and converts all metadata attached to individual fields into individual attributes
+/// which can be attached to a [`TraceItem`].
+fn collect_meta(log: &mut Annotated<OurLog>) -> HashMap<String, AnyValue> {
+    let mut meta = relay_event_normalization::MetaCollectProcessor::new();
+
+    if let Err(_) = process_value(log, &mut meta, ProcessingState::root()) {
+        debug_assert!(false, "meta collect processor should never fail");
+        return HashMap::new();
+    }
+
+    meta.into_inner()
+        .into_iter()
+        .filter_map(|(key, meta)| {
+            let value = serde_json::to_string(&AttributeMeta { meta })
+                .inspect_err(|err| {
+                    debug_assert!(
+                        false,
+                        "attribute meta serialization should never fail: {err:?}"
+                    )
+                })
+                .ok()?;
+
+            let key = format!("sentry._meta.fields.{key}");
+            let value = AnyValue {
+                value: Some(any_value::Value::StringValue(value)),
+            };
+            Some((key, value))
+        })
+        .collect()
+}
+
+fn attributes(
+    meta: HashMap<String, AnyValue>,
+    attributes: Attributes,
+) -> HashMap<String, AnyValue> {
+    let mut result = meta;
+    result.reserve(attributes.0.len());
 
     for (name, attribute) in attributes {
         let value = attribute
@@ -108,4 +162,100 @@ fn attributes(attributes: Attributes) -> HashMap<String, AnyValue> {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_base_schema::organization::OrganizationId;
+    use relay_base_schema::project::ProjectId;
+    use relay_event_schema::protocol::OurLogHeader;
+    use relay_protocol::{Error as MetaError, FromValue, Meta};
+
+    use super::*;
+
+    macro_rules! ourlog {
+        ($($tt:tt)*) => {{
+           WithHeader {
+               header: Some(OurLogHeader {
+                   byte_size: Some(420),
+                   other: Default::default(),
+               }),
+               value: OurLog::from_value(serde_json::json!($($tt)*).into())
+           }
+        }};
+    }
+
+    macro_rules! get_mut {
+        ($e:expr) => {{ $e.value_mut().as_mut().unwrap() }};
+    }
+
+    fn test_context() -> Context {
+        Context {
+            received_at: DateTime::from_timestamp(1, 0).unwrap(),
+            scoping: Scoping {
+                organization_id: OrganizationId::new(1),
+                project_id: ProjectId::new(42),
+                project_key: "12333333333333333333333333333333".parse().unwrap(),
+                key_id: Some(3),
+            },
+            retention: Some(42),
+        }
+    }
+
+    #[test]
+    fn test_log_meta() {
+        let mut log = ourlog!({
+            "timestamp": 946684800.0,
+            "level": "info",
+            "trace_id": "5B8EFFF798038103D269B633813FC60C",
+            "span_id": "EEE19B7EC3C1B174",
+            "body": "Example log record",
+            "attributes": {
+                "foo": {
+                    "value": "9",
+                    "type": "string"
+                }
+            }
+        });
+
+        {
+            let log = get_mut!(log.value);
+            log.body
+                .meta_mut()
+                .add_error(MetaError::expected("something in the body"));
+
+            let attributes = get_mut!(log.attributes);
+            attributes.insert_raw(
+                "bar".to_owned(),
+                Annotated(None, Meta::from_error(MetaError::expected("invalid type"))),
+            );
+        }
+
+        let log = convert(log, &test_context()).unwrap();
+        insta::assert_debug_snapshot!(log.trace_item.attributes, @r###"
+        {
+            "asd.attributes.bar": AnyValue {
+                value: Some(
+                    StringValue(
+                        "{\"meta\":{\"err\":[[\"invalid_data\",{\"reason\":\"expected invalid type\"}]]}}",
+                    ),
+                ),
+            },
+            "foo": AnyValue {
+                value: Some(
+                    StringValue(
+                        "9",
+                    ),
+                ),
+            },
+            "asd.body": AnyValue {
+                value: Some(
+                    StringValue(
+                        "{\"meta\":{\"err\":[[\"invalid_data\",{\"reason\":\"expected something in the body\"}]]}}",
+                    ),
+                ),
+            },
+        }
+        "###);
+    }
 }


### PR DESCRIPTION
This is an processor based approach, which kind of works for the logs use-case but does not work in general due to a few limitations of the processing framework.

Nested fields do not work, as it will either extract each nested key individually, while top level fields should be grouped into a single `MetaTree`, the same for attributes, as long as attribute values are just a single value it works, the moment there would be any nested attributes this breaks.

Making a generic extractor/processor to extract meta trees from processed values might be possible by extracting it from a `T` in `before_process` using `IntoValue::extract_meta_tree`, but there is no simple way to stop recursive descend into the actual value, other than possibly return `DeleteValue*` from the `before_process`, which does not really make sense.

Due to missing mutable access to `T` in the `before_process`, we also are limited to cloning the metadata out, which might not be that big of a deal but another limitation.
 