### PR TITLE
ref(ourlogs): Graduate calculated byte count flag

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -90,9 +90,6 @@ pub enum Feature {
     /// Serialized as `organizations:ourlogs-ingestion`.
     #[serde(rename = "organizations:ourlogs-ingestion")]
     OurLogsIngestion,
-    /// Use a new/alternative way of counting bytes per log.
-    #[serde(rename = "organizations:ourlogs-calculated-byte-count")]
-    OurLogsCalculatedByteCount,
     /// Enables extraction of meta attributes, which will be added to EAP.
     #[serde(rename = "organizations:ourlogs-meta-attributes")]
     OurLogsMetaAttributes,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -343,7 +343,17 @@ impl StoreService {
                 ItemType::Span => {
                     self.produce_span(scoping, received_at, event_id, retention, item)?
                 }
-                ItemType::Log => self.produce_log(scoping, received_at, retention, item)?,
+                ty @ ItemType::Log => {
+                    debug_assert!(
+                        false,
+                        "received {ty} through an envelope, \
+                        this item must be submitted via a specific store message instead"
+                    );
+                    relay_log::error!(
+                        tags.project_key = %scoping.project_key,
+                        "StoreService received unsupported item type '{ty}' in envelope"
+                    );
+                }
                 ItemType::ProfileChunk => self.produce_profile_chunk(
                     scoping.organization_id,
                     scoping.project_id,
@@ -1281,142 +1291,6 @@ impl StoreService {
         Ok(())
     }
 
-    fn produce_log(
-        &self,
-        scoping: Scoping,
-        received_at: DateTime<Utc>,
-        retention_days: u16,
-        item: &Item,
-    ) -> Result<(), StoreError> {
-        relay_log::trace!("Producing log");
-
-        let payload = item.payload();
-        let d = &mut Deserializer::from_slice(&payload);
-        let logs: LogKafkaMessages = match serde_path_to_error::deserialize(d) {
-            Ok(logs) => logs,
-            Err(error) => {
-                relay_log::error!(
-                    error = &error as &dyn std::error::Error,
-                    "failed to parse log"
-                );
-                self.outcome_aggregator.send(TrackOutcome {
-                    category: DataCategory::LogItem,
-                    event_id: None,
-                    outcome: Outcome::Invalid(DiscardReason::InvalidLog),
-                    quantity: 1,
-                    remote_addr: None,
-                    scoping,
-                    timestamp: received_at,
-                });
-                self.outcome_aggregator.send(TrackOutcome {
-                    category: DataCategory::LogByte,
-                    event_id: None,
-                    outcome: Outcome::Invalid(DiscardReason::InvalidLog),
-                    quantity: payload.len() as u32,
-                    remote_addr: None,
-                    scoping,
-                    timestamp: received_at,
-                });
-                return Ok(());
-            }
-        };
-
-        let num_logs = logs.items.len() as u32;
-        for log in logs.items {
-            let timestamp_seconds = log.timestamp as i64;
-            let timestamp_nanos = (log.timestamp.fract() * 1e9) as u32;
-            let item_id = u128::from_be_bytes(
-                *Uuid::new_v7(uuid::Timestamp::from_unix(
-                    uuid::NoContext,
-                    timestamp_seconds as u64,
-                    timestamp_nanos,
-                ))
-                .as_bytes(),
-            )
-            .to_le_bytes()
-            .to_vec();
-            let mut trace_item = TraceItem {
-                item_type: TraceItemType::Log.into(),
-                organization_id: scoping.organization_id.value(),
-                project_id: scoping.project_id.value(),
-                received: Some(Timestamp {
-                    seconds: safe_timestamp(received_at) as i64,
-                    nanos: 0,
-                }),
-                retention_days: retention_days.into(),
-                timestamp: Some(Timestamp {
-                    seconds: timestamp_seconds,
-                    nanos: 0,
-                }),
-                trace_id: log.trace_id.to_string(),
-                item_id,
-                attributes: Default::default(),
-                client_sample_rate: 1.0,
-                server_sample_rate: 1.0,
-            };
-
-            for (name, attribute) in log.attributes.unwrap_or_default() {
-                if let Some(attribute_value) = attribute {
-                    if let Some(v) = attribute_value.value {
-                        let any_value = match v {
-                            LogAttributeValue::String(value) => AnyValue {
-                                value: Some(Value::StringValue(value)),
-                            },
-                            LogAttributeValue::Int(value) => AnyValue {
-                                value: Some(Value::IntValue(value)),
-                            },
-                            LogAttributeValue::Bool(value) => AnyValue {
-                                value: Some(Value::BoolValue(value)),
-                            },
-                            LogAttributeValue::Double(value) => AnyValue {
-                                value: Some(Value::DoubleValue(value)),
-                            },
-                            LogAttributeValue::Unknown(_) => continue,
-                        };
-
-                        trace_item.attributes.insert(name.into(), any_value);
-                    }
-                }
-            }
-
-            let message = KafkaMessage::Item {
-                item_type: TraceItemType::Log,
-                headers: BTreeMap::from([
-                    ("project_id".to_owned(), scoping.project_id.to_string()),
-                    (
-                        "item_type".to_owned(),
-                        (TraceItemType::Log as i32).to_string(),
-                    ),
-                ]),
-                message: trace_item,
-            };
-
-            self.produce(KafkaTopic::Items, message)?;
-        }
-
-        // We need to track the count and bytes separately for possible rate limits and quotas on both counts and bytes.
-        self.outcome_aggregator.send(TrackOutcome {
-            category: DataCategory::LogItem,
-            event_id: None,
-            outcome: Outcome::Accepted,
-            quantity: num_logs,
-            remote_addr: None,
-            scoping,
-            timestamp: received_at,
-        });
-        self.outcome_aggregator.send(TrackOutcome {
-            category: DataCategory::LogByte,
-            event_id: None,
-            outcome: Outcome::Accepted,
-            quantity: payload.len() as u32,
-            remote_addr: None,
-            scoping,
-            timestamp: received_at,
-        });
-
-        Ok(())
-    }
-
     fn produce_profile_chunk(
         &self,
         organization_id: OrganizationId,
@@ -1896,44 +1770,6 @@ impl SpanKafkaMessage<'_> {
             }
         }
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(tag = "type", content = "value")]
-enum LogAttributeValue {
-    #[serde(rename = "string")]
-    String(String),
-    #[serde(rename = "boolean")]
-    Bool(bool),
-    #[serde(rename = "integer")]
-    Int(i64),
-    #[serde(rename = "double")]
-    Double(f64),
-    #[serde(rename = "unknown")]
-    Unknown(()),
-}
-
-/// This is a temporary struct to convert the old attribute format to the new one.
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct LogAttribute {
-    #[serde(flatten)]
-    value: Option<LogAttributeValue>,
-}
-
-#[derive(Debug, Deserialize)]
-struct LogKafkaMessages<'a> {
-    #[serde(borrow)]
-    items: Vec<LogKafkaMessage<'a>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct LogKafkaMessage<'a> {
-    trace_id: EventId,
-    #[serde(default)]
-    timestamp: f64,
-    #[serde(borrow, default)]
-    attributes: Option<BTreeMap<&'a str, Option<LogAttribute>>>,
 }
 
 fn none_or_empty_object(value: &Option<&RawValue>) -> bool {


### PR DESCRIPTION
This has been since fully rolled out. We can graduate the flag by deleting it, because this was only relevant for processing Relays and we do not need to propagate it.

#skip-changelog