### PR TITLE
ci(artifacts): No longer store debug/source artifacts in docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,6 @@ jobs:
 
     strategy:
       matrix:
-        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
         platform: ${{ fromJson(needs.build-setup.outputs.platforms) }}
 
     # required for google auth
@@ -665,14 +664,11 @@ jobs:
       id-token: "write"
 
     env:
-      AR_DOCKER_IMAGE: "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}"
       REVISION: "${{ github.event.pull_request.head.sha || github.sha }}"
 
     if: "!startsWith(github.ref, 'refs/heads/release-library/') && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && needs.build-setup.outputs.full_ci == 'true'"
 
     steps:
-      - uses: docker/setup-qemu-action@v3
-
       - name: Google Auth
         id: auth
         uses: google-github-actions/auth@v2
@@ -691,31 +687,31 @@ jobs:
           # You must use the Cloud SDK version 390.0.0 or later to authenticate the bq and gsutil tools.
           version: ">= 390.0.0"
 
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "internal-${{ matrix.image_name }}@*"
+          merge-multiple: true
+
+      - name: Decrypt Artifacts
+        run: |
+          find . -name "*.gpg" | while read file; do
+            output_file="${file%.gpg}"
+            gpg --quiet --batch --yes --decrypt \
+                --passphrase "${{ secrets.ENCRYPTION_KEY }}" \
+                --output "$output_file" "$file"
+            rm "$file"
+          done
+
       - name: Upload gocd deployment assets
-        env:
-          LIB_PATH: ${{ fromJson('{"linux/amd64":"/lib/x86_64-linux-gnu","linux/arm64":"/lib/aarch64-linux-gnu"}')[matrix.platform] }}
         run: |
           set -euxo pipefail
-          VERSION="$(docker run --rm "${AR_DOCKER_IMAGE}:${REVISION}" --version | cut -d" " -f2)"
+          VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/relay:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
-          docker run --rm --platform ${{ matrix.platform }} --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay-debug.zip > relay-debug.zip
-          docker run --rm --platform ${{ matrix.platform }} --entrypoint cat "${AR_DOCKER_IMAGE}:${REVISION}" /opt/relay.src.zip > relay.src.zip
-          docker run --rm --platform ${{ matrix.platform }} --entrypoint tar "${AR_DOCKER_IMAGE}:${REVISION}" -cf - "${LIB_PATH}" > libs.tar
-
-          # debugging for mysterious "Couldn't write tracker file" issue:
-          (env | grep runner) || true
-          ls -ld  \
-            /home \
-            /home/runner \
-            /home/runner/.gsutil \
-            /home/runner/.gsutil/tracker-files \
-            /home/runner/.gsutil/tracker-files/upload_TRACKER_*.rc.zip__JSON.url \
-          || true
-          gsutil -m cp -L gsutil.log ./libs.tar ./relay-debug.zip ./relay.src.zip ./release-name \
-            "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${{ matrix.platform }}/" || status=$? && status=$?
-          cat gsutil.log
-          exit "$status"
+          for PLATFORM in "linux/amd64" "linux/arm64"; do
+            gsutil -m cp -L /dev/stderr $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
+              "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${{ matrix.platform }}/"
+          done
 
   test_integration:
     needs: build-setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,15 +705,12 @@ jobs:
       - name: Upload gocd deployment assets
         run: |
           set -euxo pipefail
-          VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/relay:${REVISION}" --version | cut -d" " -f2)"
+          VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
-          tree
-
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            echo $PLATFORM
             gsutil -m cp $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
-              "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${{ matrix.platform }}/"
+              "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"
           done
 
   test_integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
 
   gocd-artifacts:
     timeout-minutes: 10
-    needs: [build-setup, publish-to-ar-internal]
+    needs: [build-setup, build-internal, publish-to-ar-internal]
 
     name: Upload build artifacts to gocd
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,15 +648,11 @@ jobs:
         run: docker buildx imagetools create --tag "${AR_DOCKER_IMAGE}:nightly" "${GHCR_DOCKER_IMAGE}:nightly"
 
   gocd-artifacts:
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [build-setup, publish-to-ar-internal]
 
     name: Upload build artifacts to gocd
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        platform: ${{ fromJson(needs.build-setup.outputs.platforms) }}
 
     # required for google auth
     permissions:
@@ -708,8 +704,11 @@ jobs:
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/relay:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
+          tree
+
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            gsutil -m cp -L /dev/stderr $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
+            echo $PLATFORM
+            gsutil -m cp $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${{ matrix.platform }}/"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,6 +654,10 @@ jobs:
     name: Upload build artifacts to gocd
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        image_name: ${{ fromJson(needs.build-setup.outputs.image_names) }}
+
     # required for google auth
     permissions:
       contents: "read"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Internal**:
 
+- No longer store debug symbols and the source in the docker image. ([#4942](https://github.com/getsentry/relay/pull/4942))
 - Forward logs to Kafka directly instead of serialized as envelope. ([#4875](https://github.com/getsentry/relay/pull/4875))
 - Remember accepted/ingested bytes for log outcomes. ([#4886](https://github.com/getsentry/relay/pull/4886))
 - Add `gen_ai.response.tokens_per_second` span attribute on AI spans. ([#4883](https://github.com/getsentry/relay/pull/4883))

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -24,8 +24,6 @@ EXPOSE 3000
 
 COPY $TARGETPLATFORM/relay /bin/relay
 RUN chmod +x /bin/relay
-COPY $TARGETPLATFORM/relay-debug.zip /opt/relay-debug.zip
-COPY $TARGETPLATFORM/relay.src.zip /opt/relay.src.zip
 
 COPY ./docker-entrypoint.sh /
 ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -33,16 +33,11 @@ for PLATFORM in "linux/amd64" "linux/arm64"; do
   gsutil cp \
     "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/relay-debug.zip" \
     "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/relay.src.zip" \
-    "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/${PLATFORM}/libs.tar" \
     .
   echo "Uploading debug information and source bundle for $PLATFORM..."
   sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
 
-  echo "Uploading system symbols for $PLATFORM..."
-  tar xf libs.tar
-  sentry-cli upload-dif lib/
-
-  rm relay-debug.zip relay.src.zip libs.tar
+  rm relay-debug.zip relay.src.zip
   rm -rf lib
 done
 

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -38,7 +38,6 @@ for PLATFORM in "linux/amd64" "linux/arm64"; do
   sentry-cli upload-dif ./relay-debug.zip ./relay.src.zip
 
   rm relay-debug.zip relay.src.zip
-  rm -rf lib
 done
 
 gsutil cp "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${NAME}/linux/amd64/release-name" .


### PR DESCRIPTION
Simplifies the uploading of debug symbols and source files to gocd.

- No longer add them to the image itself, this should save quite a bit of size of the image (~130-150 MiB)
- Use the previously uploaded artifacts to push them to gocd
- No longer upload libraries from the docker image, this seems to have been largely not used, and is following Symbolicator, if it turns out the symbols are useful, we can always add them back. I suspect most of the libraries do not contain debug information anyways.

This is a preparation for using a distroless base image (#4871), which will not contain (m)any system libraries either.