### PR TITLE
ref(instr): add timer metric to signature creation

### DIFF
--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -12,9 +12,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::http::{HttpError, Request, RequestBuilder, Response, StatusCode};
-use crate::statsd::{RelayHistograms, RelayTimers};
-use crate::utils::{self, ApiErrorResponse, RelayErrorAction, RetryBackoff};
 use bytes::Bytes;
 use itertools::Itertools;
 use relay_auth::{
@@ -35,6 +32,10 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
+
+use crate::http::{HttpError, Request, RequestBuilder, Response, StatusCode};
+use crate::statsd::{RelayHistograms, RelayTimers};
+use crate::utils::{self, ApiErrorResponse, RelayErrorAction, RetryBackoff};
 
 /// Rate limits returned by the upstream.
 ///

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -593,6 +593,9 @@ pub enum RelayTimers {
     CheckNestedSpans,
     /// The time in milliseconds it takes to expand a Span V2 container into Spans V1.
     SpanV2Expansion,
+    /// The time it needs to create a signature. Includes both the signature used for
+    /// trusted relays and for register challenges.
+    SignatureCreationDuration,
 }
 
 impl TimerMetric for RelayTimers {
@@ -647,6 +650,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::BodyReadDuration => "requests.body_read.duration",
             RelayTimers::CheckNestedSpans => "envelope.check_nested_spans",
             RelayTimers::SpanV2Expansion => "envelope.span_v2_expansion",
+            RelayTimers::SignatureCreationDuration => "signature.create.duration",
         }
     }
 }


### PR DESCRIPTION
Adds a timer metric so that we can measure how long signature creation takes.

#skip-changelog