### PR TITLE
feat(devservices): Use ghcr instead of artifact registry

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -27,7 +27,7 @@ x-programs:
 
 services:
   relay:
-    image: us-central1-docker.pkg.dev/sentryio/relay/relay:nightly
+    image: ghcr.io/getsentry/relay:nightly
     ports:
       - 127.0.0.1:7899:7899
     command: [run, --config, /etc/relay]


### PR DESCRIPTION
We're trying to move over to using GHCR for CI, and it looks like artifact registry is failing in CI for us so trying to switch this over now. Note: this won't solve all our problems if ghcr fails, but given that artifact registry is letting us down and the fact we were going to do this regardless due to standardization efforts, let's get this in now

https://github.com/getsentry/sentry/actions/runs/16942340945/job/48014467753

#skip-changelog