### PR TITLE
ci(gocd): Check crashloop monitor, rm flaky monitor

### DIFF
--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -58,7 +58,7 @@ local soak_time(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
-                DATADOG_MONITOR_IDS: '165839953 165839957 165839955 165839949',
+                DATADOG_MONITOR_IDS: '165839953 165839955 165839949 165839921',
                 // Sentry projects to check for errors <project_id>:<project_slug>:<service>
                 SENTRY_PROJECTS: if region == 's4s' then '1513938:sentry-for-sentry:relay' else '9:pop-relay:relay-pop 4:relay:relay',
                 SENTRY_SINGLE_TENANT: if region == 's4s' then 'true' else 'false',
@@ -98,7 +98,7 @@ local deploy_pop_canary_job(region) =
       DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
       DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
       // Datadog monitor IDs for the canary deployment
-      DATADOG_MONITOR_IDS: '165839953 165839957 165839955 165839949',
+      DATADOG_MONITOR_IDS: '165839953 165839955 165839949 165839921',
       // Sentry projects to check for errors <project_id>:<project_slug>:<service>
       SENTRY_PROJECTS: '9:pop-relay:relay-pop 4:relay:relay',
       SENTRY_SINGLE_TENANT: 'false',

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -20,7 +20,7 @@ local soak_time(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
-                DATADOG_MONITOR_IDS: '14146876 154096671 154096678',
+                DATADOG_MONITOR_IDS: '14146876 154096671 154096678 165254216',
                 // Sentry projects to check for errors <project_id>:<project_slug>:<service>
                 SENTRY_PROJECTS: if region == 's4s' then '1513938:sentry-for-sentry:relay' else '4:relay:relay 9:pop-relay:relay-pop',
                 SENTRY_SINGLE_TENANT: if region == 's4s' then 'true' else 'false',
@@ -82,7 +82,7 @@ local deploy_canary(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the canary deployment
-                DATADOG_MONITOR_IDS: '14146876 154096671',
+                DATADOG_MONITOR_IDS: '14146876 154096671 165254216',
                 // Sentry projects to check for errors <project_id>:<project_slug>:<service>
                 SENTRY_PROJECTS: '4:relay:relay 9:pop-relay:relay-pop',
                 SENTRY_SINGLE_TENANT: 'false',


### PR DESCRIPTION
Removes flaky pop monitor, instead adds a crashloop monitor.

#skip-changelog