### PR TITLE
ref(beta): Fix a beta lint

### DIFF
--- a/relay-common/src/glob2.rs
+++ b/relay-common/src/glob2.rs
@@ -101,7 +101,7 @@ pub struct Glob {
 
 impl Glob {
     /// Creates the [`GlobBuilder`], which can be fine-tunned using helper methods.
-    pub fn builder(glob: &'_ str) -> GlobBuilder {
+    pub fn builder(glob: &str) -> GlobBuilder<'_> {
         GlobBuilder::new(glob)
     }
 


### PR DESCRIPTION
```
error: hiding a lifetime that's elided elsewhere is confusing
   --> relay-common/src/glob2.rs:104:27
    |
104 |     pub fn builder(glob: &'_ str) -> GlobBuilder {
    |                           ^^         ----------- the same lifetime is hidden here
    |                           |
    |                           the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
    |
104 |     pub fn builder(glob: &'_ str) -> GlobBuilder<'_> {
```

#skip-changelog