### PR TITLE
fix(ourlogs): Removal of unnecessary rounding of nano seconds

### DIFF
--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -3,10 +3,10 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 
 use crate::OtelLog;
 use relay_common::time::UnixTimestamp;
+use relay_event_schema::protocol::Attributes;
 use relay_event_schema::protocol::{
     Attribute, AttributeType, OurLog, OurLogLevel, SpanId, Timestamp, TraceId,
 };
-use relay_event_schema::protocol::{Attributes, datetime_to_timestamp};
 use relay_protocol::{Annotated, Error, Object, Value};
 
 fn otel_value_to_log_attribute(value: OtelValue) -> Option<Attribute> {
@@ -112,19 +112,16 @@ pub fn ourlog_merge_otel(ourlog: &mut Annotated<OurLog>, received_at: DateTime<U
         return;
     };
     let attributes = ourlog_value.attributes.value_mut().get_or_insert_default();
-    // We can only extract microseconds as the conversion from float to Timestamp
-    // messes up with the precision and nanoseconds are never preserved.
-    let timestamp_nanos = ourlog_value
-        .timestamp
-        .value()
-        .map(|timestamp| {
-            ((datetime_to_timestamp(timestamp.into_inner()) * 1e6).round() as i64) * 1000
-        })
-        .unwrap_or_default();
 
     let received_at_nanos = received_at
         .timestamp_nanos_opt()
         .unwrap_or_else(|| UnixTimestamp::now().as_nanos() as i64);
+
+    let timestamp_nanos = ourlog_value
+        .timestamp
+        .value()
+        .and_then(|timestamp| timestamp.into_inner().timestamp_nanos_opt())
+        .unwrap_or(received_at_nanos);
 
     attributes.insert(
         "sentry.severity_text".to_owned(),


### PR DESCRIPTION
There is no need to go from a data type which supports nano precision to a float then just to convert back into a type which can express nanos correctly.

#skip-changelog