### PR TITLE
ref(items): Force a random routing key instead of letting Kafka handle it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Disable span metrics. ([#4931](https://github.com/getsentry/relay/pull/4931),[#4955](https://github.com/getsentry/relay/pull/4955))
 - Deprecate old AI monitoring attributes. ([#4960](https://github.com/getsentry/relay/pull/4960))
 - Normalize legacy `ai.*` attributes to `gen_ai.*` names. ([#4924](https://github.com/getsentry/relay/pull/4924))
+- Force the routing key to be random instead of letting Kafka handle the randomization. ([#4974](https://github.com/getsentry/relay/pull/4974))
 
 ## 25.7.0
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -2046,13 +2046,10 @@ impl Message for KafkaMessage<'_> {
             // This results in significantly more work for Kafka, but we've seen that the metrics
             // indexer consumer in Sentry, cannot deal with this load shape.
             // Until the metric indexer is updated, we still need to assign random keys here.
-            Self::Metric { .. } => Some(Uuid::new_v4()),
+            Self::Metric { .. } | Self::Item { .. } => Some(Uuid::new_v4()),
 
             // Random partitioning
-            Self::Profile(_)
-            | Self::ReplayRecordingNotChunked(_)
-            | Self::ProfileChunk(_)
-            | Self::Item { .. } => None,
+            Self::Profile(_) | Self::ReplayRecordingNotChunked(_) | Self::ProfileChunk(_) => None,
         }
         .filter(|uuid| !uuid.is_nil())
         .map(|uuid| uuid.into_bytes())


### PR DESCRIPTION
We notice partitions not having equal load, especially when Relay sees a spike in items (maybe it's scaling up, maybe it's Monday morning).

We'd like to try this to see if we can improve randomizing our items to every partitions.