### PR TITLE
ref(ourlogs): Remove unused ourlogs sampling global config

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -173,21 +173,6 @@ pub struct Options {
     )]
     pub span_extraction_sample_rate: Option<f32>,
 
-    /// Sample rate at which to ingest logs.
-    ///
-    /// This number represents the fraction of received logs that are processed. It only applies if
-    /// [`crate::Feature::OurLogsIngestion`] is enabled.
-    ///
-    /// `None` is the default and interpreted as a value of 1.0 (ingest everything).
-    ///
-    /// Note: Any value below 1.0 will cause the product to not show all the users data, so use with caution.
-    #[serde(
-        rename = "relay.ourlogs-ingestion.sample-rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub ourlogs_ingestion_sample_rate: Option<f32>,
-
     /// List of values on span description that are allowed to be sent to Sentry without being scrubbed.
     ///
     /// At this point, it doesn't accept IP addresses in CIDR format.. yet.

--- a/relay-server/src/processing/logs/filter.rs
+++ b/relay-server/src/processing/logs/filter.rs
@@ -2,20 +2,10 @@ use relay_dynamic_config::Feature;
 
 use crate::processing::Context;
 use crate::processing::logs::{Error, Result};
-use crate::utils::{PickResult, sample};
 
 pub fn feature_flag(ctx: Context<'_>) -> Result<()> {
     match ctx.should_filter(Feature::OurLogsIngestion) {
         true => Err(Error::FilterFeatureFlag),
         false => Ok(()),
-    }
-}
-
-pub fn sampled(ctx: Context<'_>) -> Result<()> {
-    let sample_rate = ctx.global_config.options.ourlogs_ingestion_sample_rate;
-
-    match sample_rate.map(sample).unwrap_or_default() {
-        PickResult::Discard => Err(Error::FilterSampling),
-        PickResult::Keep => Ok(()),
     }
 }


### PR DESCRIPTION
We no longer need that, we're past using this.

#skip-changelog