### PR TITLE
ref(processing): Implement debug for logs processor

### DIFF
--- a/relay-server/src/processing/limits.rs
+++ b/relay-server/src/processing/limits.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use relay_quotas::{ItemScoping, Quota, RateLimits};
 
 use crate::processing::{Context, Counted, Managed, Rejected};
@@ -69,6 +71,12 @@ impl QuotaRateLimiter {
         };
 
         data.enforce(limiter, ctx).await
+    }
+}
+
+impl fmt::Debug for QuotaRateLimiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuotaRateLimiter").finish()
     }
 }
 

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -78,6 +78,7 @@ impl OutcomeError for Error {
 /// A processor for Logs.
 ///
 /// It processes items of type: [`ItemType::OtelLog`] and [`ItemType::Log`].
+#[derive(Debug)]
 pub struct LogsProcessor {
     limiter: Arc<QuotaRateLimiter>,
 }


### PR DESCRIPTION
Just small QoL. We used to have a lint which enforced this, but seems like it got lost.