### PR TITLE
ref(rate-limits): Add convenience trait to rate limit by quantities

### DIFF
--- a/relay-server/src/processing/limits.rs
+++ b/relay-server/src/processing/limits.rs
@@ -1,5 +1,6 @@
 use relay_quotas::{ItemScoping, Quota, RateLimits};
 
+use crate::managed::OutcomeError;
 use crate::processing::{Context, Counted, Managed, Rejected};
 
 #[cfg(feature = "processing")]
@@ -113,6 +114,46 @@ where
             Some(limiter) => limiter.try_consume(scope, quantity).await,
             None => RateLimits::default(),
         }
+    }
+}
+
+/// A convenience trait for types which need to be rate limited by their [`Counted::quantities`].
+///
+/// For rate limiting, each category and quantity is rate limited individually,
+/// if any category has rate limits enforced the implementation will reject the entire item.
+pub trait CountRateLimited {
+    type Error: From<RateLimits> + OutcomeError;
+}
+
+impl<T> RateLimited for Managed<T>
+where
+    Managed<T>: CountRateLimited,
+    T: Counted,
+{
+    type Error = <<Managed<T> as CountRateLimited>::Error as OutcomeError>::Error;
+
+    async fn enforce<R>(
+        &mut self,
+        mut rate_limiter: R,
+        _ctx: Context<'_>,
+    ) -> Result<(), Rejected<Self::Error>>
+    where
+        R: RateLimiter,
+    {
+        let scoping = self.scoping();
+
+        for (category, quantity) in self.quantities() {
+            let limits = rate_limiter
+                .try_consume(scoping.item(category), quantity)
+                .await;
+
+            if !limits.is_empty() {
+                let error = <Managed<T> as CountRateLimited>::Error::from(limits);
+                return Err(self.reject_err(error));
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -14,7 +14,7 @@ use crate::managed::{
     Counted, Managed, ManagedEnvelope, ManagedResult as _, OutcomeError, Quantities,
 };
 use crate::processing::{
-    self, Context, Forward, Output, QuotaRateLimiter, RateLimited, RateLimiter, Rejected,
+    self, Context, CountRateLimited, Forward, Output, QuotaRateLimiter, Rejected,
 };
 use crate::services::outcome::{DiscardReason, Outcome};
 
@@ -72,6 +72,12 @@ impl OutcomeError for Error {
         };
 
         (outcome, self)
+    }
+}
+
+impl From<RateLimits> for Error {
+    fn from(value: RateLimits) -> Self {
+        Self::RateLimited(value)
     }
 }
 
@@ -257,33 +263,8 @@ impl Counted for SerializedLogs {
     }
 }
 
-impl RateLimited for Managed<SerializedLogs> {
+impl CountRateLimited for Managed<SerializedLogs> {
     type Error = Error;
-
-    async fn enforce<T>(
-        &mut self,
-        mut rate_limiter: T,
-        _ctx: Context<'_>,
-    ) -> Result<(), Rejected<Self::Error>>
-    where
-        T: RateLimiter,
-    {
-        let scoping = self.scoping();
-
-        let items = rate_limiter
-            .try_consume(scoping.item(DataCategory::LogItem), self.count())
-            .await;
-        let bytes = rate_limiter
-            .try_consume(scoping.item(DataCategory::LogByte), self.bytes())
-            .await;
-
-        let limits = items.merge_with(bytes);
-        if !limits.is_empty() {
-            return Err(self.reject_err(Error::RateLimited(limits)));
-        }
-
-        Ok(())
-    }
 }
 
 /// Logs which have been parsed and expanded from their serialized state.
@@ -304,24 +285,17 @@ pub struct ExpandedLogs {
 
 impl Counted for ExpandedLogs {
     fn quantities(&self) -> Quantities {
+        let count = self.logs.len();
+        let bytes = self.logs.iter().map(get_calculated_byte_size).sum();
+
         smallvec::smallvec![
-            (DataCategory::LogItem, self.logs.len()),
-            (DataCategory::LogByte, self.bytes())
+            (DataCategory::LogItem, count),
+            (DataCategory::LogByte, bytes)
         ]
     }
 }
 
 impl ExpandedLogs {
-    /// Returns the total count of all logs contained.
-    fn count(&self) -> usize {
-        self.logs.len()
-    }
-
-    /// Returns the sum of bytes of all logs contained.
-    fn bytes(&self) -> usize {
-        self.logs.iter().map(get_calculated_byte_size).sum()
-    }
-
     fn serialize(self) -> Result<SerializedLogs, ContainerWriteError> {
         let mut logs = Vec::new();
 
@@ -341,31 +315,6 @@ impl ExpandedLogs {
     }
 }
 
-impl RateLimited for Managed<ExpandedLogs> {
+impl CountRateLimited for Managed<ExpandedLogs> {
     type Error = Error;
-
-    async fn enforce<T>(
-        &mut self,
-        mut rate_limiter: T,
-        _ctx: Context<'_>,
-    ) -> Result<(), Rejected<Self::Error>>
-    where
-        T: RateLimiter,
-    {
-        let scoping = self.scoping();
-
-        let items = rate_limiter
-            .try_consume(scoping.item(DataCategory::LogItem), self.count())
-            .await;
-        let bytes = rate_limiter
-            .try_consume(scoping.item(DataCategory::LogByte), self.bytes())
-            .await;
-
-        let limits = items.merge_with(bytes);
-        if !limits.is_empty() {
-            return Err(self.reject_err(Error::RateLimited(limits)));
-        }
-
-        Ok(())
-    }
 }


### PR DESCRIPTION
Slightly changes rate limiting to logic to abort on the first breached rate limit instead of all. I could not come up with a reason why doing this would be disadvantageous and it will always be easier to later (if we deem it necessary) to evaluate all. Doing the reverse requires more considerations, since this code is completely new and unused, I think we should start with this option.

The introduced type is also quite a generic type salad, but apart from the error handling it isn't that bad and it reduces boilerplate, also we end up with a single implementation used for multiple types preventing bugs in the future.