### PR TITLE
ref(quotas): Enforce span limits for transactions and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Internal**:
 
+- Enforce span limits for transactions and vice versa. ([#4963](https://github.com/getsentry/relay/pull/4963))
 - Emit outcomes for skipped large attachments on playstation crashes. ([#4862](https://github.com/getsentry/relay/pull/4862))
 - Disable span metrics. ([#4931](https://github.com/getsentry/relay/pull/4931),[#4955](https://github.com/getsentry/relay/pull/4955))
 

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -468,7 +468,11 @@ def test_processing_quotas(
         assert int(retry_after) <= max_rate_limit
         retry_after2, rest = headers["x-sentry-rate-limits"].split(":", 1)
         assert int(retry_after2) == int(retry_after)
-        assert rest == "%s:key:get_lost" % category
+        if event_type == "transaction":
+            # Transaction limits also apply to spans.
+            assert rest == "transaction;span:key:get_lost"
+        else:
+            assert rest == "%s:key:get_lost" % category
         if outcomes_consumer is not None:
             outcomes_consumer.assert_rate_limited(
                 "get_lost", key_id=key_id, categories=[category]


### PR DESCRIPTION
Propagates and enforces span rate limits for transactions in the fast path and vice versa.

This only implements the enforcement in the fast path and propagation, it does *not* implement the enforcement side for consistent rate limits. This is a different beast to implement and currently does not touch it, this to be done in a follow up.

For motivation and justification: https://develop.sentry.dev/ingestion/relay/transaction-span-ratelimits/

Refs: #4961