### PR TITLE
feat(otlp): Serialize OTEL span array attributes to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
-- Serialize OTEL span array attributes to JSON ([#4930](https://github.com/getsentry/relay/pull/4930))
+- Serialize OTEL span array attributes to JSON. ([#4930](https://github.com/getsentry/relay/pull/4930))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
+- Serialize array attributes to JSON ([#4930](https://github.com/getsentry/relay/pull/4930))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
-- Serialize array attributes to JSON ([#4930](https://github.com/getsentry/relay/pull/4930))
+- Serialize standalone span array attributes to JSON ([#4930](https://github.com/getsentry/relay/pull/4930))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**:
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
-- Serialize standalone span array attributes to JSON ([#4930](https://github.com/getsentry/relay/pull/4930))
+- Serialize OTEL span array attributes to JSON ([#4930](https://github.com/getsentry/relay/pull/4930))
 
 **Bug Fixes**:
 

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -437,6 +437,7 @@ mod tests {
           "data": {
             "sentry.name": "cmd.run",
             "sentry.status.message": ""
+            "process.args": "[\"node\",\"--require\",\"preflight.cjs\"]"
           },
           "links": []
         }

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -451,7 +451,7 @@ mod tests {
           "status": "ok",
           "description": "cmd.run",
           "data": {
-            "process.args": "[\"node\",\"--require\",\"preflight.cjs\"]"
+            "process.args": "[\"node\",\"--require\",\"preflight.cjs\"]",
             "process.info": "[41]",
             "sentry.name": "cmd.run",
             "sentry.status.message": ""
@@ -613,6 +613,7 @@ mod tests {
             "sentry.release": "myapp@1.0.0",
             "sentry.segment.name": "my 1st transaction",
             "sentry.sdk.name": "sentry.php",
+            "sentry.metrics_summary.some_metric": "[]",
             "sentry.name": "myname",
             "sentry.status.message": "foo"
           },

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -393,6 +393,56 @@ mod tests {
         "###);
     }
 
+    #[test]
+    fn parse_array_attribute() {
+        let json = r#"{
+            "traceId": "4c79f60c11214eb38604f4ae0781bfb2",
+            "spanId": "fa90fdead5f74052",
+            "parentSpanId": "fa90fdead5f74051",
+            "startTimeUnixNano": "123000000000",
+            "endTimeUnixNano": "123500000000",
+            "name": "cmd.run",
+            "status": {"code": 0},
+            "attributes": [
+                {
+                    "key": "process.args",
+                    "value": {
+                        "arrayValue": {
+                            "values": [
+                                {"stringValue": "node"},
+                                {"stringValue": "--require"},
+                                {"stringValue": "preflight.cjs"}
+                            ]
+                        }
+                    }
+                }
+            ]
+        }"#;
+
+        let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
+        let event_span = otel_to_sentry_span(otel_span).unwrap();
+
+        let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        {
+          "timestamp": 123.5,
+          "start_timestamp": 123.0,
+          "exclusive_time": 500.0,
+          "op": "default",
+          "span_id": "fa90fdead5f74052",
+          "parent_span_id": "fa90fdead5f74051",
+          "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+          "status": "ok",
+          "description": "cmd.run",
+          "data": {
+            "sentry.name": "cmd.run",
+            "sentry.status.message": ""
+          },
+          "links": []
+        }
+        "###);
+    }
+
     /// Intended to be synced with `relay-event-schema::protocol::span::convert::tests::roundtrip`.
     #[test]
     fn parse_sentry_attributes() {

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -415,6 +415,22 @@ mod tests {
                             ]
                         }
                     }
+                },
+                {
+                    "key": "process.info",
+                    "value": {
+                        "arrayValue": {
+                            "values": [
+                                {"intValue": 41},
+                                {
+                                    "arrayValue": {
+                                        "values": [
+                                            {"intValue": 42}
+                                    ]}
+                                }
+                            ]
+                        }
+                    }
                 }
             ]
         }"#;
@@ -435,9 +451,10 @@ mod tests {
           "status": "ok",
           "description": "cmd.run",
           "data": {
+            "process.args": "[\"node\",\"--require\",\"preflight.cjs\"]"
+            "process.info": "[41]",
             "sentry.name": "cmd.run",
             "sentry.status.message": ""
-            "process.args": "[\"node\",\"--require\",\"preflight.cjs\"]"
           },
           "links": []
         }

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -153,8 +153,7 @@ fn otel_value_to_attr(otel_value: OtelValue) -> Option<Attribute> {
             let safe_values: Vec<serde_json::Value> = array
                 .values
                 .into_iter()
-                .filter_map(|v| v.value)
-                .filter_map(|v| match v {
+                .filter_map(|v| match v.value? {
                     OtelValue::StringValue(s) => Some(serde_json::Value::String(s)),
                     OtelValue::BoolValue(b) => Some(serde_json::Value::Bool(b)),
                     OtelValue::IntValue(i) => {


### PR DESCRIPTION
OTLP supports array attributes, and there are many common semantic attributes that are expected to be arrays. Right now, we discard this information because we don't have system-level handling for arrays at all, and a proper solution is very hard.

For now, let's hack around this, and serialize array types to a JSON string, which is a common recommended approach by OTel when a protocol cannot support every data type.

Convert array attributes _very early_ to strings, and then sends them along.
