### PR TITLE
ref(ratelimits): Count a transaction also as a span

### DIFF
--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -106,7 +106,10 @@ impl Item {
 
         match self.ty() {
             ItemType::Event => smallvec![(DataCategory::Error, item_count)],
-            ItemType::Transaction => smallvec![(DataCategory::Transaction, item_count)],
+            ItemType::Transaction => smallvec![
+                (DataCategory::Transaction, item_count),
+                (DataCategory::Span, item_count)
+            ],
             ItemType::Security | ItemType::RawSecurity => {
                 smallvec![(DataCategory::Security, item_count)]
             }

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -178,9 +178,7 @@ fn count_nested_spans(envelope: &ManagedEnvelope) -> usize {
         .items()
         .find(|item| *item.ty() == ItemType::Transaction && !item.spans_extracted())
         .and_then(|item| serde_json::from_slice::<PartialEvent>(&item.payload()).ok())
-        // We do + 1, since we count the transaction itself because it will be extracted
-        // as a span and counted during the slow path of rate limiting.
-        .map_or(0, |event| event.spans.0 + 1)
+        .map_or(0, |event| event.spans.0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of special casing span as transaction counts, we can always count a transaction as a span.

This will also consistently emit outcomes in all places, at least for the segment span (aka transaction). Contained spans still need special casing.

Refs: #4961