### PR TITLE
ref(ai): Clean up legacy AI attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-
 ## Unreleased
 
 **Internal**:
 
 - Emit outcomes for skipped large attachments on playstation crashes. ([#4862](https://github.com/getsentry/relay/pull/4862))
 - Disable span metrics. ([#4931](https://github.com/getsentry/relay/pull/4931),[#4955](https://github.com/getsentry/relay/pull/4955))
+- Deprecate old AI monitoring attributes. ([#4960](https://github.com/getsentry/relay/pull/4960))
 
 ## 25.7.0
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2257,7 +2257,6 @@ mod tests {
                             }
                         },
                         "data": {
-                            "ai.pipeline.name": "Autofix Pipeline",
                             "ai.model_id": "claude-2.1"
                         }
                     },
@@ -2278,7 +2277,6 @@ mod tests {
                             }
                         },
                         "data": {
-                            "ai.pipeline.name": "Autofix Pipeline",
                             "ai.model_id": "gpt4-21-04"
                         }
                     }

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -135,9 +135,6 @@ pub fn extract_ai_data(span: &mut Span, ai_model_costs: &ModelCosts) {
         .gen_ai_request_model
         .value()
         .and_then(|val| val.as_str())
-        // xxx (vgrozdanic): temporal fallback to legacy field, until we fix
-        // sentry conventions and standardize what SDKs send
-        .or_else(|| data.ai_model_id.value().and_then(|val| val.as_str()))
         .or_else(|| {
             data.gen_ai_response_model
                 .value()

--- a/relay-event-normalization/src/normalize/span/tag_extraction.rs
+++ b/relay-event-normalization/src/normalize/span/tag_extraction.rs
@@ -800,19 +800,6 @@ pub fn extract_tags(
             _ => None,
         };
 
-        if category.as_deref() == Some("ai") {
-            if let Some(ai_pipeline_name) = span
-                .data
-                .value()
-                .and_then(|data| data.ai_pipeline_name.value())
-                .and_then(|val| val.as_str())
-            {
-                let mut ai_pipeline_group = format!("{:?}", md5::compute(ai_pipeline_name));
-                ai_pipeline_group.truncate(16);
-                span_tags.ai_pipeline_group = ai_pipeline_group.into();
-            }
-        }
-
         if let Some(category) = category {
             span_tags.category = category.into_owned().into();
         }
@@ -2004,9 +1991,7 @@ LIMIT 1
                         "data": {
                             "ai.total_tokens.used": 300,
                             "ai.completion_tokens.used": 200,
-                            "ai.prompt_tokens.used": 100,
-                            "ai.streaming": true,
-                            "ai.pipeline.name": "My AI pipeline"
+                            "ai.prompt_tokens.used": 100
                         },
                         "hash": "e2fae740cccd3781"
                     }
@@ -2029,21 +2014,14 @@ LIMIT 1
             .unwrap()
             .value()
             .unwrap();
-        let tags = span.sentry_tags.value().unwrap();
 
-        assert_eq!(
-            tags.get_value("ai_pipeline_group").unwrap().as_str(),
-            Some("68e6cafc5b68d276")
-        );
-        assert_json_snapshot!(SerializableAnnotated(&span.data), @r###"
+        assert_json_snapshot!(SerializableAnnotated(&span.data), @r#"
         {
           "gen_ai.usage.total_tokens": 300,
           "gen_ai.usage.input_tokens": 100,
-          "gen_ai.usage.output_tokens": 200,
-          "ai.pipeline.name": "My AI pipeline",
-          "ai.streaming": true
+          "gen_ai.usage.output_tokens": 200
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -2063,9 +2041,7 @@ LIMIT 1
                         "data": {
                             "gen_ai.usage.total_tokens": 300,
                             "gen_ai.usage.output_tokens": 200,
-                            "gen_ai.usage.input_tokens": 100,
-                            "ai.streaming": true,
-                            "ai.pipeline.name": "My AI pipeline"
+                            "gen_ai.usage.input_tokens": 100
                         },
                         "hash": "e2fae740cccd3781"
                     }
@@ -2088,21 +2064,14 @@ LIMIT 1
             .unwrap()
             .value()
             .unwrap();
-        let tags = span.sentry_tags.value().unwrap();
 
-        assert_eq!(
-            tags.get_value("ai_pipeline_group").unwrap().as_str(),
-            Some("68e6cafc5b68d276")
-        );
-        assert_json_snapshot!(SerializableAnnotated(&span.data), @r###"
+        assert_json_snapshot!(SerializableAnnotated(&span.data), @r#"
         {
           "gen_ai.usage.total_tokens": 300,
           "gen_ai.usage.input_tokens": 100,
-          "gen_ai.usage.output_tokens": 200,
-          "ai.pipeline.name": "My AI pipeline",
-          "ai.streaming": true
+          "gen_ai.usage.output_tokens": 200
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -134,7 +134,7 @@ mod tests {
         .unwrap();
 
         let span_from_event = Span::from(&event);
-        insta::assert_debug_snapshot!(span_from_event, @r###"
+        insta::assert_debug_snapshot!(span_from_event, @r#"
         Span {
             timestamp: ~,
             start_timestamp: ~,
@@ -169,6 +169,7 @@ mod tests {
                 gen_ai_tool_input: ~,
                 gen_ai_tool_output: ~,
                 gen_ai_response_tool_calls: ~,
+                gen_ai_tool_name: ~,
                 gen_ai_response_text: ~,
                 gen_ai_response_object: ~,
                 gen_ai_response_tokens_per_second: ~,
@@ -194,10 +195,6 @@ mod tests {
                 cache_key: ~,
                 cache_item_size: ~,
                 http_response_status_code: ~,
-                ai_pipeline_name: ~,
-                ai_model_id: ~,
-                ai_input_messages: ~,
-                ai_responses: ~,
                 thread_name: ~,
                 thread_id: ~,
                 segment_name: "my 1st transaction",
@@ -276,6 +273,6 @@ mod tests {
             _performance_issues_spans: ~,
             other: {},
         }
-        "###);
+        "#);
     }
 }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1232,8 +1232,7 @@ mod tests {
                     "parent_span_id": "bd429c44b67a3eb4",
                     "trace_id": "922dda2462ea4ac2b6a4b339bee90863",
                     "data": {
-                        "gen_ai.usage.total_tokens": 20,
-                        "ai.pipeline.name": "Autofix Pipeline"
+                        "gen_ai.usage.total_tokens": 20
                     }
                 },
                 {


### PR DESCRIPTION
Removes old AI attributes (everything prefixed with `ai.`), and maps most of them to the new fields (`gen_ai.` prefix). 

Closes [TET-626: relay task for mapping attributes (like we already do for tokens)](https://linear.app/getsentry/issue/TET-626/relay-task-for-mapping-attributes-like-we-already-do-for-tokens)