### PR TITLE
ref(spans): Always emit a usage metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Always emit a span usage metric, independent of span feature flags. ([#4976](https://github.com/getsentry/relay/pull/4976))
+
 **Bug Fixes**:
 
 - Normalize OS and Browser names in contexts when missing a version. ([#4957](https://github.com/getsentry/relay/pull/4957))

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -14,9 +14,10 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
 
     let features = &project_config.features;
 
-    if !config.is_supported() || config._span_metrics_extended || !features.produces_spans() {
+    if !config.is_supported() || config._span_metrics_extended {
         return;
     }
+    config._span_metrics_extended = true;
 
     // If there are any spans in the system, extract the usage metric for them:
     config.metrics.push(MetricSpec {
@@ -26,6 +27,10 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         condition: None,
         tags: vec![],
     });
+
+    if !features.produces_spans() {
+        return;
+    }
 
     config
         .global_groups
@@ -38,7 +43,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         .or_default()
         .is_enabled = true;
 
-    config._span_metrics_extended = true;
     if config.version == 0 {
         config.version = MetricExtractionConfig::MAX_SUPPORTED_VERSION;
     }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1276,7 +1276,14 @@ mod tests {
     #[test]
     fn no_feature_flags_enabled() {
         let metrics = extract_span_metrics([]);
-        assert!(metrics.project_metrics.is_empty());
+
+        assert_eq!(metrics.project_metrics.len(), 75);
+        assert!(
+            metrics
+                .project_metrics
+                .into_iter()
+                .all(|x| &x.name == "c:spans/usage@none")
+        );
 
         assert_eq!(metrics.sampling_metrics.len(), 1);
         assert_eq!(


### PR DESCRIPTION
Always emit a Span usage metric. The idea is that we can give every customer an idea about their span volume, without having to 'blindly' upgrade to a plan which is span based.