### PR TITLE
ref(logs): Process logs in all non-proxy Relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Stop extracting the `sentry.severity_number` attribute for logs. ([#4989](https://github.com/getsentry/relay/pull/4989))
 - Stop extracting the `sentry.trace_flags` attribute for logs. ([#4988](https://github.com/getsentry/relay/pull/4988))
 - Add Jwm to the supported image types. ([#4975](https://github.com/getsentry/relay/pull/4975))
+- Process logs in all non-proxy Relays. ([#4973](https://github.com/getsentry/relay/pull/4973))
 
 ## 25.7.0
 

--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -201,6 +201,17 @@ impl Attributes {
         inner(self, key, value);
     }
 
+    /// Inserts an attribute with the given value if it was not already present.
+    pub fn insert_if_missing<F, V>(&mut self, key: &str, value: F)
+    where
+        F: FnOnce() -> V,
+        V: Into<AttributeValue>,
+    {
+        if !self.0.contains_key(key) {
+            self.insert(key.to_owned(), value());
+        }
+    }
+
     /// Inserts an annotated attribute into this collection.
     pub fn insert_raw(&mut self, key: String, attribute: Annotated<Attribute>) {
         self.0.insert(key, attribute);

--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -105,16 +105,16 @@ pub fn ourlog_merge_otel(ourlog: &mut Annotated<OurLog>, received_at: DateTime<U
     let Some(ourlog_value) = ourlog.value_mut() else {
         return;
     };
+
     let attributes = ourlog_value.attributes.value_mut().get_or_insert_default();
 
     let received_at_nanos = received_at
         .timestamp_nanos_opt()
         .unwrap_or_else(|| UnixTimestamp::now().as_nanos() as i64);
 
-    attributes.insert(
-        "sentry.observed_timestamp_nanos".to_owned(),
-        received_at_nanos.to_string(),
-    );
+    attributes.insert_if_missing("sentry.observed_timestamp_nanos", || {
+        received_at_nanos.to_string()
+    });
 }
 
 #[cfg(test)]

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -107,8 +107,8 @@ fn expand_log_container(
 
     for log in &mut logs {
         // Calculate the received byte size and remember it as metadata, in the header.
-        // As Relay may later modify the payload later, adding attributes or removing them
-        // and in any case we want to track the originally received size.
+        // This is to keep track of the originally received size even as Relay adds, removes or
+        // modifies attributes.
         //
         // Since Relay can be deployed in multiple layers, we need to remember the size of the
         // first Relay which received the log, but at the same time we must be able to trust that

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -10,7 +10,7 @@ use relay_protocol::{Annotated, ErrorKind, Value};
 use relay_quotas::DataCategory;
 
 use crate::envelope::{ContainerItems, Item, ItemContainer, WithHeader};
-use crate::extractors::RequestMeta;
+use crate::extractors::{RequestMeta, RequestTrust};
 use crate::processing::logs::{Error, ExpandedLogs, Result, SerializedLogs};
 use crate::processing::{Context, Managed};
 use crate::services::outcome::DiscardReason;
@@ -20,13 +20,14 @@ use crate::services::outcome::DiscardReason;
 /// Individual, invalid logs will be discarded.
 pub fn expand(logs: Managed<SerializedLogs>, _ctx: Context<'_>) -> Managed<ExpandedLogs> {
     let received_at = logs.received_at();
+    let trust = logs.headers.meta().request_trust();
+
     logs.map(|logs, records| {
         records.lenient(DataCategory::LogByte);
 
         let mut all_logs = Vec::with_capacity(logs.count());
-
         for logs in logs.logs {
-            let expanded = expand_log_container(&logs, received_at);
+            let expanded = expand_log_container(&logs, received_at, trust);
             let expanded = records.or_default(expanded, logs);
             all_logs.extend(expanded);
         }
@@ -92,7 +93,11 @@ fn expand_otel_log(item: &Item, received_at: DateTime<Utc>) -> Result<WithHeader
     })
 }
 
-fn expand_log_container(item: &Item, received_at: DateTime<Utc>) -> Result<ContainerItems<OurLog>> {
+fn expand_log_container(
+    item: &Item,
+    received_at: DateTime<Utc>,
+    trust: RequestTrust,
+) -> Result<ContainerItems<OurLog>> {
     let mut logs = ItemContainer::parse(item)
         .map_err(|err| {
             relay_log::debug!("failed to parse logs container: {err}");
@@ -101,16 +106,20 @@ fn expand_log_container(item: &Item, received_at: DateTime<Utc>) -> Result<Conta
         .into_items();
 
     for log in &mut logs {
-        let byte_size = log.value().map(relay_ourlogs::calculate_size).unwrap_or(1);
-        let header = log.header.get_or_insert_default();
-        // Unconditionally override the size of the log, before making any modifications.
+        // Calculate the received byte size and remember it as metadata, in the header.
+        // As Relay may later modify the payload later, adding attributes or removing them
+        // and in any case we want to track the originally received size.
         //
-        // Relay later may deem certain attributes to be invalid and therefore drop or modify them,
-        // we still keep the original size.
+        // Since Relay can be deployed in multiple layers, we need to remember the size of the
+        // first Relay which received the log, but at the same time we must be able to trust that
+        // size.
         //
-        // Once there is processing of logs in other internal Relays, we will have to respect
-        // the value set by the header, if it is coming from an internal Relay.
-        header.byte_size = Some(byte_size);
+        // If there is no size calculated or we cannot trust the source, we re-calculate the size.
+        let byte_size = log.header.as_ref().and_then(|h: &OurLogHeader| h.byte_size);
+        if trust.is_untrusted() || matches!(byte_size, None | Some(0)) {
+            let byte_size = log.value().map(relay_ourlogs::calculate_size).unwrap_or(1);
+            log.header.get_or_insert_default().byte_size = Some(byte_size);
+        }
 
         relay_ourlogs::ourlog_merge_otel(log, received_at);
     }
@@ -166,21 +175,26 @@ fn normalize(log: &mut Annotated<OurLog>, meta: &RequestMeta) -> Result<()> {
 
 fn populate_ua_fields(log: &mut OurLog, user_agent: Option<&str>, client_hints: ClientHints<&str>) {
     let attributes = log.attributes.get_or_insert_with(Default::default);
-    if let Some(context) = BrowserContext::from_hints_or_ua(&RawUserAgentInfo {
+
+    const BROWSER_NAME: &str = "sentry.browser.name";
+    const BROWSER_VERSION: &str = "sentry.browser.version";
+
+    if attributes.contains_key(BROWSER_NAME) && attributes.contains_key(BROWSER_VERSION) {
+        return;
+    }
+
+    let Some(context) = BrowserContext::from_hints_or_ua(&RawUserAgentInfo {
         user_agent,
         client_hints,
-    }) {
-        if !attributes.contains_key("sentry.browser.name") {
-            if let Some(name) = context.name.value() {
-                attributes.insert("sentry.browser.name".to_owned(), name.to_owned());
-            }
-        }
+    }) else {
+        return;
+    };
 
-        if !attributes.contains_key("sentry.browser.version") {
-            if let Some(version) = context.version.value() {
-                attributes.insert("sentry.browser.version".to_owned(), version.to_owned());
-            }
-        }
+    if let Some(name) = context.name.into_value() {
+        attributes.insert_if_missing(BROWSER_NAME, || name);
+    }
+    if let Some(version) = context.version.into_value() {
+        attributes.insert_if_missing(BROWSER_VERSION, || version);
     }
 }
 

--- a/relay-server/src/processing/logs/validate.rs
+++ b/relay-server/src/processing/logs/validate.rs
@@ -1,23 +1,20 @@
 use crate::processing::logs::{Error, SerializedLogs};
-use crate::processing::{Context, Managed, Rejected};
+use crate::processing::{Managed, Rejected};
 
 /// Validates that there is only a single log container processed at a time.
 ///
 /// The `Log` item must always be sent as an `ItemContainer`, currently it is not allowed to
 /// send multiple containers for logs.
 ///
-/// This restriction may be lifted in the future, this is why this validation only happens
-/// when processing is enabled, allowing it to be changed easily in the future.
+/// This restriction may be lifted in the future.
 ///
 /// This limit mostly exists to incentivise SDKs to batch multiple logs into a single container,
 /// technically it can be removed without issues.
-pub fn container(logs: &Managed<SerializedLogs>, ctx: Context<'_>) -> Result<(), Rejected<Error>> {
-    if ctx.is_processing() {
-        // It's fine if there was no log container, as we still accept OTel logs.
-        if logs.logs.len() > 1 {
-            return Err(logs.reject_err(Error::DuplicateContainer));
-        }
-    };
+pub fn container(logs: &Managed<SerializedLogs>) -> Result<(), Rejected<Error>> {
+    // It's fine if there was no log container, as we still accept OTel logs.
+    if logs.logs.len() > 1 {
+        return Err(logs.reject_err(Error::DuplicateContainer));
+    }
 
     Ok(())
 }

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -66,9 +66,9 @@ pub struct Context<'a> {
 }
 
 impl Context<'_> {
-    /// Returns `true` if Relay is running in processing mode.
-    pub fn is_processing(&self) -> bool {
-        self.config.processing_enabled()
+    /// Returns `true` if Relay is running in proxy mode.
+    pub fn is_proxy(&self) -> bool {
+        matches!(self.config.relay_mode(), relay_config::RelayMode::Proxy)
     }
 
     /// Checks on-off feature flags for envelope items, like profiles and spans.

--- a/relay-server/src/services/projects/project/info.rs
+++ b/relay-server/src/services/projects/project/info.rs
@@ -149,9 +149,10 @@ impl ProjectInfo {
         envelope: &Envelope,
         config: &Config,
     ) -> Result<(), DiscardReason> {
-        if envelope.meta().is_from_internal_relay() {
+        if envelope.meta().request_trust().is_trusted() {
             return Ok(());
         }
+
         match self.config.trusted_relay_settings.verify_signature {
             SignatureVerification::Disabled => Ok(()),
             SignatureVerification::Enabled => match envelope.meta().signature() {

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -121,6 +121,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
         external=None,
         wait_health_check=True,
         static_relays=None,
+        static_credentials=None,
         credentials=None,
         version="latest",
     ):
@@ -154,6 +155,13 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
 
         if static_relays is not None:
             default_opts["auth"] = {"static_relays": static_relays}
+        if static_credentials is not None:
+            auth = default_opts.setdefault("auth", {})
+            static_relays = auth.setdefault("static_relays", {})
+            static_relays[static_credentials["id"]] = {
+                "public_key": static_credentials["public_key"],
+                "internal": True,
+            }
 
         if options is not None:
             for key, value in options.items():

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -12,10 +12,19 @@ import pytest
 
 
 TEST_CONFIG = {
+    "outcomes": {
+        "emit_outcomes": True,
+        "batch_size": 1,
+        "batch_interval": 1,
+        "aggregator": {
+            "bucket_interval": 1,
+            "flush_interval": 1,
+        },
+    },
     "aggregator": {
         "bucket_interval": 1,
         "initial_delay": 0,
-    }
+    },
 }
 
 
@@ -90,6 +99,7 @@ def timestamps(ts: datetime):
 
 def test_ourlog_extraction_with_otel_logs(
     mini_sentry,
+    relay,
     relay_with_processing,
     items_consumer,
 ):
@@ -99,7 +109,7 @@ def test_ourlog_extraction_with_otel_logs(
     project_config["config"]["features"] = [
         "organizations:ourlogs-ingestion",
     ]
-    relay = relay_with_processing(options=TEST_CONFIG)
+    relay = relay(relay_with_processing(options=TEST_CONFIG))
 
     ts = datetime.now(timezone.utc)
     envelope = envelope_with_otel_logs(ts)
@@ -137,6 +147,7 @@ def test_ourlog_extraction_with_otel_logs(
 
 def test_ourlog_multiple_containers_not_allowed(
     mini_sentry,
+    relay,
     relay_with_processing,
     items_consumer,
     outcomes_consumer,
@@ -149,7 +160,7 @@ def test_ourlog_multiple_containers_not_allowed(
         "organizations:ourlogs-ingestion",
     ]
 
-    relay = relay_with_processing(options=TEST_CONFIG)
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
     start = datetime.now(timezone.utc)
     envelope = Envelope()
 
@@ -202,6 +213,7 @@ def test_ourlog_multiple_containers_not_allowed(
 @pytest.mark.parametrize("meta_enabled", [False, True])
 def test_ourlog_meta_attributes(
     mini_sentry,
+    relay,
     relay_with_processing,
     items_consumer,
     meta_enabled,
@@ -217,7 +229,7 @@ def test_ourlog_meta_attributes(
         "organizations:ourlogs-meta-attributes" if meta_enabled else "",
     ]
 
-    relay = relay_with_processing(options=TEST_CONFIG)
+    relay = relay(relay_with_processing(options=TEST_CONFIG))
     ts = datetime.now(timezone.utc)
 
     envelope = envelope_with_sentry_logs(
@@ -272,13 +284,33 @@ def test_ourlog_meta_attributes(
     }
 
 
+@pytest.mark.parametrize(
+    "external_mode,expected_byte_size",
+    [
+        # 260 here is a billing relevant metric, do not arbitrarily change it,
+        # this value is supposed to be static and purely based on data received,
+        # independent of any normalization.
+        (None, 260),
+        # Same applies as above, a proxy Relay does not need to run normalization.
+        ("proxy", 260),
+        # If an external Relay/Client makes modifications, sizes can change,
+        # this is fuzzy due to slight changes in sizes due to added timestamps
+        # and may need to be adjusted when changing normalization.
+        ("managed", 454),
+    ],
+)
 def test_ourlog_extraction_with_sentry_logs(
     mini_sentry,
     relay,
     relay_with_processing,
+    relay_credentials,
     items_consumer,
     outcomes_consumer,
+    external_mode,
+    expected_byte_size,
 ):
+    relay_fn = relay
+
     items_consumer = items_consumer()
     outcomes_consumer = outcomes_consumer()
 
@@ -287,7 +319,18 @@ def test_ourlog_extraction_with_sentry_logs(
     project_config["config"]["features"] = [
         "organizations:ourlogs-ingestion",
     ]
-    relay = relay(relay_with_processing(options=TEST_CONFIG))
+
+    credentials = relay_credentials()
+    relay = relay_fn(
+        relay_with_processing(options=TEST_CONFIG, static_credentials=credentials),
+        credentials=credentials,
+        options=TEST_CONFIG,
+    )
+    if external_mode is not None:
+        relay = relay_fn(
+            relay, options={"relay": {"mode": external_mode}, **TEST_CONFIG}
+        )
+
     ts = datetime.now(timezone.utc)
 
     envelope = envelope_with_sentry_logs(
@@ -378,7 +421,7 @@ def test_ourlog_extraction_with_sentry_logs(
         },
     ]
 
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=4)
+    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
     assert outcomes == [
         {
             "category": DataCategory.LOG_ITEM.value,
@@ -394,7 +437,7 @@ def test_ourlog_extraction_with_sentry_logs(
             "org_id": 1,
             "outcome": 0,
             "project_id": 42,
-            "quantity": 260,
+            "quantity": expected_byte_size,
         },
     ]
 
@@ -522,6 +565,7 @@ def test_ourlog_extraction_is_disabled_without_feature(
 )
 def test_browser_name_version_extraction(
     mini_sentry,
+    relay,
     relay_with_processing,
     items_consumer,
     user_agent,
@@ -534,7 +578,7 @@ def test_browser_name_version_extraction(
     project_config["config"]["features"] = [
         "organizations:ourlogs-ingestion",
     ]
-    relay = relay_with_processing(options=TEST_CONFIG)
+    relay = relay(relay_with_processing(options=TEST_CONFIG))
     ts = datetime.now(timezone.utc)
 
     envelope = envelope_with_sentry_logs(


### PR DESCRIPTION
The first big step at supporting inbound filters for logs.

Expansion and normalization of logs must happen in the same stage as inbound filters, since inbound filters must run at the earliest point possible to minimize unnecessary processing/traffic the normalization must also happen then.

This change enables processing of logs in all Relays except Relays running in proxy mode. Proxy mode does not have access to the necessary processing config to apply inbound filters or do full processing.

As a side effect, static and other customer managed Relays will now (correctly) apply PII rules, as they always should've been.

Tests have been improved to always use a Relay chain, size assertions are done on a trusted and untrusted Relay chain.

I also replaced the `is_from_trusted_relay` with a proper enum to not run into an issue where somewhat important information is passed around as a boolean. Adds some type-safety.

Things to be done in a follow-up:
- Actually implement inbound filters
- Split logs processing into more granular stages, normalization and scrubbing. We may want to run scrubbing only after filters to not apply unnecessary work to dropped data.

Closes: #4990
Closes: INGEST-469