### PR TITLE
feat(ourlogs): Implements legacy browser filters for logs

### DIFF
--- a/relay-filter/src/legacy_browsers.rs
+++ b/relay-filter/src/legacy_browsers.rs
@@ -2,16 +2,12 @@
 
 use std::collections::BTreeSet;
 
-use crate::interface::UserAgent;
+use relay_ua::UserAgent;
+
 use crate::{FilterStatKey, Filterable, LegacyBrowser, LegacyBrowsersFilterConfig};
 
 /// Checks if the event originates from legacy browsers.
-fn matches(user_agent: UserAgent<'_>, browsers: &BTreeSet<LegacyBrowser>) -> bool {
-    let user_agent = match user_agent {
-        UserAgent::Raw(user_agent) => relay_ua::parse_user_agent(user_agent),
-        UserAgent::Parsed(user_agent) => user_agent,
-    };
-
+fn matches(user_agent: &UserAgent<'_>, browsers: &BTreeSet<LegacyBrowser>) -> bool {
     // remap IE Mobile to IE (sentry python, filter compatibility)
     let family = match user_agent.family.as_ref() {
         "IE Mobile" => "IE",
@@ -19,32 +15,32 @@ fn matches(user_agent: UserAgent<'_>, browsers: &BTreeSet<LegacyBrowser>) -> boo
     };
 
     if browsers.contains(&LegacyBrowser::Default) {
-        return default_filter(family, &user_agent);
+        return default_filter(family, user_agent);
     }
 
     for browser_type in browsers {
         let should_filter = match browser_type {
-            LegacyBrowser::IePre9 => filter_browser(family, &user_agent, "IE", |x| x <= 8),
-            LegacyBrowser::Ie9 => filter_browser(family, &user_agent, "IE", |x| x == 9),
-            LegacyBrowser::Ie10 => filter_browser(family, &user_agent, "IE", |x| x == 10),
-            LegacyBrowser::Ie11 => filter_browser(family, &user_agent, "IE", |x| x == 11),
+            LegacyBrowser::IePre9 => filter_browser(family, user_agent, "IE", |x| x <= 8),
+            LegacyBrowser::Ie9 => filter_browser(family, user_agent, "IE", |x| x == 9),
+            LegacyBrowser::Ie10 => filter_browser(family, user_agent, "IE", |x| x == 10),
+            LegacyBrowser::Ie11 => filter_browser(family, user_agent, "IE", |x| x == 11),
             LegacyBrowser::OperaMiniPre8 => {
-                filter_browser(family, &user_agent, "Opera Mini", |x| x < 8)
+                filter_browser(family, user_agent, "Opera Mini", |x| x < 8)
             }
-            LegacyBrowser::OperaPre15 => filter_browser(family, &user_agent, "Opera", |x| x < 15),
-            LegacyBrowser::AndroidPre4 => filter_browser(family, &user_agent, "Android", |x| x < 4),
-            LegacyBrowser::SafariPre6 => filter_browser(family, &user_agent, "Safari", |x| x < 6),
-            LegacyBrowser::EdgePre79 => filter_browser(family, &user_agent, "Edge", |x| x < 79),
-            LegacyBrowser::Ie => filter_browser(family, &user_agent, "IE", |x| x < 12),
+            LegacyBrowser::OperaPre15 => filter_browser(family, user_agent, "Opera", |x| x < 15),
+            LegacyBrowser::AndroidPre4 => filter_browser(family, user_agent, "Android", |x| x < 4),
+            LegacyBrowser::SafariPre6 => filter_browser(family, user_agent, "Safari", |x| x < 6),
+            LegacyBrowser::EdgePre79 => filter_browser(family, user_agent, "Edge", |x| x < 79),
+            LegacyBrowser::Ie => filter_browser(family, user_agent, "IE", |x| x < 12),
             LegacyBrowser::OperaMini => {
-                filter_browser(family, &user_agent, "Opera Mini", |x| x < 35)
+                filter_browser(family, user_agent, "Opera Mini", |x| x < 35)
             }
-            LegacyBrowser::Opera => filter_browser(family, &user_agent, "Opera", |x| x < 51),
-            LegacyBrowser::Android => filter_browser(family, &user_agent, "Android", |x| x < 4),
-            LegacyBrowser::Safari => filter_browser(family, &user_agent, "Safari", |x| x < 12),
-            LegacyBrowser::Edge => filter_browser(family, &user_agent, "Edge", |x| x < 79),
-            LegacyBrowser::Chrome => filter_browser(family, &user_agent, "Chrome", |x| x < 64),
-            LegacyBrowser::Firefox => filter_browser(family, &user_agent, "Firefox", |x| x < 67),
+            LegacyBrowser::Opera => filter_browser(family, user_agent, "Opera", |x| x < 51),
+            LegacyBrowser::Android => filter_browser(family, user_agent, "Android", |x| x < 4),
+            LegacyBrowser::Safari => filter_browser(family, user_agent, "Safari", |x| x < 12),
+            LegacyBrowser::Edge => filter_browser(family, user_agent, "Edge", |x| x < 79),
+            LegacyBrowser::Chrome => filter_browser(family, user_agent, "Chrome", |x| x < 64),
+            LegacyBrowser::Firefox => filter_browser(family, user_agent, "Firefox", |x| x < 67),
             LegacyBrowser::Unknown(_) => {
                 // unknown browsers should not be filtered
                 false
@@ -67,15 +63,15 @@ pub fn should_filter<F: Filterable>(
         return Ok(()); // globally disabled or no individual browser enabled
     }
 
-    let browsers = &config.browsers;
-    if item.user_agent().is_some_and(|ua| matches(ua, browsers)) {
+    let matches = |ua| matches(ua, &config.browsers);
+    if item.user_agent().parsed().is_some_and(matches) {
         Err(FilterStatKey::LegacyBrowsers)
     } else {
         Ok(())
     }
 }
 
-fn get_browser_major_version(user_agent: &relay_ua::UserAgent<'_>) -> Option<i32> {
+fn get_browser_major_version(user_agent: &UserAgent<'_>) -> Option<i32> {
     if let Some(browser_major_version_str) = &user_agent.major
         && let Ok(browser_major_version) = browser_major_version_str.parse::<i32>()
     {
@@ -99,7 +95,7 @@ fn min_version(family: &str) -> Option<i32> {
     }
 }
 
-fn default_filter(mapped_family: &str, user_agent: &relay_ua::UserAgent<'_>) -> bool {
+fn default_filter(mapped_family: &str, user_agent: &UserAgent<'_>) -> bool {
     if let Some(browser_major_version) = get_browser_major_version(user_agent)
         && let Some(min_version) = min_version(mapped_family)
         && min_version > browser_major_version
@@ -111,7 +107,7 @@ fn default_filter(mapped_family: &str, user_agent: &relay_ua::UserAgent<'_>) -> 
 
 fn filter_browser<F>(
     mapped_family: &str,
-    user_agent: &relay_ua::UserAgent<'_>,
+    user_agent: &UserAgent<'_>,
     family: &str,
     should_filter: F,
 ) -> bool

--- a/relay-filter/src/lib.rs
+++ b/relay-filter/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::common::*;
 pub use crate::config::*;
 pub use crate::csp::matches_any_origin;
 pub use crate::generic::are_generic_filters_supported;
-pub use interface::Filterable;
+pub use interface::{Filterable, UserAgent};
 
 /// Checks whether an event should be filtered for a particular configuration.
 ///

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -3,7 +3,6 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::interface::UserAgent;
 use crate::{FilterConfig, FilterStatKey, Filterable};
 
 static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
@@ -71,9 +70,7 @@ pub fn should_filter<F: Filterable>(item: &F, config: &FilterConfig) -> Result<(
         return Ok(());
     }
 
-    if let Some(UserAgent::Raw(user_agent)) = item.user_agent()
-        && matches(user_agent)
-    {
+    if item.user_agent().raw.is_some_and(matches) {
         return Err(FilterStatKey::WebCrawlers);
     }
 

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -3,6 +3,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use crate::interface::UserAgent;
 use crate::{FilterConfig, FilterStatKey, Filterable};
 
 static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
@@ -60,12 +61,8 @@ static ALLOWED_WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Checks if the event originates from a known web crawler.
-fn matches(user_agent: Option<&str>) -> bool {
-    if let Some(user_agent) = user_agent {
-        WEB_CRAWLERS.is_match(user_agent) && !ALLOWED_WEB_CRAWLERS.is_match(user_agent)
-    } else {
-        false
-    }
+fn matches(user_agent: &str) -> bool {
+    WEB_CRAWLERS.is_match(user_agent) && !ALLOWED_WEB_CRAWLERS.is_match(user_agent)
 }
 
 /// Filters events originating from a known web crawler.
@@ -74,7 +71,9 @@ pub fn should_filter<F: Filterable>(item: &F, config: &FilterConfig) -> Result<(
         return Ok(());
     }
 
-    if matches(item.user_agent()) {
+    if let Some(UserAgent::Raw(user_agent)) = item.user_agent()
+        && matches(user_agent)
+    {
         return Err(FilterStatKey::WebCrawlers);
     }
 

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -146,8 +146,8 @@ impl Filterable for MinimalProfile {
         None
     }
 
-    fn user_agent(&self) -> Option<UserAgent<'_>> {
-        None
+    fn user_agent(&self) -> UserAgent<'_> {
+        Default::default()
     }
 
     fn header(&self, _: &str) -> Option<&str> {

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -49,7 +49,7 @@ use url::Url;
 use relay_base_schema::project::ProjectId;
 use relay_dynamic_config::GlobalConfig;
 use relay_event_schema::protocol::{Csp, Event, EventId, Exception, LogEntry, Values};
-use relay_filter::{Filterable, ProjectFiltersConfig};
+use relay_filter::{Filterable, ProjectFiltersConfig, UserAgent};
 use relay_protocol::{Getter, Val};
 use serde::Deserialize;
 use serde_json::Deserializer;
@@ -146,7 +146,7 @@ impl Filterable for MinimalProfile {
         None
     }
 
-    fn user_agent(&self) -> Option<&str> {
+    fn user_agent(&self) -> Option<UserAgent<'_>> {
         None
     }
 

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -563,6 +563,11 @@ def test_browser_name_version_extraction(
             "release-version", {"releases": {"releases": ["foobar@1.0"]}}, id="release"
         ),
         pytest.param(
+            "legacy-browsers",
+            {"legacyBrowsers": {"isEnabled": True, "options": ["ie9"]}},
+            id="legacy-browsers",
+        ),
+        pytest.param(
             "gen_body",
             {
                 "generic": {
@@ -635,7 +640,10 @@ def test_filters_are_applied_to_logs(
         },
     )
 
-    relay.send_envelope(project_id, envelope)
+    headers = {
+        "User-Agent": "Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.0; Trident/5.0)"
+    }
+    relay.send_envelope(project_id, envelope, headers=headers)
 
     outcomes = []
     for _ in range(2):


### PR DESCRIPTION
Implements legacy browser filters for logs.

Closes: #5010

Follow-up for implementing web crawlers and improving user agent extraction: https://github.com/getsentry/relay/issues/5024