### PR TITLE
ci(gocd): Fix experimental deploy checks

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -43,10 +43,8 @@ pipelines:
                     "Test All Features (ubuntu-latest)" \
                     "Publish Relay to Internal AR (relay)" \
                     "Publish Relay to Internal AR (relay-pop)" \
-                    "Upload build artifacts to gocd (relay, linux/amd64)" \
-                    "Upload build artifacts to gocd (relay, linux/arm64)" \
-                    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
-                    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \
+                    "Upload build artifacts to gocd (relay)" \
+                    "Upload build artifacts to gocd (relay-pop)" \
 
       - deploy-experimental:
           approval:

--- a/gocd/pipelines/relay-pop-experimental.yaml
+++ b/gocd/pipelines/relay-pop-experimental.yaml
@@ -43,10 +43,8 @@ pipelines:
                     "Test All Features (ubuntu-latest)" \
                     "Publish Relay to Internal AR (relay)" \
                     "Publish Relay to Internal AR (relay-pop)" \
-                    "Upload build artifacts to gocd (relay, linux/amd64)" \
-                    "Upload build artifacts to gocd (relay, linux/arm64)" \
-                    "Upload build artifacts to gocd (relay-pop, linux/amd64)" \
-                    "Upload build artifacts to gocd (relay-pop, linux/arm64)" \
+                    "Upload build artifacts to gocd (relay)" \
+                    "Upload build artifacts to gocd (relay-pop)" \
 
       - deploy-experimental:
           approval:


### PR DESCRIPTION
They are outdated, copied over the checks from the script, but since these pipelines seem to be special I didn't dare to re-use the existing bash script.

#skip-changelog