### PR TITLE
ref(gocd): use console scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add support for playstation data requests. ([#4870](https://github.com/getsentry/relay/pull/4870))
 - Expand the NEL attributes & others. ([#4874](https://github.com/getsentry/relay/pull/4874))
 - Normalize legacy AI agents attributes to OTel compatible names. ([#4916](https://github.com/getsentry/relay/pull/4916))
+- Update GoCD agent scripts to use console script entry points. ([#4923](https://github.com/getsentry/relay/pull/4923))
 
 ## 25.6.2
 

--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -74,7 +74,7 @@ pipelines:
               elastic_profile_id: relay
               tasks:
                 - script: |
-                    /devinfra/scripts/k8s/k8stunnel \
+                    /devinfra/scripts/get-cluster-credentials \
                     && k8s-deploy \
                     --label-selector="service=relay,deploy_if_canary=true" \
                     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay:${GO_REVISION_RELAY_REPO}" \

--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -36,7 +36,7 @@ pipelines:
               elastic_profile_id: relay
               tasks:
                 - script: |
-                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                    checks-githubactions-checkruns \
                     getsentry/relay \
                     ${GO_REVISION_RELAY_REPO} \
                     "Integration Tests" \
@@ -75,7 +75,7 @@ pipelines:
               tasks:
                 - script: |
                     /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                     --label-selector="service=relay,deploy_if_canary=true" \
                     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay:${GO_REVISION_RELAY_REPO}" \
                     --container-name="relay"

--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -74,7 +74,7 @@ pipelines:
               elastic_profile_id: relay-pop
               tasks:
                 - script: |
-                    /devinfra/scripts/k8s/k8stunnel \
+                    /devinfra/scripts/get-cluster-credentials \
                     && k8s-deploy \
                     --label-selector="service=relay-pop,env=canary" \
                     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \

--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -36,7 +36,7 @@ pipelines:
               elastic_profile_id: relay-pop
               tasks:
                 - script: |
-                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                    checks-githubactions-checkruns \
                     getsentry/relay \
                     ${GO_REVISION_RELAY_REPO} \
                     "Integration Tests" \
@@ -75,7 +75,7 @@ pipelines:
               tasks:
                 - script: |
                     /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                     --label-selector="service=relay-pop,env=canary" \
                     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
                     --container-name="relay"

--- a/gocd/pipelines/relay.yaml
+++ b/gocd/pipelines/relay.yaml
@@ -29,7 +29,7 @@ pipelines:
               elastic_profile_id: relay
               tasks:
                 - script: |
-                    /devinfra/scripts/checks/gocd/pipeline_status.py \
+                    checks-gocd-pipeline-status \
                     deploy-relay-processing \
                     deploy-relay-pop
       - deploy-relay:
@@ -46,7 +46,7 @@ pipelines:
               elastic_profile_id: relay
               tasks:
                 - script: |
-                    /devinfra/scripts/gocd/trigger_pipeline.py \
+                    gocd-trigger-pipeline \
                     --pipeline-name=deploy-relay-processing \
                     --pipeline-name=deploy-relay-pop \
                     --material-name=relay_repo \

--- a/gocd/templates/bash/check-datadog-status.sh
+++ b/gocd/templates/bash/check-datadog-status.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py \
+checks-datadog-monitor-status \
   ${DATADOG_MONITOR_IDS} \
   --skip-check=false

--- a/gocd/templates/bash/check-sentry-errors.sh
+++ b/gocd/templates/bash/check-sentry-errors.sh
@@ -32,7 +32,7 @@ for project in "${projects[@]}"; do
     continue
   fi
 
-  /devinfra/scripts/checks/sentry/release_error_events.py \
+  checks-sentry-release-error-events \
     --project-id="${project_id}" \
     --project-slug="${project_slug}" \
     --release="${release_name}" \

--- a/gocd/templates/bash/check-sentry-new-errors.sh
+++ b/gocd/templates/bash/check-sentry-new-errors.sh
@@ -31,8 +31,7 @@ for project in "${projects[@]}"; do
 
     continue
   fi
-
-  /devinfra/scripts/checks/sentry/release_new_issues.py \
+  checks-sentry-release-new-issues \
     --project-id="${project_id}" \
     --project-slug="${project_slug}" \
     --release="${release_name}" \

--- a/gocd/templates/bash/deploy-pop-canary.sh
+++ b/gocd/templates/bash/deploy-pop-canary.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
     --label-selector="service=relay-pop,env=canary" \
     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"

--- a/gocd/templates/bash/deploy-pop-canary.sh
+++ b/gocd/templates/bash/deploy-pop-canary.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-deploy \
     --label-selector="service=relay-pop,env=canary" \

--- a/gocd/templates/bash/deploy-pop.sh
+++ b/gocd/templates/bash/deploy-pop.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(project_env_vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
     --label-selector="service=relay-pop" \
     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay-pop:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"

--- a/gocd/templates/bash/deploy-pop.sh
+++ b/gocd/templates/bash/deploy-pop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eval $(project_env_vars --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 

--- a/gocd/templates/bash/deploy-pop.sh
+++ b/gocd/templates/bash/deploy-pop.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-deploy \
     --label-selector="service=relay-pop" \

--- a/gocd/templates/bash/deploy-processing-canary.sh
+++ b/gocd/templates/bash/deploy-processing-canary.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(project_env_vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy.py \
     --label-selector="service=relay,env=canary" \
     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"

--- a/gocd/templates/bash/deploy-processing-canary.sh
+++ b/gocd/templates/bash/deploy-processing-canary.sh
@@ -2,9 +2,9 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
-k8s-deploy.py \
+k8s-deploy \
     --label-selector="service=relay,env=canary" \
     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"

--- a/gocd/templates/bash/deploy-processing-canary.sh
+++ b/gocd/templates/bash/deploy-processing-canary.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eval $(project_env_vars --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 

--- a/gocd/templates/bash/deploy-processing.sh
+++ b/gocd/templates/bash/deploy-processing.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-deploy \
     --label-selector="service=relay" \

--- a/gocd/templates/bash/deploy-processing.sh
+++ b/gocd/templates/bash/deploy-processing.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(project_env_vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
     --label-selector="service=relay" \
     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"

--- a/gocd/templates/bash/deploy-processing.sh
+++ b/gocd/templates/bash/deploy-processing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eval $(project_env_vars --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 

--- a/gocd/templates/bash/deploy-relay.sh
+++ b/gocd/templates/bash/deploy-relay.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-deploy \
     --label-selector="service=relay" \

--- a/gocd/templates/bash/deploy-relay.sh
+++ b/gocd/templates/bash/deploy-relay.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(project_env_vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
     --label-selector="service=relay" \
     --image="us-central1-docker.pkg.dev/internal-sentry/relay/relay:${GO_REVISION_RELAY_REPO}" \
     --container-name="relay"

--- a/gocd/templates/bash/deploy-relay.sh
+++ b/gocd/templates/bash/deploy-relay.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eval $(project_env_vars --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/githubactions/checkruns.py \
+checks-githubactions-checkruns \
     getsentry/relay \
     "${GO_REVISION_RELAY_REPO}" \
     "Integration Tests" \


### PR DESCRIPTION
Updating gocd scripts to use console script entry points.

Please see: https://github.com/getsentry/devinfra-deployment-service/pull/698

#skip-changelog