### PR TITLE
ref(relay): explicitly use disabled instead of defaulting to empty

### DIFF
--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
-- Add `trusted_relay_settings` to the project configuration. ([#4772](https://github.com/getsentry/relay/pull/4772))
+- Explicitly keep `disabled` in `trusted_relay_settings` instead of defaulting to empty.
 
 ## 0.9.10
 
-- No documented changes.
+- Add `trusted_relay_settings` to the project configuration. ([#4772](https://github.com/getsentry/relay/pull/4772))
 
 ## 0.9.9
 

--- a/py/tests/test_processing.py
+++ b/py/tests/test_processing.py
@@ -320,7 +320,12 @@ def test_validate_sampling_configuration():
 
 
 def test_normalize_project_config():
-    config = {"allowedDomains": ["*"], "trustedRelays": [], "piiConfig": None}
+    config = {
+        "allowedDomains": ["*"],
+        "trustedRelays": [],
+        "trustedRelaySettings": {"verifySignature": "disabled"},
+        "piiConfig": None,
+    }
     normalized = sentry_relay.normalize_project_config(config)
     assert config == normalized
 

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -28,7 +28,6 @@ pub struct ProjectConfig {
     /// List of relay public keys that are permitted to access this project.
     pub trusted_relays: Vec<PublicKey>,
     /// Configuration for trusted Relay behaviour.
-    #[serde(skip_serializing_if = "TrustedRelayConfig::is_empty")]
     pub trusted_relay_settings: TrustedRelayConfig,
     /// Configuration for PII stripping.
     pub pii_config: Option<PiiConfig>,

--- a/relay-dynamic-config/src/trusted_relay.rs
+++ b/relay-dynamic-config/src/trusted_relay.rs
@@ -5,17 +5,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default, rename_all = "camelCase")]
 pub struct TrustedRelayConfig {
     /// Checks the signature of an event and rejects it if enabled.
-    #[serde(skip_serializing_if = "SignatureVerification::is_default")]
     pub verify_signature: SignatureVerification,
-}
-
-impl TrustedRelayConfig {
-    /// Checks whether the config can be considered empty.
-    ///
-    /// Empty here means that all values are equal to their default values.
-    pub fn is_empty(&self) -> bool {
-        self.verify_signature == SignatureVerification::default()
-    }
 }
 
 /// Types of verification that can be performed on the signature.
@@ -28,13 +18,6 @@ pub enum SignatureVerification {
     /// Does not perform any validation on the signature.
     #[default]
     Disabled,
-}
-
-impl SignatureVerification {
-    /// Checks if it is the default variant.
-    pub fn is_default(&self) -> bool {
-        *self == SignatureVerification::default()
-    }
 }
 
 #[cfg(test)]
@@ -72,6 +55,13 @@ mod tests {
     #[test]
     fn test_default_serialize() {
         let serialized = serde_json::to_string(&TrustedRelayConfig::default()).unwrap();
-        assert_eq!(serialized, r#"{}"#);
+        assert_eq!(serialized, r#"{"verifySignature":"disabled"}"#);
+    }
+
+    #[test]
+    fn test_serialize_empty_to_default() {
+        let json = "{}";
+        let result: TrustedRelayConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(result.verify_signature, SignatureVerification::Disabled);
     }
 }


### PR DESCRIPTION
Changes the `verifiySignature` setting to no longer skip serialization. The reasoning behind this is that we can easier test against those values and we have more options to change the default in the future if the value is explicitly set.