### PR TITLE
ref(ourlogs): Move body, span_id to attributes in store conversion, not earlier

### DIFF
--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -64,8 +64,6 @@ pub fn otel_to_sentry_log(otel_log: OtelLog, received_at: DateTime<Utc>) -> Resu
         received_at_nanos.to_string(),
     );
     attribute_data.insert("sentry.trace_flags".to_owned(), 0);
-    attribute_data.insert("sentry.body".to_owned(), body.clone());
-    attribute_data.insert("sentry.span_id".to_owned(), span_id.to_string());
 
     for attribute in attributes.into_iter() {
         if let Some(value) = attribute.value.and_then(|v| v.value) {
@@ -151,14 +149,6 @@ pub fn ourlog_merge_otel(ourlog: &mut Annotated<OurLog>, received_at: DateTime<U
         received_at_nanos.to_string(),
     );
     attributes.insert("sentry.trace_flags".to_owned(), 0);
-    attributes.insert(
-        "sentry.body".to_owned(),
-        ourlog_value.body.value().cloned().unwrap_or_default(),
-    );
-
-    if let Some(span_id) = ourlog_value.span_id.value() {
-        attributes.insert("sentry.span_id".to_owned(), span_id.to_string());
-    }
 }
 
 fn level_to_otel_severity_number(level: Option<OurLogLevel>) -> i64 {
@@ -441,10 +431,6 @@ mod tests {
               "type": "string",
               "value": "9"
             },
-            "sentry.body": {
-              "type": "string",
-              "value": "Example log record"
-            },
             "sentry.observed_timestamp_nanos": {
               "type": "string",
               "value": "946684800000000000"
@@ -456,10 +442,6 @@ mod tests {
             "sentry.severity_text": {
               "type": "string",
               "value": "info"
-            },
-            "sentry.span_id": {
-              "type": "string",
-              "value": "eee19b7ec3c1b174"
             },
             "sentry.timestamp_nanos": {
               "type": "string",
@@ -537,10 +519,6 @@ mod tests {
             "foo": {
               "type": "string",
               "value": "9"
-            },
-            "sentry.body": {
-              "type": "string",
-              "value": "somebody"
             },
             "sentry.observed_timestamp_nanos": {
               "type": "string",

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use prost_types::Timestamp;
-use relay_event_schema::protocol::{Attributes, OurLog};
+use relay_event_schema::protocol::{Attributes, OurLog, SpanId};
 use relay_protocol::{Annotated, IntoValue, MetaTree, Value};
 use relay_quotas::Scoping;
 use sentry_protos::snuba::v1::{AnyValue, TraceItem, TraceItemType, any_value};
@@ -53,7 +53,12 @@ pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreLog> {
         false => HashMap::new(),
     };
     let timestamp = required!(log.timestamp);
+
     let attrs = log.attributes.0.unwrap_or_default();
+    let fields = FieldAttributes {
+        body: required!(log.body),
+        span_id: log.span_id.into_value(),
+    };
 
     let trace_item = TraceItem {
         item_type: TraceItemType::Log.into(),
@@ -64,7 +69,7 @@ pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreLog> {
         timestamp: Some(ts(timestamp.0)),
         trace_id: required!(log.trace_id).to_string(),
         item_id: Uuid::new_v7(timestamp.into()).as_bytes().to_vec(),
-        attributes: attributes(meta, attrs, ctx),
+        attributes: attributes(meta, attrs, fields, ctx),
         client_sample_rate: 1.0,
         server_sample_rate: 1.0,
     };
@@ -193,14 +198,28 @@ fn size_of_meta_tree(meta: &MetaTree) -> usize {
     size
 }
 
+/// Fields on the log message which are stored as fields.
+struct FieldAttributes {
+    /// The log body.
+    ///
+    /// See: [`OurLog::body`].
+    body: String,
+    /// The optionally associated span id.
+    ///
+    /// See: [`OurLog::span_id`].
+    span_id: Option<SpanId>,
+}
+
 /// Extracts all attributes of a log, combines it with extracted meta attributes.
 fn attributes(
     meta: HashMap<String, AnyValue>,
     attributes: Attributes,
+    fields: FieldAttributes,
     ctx: &Context,
 ) -> HashMap<String, AnyValue> {
     let mut result = meta;
-    result.reserve(attributes.0.len());
+    // +2 for field attributes.
+    result.reserve(attributes.0.len() + 2);
 
     for (name, attribute) in attributes {
         let meta = AttributeMeta {
@@ -239,6 +258,27 @@ fn attributes(
         };
 
         result.insert(name, AnyValue { value: Some(value) });
+    }
+
+    let FieldAttributes { body, span_id } = fields;
+    // Unconditionally override any prior set attributes with the same key, as they should always
+    // come from the log itself.
+    //
+    // Ideally these attributes are marked as private in sentry-conventions and potentially
+    // validated against.
+    result.insert(
+        "sentry.body".to_owned(),
+        AnyValue {
+            value: Some(any_value::Value::StringValue(body)),
+        },
+    );
+    if let Some(span_id) = span_id {
+        result.insert(
+            "sentry.span_id".to_owned(),
+            AnyValue {
+                value: Some(any_value::Value::StringValue(span_id.to_string())),
+            },
+        );
     }
 
     result
@@ -361,6 +401,20 @@ mod tests {
                 value: Some(
                     StringValue(
                         "{\"meta\":{\"\":{\"err\":[[\"invalid_data\",{\"reason\":\"expected something in the body\"}]]}}}",
+                    ),
+                ),
+            },
+            "sentry.body": AnyValue {
+                value: Some(
+                    StringValue(
+                        "Example log record",
+                    ),
+                ),
+            },
+            "sentry.span_id": AnyValue {
+                value: Some(
+                    StringValue(
+                        "eee19b7ec3c1b174",
                     ),
                 ),
             },


### PR DESCRIPTION
We do the same for spans, we should not have redundant attributes which can differ, instead let's upgrade/change fields to attributes in the mapping layer from `OurLog -> TraceItem`.

#skip-changelog