### PR TITLE
feat(performance): Updates standalone spans to extract geo data as tags

### DIFF
--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -1058,19 +1058,14 @@ pub fn extract_tags(
                     .data
                     .value()
                     .and_then(|data| data.client_address.value())
+                    && let Some(geoip_lookup) = geoip_lookup
+                    && let Ok(Some(geo)) = geoip_lookup.lookup(client_address.as_str())
+                    && let Some(country_code) = geo.country_code.value()
                 {
-                    if let Some(geoip_lookup) = geoip_lookup {
-                        if let Ok(Some(geo)) = geoip_lookup.lookup(client_address.as_str()) {
-                            if let Some(country_code) = geo.country_code.value() {
-                                span_tags.user_country_code = country_code.to_owned().into();
-                                if let Some(subregion) = Subregion::from_iso2(country_code.as_str())
-                                {
-                                    let numerical_subregion = subregion as u8;
-                                    span_tags.user_subregion =
-                                        numerical_subregion.to_string().into();
-                                }
-                            }
-                        }
+                    span_tags.user_country_code = country_code.to_owned().into();
+                    if let Some(subregion) = Subregion::from_iso2(country_code.as_str()) {
+                        let numerical_subregion = subregion as u8;
+                        span_tags.user_subregion = numerical_subregion.to_string().into();
                     }
                 }
             }

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -114,6 +114,7 @@ pub fn extract_span_tags(
             is_mobile,
             start_type,
             span_allowed_hosts,
+            None,
         );
 
         shared_tags.copy_into(&mut tags);
@@ -741,6 +742,7 @@ pub fn extract_tags(
     is_mobile: bool,
     start_type: Option<&str>,
     span_allowed_hosts: &[String],
+    geoip_lookup: Option<&crate::GeoIpLookup>,
 ) -> SentryTags {
     let mut span_tags = SentryTags::default();
 
@@ -1049,6 +1051,27 @@ pub fn extract_tags(
                 }
                 if let Some(release) = span.data.value().and_then(|data| data.release.as_str()) {
                     span_tags.release = release.to_owned().into();
+                }
+                // Standalone vital spans don't come from an event with geo data.
+                // Derive geo data from the client address inferred on the span.
+                if let Some(client_address) = span
+                    .data
+                    .value()
+                    .and_then(|data| data.client_address.value())
+                {
+                    if let Some(geoip_lookup) = geoip_lookup {
+                        if let Ok(Some(geo)) = geoip_lookup.lookup(client_address.as_str()) {
+                            if let Some(country_code) = geo.country_code.value() {
+                                span_tags.user_country_code = country_code.to_owned().into();
+                                if let Some(subregion) = Subregion::from_iso2(country_code.as_str())
+                                {
+                                    let numerical_subregion = subregion as u8;
+                                    span_tags.user_subregion =
+                                        numerical_subregion.to_string().into();
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1469,7 +1492,7 @@ mod tests {
 
     use super::*;
     use crate::span::description::{Mode, scrub_queries};
-    use crate::{NormalizationConfig, normalize_event};
+    use crate::{GeoIpLookup, NormalizationConfig, normalize_event};
 
     #[test]
     fn test_truncate_string_no_panic() {
@@ -2491,7 +2514,7 @@ LIMIT 1
             .unwrap()
             .into_value()
             .unwrap();
-        let tags = extract_tags(&span, 200, None, None, false, None, &[]);
+        let tags = extract_tags(&span, 200, None, None, false, None, &[], None);
 
         assert_eq!(tags.browser_name.value(), Some(&"Chrome".to_owned()));
     }
@@ -2558,7 +2581,7 @@ LIMIT 1
             .unwrap()
             .into_value()
             .unwrap();
-        let tags = extract_tags(&span, 200, None, None, false, None, &[]);
+        let tags = extract_tags(&span, 200, None, None, false, None, &[], None);
 
         assert_eq!(
             tags.messaging_destination_name.value(),
@@ -2864,7 +2887,7 @@ LIMIT 1
             .unwrap();
         span.description.set_value(Some(description.into()));
 
-        extract_tags(&span, 200, None, None, false, None, &[])
+        extract_tags(&span, 200, None, None, false, None, &[], None)
     }
 
     #[test]
@@ -2919,7 +2942,7 @@ LIMIT 1
             .unwrap()
             .into_value()
             .unwrap();
-        let tags = extract_tags(&span, 200, None, None, false, None, &[]);
+        let tags = extract_tags(&span, 200, None, None, false, None, &[], None);
 
         assert_eq!(tags.action.value(), Some(&"FIND".to_owned()));
 
@@ -2946,7 +2969,7 @@ LIMIT 1
             .unwrap()
             .into_value()
             .unwrap();
-        let tags = extract_tags(&span, 200, None, None, false, None, &[]);
+        let tags = extract_tags(&span, 200, None, None, false, None, &[], None);
 
         assert_eq!(tags.domain.value(), Some(&"documents_{%s}".to_owned()));
     }
@@ -3307,5 +3330,35 @@ LIMIT 1
             ..Default::default()
         };
         assert_eq!(category_for_span(&span), Some("browser".into()));
+    }
+
+    #[test]
+    fn extract_geo_location_on_standalone_vital_span() {
+        let lookup = GeoIpLookup::open("tests/fixtures/GeoIP2-Enterprise-Test.mmdb").unwrap();
+        let span: Span = Annotated::<Span>::from_json(
+            r#"{
+            "start_timestamp": 0,
+            "timestamp": 1,
+            "trace_id": "922dda2462ea4ac2b6a4b339bee90863",
+            "span_id": "922dda2462ea4ac2",
+            "data": {
+                "client.address": "2.125.160.216"
+            },
+            "op": "ui.webvital.lcp",
+            "measurements": {
+                "lcp": {
+                    "value": 632,
+                    "unit": "millisecond"
+                }
+            }
+        }"#,
+        )
+        .unwrap()
+        .into_value()
+        .unwrap();
+
+        let tags = extract_tags(&span, 200, None, None, false, None, &[], Some(&lookup));
+        assert_eq!(tags.user_country_code.value(), Some(&"GB".to_owned()));
+        assert_eq!(tags.user_subregion.value(), Some(&"154".to_owned()));
     }
 }

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -644,6 +644,7 @@ fn normalize(
         is_mobile,
         None,
         allowed_hosts,
+        geo_lookup,
     );
     span.sentry_tags = Annotated::new(tags);
 


### PR DESCRIPTION
Updates `extract_tags` function in standalone span tag extraction to derive and extract `user_country_code` and `user_subregion` tags using GeoIpLookup, specifically for standalone Web Vitals span measurements. Standalone spans should already have an inferred `client_address` to support this.

Geo data lookup already happens on Event normalization and their child spans, but standalone spans skip this because they are not part of an Event, which is why this change is needed.

#skip-changelog