### PR TITLE
feat(globalconfig): Request global config from upstream if loading local fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
+- Request global config from upstream if loading local fails. ([#4937](https://github.com/getsentry/relay/pull/4937))
 
 **Bug Fixes**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2234,7 +2234,7 @@ impl Config {
     }
 
     /// Returns the interval in seconds in which fresh global configs should be
-    /// fetched from  upstream.
+    /// fetched from upstream.
     pub fn global_config_fetch_interval(&self) -> Duration {
         Duration::from_secs(self.values.cache.global_config_fetch_interval.into())
     }


### PR DESCRIPTION
Changes the logic around the global config fetching for Proxy, Static & Capture mode.
In these modes we try to obtain the config from the `.relay/global_config.json`. Previously if this failed we would return the default config, instead we now try to fetch the global config from the upstream (which will still return the default if fetching from the upstream is not possible for any reason). 

---

Sounds good in theory but will not work due to: `failed to fetch global config from upstream error=attempted to send upstream request without credentials configured` and https://docs.sentry.io/product/relay/getting-started/#creating-credentials so the users might not have the credentials in Proxy or Static mode.