### PR TITLE
chore: Update python dev deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,9 +18,9 @@ pytest-xdist==3.5.0
 pytest==7.4.3
 PyYAML==6.0.2
 redis==4.5.4
-requests==2.32.2
+requests==2.32.4
 sentry_sdk==2.30.0
-setuptools==70.0.0
+setuptools==78.1.1
 werkzeug==3.0.6
 zstandard==0.18.0
 sentry_protos==0.2.0

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -993,7 +993,7 @@ def test_span_ingestion(
                 "browser.name": "Python Requests",
                 "client.address": "127.0.0.1",
                 "sentry.name": "my 2nd OTel span",
-                "user_agent.original": "python-requests/2.32.2",
+                "user_agent.original": "python-requests/2.32.4",
                 # Backfilled from `sentry_tags`:
                 "sentry.browser.name": "Python Requests",
                 "sentry.op": "default",
@@ -1067,7 +1067,7 @@ def test_span_ingestion(
                 "client.address": "127.0.0.1",
                 "sentry.name": "my 3rd protobuf OTel span",
                 "ui.component_name": "MyComponent",
-                "user_agent.original": "python-requests/2.32.2",
+                "user_agent.original": "python-requests/2.32.4",
                 # Backfilled from `sentry_tags`:
                 "sentry.browser.name": "Python Requests",
                 "sentry.op": "default",
@@ -1842,7 +1842,7 @@ def test_span_ingestion_with_performance_scores(
             "data": {
                 "browser.name": "Python Requests",
                 "client.address": "127.0.0.1",
-                "user_agent.original": "python-requests/2.32.2",
+                "user_agent.original": "python-requests/2.32.4",
                 # Backfilled from `sentry_tags`:
                 "sentry.browser.name": "Python Requests",
                 "sentry.op": "ui.interaction.click",
@@ -1935,7 +1935,7 @@ def test_span_ingestion_with_performance_scores(
                 "sentry.replay.id": "8477286c8e5148b386b71ade38374d58",
                 "sentry.segment.name": "/page/with/click/interaction/*/*",
                 "user": "[email]",
-                "user_agent.original": "python-requests/2.32.2",
+                "user_agent.original": "python-requests/2.32.4",
                 # Backfilled from `sentry_tags`:
                 "sentry.browser.name": "Python Requests",
                 "sentry.op": "ui.interaction.click",


### PR DESCRIPTION
Address some dependabot security complains in the dev setup

addresses https://github.com/getsentry/relay/security/dependabot/106
and also https://github.com/getsentry/relay/security/dependabot/107

#skip-changelog