### PR TITLE
ref(ourlogs): Graduate metadata feature flag

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -90,10 +90,7 @@ pub enum Feature {
     /// Serialized as `organizations:ourlogs-ingestion`.
     #[serde(rename = "organizations:ourlogs-ingestion")]
     OurLogsIngestion,
-    /// Enables extraction of meta attributes, which will be added to EAP.
-    #[serde(rename = "organizations:ourlogs-meta-attributes")]
-    OurLogsMetaAttributes,
-    /// This feature has graduated and is hard-coded for external Relays.
+    /// This feature has graduated ant is hard-coded for external Relays.
     #[doc(hidden)]
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]
     IngestUnsampledProfiles,

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -181,13 +181,11 @@ impl Forward for LogOutput {
         let scoping = logs.scoping();
         let received_at = logs.received_at();
 
-        let (logs, (retention, meta_attrs)) = logs
-            .split_with_context(|logs| (logs.logs, (logs.retention, logs.serialize_meta_attrs)));
+        let (logs, retention) = logs.split_with_context(|logs| (logs.logs, logs.retention));
         let ctx = store::Context {
             scoping,
             received_at,
             retention,
-            meta_attrs,
         };
 
         for log in logs {
@@ -294,9 +292,6 @@ pub struct ExpandedLogs {
     /// Retention in days.
     #[cfg(feature = "processing")]
     retention: Option<u16>,
-    /// Enables serialization of log metadata into attributes.
-    #[cfg(feature = "processing")]
-    serialize_meta_attrs: bool,
 }
 
 impl Counted for ExpandedLogs {

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -45,10 +45,6 @@ pub fn expand(logs: Managed<SerializedLogs>, _ctx: Context<'_>) -> Managed<Expan
             headers: logs.headers,
             #[cfg(feature = "processing")]
             retention: _ctx.project_info.config.event_retention,
-            #[cfg(feature = "processing")]
-            serialize_meta_attrs: _ctx
-                .project_info
-                .has_feature(relay_dynamic_config::Feature::OurLogsMetaAttributes),
             logs: all_logs,
         }
     })

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -199,79 +199,6 @@ def test_ourlog_multiple_containers_not_allowed(
     ]
 
 
-@pytest.mark.parametrize("meta_enabled", [False, True])
-def test_ourlog_meta_attributes(
-    mini_sentry,
-    relay_with_processing,
-    items_consumer,
-    meta_enabled,
-):
-    items_consumer = items_consumer()
-    project_id = 42
-    project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["datascrubbingSettings"] = {
-        "scrubData": True,
-    }
-    project_config["config"]["features"] = [
-        "organizations:ourlogs-ingestion",
-        "organizations:ourlogs-meta-attributes" if meta_enabled else "",
-    ]
-
-    relay = relay_with_processing(options=TEST_CONFIG)
-    ts = datetime.now(timezone.utc)
-
-    envelope = envelope_with_sentry_logs(
-        {
-            "timestamp": ts.timestamp(),
-            "trace_id": "5b8efff798038103d269b633813fc60c",
-            "span_id": "eee19b7ec3c1b175",
-            "level": "error",
-            "body": "oops, not again",
-            "attributes": {
-                "creditcard": {
-                    "value": "4242424242424242",
-                    "type": "string",
-                }
-            },
-        }
-    )
-
-    relay.send_envelope(project_id, envelope)
-
-    assert items_consumer.get_item() == {
-        "attributes": {
-            "creditcard": {"stringValue": "[creditcard]"},
-            "sentry.body": {"stringValue": "oops, not again"},
-            "sentry.browser.name": {"stringValue": "Python Requests"},
-            "sentry.browser.version": {"stringValue": "2.32"},
-            "sentry.severity_text": {"stringValue": "error"},
-            "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
-            **timestamps(ts),
-            **(
-                {
-                    "sentry._meta.fields.attributes.creditcard": {
-                        "stringValue": '{"meta":{"value":{"":{"rem":[["@creditcard","s",0,12]],"len":16}}}}'
-                    }
-                }
-                if meta_enabled
-                else {}
-            ),
-        },
-        "clientSampleRate": 1.0,
-        "itemId": mock.ANY,
-        "itemType": "TRACE_ITEM_TYPE_LOG",
-        "organizationId": "1",
-        "projectId": "42",
-        "received": time_within_delta(),
-        "retentionDays": 90,
-        "serverSampleRate": 1.0,
-        "timestamp": time_within_delta(
-            ts, delta=timedelta(seconds=1), expect_resolution="ns"
-        ),
-        "traceId": "5b8efff798038103d269b633813fc60c",
-    }
-
-
 def test_ourlog_extraction_with_sentry_logs(
     mini_sentry,
     relay,
@@ -350,10 +277,23 @@ def test_ourlog_extraction_with_sentry_logs(
         },
         {
             "attributes": {
+                "sentry._meta.fields.attributes.broken_type": {
+                    "stringValue": '{"meta":{"":{"err":["invalid_data"],"val":{"type":"not_a_real_type","value":"info"}}}}'
+                },
+                "sentry._meta.fields.attributes.mismatched_type": {
+                    "stringValue": '{"meta":{"":{"err":["invalid_data"],"val":{"type":"boolean","value":"some '
+                    'string"}}}}'
+                },
+                "sentry._meta.fields.attributes.unknown_type": {
+                    "stringValue": '{"meta":{"":{"err":["invalid_data"],"val":{"type":"unknown","value":"info"}}}}'
+                },
                 "boolean.attribute": {"boolValue": True},
                 "double.attribute": {"doubleValue": 1.23},
                 "integer.attribute": {"intValue": "42"},
                 "pii": {"stringValue": "[creditcard]"},
+                "sentry._meta.fields.attributes.pii": {
+                    "stringValue": '{"meta":{"value":{"":{"rem":[["@creditcard","s",0,12]],"len":19}}}}'
+                },
                 "sentry.body": {"stringValue": "Example log record"},
                 "sentry.browser.name": {"stringValue": "Python Requests"},
                 "sentry.browser.version": {"stringValue": "2.32"},


### PR DESCRIPTION
This has been since fully rolled out. We can graduate the flag by deleting it, because this was only relevant for processing Relays and we do not need to propagate it.

Removes a now redundant log, as well as removing the `debug_assert` for capacity as it depends too much on the amount of metadata to add.



#skip-changelog