### PR TITLE
ref(ourlogs): Split processing into normalization and scrubbing

### DIFF
--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -137,7 +137,8 @@ impl processing::Processor for LogsProcessor {
         filter::sampled(ctx).reject(&logs)?;
 
         let mut logs = process::expand(logs, ctx);
-        process::process(&mut logs, ctx);
+        process::normalize(&mut logs);
+        process::scrub(&mut logs, ctx);
 
         self.limiter.enforce_quotas(&mut logs, ctx).await?;
 

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -51,14 +51,33 @@ pub fn expand(logs: Managed<SerializedLogs>, _ctx: Context<'_>) -> Managed<Expan
     })
 }
 
-/// Processes expanded logs.
+/// Normalizes individual log entries.
 ///
-/// Validates, scrubs, normalizes and enriches individual log entries.
-pub fn process(logs: &mut Managed<ExpandedLogs>, ctx: Context<'_>) {
+/// Normalization must happen before any filters are applied or other procedures which rely on the
+/// presence and well-formedness of attributes and fields.
+pub fn normalize(logs: &mut Managed<ExpandedLogs>) {
     logs.modify(|logs, records| {
         let meta = logs.headers.meta();
-        logs.logs
-            .retain_mut(|log| records.or_default(process_log(log, meta, ctx).map(|_| true), &*log));
+        logs.logs.retain_mut(|log| {
+            let r = normalize_log(log, meta).inspect_err(|err| {
+                relay_log::debug!("failed to normalize log: {err}");
+            });
+
+            records.or_default(r.map(|_| true), &*log)
+        })
+    });
+}
+
+/// Applies PII scrubbing to individual log entries.
+pub fn scrub(logs: &mut Managed<ExpandedLogs>, ctx: Context<'_>) {
+    logs.modify(|logs, records| {
+        logs.logs.retain_mut(|log| {
+            let r = scrub_log(log, ctx).inspect_err(|err| {
+                relay_log::debug!("failed to scrub pii from log: {err}");
+            });
+
+            records.or_default(r.map(|_| true), &*log)
+        })
     });
 }
 
@@ -123,19 +142,7 @@ fn expand_log_container(
     Ok(logs)
 }
 
-fn process_log(log: &mut Annotated<OurLog>, meta: &RequestMeta, ctx: Context<'_>) -> Result<()> {
-    scrub(log, ctx).inspect_err(|err| {
-        relay_log::debug!("failed to scrub pii from log: {err}");
-    })?;
-
-    normalize(log, meta).inspect_err(|err| {
-        relay_log::debug!("failed to normalize log: {err}");
-    })?;
-
-    Ok(())
-}
-
-fn scrub(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
+fn scrub_log(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
     let pii_config = ctx
         .project_info
         .config
@@ -156,7 +163,7 @@ fn scrub(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
     Ok(())
 }
 
-fn normalize(log: &mut Annotated<OurLog>, meta: &RequestMeta) -> Result<()> {
+fn normalize_log(log: &mut Annotated<OurLog>, meta: &RequestMeta) -> Result<()> {
     process_value(log, &mut SchemaProcessor, ProcessingState::root())?;
 
     let Some(log) = log.value_mut() else {


### PR DESCRIPTION
Another preparation for inbound filters. We want to run inbound filters before PII scrubbing, this does save some CPU cycles, but more importantly this currently matches the behavior of errors.

This does lead to slightly inconsistent filters depending on in which state they are executed (e.g. a filter that matches on a replaced value will sometimes filter, sometimes not). But if we want to change this, we should think about this more and change it for all item types.

Potentially in the future we may want to make a 'sub pipeline' which processes individual logs one by one: `normalize -> filter -> scrub`. I opted for this for now, as it matches more closely what we do for spans and transactions. This is a simple refactor if need be.

#skip-changelog