### PR TITLE
fix(nel): Change attribute to nel.elapsed_time

### DIFF
--- a/relay-event-normalization/src/normalize/nel.rs
+++ b/relay-event-normalization/src/normalize/nel.rs
@@ -253,7 +253,6 @@ pub fn create_log_with_trace_id(
         add_string_attribute!("url.domain", &url_domain);
     }
     add_attribute!("url.full", raw_report.url);
-    add_attribute!("http.request.duration", body.elapsed_time);
     add_attribute!("http.request.method", body.method);
     add_attribute!("http.request.header.referer", body.referrer.clone());
     add_attribute!("http.response.status_code", body.status_code);
@@ -280,6 +279,7 @@ pub fn create_log_with_trace_id(
     }
 
     // NEL-specific attributes
+    add_attribute!("nel.elapsed_time", body.elapsed_time);
     add_attribute!("nel.referrer", body.referrer);
     add_attribute!("nel.phase", body.phase.map_value(|s| s.to_string()));
     add_attribute!("nel.sampling_fraction", body.sampling_fraction);

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__nel__tests__create_log_basic.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__nel__tests__create_log_basic.snap
@@ -12,10 +12,6 @@ expression: "SerializableAnnotated(&Annotated::new(log))"
       "type": "string",
       "value": "network-error"
     },
-    "http.request.duration": {
-      "type": "integer",
-      "value": 1000
-    },
     "http.request.header.referer": {
       "type": "string",
       "value": "https://example.com/referer"
@@ -27,6 +23,10 @@ expression: "SerializableAnnotated(&Annotated::new(log))"
     "http.response.status_code": {
       "type": "integer",
       "value": 500
+    },
+    "nel.elapsed_time": {
+      "type": "integer",
+      "value": 1000
     },
     "nel.phase": {
       "type": "string",

--- a/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__nel__tests__create_log_dns_error.snap
+++ b/relay-event-normalization/src/normalize/snapshots/relay_event_normalization__normalize__nel__tests__create_log_dns_error.snap
@@ -12,13 +12,13 @@ expression: "SerializableAnnotated(&Annotated::new(log))"
       "type": "string",
       "value": "network-error"
     },
-    "http.request.duration": {
-      "type": "integer",
-      "value": 2000
-    },
     "http.request.method": {
       "type": "string",
       "value": "POST"
+    },
+    "nel.elapsed_time": {
+      "type": "integer",
+      "value": 2000
     },
     "nel.phase": {
       "type": "string",


### PR DESCRIPTION
While reviewing the duration in logs it became unclear if requests could take up to 17 minutes.

This restores the attribute to be grouped under the `nel` prefix.