### PR TITLE
feat(spanv2): Implement basic forwarding of span v2 to Kafka and upstream

### DIFF
--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -1,4 +1,5 @@
-use relay_event_schema::protocol::OurLog;
+use relay_event_schema::protocol::{OurLog, Span, SpanV2};
+use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 use smallvec::SmallVec;
 
@@ -84,6 +85,18 @@ impl Counted for WithHeader<OurLog> {
                 processing::logs::get_calculated_byte_size(self)
             )
         ]
+    }
+}
+
+impl Counted for WithHeader<SpanV2> {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Span, 1), (DataCategory::SpanIndexed, 1)]
+    }
+}
+
+impl Counted for Annotated<Span> {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Span, 1), (DataCategory::SpanIndexed, 1)]
     }
 }
 

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -647,6 +647,20 @@ impl RecordKeeper<'_> {
         }
         err
     }
+
+    /// Rejects an item with an internal error.
+    ///
+    /// See also: [`Managed::internal_error`].
+    #[track_caller]
+    pub fn internal_error<E, Q>(&mut self, error: E, q: Q)
+    where
+        E: std::error::Error + 'static,
+        Q: Counted,
+    {
+        relay_log::error!(error = &error as &dyn std::error::Error, "internal error");
+        debug_assert!(false, "internal error: {error}");
+        self.reject_err((Outcome::Invalid(DiscardReason::Internal), ()), q);
+    }
 }
 
 /// Iterator returned by [`Managed::split`].

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -74,17 +74,14 @@ impl processing::Processor for SpansProcessor {
         &self,
         envelope: &mut ManagedEnvelope,
     ) -> Option<Managed<Self::UnitOfWork>> {
-        let _headers = envelope.envelope().headers().clone();
+        let headers = envelope.envelope().headers().clone();
 
         let spans = envelope
             .envelope_mut()
             .take_items_by(|item| matches!(*item.ty(), ItemType::Span))
             .into_vec();
 
-        let work = SerializedSpans {
-            headers: _headers,
-            spans,
-        };
+        let work = SerializedSpans { headers, spans };
         Some(Managed::from_envelope(envelope, work))
     }
 

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -2,10 +2,8 @@ use relay_event_schema::protocol::SpanV2;
 
 use crate::envelope::{ContainerItems, Item, ItemContainer};
 use crate::managed::Managed;
-use crate::processing::spans::{Error, ExpandedSpans, Result};
+use crate::processing::spans::{Error, ExpandedSpans, Result, SerializedSpans};
 use crate::services::outcome::DiscardReason;
-
-use super::SerializedSpans;
 
 /// Parses all serialized spans.
 ///
@@ -21,7 +19,7 @@ pub fn expand(spans: Managed<SerializedSpans>) -> Managed<ExpandedSpans> {
         }
 
         ExpandedSpans {
-            _headers: spans._headers,
+            headers: spans.headers,
             spans: all_spans,
         }
     })


### PR DESCRIPTION
Implements the `Forward` trait for the span v2 processing pipeline. We will in a follow-up have to improve how we forward spans upstream, ideally we get rid of this additional json roundtrip, but currently that is the easiest way forward.