### PR TITLE
test(time): Fixes time based assertions with precisions

### DIFF
--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -77,12 +77,12 @@ def timestamps(ts: datetime):
         },
         "sentry.timestamp_nanos": {
             "stringValue": time_within_delta(
-                ts, delta=timedelta(seconds=0), expect_resolution="ns", precision="us"
+                ts, delta=timedelta(seconds=0), expect_resolution="ns", precision="ms"
             )
         },
         "sentry.timestamp_precise": {
             "intValue": time_within_delta(
-                ts, delta=timedelta(seconds=0), expect_resolution="ns", precision="us"
+                ts, delta=timedelta(seconds=0), expect_resolution="ns", precision="ms"
             )
         },
     }


### PR DESCRIPTION
Since the value itself isn't also truncated, now floors the lower bound and ceils the upper bound.

#skip-changelog