### PR TITLE
ref(devservices): Disable Relay healthchecks

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -31,11 +31,12 @@ services:
     ports:
       - 127.0.0.1:7899:7899
     command: [run, --config, /etc/relay]
-    healthcheck:
-      test: curl -f http://127.0.0.1:7899/api/relay/healthcheck/live/
-      interval: 5s
-      timeout: 5s
-      retries: 3
+    # Temporarily removed, due to a distroless image not having access to curl.
+    # healthcheck:
+    #   test: curl -f http://127.0.0.1:7899/api/relay/healthcheck/live/
+    #   interval: 5s
+    #   timeout: 5s
+    #   retries: 3
     volumes:
       - ./config/relay.yml:/etc/relay/config.yml
       - ./config/devservices-credentials.json:/etc/relay/credentials.json


### PR DESCRIPTION
Distroless = no curl, makes Sentry CI fail:  https://github.com/getsentry/sentry/actions/runs/16675030965/job/47199575669

#skip-changelog