### PR TITLE
feat(logs): Handle inbound filters for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
+- Handle inbound filters for logs. (#4938)
 
 **Bug Fixes**:
 

--- a/relay-event-schema/src/protocol/ourlog.rs
+++ b/relay-event-schema/src/protocol/ourlog.rs
@@ -42,7 +42,6 @@ pub struct OurLog {
 
 impl Getter for OurLog {
     fn get_value(&self, path: &str) -> Option<Val<'_>> {
-        println!("path {:?}", path);
         Some(match path.strip_prefix("event.")? {
             "release" => self
                 .attributes

--- a/relay-filter/src/interface.rs
+++ b/relay-filter/src/interface.rs
@@ -3,8 +3,8 @@
 use url::Url;
 
 use relay_event_schema::protocol::{
-    Csp, Event, EventType, Exception, LogEntry, Replay, SessionAggregates, SessionUpdate, Span,
-    Values,
+    Csp, Event, EventType, Exception, LogEntry, OurLog, Replay, SessionAggregates, SessionUpdate,
+    Span, Values,
 };
 
 /// A data item to which filters can be applied.
@@ -89,6 +89,46 @@ impl Filterable for Event {
             .headers
             .value()?
             .get_header(header_name)
+    }
+}
+
+impl Filterable for OurLog {
+    fn csp(&self) -> Option<&Csp> {
+        None
+    }
+
+    fn exceptions(&self) -> Option<&Values<Exception>> {
+        None
+    }
+
+    fn ip_addr(&self) -> Option<&str> {
+        None
+    }
+
+    fn logentry(&self) -> Option<&LogEntry> {
+        None
+    }
+
+    fn release(&self) -> Option<&str> {
+        let attributes = self.attributes.value()?;
+        let release = attributes.get_value("sentry.release")?;
+        release.as_str()
+    }
+
+    fn transaction(&self) -> Option<&str> {
+        None
+    }
+
+    fn url(&self) -> Option<Url> {
+        None
+    }
+
+    fn user_agent(&self) -> Option<&str> {
+        None
+    }
+
+    fn header(&self, header_name: &str) -> Option<&str> {
+        None
     }
 }
 


### PR DESCRIPTION
This adds support for the release inbound filter on logs. We currently do not support client ip because logs do not have an ip attribute.