### PR TITLE
fix(normalization): Do not drop custom measurements if no config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
 - Serialize OTEL span array attributes to JSON. ([#4930](https://github.com/getsentry/relay/pull/4930))
+- Do not drop custom measurements if no config is present. ([#4941](https://github.com/getsentry/relay/pull/4941))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Add mechanism to allow ingestion only from trusted relays. ([#4772](https://github.com/getsentry/relay/pull/4772))
 - Serialize OTEL span array attributes to JSON. ([#4930](https://github.com/getsentry/relay/pull/4930))
-- Do not drop custom measurements if no config is present. ([#4941](https://github.com/getsentry/relay/pull/4941))
 
 **Bug Fixes**:
 
@@ -15,6 +14,7 @@
 - Do not overwrite geo information if already set. ([#4888](https://github.com/getsentry/relay/pull/4888))
 - The `type` fields of contexts are now enforced to be strings. Non-string values are replaced with the
   context's key. ([#4932](https://github.com/getsentry/relay/pull/4932))
+- Do not drop custom measurements if no config is present. ([#4941](https://github.com/getsentry/relay/pull/4941))
 
 **Internal**:
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1391,7 +1391,7 @@ fn remove_invalid_measurements(
     measurements_config: CombinedMeasurementsConfig,
     max_name_and_unit_len: Option<usize>,
 ) {
-    // If there is no project and global config allow all the custom measurements through.
+    // If there is no project or global config allow all the custom measurements through.
     let max_custom_measurements = measurements_config
         .max_custom_measurements()
         .unwrap_or(usize::MAX);

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2136,7 +2136,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_measurement_not_dropped() {
+    fn test_custom_measurements_not_dropped() {
         let mut measurements = Measurements(BTreeMap::from([(
             "custom_measurement".to_owned(),
             Annotated::new(Measurement {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1391,7 +1391,11 @@ fn remove_invalid_measurements(
     measurements_config: CombinedMeasurementsConfig,
     max_name_and_unit_len: Option<usize>,
 ) {
-    let max_custom_measurements = measurements_config.max_custom_measurements().unwrap_or(0);
+    // If there is no project and global config allow for all the custom configs to pass through
+    // instead of dropping them here.
+    let max_custom_measurements = measurements_config
+        .max_custom_measurements()
+        .unwrap_or(usize::MAX);
 
     let mut custom_measurements_count = 0;
     let mut removed_measurements = Object::new();

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2136,6 +2136,27 @@ mod tests {
     }
 
     #[test]
+    fn custom_measurement_not_dropped() {
+        let mut measurements = Measurements(BTreeMap::from([(
+            "custom_measurement".to_owned(),
+            Annotated::new(Measurement {
+                value: Annotated::new(42.0.try_into().unwrap()),
+                unit: Annotated::new(MetricUnit::Duration(DurationUnit::MilliSecond)),
+            }),
+        )]));
+
+        let original = measurements.clone();
+        remove_invalid_measurements(
+            &mut measurements,
+            &mut Meta::default(),
+            CombinedMeasurementsConfig::new(None, None),
+            Some(30),
+        );
+
+        assert_eq!(original, measurements);
+    }
+
+    #[test]
     fn test_normalize_app_start_measurements_does_not_add_measurements() {
         let mut measurements = Annotated::<Measurements>::from_json(r###"{}"###)
             .unwrap()

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1391,8 +1391,7 @@ fn remove_invalid_measurements(
     measurements_config: CombinedMeasurementsConfig,
     max_name_and_unit_len: Option<usize>,
 ) {
-    // If there is no project and global config allow for all the custom configs to pass through
-    // instead of dropping them here.
+    // If there is no project and global config allow all the custom measurements through.
     let max_custom_measurements = measurements_config
         .max_custom_measurements()
         .unwrap_or(usize::MAX);

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1349,10 +1349,9 @@ def test_limit_custom_measurements(
 
 
 @pytest.mark.parametrize("has_measurements_config", [True, False])
-def test_do_not_drop_custom_measurements(
+def test_do_not_drop_custom_measurements_in_static(
     mini_sentry,
     relay,
-    relay_with_processing,
     metrics_consumer,
     transactions_consumer,
     has_measurements_config,
@@ -1374,7 +1373,7 @@ def test_do_not_drop_custom_measurements(
         dir.join("projects").join(f"{project_id}.json").write(json.dumps(config))
 
     relay = relay(
-        relay_with_processing(options=TEST_CONFIG),
+        mini_sentry,
         options=TEST_CONFIG | {"relay": {"mode": "static"}},
         prepare=configure_static_project,
     )
@@ -1389,7 +1388,7 @@ def test_do_not_drop_custom_measurements(
     }
 
     relay.send_transaction(42, transaction)
-    event, _ = transactions_consumer.get_event()
+    event = mini_sentry.captured_events.get(timeout=2).items[0].payload.json
 
     if has_measurements_config:
         # With maxCustomMeasurements: 1, only 1 measurement should pass through

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -11,6 +11,7 @@ from .consts import (
     TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
 )
 
+import os
 import pytest
 import requests
 from requests.exceptions import HTTPError
@@ -1345,6 +1346,61 @@ def test_limit_custom_measurements(
         "d:transactions/measurements.foo@none",
         "d:transactions/measurements.bar@none",
     }
+
+
+@pytest.mark.parametrize("has_measurements_config", [True, False])
+def test_do_not_drop_custom_measurements(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    metrics_consumer,
+    transactions_consumer,
+    has_measurements_config,
+):
+    project_id = 42
+    config = mini_sentry.add_full_project_config(project_id)
+
+    if has_measurements_config:
+        config["config"]["measurements"] = {
+            "maxCustomMeasurements": 1,
+        }
+
+    metrics_consumer = metrics_consumer()
+    transactions_consumer = transactions_consumer()
+
+    def configure_static_project(dir):
+        os.remove(dir.join("credentials.json"))
+        os.makedirs(dir.join("projects"))
+        dir.join("projects").join(f"{project_id}.json").write(json.dumps(config))
+
+    relay = relay(
+        relay_with_processing(options=TEST_CONFIG),
+        options=TEST_CONFIG | {"relay": {"mode": "static"}},
+        prepare=configure_static_project,
+    )
+
+    timestamp = datetime.now(tz=timezone.utc)
+    transaction = generate_transaction_item()
+    transaction["timestamp"] = timestamp.isoformat()
+    transaction["measurements"] = {
+        "foo": {"value": 1.2},
+        "baz": {"value": 1.3},
+        "bar": {"value": 1.4},
+    }
+
+    relay.send_transaction(42, transaction)
+    event, _ = transactions_consumer.get_event()
+
+    if has_measurements_config:
+        # With maxCustomMeasurements: 1, only 1 measurement should pass through
+        assert event["measurements"] == {"bar": {"value": 1.4, "unit": "none"}}
+    else:
+        # Without measurements config, all measurements should pass through
+        assert event["measurements"] == {
+            "bar": {"value": 1.4, "unit": "none"},
+            "baz": {"value": 1.3, "unit": "none"},
+            "foo": {"value": 1.2, "unit": "none"},
+        }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously if there was neither a global or project config the `max_custom_measurements` would be `0` which would cause custom measurements to be dropped. Now this limit is set to `usize::MAX` to allow all the custom measurements through.
