### PR TITLE
ref(build): Build kafka with a static libz for less rt dependencies

### DIFF
--- a/relay-kafka/Cargo.toml
+++ b/relay-kafka/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 workspace = true
 
 [dependencies]
-rdkafka = { workspace = true, optional = true, features = ["tracing", "ssl"] }
+rdkafka = { workspace = true, optional = true, features = ["tracing", "ssl", "libz-static"] }
 rdkafka-sys = { workspace = true, optional = true }
 relay-log = { workspace = true, optional = true }
 relay-statsd = { workspace = true, optional = true }


### PR DESCRIPTION
Removes another runtime dependency, we can statically compile. This simplifies cross compiling and makes it possible to run Relay in a distroless container.

#skip-changelog