### PR TITLE
ref(beta): Fix failing beta lint, elided lifetime

### DIFF
--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -115,7 +115,7 @@ impl Pattern {
 
     /// Create a new [`PatternBuilder`]. The builder can be used to adjust the
     /// pattern settings.
-    pub fn builder(pattern: &str) -> PatternBuilder {
+    pub fn builder(pattern: &str) -> PatternBuilder<'_> {
         PatternBuilder {
             pattern,
             options: Options::default(),


### PR DESCRIPTION
Beta currently fails:

```
error: hiding a lifetime that's elided elsewhere is confusing
   --> relay-pattern/src/lib.rs:118:29
    |
118 |     pub fn builder(pattern: &str) -> PatternBuilder {
    |                             ^^^^     -------------- the same lifetime is hidden here
    |                             |
    |                             the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
    |
118 |     pub fn builder(pattern: &str) -> PatternBuilder<'_> {
    |                                                    ++++
```

https://github.com/getsentry/relay/actions/runs/16562700738/job/46835468689

#skip-changelog