### PR TITLE
Revert "feat(docker): Switch to a distroless base image (#4940)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Features**:
 
-- Build and publish Relay containers with a distroless base image. ([#4940](https://github.com/getsentry/relay/pull/4940))
 - Add `unhandled` status type for Release Health `session` and `sessions` envelopes. ([#4939](https://github.com/getsentry/relay/pull/4939))
 - Always emit a span usage metric, independent of span feature flags. ([#4976](https://github.com/getsentry/relay/pull/4976))
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,21 +1,31 @@
-FROM gcr.io/distroless/cc-debian12:debug AS builder
-
-RUN ["/busybox/busybox", "mkdir", "/work", "/etc/relay"]
-
-
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM debian:bookworm-slim
 
 ARG TARGETPLATFORM
 
-EXPOSE 3000
+RUN apt-get update \
+  && apt-get install -y ca-certificates gosu curl --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder --chown=nonroot:nonroot /etc/relay /etc/relay
-COPY --from=builder --chown=nonroot:nonroot /work /work
+ENV \
+  RELAY_UID=10001 \
+  RELAY_GID=10001
 
-VOLUME ["/etc/relay", "/work"]
+# Create a new user and group with fixed uid/gid
+RUN groupadd --system relay --gid $RELAY_GID \
+  && useradd --system --gid relay --uid $RELAY_UID relay
+
+RUN mkdir /work /etc/relay \
+  && chown relay:relay /work /etc/relay
+VOLUME ["/work", "/etc/relay"]
 WORKDIR /work
 
-COPY --chmod=755 $TARGETPLATFORM/relay /bin/relay
+EXPOSE 3000
 
-ENTRYPOINT ["/bin/relay"]
+COPY $TARGETPLATFORM/relay /bin/relay
+RUN chmod +x /bin/relay
+
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]
 CMD ["run"]
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+# Enable core dumps. Requires privileged mode.
+if [[ "${RELAY_ENABLE_COREDUMPS:-}" == "1" ]]; then
+  mkdir -p /var/dumps
+  chmod a+rwx /var/dumps
+  echo '/var/dumps/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
+  ulimit -c unlimited
+fi
+
+# Sleep for the specified number of seconds before starting.
+# For example, can be helpful to synchronize container startup in Kubernetes environment.
+if [[ -n "${RELAY_DELAY_STARTUP_SECONDS:-}" ]]; then
+  echo "Sleeping for ${RELAY_DELAY_STARTUP_SECONDS}s..."
+  sleep "${RELAY_DELAY_STARTUP_SECONDS}"
+fi
+
+# Make sure that a specified URL (e.g. the upstream or a proxy sidecar) is reachable before starting.
+# Only 200 response is accepted as success.
+if [[ -n "${RELAY_PRESTART_ENDPOINT:-}" ]]; then
+  max_retry="${RELAY_PRESTART_MAX_RETRIES:-120}"
+  curl_timeout="${RELAY_PRESTART_REQUEST_TIMEOUT:-1}"
+  for attempt in $(seq 0 "${max_retry}"); do
+    if [[ "${attempt}" == "${max_retry}" ]]; then
+      echo "The prestart endpoint has not returned 200 after ${max_retry} attempts, exiting!"
+      exit 1
+    fi
+    status=$(curl --max-time "${curl_timeout}" --show-error --silent \
+                  --output /dev/null --write-out "%{http_code}" \
+                  -H 'Connection: close' \
+                  "${RELAY_PRESTART_ENDPOINT}" \
+              || true)
+    if [[ "${status}" == "200" ]]; then
+      break
+    fi
+    echo "Waiting for a 200 response from ${RELAY_PRESTART_ENDPOINT}, got ${status}"
+    sleep 1
+  done
+fi
+
+# For compatibility with older images
+if [ "$1" == "bash" ]; then
+  set -- bash "${@:2}"
+elif [ "$(id -u)" == "0" ]; then
+  set -- gosu relay /bin/relay "$@"
+else
+  set -- /bin/relay "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This reverts commit 3eadb1c4b4f5f832144aa7873d1fd6e8762a078f. 
This reverts commit 8081d0caab4d73e641c9804fd7d41898e34ea1cd.

Looks like CI in Sentry fails now... https://github.com/getsentry/sentry/actions/runs/16675030965/job/47199575669

#skip-changelog