### PR TITLE
ref(ourlogs): Move timestamp attribute conversion to store

### DIFF
--- a/relay-ourlogs/src/ourlog.rs
+++ b/relay-ourlogs/src/ourlog.rs
@@ -54,11 +54,6 @@ pub fn otel_to_sentry_log(otel_log: OtelLog, received_at: DateTime<Utc>) -> Resu
 
     attribute_data.insert("sentry.severity_number".to_owned(), severity_number as i64);
     attribute_data.insert(
-        "sentry.timestamp_nanos".to_owned(),
-        time_unix_nano.to_string(),
-    );
-    attribute_data.insert("sentry.timestamp_precise".to_owned(), time_unix_nano as i64);
-    attribute_data.insert(
         "sentry.observed_timestamp_nanos".to_owned(),
         received_at_nanos.to_string(),
     );
@@ -116,17 +111,6 @@ pub fn ourlog_merge_otel(ourlog: &mut Annotated<OurLog>, received_at: DateTime<U
         .timestamp_nanos_opt()
         .unwrap_or_else(|| UnixTimestamp::now().as_nanos() as i64);
 
-    let timestamp_nanos = ourlog_value
-        .timestamp
-        .value()
-        .and_then(|timestamp| timestamp.into_inner().timestamp_nanos_opt())
-        .unwrap_or(received_at_nanos);
-
-    attributes.insert(
-        "sentry.timestamp_nanos".to_owned(),
-        timestamp_nanos.to_string(),
-    );
-    attributes.insert("sentry.timestamp_precise".to_owned(), timestamp_nanos);
     attributes.insert(
         "sentry.observed_timestamp_nanos".to_owned(),
         received_at_nanos.to_string(),
@@ -402,14 +386,6 @@ mod tests {
             "sentry.observed_timestamp_nanos": {
               "type": "string",
               "value": "946684800000000000"
-            },
-            "sentry.timestamp_nanos": {
-              "type": "string",
-              "value": "946684800000000000"
-            },
-            "sentry.timestamp_precise": {
-              "type": "integer",
-              "value": 946684800000000000
             }
           }
         }
@@ -446,14 +422,6 @@ mod tests {
             "sentry.observed_timestamp_nanos": {
               "type": "string",
               "value": "946684800000000000"
-            },
-            "sentry.timestamp_nanos": {
-              "type": "string",
-              "value": "1638144000000000000"
-            },
-            "sentry.timestamp_precise": {
-              "type": "integer",
-              "value": 1638144000000000000
             }
           }
         }

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -228,7 +228,7 @@ fn attributes(
     ctx: &Context,
 ) -> HashMap<String, AnyValue> {
     let mut result = meta;
-    // +3 for field attributes.
+    // +N, one for each field attribute added.
     result.reserve(attributes.0.len() + 5);
     let capacity = result.capacity();
 

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -57,6 +57,7 @@ pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreTraceItem>
     let attrs = log.attributes.0.unwrap_or_default();
     let fields = FieldAttributes {
         level: required!(log.level),
+        timestamp,
         body: required!(log.body),
         span_id: log.span_id.into_value(),
     };
@@ -205,6 +206,10 @@ struct FieldAttributes {
     ///
     /// See: [`OurLog::level`].
     level: OurLogLevel,
+    /// The original timestamp when the log was created.
+    ///
+    /// See: [`OurLog::timestamp`].
+    timestamp: relay_event_schema::protocol::Timestamp,
     /// The log body.
     ///
     /// See: [`OurLog::body`].
@@ -224,7 +229,7 @@ fn attributes(
 ) -> HashMap<String, AnyValue> {
     let mut result = meta;
     // +3 for field attributes.
-    result.reserve(attributes.0.len() + 3);
+    result.reserve(attributes.0.len() + 5);
     let capacity = result.capacity();
 
     for (name, attribute) in attributes {
@@ -268,6 +273,7 @@ fn attributes(
 
     let FieldAttributes {
         level,
+        timestamp,
         body,
         span_id,
     } = fields;
@@ -280,6 +286,24 @@ fn attributes(
         "sentry.severity_text".to_owned(),
         AnyValue {
             value: Some(any_value::Value::StringValue(level.to_string())),
+        },
+    );
+    let timestamp_nanos = timestamp
+        .into_inner()
+        .timestamp_nanos_opt()
+        // We can expect valid timestamps at this point, clock drift correction / normalization
+        // should've taken care of this already.
+        .unwrap_or_default();
+    result.insert(
+        "sentry.timestamp_nanos".to_owned(),
+        AnyValue {
+            value: Some(any_value::Value::StringValue(timestamp_nanos.to_string())),
+        },
+    );
+    result.insert(
+        "sentry.timestamp_precise".to_owned(),
+        AnyValue {
+            value: Some(any_value::Value::IntValue(timestamp_nanos)),
         },
     );
     result.insert(
@@ -443,6 +467,20 @@ mod tests {
                 value: Some(
                     StringValue(
                         "eee19b7ec3c1b174",
+                    ),
+                ),
+            },
+            "sentry.timestamp_nanos": AnyValue {
+                value: Some(
+                    StringValue(
+                        "946684800000000000",
+                    ),
+                ),
+            },
+            "sentry.timestamp_precise": AnyValue {
+                value: Some(
+                    IntValue(
+                        946684800000000000,
                     ),
                 ),
             },


### PR DESCRIPTION
Like its predecessors, moves more field -> attribute logic to the store conversion.

#skip-changelog