### PR TITLE
ci(gocd): Fix upload artifact job names

### DIFF
--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -7,7 +7,5 @@ checks-githubactions-checkruns \
     "Test All Features (ubuntu-latest)" \
     "Publish Relay to Internal AR (relay)" \
     "Publish Relay to Internal AR (relay-pop)" \
-    "Upload build artifacts to gocd (relay, linux/amd64)" \
-    "Upload build artifacts to gocd (relay, linux/arm64)" \
-    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
-    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \
+    "Upload build artifacts to gocd (relay)" \
+    "Upload build artifacts to gocd (relay-pop)" \


### PR DESCRIPTION
The job is no longer a matrix job over the architecture, we need to refer to the correct job name in gocd.

#skip-changelog