### PR TITLE
fix(ci): Update from windows 2019 to windows 2022

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -130,7 +130,7 @@ jobs:
     name: Windows
     # Make sure to update documentation once the version is updated:
     # https://docs.sentry.io/product/relay/operating-guidelines/
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -130,7 +130,7 @@ jobs:
     name: Windows
     # Make sure to update documentation once the version is updated:
     # https://docs.sentry.io/product/relay/operating-guidelines/
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Self-hosted release is failing here: https://github.com/getsentry/relay/actions/runs/16299548810/job/46030294864

Seems like windows-2019 is deprecated

#skip-changelog