### PR TITLE
feat(spanv2): Implements metric extraction and improves dynamic sampling

### DIFF
--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -147,7 +147,7 @@ impl<T: Counted> Managed<T> {
 
     /// Splits [`Self`] into two other [`Managed`] items.
     ///
-    /// The two resulting managed instances are expected to have the same outcomes.
+    /// The two resulting managed instances together are expected to have the same outcomes as the original instance..
     /// Since splitting may introduce a new type of item, which some of the original
     /// quantities are transferred to, there may be new additional data categories created.
     pub fn split_once<F, S, U>(self, f: F) -> (Managed<S>, Managed<U>)

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -148,7 +148,7 @@ impl<T: Counted> Managed<T> {
     /// Splits [`Self`] into two other [`Managed`] items.
     ///
     /// The two resulting managed instances are expected to have the same outcomes.
-    /// Since splitting may introduce a new type of item, which get some of the original
+    /// Since splitting may introduce a new type of item, which some of the original
     /// quantities are transferred to, there may be new additional data categories created.
     pub fn split_once<F, S, U>(self, f: F) -> (Managed<S>, Managed<U>)
     where

--- a/relay-server/src/managed/managed/debug.rs
+++ b/relay-server/src/managed/managed/debug.rs
@@ -8,7 +8,7 @@ use crate::managed;
 pub struct Quantities(pub BTreeMap<DataCategory, usize>);
 
 impl Quantities {
-    /// Asserts that all categories contained in this instance are also contained in `other`.
+    /// Asserts that all categories contained in this instance are also contained in `other` with the same quantities.
     ///
     /// Additional entries in `other` are ignored.
     #[track_caller]

--- a/relay-server/src/managed/managed/debug.rs
+++ b/relay-server/src/managed/managed/debug.rs
@@ -1,0 +1,72 @@
+use std::collections::BTreeMap;
+
+use relay_quotas::DataCategory;
+
+use crate::managed;
+
+#[derive(Debug)]
+pub struct Quantities(pub BTreeMap<DataCategory, usize>);
+
+impl Quantities {
+    /// Asserts that all categories contained in this instance are also contained in `other`.
+    ///
+    /// Additional entries in `other` are ignored.
+    #[track_caller]
+    pub fn assert_only_extra<T>(&self, other: T)
+    where
+        T: Into<Self>,
+    {
+        let mut other = other.into();
+
+        for (category, quantity) in &self.0 {
+            match other.0.remove(category) {
+                None => {
+                    panic!("Expected {quantity} outcomes in category '{category}', but got none")
+                }
+                Some(other) => {
+                    assert_eq!(
+                        *quantity, other,
+                        "Expected {quantity} outcomes in category '{category}', but got '{other}'"
+                    );
+                }
+            }
+        }
+
+        if !other.0.is_empty() {
+            relay_log::debug!("Additional outcomes created: {:?}", other.0);
+        }
+    }
+}
+
+impl std::ops::Add for Quantities {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        for (category, quantity) in rhs.0 {
+            *self.0.entry(category).or_default() += quantity;
+        }
+        self
+    }
+}
+
+impl From<&managed::Quantities> for Quantities {
+    fn from(value: &managed::Quantities) -> Self {
+        Self(
+            value
+                .iter()
+                .fold(Default::default(), |mut acc, (category, quantity)| {
+                    *acc.entry(*category).or_default() += *quantity;
+                    acc
+                }),
+        )
+    }
+}
+
+impl<T> From<&T> for Quantities
+where
+    T: managed::Counted,
+{
+    fn from(value: &T) -> Self {
+        Self::from(&value.quantities())
+    }
+}

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -179,7 +179,7 @@ fn create_metrics(
         return metrics;
     }
 
-    // For extracted metrics, Relay has always used the moment when the metrics was extracted
+    // For extracted metrics, Relay has always used the moment when the metrics were extracted
     // as the received time, instead of the source item's received time.
     let timestamp = UnixTimestamp::now();
     let mut metadata = BucketMetadata::new(timestamp);

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -1,14 +1,20 @@
+use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 
 use chrono::Utc;
 use relay_dynamic_config::ErrorBoundary;
+use relay_metrics::{Bucket, BucketMetadata, BucketValue, UnixTimestamp};
+use relay_quotas::{DataCategory, Scoping};
 use relay_sampling::SamplingConfig;
 use relay_sampling::config::RuleType;
-use relay_sampling::evaluation::SamplingEvaluator;
+use relay_sampling::evaluation::{SamplingDecision, SamplingEvaluator};
 
-use crate::managed::Managed;
+use crate::envelope::Item;
+use crate::managed::{Counted, Managed, Quantities};
+use crate::metrics_extraction::transactions::ExtractedMetrics;
 use crate::processing::Context;
-use crate::processing::spans::SerializedSpans;
+use crate::processing::spans::{ExpandedSpans, SampledSpans, SerializedSpans, outcome_count};
+use crate::services::outcome::Outcome;
 use crate::services::projects::project::ProjectInfo;
 use crate::utils::SamplingResult;
 
@@ -45,7 +51,61 @@ pub fn validate_configs(ctx: Context<'_>) {
 ///
 /// All spans are evaluated in one go as they are required by the protocol to share the same
 /// DSC, which contains all the sampling relevant information.
-pub async fn run(spans: &Managed<SerializedSpans>, ctx: Context<'_>) -> SamplingResult {
+pub async fn run(
+    spans: Managed<SerializedSpans>,
+    ctx: Context<'_>,
+) -> Result<Managed<SampledSpans>, Managed<ExtractedMetrics>> {
+    let sampling_result = compute(&spans, ctx).await;
+
+    let sampling_match = match sampling_result {
+        SamplingResult::Match(m) if m.decision().is_drop() => m,
+        sampling_result => {
+            let sample_rate = sampling_result.sample_rate();
+            return Ok(spans.map(|spans, _| spans.sampled(sample_rate)));
+        }
+    };
+
+    // At this point the decision is to drop the spans.
+    let span_count = outcome_count(&spans.spans);
+    let metrics = create_metrics(spans.scoping(), span_count, SamplingDecision::Drop);
+    let (spans, metrics) = spans.split_once(|spans| (UnsampledSpans::from(spans), metrics));
+
+    let outcome = Outcome::FilteredSampling(sampling_match.into_matched_rules().into());
+    let _ = spans.reject_err(outcome);
+
+    Err(metrics)
+}
+
+/// Creates/extracts metrics for spans which have been determined to be kept by dynamic sampling.
+///
+/// Indexed metrics can only be extracted from the Relay making the final sampling decision,
+/// if the current Relay is not the final Relay, the function returns `None`.
+pub fn create_indexed_metrics(
+    spans: &Managed<ExpandedSpans>,
+    ctx: Context<'_>,
+) -> Option<Managed<ExtractedMetrics>> {
+    if !ctx.is_processing() {
+        return None;
+    }
+
+    let metrics = create_metrics(
+        spans.scoping(),
+        spans.spans.len() as u32,
+        SamplingDecision::Keep,
+    );
+
+    // Metrics are extracted from indexed spans, they should not emit any span outcomes.
+    debug_assert!(
+        metrics
+            .quantities()
+            .into_iter()
+            .all(|(c, _)| c == DataCategory::MetricBucket)
+    );
+
+    Some(spans.wrap(metrics))
+}
+
+async fn compute(spans: &Managed<SerializedSpans>, ctx: Context<'_>) -> SamplingResult {
     // The DSC is always required, we need it to evaluate all rules, if it is missing,
     // no rules can be applied -> we sample the item.
     let Some(dsc) = spans.headers.dsc() else {
@@ -53,7 +113,12 @@ pub async fn run(spans: &Managed<SerializedSpans>, ctx: Context<'_>) -> Sampling
     };
 
     let project_sampling_config = get_sampling_config(ctx.project_info);
-    let root_sampling_config = ctx.sampling_project_info.and_then(get_sampling_config);
+    let root_sampling_config = ctx
+        .sampling_project_info
+        // Fallback to current project if there is no trace root project, this may happen,
+        // if the trace root is from a different organization.
+        .or(Some(ctx.project_info))
+        .and_then(get_sampling_config);
 
     // The root sampling config is always required for dynamic sampling. It determines the sample
     // rate which is applied to the item.
@@ -101,4 +166,70 @@ fn is_sampling_config_supported(project_info: &ProjectInfo) -> bool {
         return true;
     };
     matches!(config, ErrorBoundary::Ok(config) if !config.unsupported())
+}
+
+fn create_metrics(
+    scoping: Scoping,
+    span_count: u32,
+    sampling_decision: SamplingDecision,
+) -> ExtractedMetrics {
+    let mut metrics = ExtractedMetrics::default();
+
+    if span_count == 0 {
+        return metrics;
+    }
+
+    // For extracted metrics, Relay has always used the moment when the metrics was extracted
+    // as the received time, instead of the source item's received time.
+    let timestamp = UnixTimestamp::now();
+    let mut metadata = BucketMetadata::new(timestamp);
+    if sampling_decision.is_keep() {
+        metadata.extracted_from_indexed = true;
+    }
+
+    metrics.sampling_metrics.push(Bucket {
+        timestamp,
+        width: 0,
+        name: "c:spans/count_per_root_project@none".into(),
+        value: BucketValue::counter(span_count.into()),
+        tags: BTreeMap::from([
+            ("decision".to_owned(), sampling_decision.to_string()),
+            (
+                "target_project_id".to_owned(),
+                scoping.project_id.to_string(),
+            ),
+        ]),
+        metadata,
+    });
+    metrics.project_metrics.push(Bucket {
+        timestamp,
+        width: 0,
+        name: "c:spans/usage@none".into(),
+        value: BucketValue::counter(span_count.into()),
+        tags: Default::default(),
+        metadata,
+    });
+
+    metrics
+}
+
+/// Spans which have been rejected/dropped by dynamic sampling.
+///
+/// Contained spans will only count towards the [`DataCategory::SpanIndexed`] category,
+/// as the total category is counted from now in in metrics.
+struct UnsampledSpans {
+    spans: Vec<Item>,
+}
+
+impl From<SerializedSpans> for UnsampledSpans {
+    fn from(value: SerializedSpans) -> Self {
+        Self { spans: value.spans }
+    }
+}
+
+impl Counted for UnsampledSpans {
+    fn quantities(&self) -> Quantities {
+        let quantity = outcome_count(&self.spans) as usize;
+        smallvec::smallvec![(DataCategory::SpanIndexed, quantity),]
+    }
 }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -2,16 +2,13 @@ use relay_event_schema::protocol::SpanV2;
 
 use crate::envelope::{ContainerItems, Item, ItemContainer};
 use crate::managed::Managed;
-use crate::processing::spans::{Error, ExpandedSpans, Result, SerializedSpans};
+use crate::processing::spans::{Error, ExpandedSpans, Result, SampledSpans};
 use crate::services::outcome::DiscardReason;
 
 /// Parses all serialized spans.
 ///
 /// Individual, invalid spans are discarded.
-pub fn expand(
-    spans: Managed<SerializedSpans>,
-    server_sample_rate: Option<f64>,
-) -> Managed<ExpandedSpans> {
+pub fn expand(spans: Managed<SampledSpans>) -> Managed<ExpandedSpans> {
     spans.map(|spans, records| {
         let mut all_spans = Vec::new();
 
@@ -23,7 +20,7 @@ pub fn expand(
 
         ExpandedSpans {
             headers: spans.headers,
-            server_sample_rate,
+            server_sample_rate: spans.server_sample_rate,
             spans: all_spans,
         }
     })

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -216,7 +216,14 @@ class Sentry(SentryLike):
         item = items[0]
         assert item.headers["type"] == "metric_buckets"
 
-        return item.payload.json
+        return sorted(
+            item.payload.json,
+            key=lambda m: (
+                m["name"],
+                sorted(m.get("tags", {}).items()),
+                m["timestamp"],
+            ),
+        )
 
 
 def _get_project_id(public_key, project_configs):

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1129,9 +1129,8 @@ def test_span_ingestion(
 
     spans_consumer.assert_empty()
 
-    metrics = [metric for (metric, _headers) in metrics_consumer.get_metrics()]
+    metrics = metrics_consumer.get_metrics(with_headers=False)
     metrics_consumer.assert_empty()
-    metrics.sort(key=lambda m: (m["name"], sorted(m["tags"].items()), m["timestamp"]))
     for metric in metrics:
         try:
             metric["value"].sort()

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -225,13 +225,9 @@ def test_spansv2_ds_sampled(
     sampling_project_id = 43
     sampling_config = mini_sentry.add_basic_project_config(sampling_project_id)
     sampling_config["organizationId"] = project_config["organizationId"]
-    _add_sampling_config(project_config, sample_rate=1.0, rule_type="trace")
+    _add_sampling_config(sampling_config, sample_rate=0.9, rule_type="trace")
 
-    print("sampling", sampling_config["publicKeys"])
-    print("normal", project_config["publicKeys"])
-
-    # relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
-    relay = relay_with_processing(options=TEST_CONFIG)
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
 
     ts = datetime.now(timezone.utc)
     envelope = envelope_with_spans(
@@ -254,8 +250,10 @@ def test_spansv2_ds_sampled(
     assert spans_consumer.get_span() == {
         "trace_id": "5b8efff798038103d269b633813fc60c",
         "span_id": "eee19b7ec3c1b175",
-        "data": {"foo": "bar", "sentry.name": "some op"},
         "description": "some op",
+        "data": {"foo": "bar", "sentry.name": "some op"},
+        "measurements": {"server_sample_rate": {"value": 0.9}},
+        "server_sample_rate": 0.9,
         "received": time_within(ts),
         "start_timestamp_ms": time_within(ts, precision="ms", expect_resolution="ms"),
         "start_timestamp_precise": time_within(ts),
@@ -327,7 +325,7 @@ def test_spansv2_ds_root_in_different_org(
     sampling_project_id = 43
     sampling_config = mini_sentry.add_basic_project_config(sampling_project_id)
     sampling_config["organizationId"] = 99
-    _add_sampling_config(project_config, sample_rate=1.0, rule_type="trace")
+    _add_sampling_config(sampling_config, sample_rate=1.0, rule_type="trace")
 
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from unittest import mock
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
@@ -41,8 +42,18 @@ def envelope_with_spans(*payloads: dict, trace_info=None) -> Envelope:
     return envelope
 
 
-def test_spansv2_basic(spans_consumer, mini_sentry, relay, relay_with_processing):
+def test_spansv2_basic(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    spans_consumer,
+    metrics_consumer,
+):
+    """
+    A basic test making sure spans can be ingested and have basic normalizations applied.
+    """
     spans_consumer = spans_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -87,12 +98,41 @@ def test_spansv2_basic(spans_consumer, mini_sentry, relay, relay_with_processing
         "project_id": 42,
     }
 
+    assert metrics_consumer.get_metrics(n=2, with_headers=False) == [
+        {
+            "name": "c:spans/count_per_root_project@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {"decision": "keep", "target_project_id": "42"},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+        {
+            "name": "c:spans/usage@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+    ]
+
 
 @pytest.mark.parametrize(
     "rule_type",
     ["transaction", "trace"],
 )
 def test_spansv2_ds_drop(mini_sentry, relay, rule_type):
+    """
+    The test asserts that dynamic sampling correctly drops items, based on different rule types
+    and makes sure the correct outcomes and metrics are emitted.
+    """
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["features"] = [
@@ -133,7 +173,216 @@ def test_spansv2_ds_drop(mini_sentry, relay, rule_type):
             "timestamp": time_within_delta(),
         },
     ]
-    # TODO: assert span metrics when implemented (usage and count per root)
+
+    assert mini_sentry.get_metrics() == [
+        {
+            "metadata": mock.ANY,
+            "name": "c:spans/count_per_root_project@none",
+            "tags": {"decision": "drop", "target_project_id": "42"},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+            "width": 1,
+        },
+        {
+            "metadata": mock.ANY,
+            "name": "c:spans/usage@none",
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+            "width": 1,
+        },
+    ]
 
     assert mini_sentry.captured_events.empty()
     assert mini_sentry.captured_outcomes.empty()
+
+
+def test_spansv2_ds_sampled(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    outcomes_consumer,
+    spans_consumer,
+    metrics_consumer,
+):
+    """
+    The test asserts, that dynamic sampling correctly samples spans with the trace rules
+    of the trace root's project.
+    """
+    outcomes_consumer = outcomes_consumer()
+    spans_consumer = spans_consumer()
+    metrics_consumer = metrics_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:standalone-span-ingestion",
+        "projects:span-v2-experimental-processing",
+    ]
+    _add_sampling_config(project_config, sample_rate=0.0, rule_type="trace")
+
+    sampling_project_id = 43
+    sampling_config = mini_sentry.add_basic_project_config(sampling_project_id)
+    sampling_config["organizationId"] = project_config["organizationId"]
+    _add_sampling_config(project_config, sample_rate=1.0, rule_type="trace")
+
+    print("sampling", sampling_config["publicKeys"])
+    print("normal", project_config["publicKeys"])
+
+    # relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+    relay = relay_with_processing(options=TEST_CONFIG)
+
+    ts = datetime.now(timezone.utc)
+    envelope = envelope_with_spans(
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.500,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b175",
+            "name": "some op",
+            "attributes": {"foo": {"value": "bar", "type": "string"}},
+        },
+        trace_info={
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "public_key": sampling_config["publicKeys"][0]["publicKey"],
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    assert spans_consumer.get_span() == {
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "span_id": "eee19b7ec3c1b175",
+        "data": {"foo": "bar", "sentry.name": "some op"},
+        "description": "some op",
+        "received": time_within(ts),
+        "start_timestamp_ms": time_within(ts, precision="ms", expect_resolution="ms"),
+        "start_timestamp_precise": time_within(ts),
+        "end_timestamp_precise": time_within(ts),
+        "duration_ms": 500,
+        "exclusive_time_ms": 500.0,
+        "is_remote": False,
+        "is_segment": False,
+        "retention_days": 90,
+        "downsampled_retention_days": 90,
+        "key_id": 123,
+        "organization_id": 1,
+        "project_id": 42,
+    }
+
+    assert metrics_consumer.get_metrics(n=2, with_headers=False) == [
+        {
+            "name": "c:spans/count_per_root_project@none",
+            "org_id": 1,
+            "project_id": 43,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {"decision": "keep", "target_project_id": "42"},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+        {
+            "name": "c:spans/usage@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+    ]
+
+    outcomes_consumer.assert_empty()
+
+
+def test_spansv2_ds_root_in_different_org(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    outcomes_consumer,
+    spans_consumer,
+    metrics_consumer,
+):
+    """
+    The test asserts that traces where the root originates from a different Sentry organization,
+    correctly uses the dynamic sampling rules of the current project and emits the count_per_root metric
+    into the current project.
+    """
+    outcomes_consumer = outcomes_consumer()
+    spans_consumer = spans_consumer()
+    metrics_consumer = metrics_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:standalone-span-ingestion",
+        "projects:span-v2-experimental-processing",
+    ]
+    _add_sampling_config(project_config, sample_rate=0.0, rule_type="trace")
+
+    sampling_project_id = 43
+    sampling_config = mini_sentry.add_basic_project_config(sampling_project_id)
+    sampling_config["organizationId"] = 99
+    _add_sampling_config(project_config, sample_rate=1.0, rule_type="trace")
+
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+
+    ts = datetime.now(timezone.utc)
+    envelope = envelope_with_spans(
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.500,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b175",
+            "name": "some op",
+            "attributes": {"foo": {"value": "bar", "type": "string"}},
+        },
+        trace_info={
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "public_key": sampling_config["publicKeys"][0]["publicKey"],
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    assert metrics_consumer.get_metrics(n=2, with_headers=False) == [
+        {
+            "name": "c:spans/count_per_root_project@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {"decision": "drop", "target_project_id": "42"},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+        {
+            "name": "c:spans/usage@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+    ]
+
+    assert outcomes_consumer.get_outcome() == {
+        "category": DataCategory.SPAN_INDEXED.value,
+        "key_id": 123,
+        "org_id": 1,
+        "outcome": 1,
+        "project_id": 42,
+        "quantity": 1,
+        "reason": "Sampled:0",
+        "timestamp": time_within_delta(),
+    }
+
+    spans_consumer.assert_empty()

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -68,7 +68,7 @@ def test_spansv2_basic(
     envelope = envelope_with_spans(
         {
             "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.500,
+            "end_timestamp": ts.timestamp() + 0.5,
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "span_id": "eee19b7ec3c1b175",
             "name": "some op",
@@ -86,7 +86,7 @@ def test_spansv2_basic(
         "received": time_within(ts),
         "start_timestamp_ms": time_within(ts, precision="ms", expect_resolution="ms"),
         "start_timestamp_precise": time_within(ts),
-        "end_timestamp_precise": time_within(ts),
+        "end_timestamp_precise": time_within(ts.timestamp() + 0.5),
         "duration_ms": 500,
         "exclusive_time_ms": 500.0,
         "is_remote": False,
@@ -147,7 +147,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, rule_type):
     envelope = envelope_with_spans(
         {
             "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.500,
+            "end_timestamp": ts.timestamp() + 0.5,
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "span_id": "eee19b7ec3c1b175",
             "name": "some op",
@@ -233,7 +233,7 @@ def test_spansv2_ds_sampled(
     envelope = envelope_with_spans(
         {
             "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.500,
+            "end_timestamp": ts.timestamp() + 0.5,
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "span_id": "eee19b7ec3c1b175",
             "name": "some op",
@@ -254,10 +254,10 @@ def test_spansv2_ds_sampled(
         "data": {"foo": "bar", "sentry.name": "some op"},
         "measurements": {"server_sample_rate": {"value": 0.9}},
         "server_sample_rate": 0.9,
-        "received": time_within(ts),
+        "received": time_within_delta(ts),
         "start_timestamp_ms": time_within(ts, precision="ms", expect_resolution="ms"),
         "start_timestamp_precise": time_within(ts),
-        "end_timestamp_precise": time_within(ts),
+        "end_timestamp_precise": time_within(ts.timestamp() + 0.5),
         "duration_ms": 500,
         "exclusive_time_ms": 500.0,
         "is_remote": False,
@@ -333,7 +333,7 @@ def test_spansv2_ds_root_in_different_org(
     envelope = envelope_with_spans(
         {
             "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.500,
+            "end_timestamp": ts.timestamp() + 0.5,
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "span_id": "eee19b7ec3c1b175",
             "name": "some op",

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -251,7 +251,11 @@ def test_spansv2_ds_sampled(
         "trace_id": "5b8efff798038103d269b633813fc60c",
         "span_id": "eee19b7ec3c1b175",
         "description": "some op",
-        "data": {"foo": "bar", "sentry.name": "some op"},
+        "data": {
+            "foo": "bar",
+            "sentry.name": "some op",
+            "sentry.server_sample_rate": 0.9,
+        },
         "measurements": {"server_sample_rate": {"value": 0.9}},
         "server_sample_rate": 0.9,
         "received": time_within_delta(ts),


### PR DESCRIPTION
Implements span metric extraction for SpanV2 items.

This is the second part to dynamic sampling which was missing, items which are dropped must still have metrics extracted. Now, accepted counts (calculated from the metrics) and the dynamic sampling rebalancing metric (count per root) are correctly extracted.

The PR includes a minor refactor to `Managed` and `Output` to be able to split off metrics and still account correctly for all outcomes and also have a way to wrap metrics in a `Managed`.

There is also a slight change how metrics are sent to the sampling project, this now includes an additional safeguard to not send the metrics to the wrong project (to be verified if this is only possible with the current implementation or also was happening before, there is now a test for spanv2 which asserts that this does not happen).

A slight modification to how `SourceQuantities` are calculated, this was a bug before, transactions and spans which are extracted from an indexed payload should not have counted towards the outcome count, luckily this was not an issue before because rate limits would've never been enforced on these metrics in the first place.