### PR TITLE
ref(spans): Only emit indexed outcomes when producing to snuba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add `gen_ai.response.tokens_per_second` span attribute on AI spans. ([#4883](https://github.com/getsentry/relay/pull/4883))
 - Add support for playstation data requests. ([#4870](https://github.com/getsentry/relay/pull/4870))
 - Expand the NEL attributes & others. ([#4874](https://github.com/getsentry/relay/pull/4874))
+- Only emit indexed span outcomes when producing directly to Snuba. ([#4936](https://github.com/getsentry/relay/pull/4936))
 - Normalize legacy AI agents attributes to OTel compatible names. ([#4916](https://github.com/getsentry/relay/pull/4916))
 - Fix cost calculation for cached and reasoning tokens. ([#4922](https://github.com/getsentry/relay/pull/4922))
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1994,16 +1994,6 @@ def test_span_outcomes(
             "category": DataCategory.SPAN_INDEXED.value,
             "key_id": 123,
             "org_id": 1,
-            "outcome": 0,  # Accepted
-            "project_id": 42,
-            "quantity": 2,
-            "source": "processing-relay",
-        },
-        {
-            "timestamp": time_within_delta(),
-            "category": DataCategory.SPAN_INDEXED.value,
-            "key_id": 123,
-            "org_id": 1,
             "outcome": 1,  # Filtered
             "project_id": 42,
             "quantity": 2,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -152,6 +152,7 @@ def test_span_extraction(
         "origin": "manual",
         "parent_span_id": "968cff94913ebb07",
         "project_id": 42,
+        "key_id": 123,
         "retention_days": 90,
         "segment_id": "968cff94913ebb07",
         "sentry_tags": {
@@ -217,6 +218,7 @@ def test_span_extraction(
         "organization_id": 1,
         "origin": "manual",
         "project_id": 42,
+        "key_id": 123,
         "retention_days": 90,
         "segment_id": "968cff94913ebb07",
         "sentry_tags": {
@@ -791,6 +793,7 @@ def test_span_ingestion(
             ],
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "a342abb1214ca181",
             "sentry_tags": {
@@ -834,6 +837,7 @@ def test_span_ingestion(
             ],
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "a342abb1214ca182",
             "sentry_tags": {
@@ -884,6 +888,7 @@ def test_span_ingestion(
             "measurements": {"score.total": {"value": 0.12121616}},
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "b0429c44b67a3eb1",
             "sentry_tags": {
@@ -936,6 +941,7 @@ def test_span_ingestion(
             ],
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "b0429c44b67a3eb2",
             "sentry_tags": {
@@ -972,6 +978,7 @@ def test_span_ingestion(
             "is_remote": False,
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "968cff94913ebb07",
             "sentry_tags": {"browser.name": "Chrome", "op": "default"},
@@ -1010,6 +1017,7 @@ def test_span_ingestion(
             ],
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "d342abb1214ca182",
             "sentry_tags": {
@@ -1040,6 +1048,7 @@ def test_span_ingestion(
             "is_remote": False,
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "segment_id": "968cff94913ebb07",
             "sentry_tags": {
@@ -1084,6 +1093,7 @@ def test_span_ingestion(
             "organization_id": 1,
             "parent_span_id": "f0f0f0abcdef1234",
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "sentry_tags": {
                 "browser.name": "Python Requests",
@@ -1865,6 +1875,7 @@ def test_span_ingestion_with_performance_scores(
             "is_remote": False,
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "sentry_tags": {
                 "browser.name": "Python Requests",
@@ -1945,6 +1956,7 @@ def test_span_ingestion_with_performance_scores(
             "profile_id": "3d9428087fda4ba0936788b70a7587d0",
             "organization_id": 1,
             "project_id": 42,
+            "key_id": 123,
             "retention_days": 90,
             "sentry_tags": {
                 "browser.name": "Python Requests",
@@ -2011,7 +2023,6 @@ def test_rate_limit_indexed_consistent(
     relay.send_envelope(project_id, envelope)
     spans = spans_consumer.get_spans(n=6, timeout=10)
     assert len(spans) == 6
-    assert summarize_outcomes() == {(16, 0): 6}  # SpanIndexed, Accepted
 
     # Second batch is limited
     relay.send_envelope(project_id, envelope)
@@ -2087,7 +2098,6 @@ def test_rate_limit_consistent_extracted(
     spans = spans_consumer.get_spans(n=2, timeout=10)
     # one for the transaction, one for the contained span
     assert len(spans) == 2
-    assert summarize_outcomes() == {(16, 0): 2}  # SpanIndexed, Accepted
     # A limit only for span_indexed does not affect extracted metrics
     metrics = metrics_consumer.get_metrics(n=11)
     span_count = sum(
@@ -2241,7 +2251,6 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     # We have one nested span and the transaction itself becomes a span
     spans = spans_consumer.get_spans(n=2, timeout=10)
     assert len(spans) == 2
-    assert summarize_outcomes() == {(16, 0): 2}  # SpanIndexed, Accepted
     assert usage_metrics() == (1, 2)
 
     # Second batch nothing passes
@@ -2497,8 +2506,7 @@ def test_dynamic_sampling(
     if sample_rate == 1.0:
         spans = spans_consumer.get_spans(timeout=10, n=6)
         assert len(spans) == 6
-        outcomes = outcomes_consumer.get_outcomes(timeout=10, n=6)
-        assert summarize_outcomes(outcomes) == {(16, 0): 6}  # SpanIndexed, Accepted
+        outcomes_consumer.assert_empty()
     else:
         outcomes = outcomes_consumer.get_outcomes(timeout=10, n=1)
         assert summarize_outcomes(outcomes) == {(16, 1): 6}  # Span, Filtered
@@ -2697,6 +2705,7 @@ def test_scrubs_ip_addresses(
         "origin": "manual",
         "parent_span_id": "968cff94913ebb07",
         "project_id": 42,
+        "key_id": 123,
         "retention_days": 90,
         "segment_id": "968cff94913ebb07",
         "sentry_tags": {
@@ -2771,6 +2780,7 @@ def test_scrubs_ip_addresses(
         "is_remote": True,
         "organization_id": 1,
         "project_id": 42,
+        "key_id": 123,
         "retention_days": 90,
         "segment_id": "968cff94913ebb07",
         "sentry_tags": {


### PR DESCRIPTION
Sentry PR: https://github.com/getsentry/sentry/pull/95422

Only emits indexed outcomes when producing as protobuf, when producing only to the spans topic, the spans consumer will emit the indexed outcome instead.