### PR TITLE
fix(timestamps): Deal with sub-microsecond inaccuracies on parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 **Bug Fixes**:
 
 - Normalize OS and Browser names in contexts when missing a version. ([#4957](https://github.com/getsentry/relay/pull/4957))
-- Normalize AI pipeline name and streaming flag to `gen_ai.*` names ([#4982](https://github.com/getsentry/relay/pull/4982))
+- Normalize AI pipeline name and streaming flag to `gen_ai.*` names. ([#4982](https://github.com/getsentry/relay/pull/4982))
+- Deal with sub-microsecond floating point inaccuracies for logs and spans correctly. ([#5002](https://github.com/getsentry/relay/pull/5002))
 
 **Internal**:
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -1347,14 +1347,14 @@ mod tests {
         let span = Annotated::<Span>::from_json(
             r#"{
                 "start_timestamp": 1694732407.8367,
-                "timestamp": 1694732408.3145
+                "timestamp": 1694732408.31451233
             }"#,
         )
         .unwrap()
         .into_value()
         .unwrap();
 
-        assert_eq!(span.get_value("span.duration"), Some(Val::F64(477.800131)));
+        assert_eq!(span.get_value("span.duration"), Some(Val::F64(477.812)));
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/types.rs
+++ b/relay-event-schema/src/protocol/types.rs
@@ -890,7 +890,7 @@ impl fmt::Display for Timestamp {
 /// Converts a [`DateTime`] to a `f64`, dealing with sub-microsecond float inaccuracies.
 ///
 /// f64s cannot store nanoseconds. To verify this just try to fit the current timestamp in
-/// nanoseconds into a 52-bit number (which is the significant of a double).
+/// nanoseconds into a 52-bit number (which is the significand of a double).
 ///
 /// Round off to microseconds to not show more decimal points than we know are correct. Anything
 /// else might trick the user into thinking the nanoseconds in those timestamps mean anything.
@@ -915,11 +915,17 @@ pub fn datetime_to_timestamp(dt: DateTime<Utc>) -> f64 {
 ///
 /// See also: [`datetime_to_timestamp`].
 pub fn timestamp_to_datetime(ts: f64) -> LocalResult<DateTime<Utc>> {
-    let secs = ts as i64;
-    // Multiplying the float to microseconds introduces a higher inaccuracy than only multiplying
-    // the fraction and rounding that.
-    let micros = (ts.fract() * 1_000_000f64).round() as u32;
-    Utc.timestamp_opt(secs, micros * 1_000)
+    // Always floor, this works correctly for negative numbers as well.
+    let secs = ts.floor();
+    // This is always going to be positive, because we floored the seconds.
+    let fract = ts - secs;
+    let micros = (fract * 1_000_000f64).round() as u32;
+    // Rounding may produce another full second, in which case we need to manually handle the extra
+    // second.
+    match micros == 1_000_000 {
+        true => Utc.timestamp_opt(secs as i64 + 1, 0),
+        false => Utc.timestamp_opt(secs as i64, micros * 1_000),
+    }
 }
 
 fn utc_result_to_annotated<V: IntoValue>(
@@ -1027,6 +1033,34 @@ mod tests {
     use similar_asserts::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn test_timestamp_to_datetime() {
+        assert_eq!(timestamp_to_datetime(0.), Utc.timestamp_opt(0, 0));
+        assert_eq!(timestamp_to_datetime(1000.), Utc.timestamp_opt(1000, 0));
+        assert_eq!(timestamp_to_datetime(-1000.), Utc.timestamp_opt(-1000, 0));
+        assert_eq!(
+            timestamp_to_datetime(1.234_567),
+            Utc.timestamp_opt(1, 234_567_000)
+        );
+        assert_eq!(timestamp_to_datetime(2.999_999_51), Utc.timestamp_opt(3, 0));
+        assert_eq!(
+            timestamp_to_datetime(2.999_999_45),
+            Utc.timestamp_opt(2, 999_999_000)
+        );
+        assert_eq!(
+            timestamp_to_datetime(-0.000_001),
+            Utc.timestamp_opt(-1, 999_999_000)
+        );
+        assert_eq!(
+            timestamp_to_datetime(-3.000_000_49),
+            Utc.timestamp_opt(-3, 0)
+        );
+        assert_eq!(
+            timestamp_to_datetime(-3.000_000_51),
+            Utc.timestamp_opt(-4, 999_999_000)
+        );
+    }
 
     #[test]
     fn test_values_serialization() {

--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -961,7 +961,7 @@ mod tests {
         {
           "timestamp": 123.1,
           "start_timestamp": 123.0,
-          "exclusive_time": 99.999999,
+          "exclusive_time": 100.0,
           "op": "cache.hit",
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -791,17 +791,11 @@ def test_transaction_metrics(
 
     def assert_transaction():
         event, _ = transactions_consumer.get_event()
-        if with_external_relay:
-            # there is some rounding error while serializing/deserializing
-            # timestamps... haven't investigated too closely
-            span_time = 9.910107
-        else:
-            span_time = 9.910106
 
         assert event["breakdowns"] == {
             "span_ops": {
-                "ops.react.mount": {"value": span_time, "unit": "millisecond"},
-                "total.time": {"value": span_time, "unit": "millisecond"},
+                "ops.react.mount": {"value": 9.91, "unit": "millisecond"},
+                "total.time": {"value": 9.91, "unit": "millisecond"},
             }
         }
 
@@ -866,7 +860,7 @@ def test_transaction_metrics(
         **common,
         "name": "d:transactions/breakdowns.span_ops.ops.react.mount@millisecond",
         "type": "d",
-        "value": [9.910106, 9.910106],
+        "value": [9.91, 9.91],
     }
     assert metrics["c:transactions/count_per_root_project@none"] == {
         "timestamp": time_after(timestamp),

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -73,7 +73,7 @@ def envelope_with_otel_logs(ts: datetime) -> Envelope:
 def timestamps(ts: datetime):
     return {
         "sentry.observed_timestamp_nanos": {
-            "stringValue": time_within(ts, expect_resolution="ns", precision="s")
+            "stringValue": time_within(ts, expect_resolution="ns")
         },
         "sentry.timestamp_nanos": {
             "stringValue": time_within_delta(


### PR DESCRIPTION
This also deals with floating point sub-microsecond inaccuracies on parsing, instead of only on serialization.

Logs access the nanoseconds of the extracted timestamp and persist these into the payload, this leads to subtle inaccuracies because it never goes through the floating point serialization code which would deal with these inaccuracies.

As it turns out this also applies to calculated span durations which were off.

Instead account for these inaccuracies when parsing from a float, but also when serializing, as the timestamp may have been constructed from something with 'perfect' accuracy.

Also fixes this:
<img width="668" height="100" alt="image" src="https://github.com/user-attachments/assets/5105d3ca-b643-4305-9bb6-620413fff181" />
