### PR TITLE
fix(span-metrics): Bring back one metric still in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 **Internal**:
 
 - Emit outcomes for skipped large attachments on playstation crashes. ([#4862](https://github.com/getsentry/relay/pull/4862))
-- Disable span metrics. ([#4931](https://github.com/getsentry/relay/pull/4931))
+- Disable span metrics. ([#4931](https://github.com/getsentry/relay/pull/4931),[#4955](https://github.com/getsentry/relay/pull/4955))
 
 ## 25.7.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -12,28 +12,31 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         .metric_extraction
         .get_or_insert_with(MetricExtractionConfig::empty);
 
-    if !config.is_supported() || config._span_metrics_extended {
+    let features = &project_config.features;
+
+    if !config.is_supported() || config._span_metrics_extended || !features.produces_spans() {
         return;
     }
 
-    let features = &project_config.features;
-
     // If there are any spans in the system, extract the usage metric for them:
-    if features.produces_spans() {
-        config.metrics.push(MetricSpec {
-            category: DataCategory::Span,
-            mri: "c:spans/usage@none".into(),
-            field: None,
-            condition: None,
-            tags: vec![],
-        });
-    }
+    config.metrics.push(MetricSpec {
+        category: DataCategory::Span,
+        mri: "c:spans/usage@none".into(),
+        field: None,
+        condition: None,
+        tags: vec![],
+    });
 
-    let span_metrics_tx = config
+    config
+        .global_groups
+        .entry(GroupKey::SpanMetricsCommon)
+        .or_default()
+        .is_enabled = true;
+    config
         .global_groups
         .entry(GroupKey::SpanMetricsTx)
-        .or_default();
-    span_metrics_tx.is_enabled = true;
+        .or_default()
+        .is_enabled = true;
 
     config._span_metrics_extended = true;
     if config.version == 0 {
@@ -63,46 +66,13 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
             "Opera Mobile",
         ],
     );
-    vec![(
-        GroupKey::SpanMetricsTx,
-        vec![
-            MetricSpec {
+    vec![
+        (
+            GroupKey::SpanMetricsCommon,
+            vec![MetricSpec {
                 category: DataCategory::Span,
-                mri: "d:transactions/measurements.score.total@ratio".into(),
-                field: Some("span.measurements.score.total.value".into()),
-                condition: Some(
-                    // If transactions are extracted from spans, the transaction processing pipeline
-                    // will take care of this metric.
-                    is_allowed_browser.clone() & RuleCondition::eq("span.was_transaction", false),
-                ),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction.op")
-                        .from_field("span.sentry_tags.transaction.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            },
-            MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.score.cls@ratio".into(),
-                field: Some("span.measurements.score.cls.value".into()),
+                mri: "d:spans/webvital.inp@millisecond".into(),
+                field: Some("span.measurements.inp.value".into()),
                 condition: Some(is_allowed_browser.clone()),
                 tags: vec![
                     Tag::with_key("span.op")
@@ -124,138 +94,204 @@ pub fn hardcoded_span_metrics() -> Vec<(GroupKey, Vec<MetricSpec>, Vec<TagMappin
                         .from_field("span.sentry_tags.user.geo.subregion")
                         .always(), // already guarded by condition on metric
                 ],
-            },
-            MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.score.weight.cls@ratio".into(),
-                field: Some("span.measurements.score.weight.cls.value".into()),
-                condition: Some(is_allowed_browser.clone()),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.sentry_tags.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            },
-            MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.cls@none".into(),
-                field: Some("span.measurements.cls.value".into()),
-                condition: Some(is_allowed_browser.clone()),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.sentry_tags.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            },
-            MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.score.lcp@ratio".into(),
-                field: Some("span.measurements.score.lcp.value".into()),
-                condition: Some(is_allowed_browser.clone()),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.sentry_tags.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            },
-            MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.score.weight.lcp@ratio".into(),
-                field: Some("span.measurements.score.weight.lcp.value".into()),
-                condition: Some(is_allowed_browser.clone()),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.sentry_tags.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            },
-            MetricSpec {
-                category: DataCategory::Span,
-                mri: "d:transactions/measurements.lcp@millisecond".into(),
-                field: Some("span.measurements.lcp.value".into()),
-                condition: Some(is_allowed_browser.clone()),
-                tags: vec![
-                    Tag::with_key("span.op")
-                        .from_field("span.sentry_tags.op")
-                        .always(),
-                    Tag::with_key("transaction")
-                        .from_field("span.sentry_tags.transaction")
-                        .always(),
-                    Tag::with_key("environment")
-                        .from_field("span.sentry_tags.environment")
-                        .always(),
-                    Tag::with_key("release")
-                        .from_field("span.sentry_tags.release")
-                        .always(),
-                    Tag::with_key("browser.name")
-                        .from_field("span.sentry_tags.browser.name")
-                        .always(), // already guarded by condition on metric
-                    Tag::with_key("user.geo.subregion")
-                        .from_field("span.sentry_tags.user.geo.subregion")
-                        .always(), // already guarded by condition on metric
-                ],
-            },
-        ],
-        vec![],
-    )]
+            }],
+            vec![],
+        ),
+        (
+            GroupKey::SpanMetricsTx,
+            vec![
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.total@ratio".into(),
+                    field: Some("span.measurements.score.total.value".into()),
+                    condition: Some(
+                        // If transactions are extracted from spans, the transaction processing pipeline
+                        // will take care of this metric.
+                        is_allowed_browser.clone()
+                            & RuleCondition::eq("span.was_transaction", false),
+                    ),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction.op")
+                            .from_field("span.sentry_tags.transaction.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.cls@ratio".into(),
+                    field: Some("span.measurements.score.cls.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.weight.cls@ratio".into(),
+                    field: Some("span.measurements.score.weight.cls.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.cls@none".into(),
+                    field: Some("span.measurements.cls.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.lcp@ratio".into(),
+                    field: Some("span.measurements.score.lcp.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.score.weight.lcp@ratio".into(),
+                    field: Some("span.measurements.score.weight.lcp.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+                MetricSpec {
+                    category: DataCategory::Span,
+                    mri: "d:transactions/measurements.lcp@millisecond".into(),
+                    field: Some("span.measurements.lcp.value".into()),
+                    condition: Some(is_allowed_browser.clone()),
+                    tags: vec![
+                        Tag::with_key("span.op")
+                            .from_field("span.sentry_tags.op")
+                            .always(),
+                        Tag::with_key("transaction")
+                            .from_field("span.sentry_tags.transaction")
+                            .always(),
+                        Tag::with_key("environment")
+                            .from_field("span.sentry_tags.environment")
+                            .always(),
+                        Tag::with_key("release")
+                            .from_field("span.sentry_tags.release")
+                            .always(),
+                        Tag::with_key("browser.name")
+                            .from_field("span.sentry_tags.browser.name")
+                            .always(), // already guarded by condition on metric
+                        Tag::with_key("user.geo.subregion")
+                            .from_field("span.sentry_tags.user.geo.subregion")
+                            .always(), // already guarded by condition on metric
+                    ],
+                },
+            ],
+            vec![],
+        ),
+    ]
 }


### PR DESCRIPTION
The diff doesn't do it justice: this is bringing back the SpanMetricsCommon group to add back `d:spans/webvital.inp@millisecond`.

I changed how we guard metrics too since, in the previous config, if `Feature::ExtractCommonSpanMetricsFromEvent` was disabled, everything should be disabled (https://github.com/getsentry/relay/pull/4931/files#diff-b391d3acb7ee266caa09903f615c9e66567dd2a2a630d07435971931175adb5eL79) and now, it's tied to span extraction (so `produces_spans()`).