### PR TITLE
ref(kafka): Cleanup Kafka key selection and headers

### DIFF
--- a/relay-kafka/src/limits.rs
+++ b/relay-kafka/src/limits.rs
@@ -6,9 +6,8 @@ use std::time::{Duration, Instant};
 use hashbrown::HashMap;
 use parking_lot::RwLock;
 
+use crate::Key;
 use crate::debounced::Debounced;
-
-type Key = [u8; 16];
 
 /// A really basic rate limiter to protect downstream systems from partition imbalance on ingestion
 /// topics.
@@ -78,7 +77,7 @@ mod tests {
     fn test_limits() {
         let limiter = KafkaRateLimits::new(10, Duration::from_secs(10));
         let now = Instant::now();
-        let key = [0; 16];
+        let key = 42;
 
         for i in 1..=5 {
             assert_eq!(

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -1212,7 +1212,7 @@ impl OutcomeBroker {
 
         let result = producer.client.send(
             topic,
-            Some(key.into_bytes()),
+            Some(key.as_u128()),
             None,
             "outcome",
             payload.as_bytes(),

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -2024,8 +2024,8 @@ impl Message for KafkaMessage<'_> {
         }
     }
 
-    /// Returns the partitioning key for this kafka message determining.
-    fn key(&self) -> Option<[u8; 16]> {
+    /// Returns the partitioning key for this Kafka message determining.
+    fn key(&self) -> Option<relay_kafka::Key> {
         match self {
             Self::Event(message) => Some(message.event_id.0),
             Self::Attachment(message) => Some(message.event_id.0),
@@ -2044,7 +2044,7 @@ impl Message for KafkaMessage<'_> {
             _ => None,
         }
         .filter(|uuid| !uuid.is_nil())
-        .map(|uuid| uuid.into_bytes())
+        .map(|uuid| uuid.as_u128())
     }
 
     fn headers(&self) -> Option<&BTreeMap<String, String>> {
@@ -2122,7 +2122,7 @@ mod tests {
         for topic in [KafkaTopic::Outcomes, KafkaTopic::OutcomesBilling] {
             let res = producer
                 .client
-                .send(topic, Some(*b"0123456789abcdef"), None, "foo", b"");
+                .send(topic, Some(0x0123456789abcdef), None, "foo", b"");
 
             assert!(matches!(res, Err(ClientError::InvalidTopicName)));
         }


### PR DESCRIPTION
Instead of giving out random keys, we can use a sequence instead.
(edit: this also rolls out the random distribution of messages/keys for all topics)

Cleans up the key code a bit also simplifies the headers.

#skip-changelog