### PR TITLE
ref(beta): Fixes latest beta lints

### DIFF
--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -507,15 +507,6 @@ impl CspRaw {
     }
 }
 
-/// Defines external, RFC-defined schema we accept, while `Csp` defines our own schema.
-///
-/// See `Csp` for meaning of fields.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct CspReportRaw {
-    csp_report: CspRaw,
-}
-
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 enum CspVariant {
@@ -2094,63 +2085,5 @@ mod tests {
             csp_raw.effective_directive(),
             Ok(CspDirective::DefaultSrc)
         ));
-    }
-
-    #[test]
-    fn test_extract_effective_directive_from_long_form() {
-        // First try from 'effective-directive' field
-        let json = r#"{
-            "csp-report": {
-                "document-uri": "http://example.com/foo",
-                "effective-directive": "script-src 'report-sample' 'strict-dynamic' 'unsafe-eval' 'nonce-random" ,
-                "blocked-uri": "data"
-            }
-        }"#;
-
-        let raw_report = serde_json::from_slice::<CspReportRaw>(json.as_bytes()).unwrap();
-        let raw_csp = raw_report.csp_report;
-
-        let effective_directive = raw_csp.effective_directive().unwrap();
-
-        assert_eq!(effective_directive, CspDirective::ScriptSrc);
-
-        // Then from 'violated-directive' field
-        let json = r#"{
-            "csp-report": {
-                "document-uri": "http://example.com/foo",
-                "violated-directive": "script-src 'report-sample' 'strict-dynamic' 'unsafe-eval' 'nonce-random" ,
-                "blocked-uri": "data"
-            }
-        }"#;
-
-        let raw_report = serde_json::from_slice::<CspReportRaw>(json.as_bytes()).unwrap();
-        let raw_csp = raw_report.csp_report;
-
-        let effective_directive = raw_csp.effective_directive().unwrap();
-
-        assert_eq!(effective_directive, CspDirective::ScriptSrc);
-    }
-
-    #[test]
-    fn test_csp_report_fenced_frame_src() {
-        let json = r#"
-            {
-              "csp-report": {
-                "document-uri": "https://example.com",
-                "referrer": "https://www.google.com/",
-                "violated-directive": "fenced-frame-src",
-                "effective-directive": "fenced-frame-src",
-                "original-policy": "default-src 'self' 'unsafe-eval'",
-                "disposition": "enforce",
-                "blocked-uri": "",
-                "status-code": 200,
-                "script-sample": ""
-              }
-            }
-        "#;
-        let raw_report = serde_json::from_slice::<CspReportRaw>(json.as_bytes()).unwrap();
-        let raw_csp = raw_report.csp_report;
-
-        assert!(raw_csp.effective_directive().is_ok());
     }
 }

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -179,7 +179,10 @@ impl Manager for CustomClusterManager {
 
         // If the interval has been reached, we optimistically assume the connection is active
         // without doing an actual `PING`.
-        if metrics.recycle_count % self.recycle_check_frequency != 0 {
+        if !metrics
+            .recycle_count
+            .is_multiple_of(self.recycle_check_frequency)
+        {
             return Ok(());
         }
 
@@ -267,7 +270,10 @@ impl Manager for CustomSingleManager {
 
         // If the interval has been reached, we optimistically assume the connection is active
         // without doing an actual `PING`.
-        if metrics.recycle_count % self.recycle_check_frequency != 0 {
+        if !metrics
+            .recycle_count
+            .is_multiple_of(self.recycle_check_frequency)
+        {
             return Ok(());
         }
 

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -545,7 +545,7 @@ mod tests {
         let items = multipart_items(
             multipart,
             |_, _| AttachmentType::Attachment,
-            |_, x| (mock_outcomes.push(x)),
+            |_, x| mock_outcomes.push(x),
             &config,
             true,
         )


### PR DESCRIPTION
More beta lints which need fixing.

```
└─ % cargo +beta clippy --workspace --all-targets --all-features
warning: struct `CspReportRaw` is never constructed
   --> relay-event-schema/src/protocol/security_report.rs:515:8
    |
515 | struct CspReportRaw {
    |        ^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `relay-event-schema` (lib) generated 1 warning
warning: manual implementation of `.is_multiple_of()`
   --> relay-redis/src/pool.rs:182:12
    |
182 |         if metrics.recycle_count % self.recycle_check_frequency != 0 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!metrics.recycle_count.is_multiple_of(self.recycle_check_frequency)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
    = note: `#[warn(clippy::manual_is_multiple_of)]` on by default

warning: manual implementation of `.is_multiple_of()`
   --> relay-redis/src/pool.rs:270:12
    |
270 |         if metrics.recycle_count % self.recycle_check_frequency != 0 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!metrics.recycle_count.is_multiple_of(self.recycle_check_frequency)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of

warning: `relay-redis` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p relay-redis` to apply 2 suggestions)
warning: unnecessary parentheses around closure body
   --> relay-server/src/utils/multipart.rs:548:20
    |
548 |             |_, x| (mock_outcomes.push(x)),
    |                    ^                     ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
548 -             |_, x| (mock_outcomes.push(x)),
548 +             |_, x| mock_outcomes.push(x),
    |
```