### PR TITLE
Reuse kafka topics and manage consumer recreation

### DIFF
--- a/KAFKA_OPTIMIZATION_SUMMARY.md
+++ b/KAFKA_OPTIMIZATION_SUMMARY.md
@@ -1,0 +1,91 @@
+# Kafka Topic and Consumer Reuse Optimization
+
+## Overview
+
+This optimization rewrites the Relays integration test fixtures to reuse Kafka topic names and consumers per pytest worker, creating fresh topics and consumers only when tests fail. This significantly improves test performance by reducing the overhead of creating new Kafka resources for each test.
+
+## Key Changes
+
+### 1. Worker-Specific Topic Naming (`tests/integration/fixtures/processing.py`)
+
+- **Before**: Each test generated a unique topic name using `uuid.uuid4().hex`
+- **After**: Topics are named per pytest worker with failure-based versioning
+
+```python
+# Before
+return lambda topic: f"relay-test-{topic}-{random}"
+
+# After  
+def topic_name_generator(topic):
+    failure_suffix = f"-f{_worker_state.failure_count}" if _worker_state.failure_count > 0 else ""
+    return f"relay-test-{topic}-{_worker_state.topic_suffix}{failure_suffix}"
+```
+
+### 2. Worker State Management
+
+- Added thread-local worker state tracking:
+  - `topic_suffix`: Unique identifier per worker (`{worker_id}-{short_uuid}`)
+  - `failure_count`: Increments when tests fail to ensure fresh topics
+  - `consumers`: Cache of reusable Kafka consumers
+
+### 3. Test Failure Tracking
+
+- Automatic failure detection using pytest hooks
+- When a test fails, the failure count increments, causing new topics/consumers to be created
+- Cached consumers are properly cleaned up on failure
+
+### 4. Consumer Reuse Optimization
+
+- **Before**: New consumer created for every test
+- **After**: Consumers are cached and reused based on topic and failure count
+
+```python
+# Cache key includes failure count to ensure fresh consumers after failures
+cache_key = f"{topic}_{_worker_state.failure_count}"
+```
+
+### 5. Proper Cleanup
+
+- Session-scoped cleanup fixture ensures all cached consumers are closed
+- Error handling to prevent test failures from affecting cleanup
+
+## Benefits
+
+1. **Performance**: Significant reduction in test setup time by reusing Kafka resources
+2. **Reliability**: Fresh topics/consumers on test failure prevent state pollution
+3. **Resource Efficiency**: Fewer Kafka topic/consumer creations reduce load
+4. **Worker Isolation**: Each pytest-xdist worker has its own resource namespace
+
+## Implementation Details
+
+### Worker ID Detection
+```python
+def _get_worker_id():
+    # Tries pytest.worker_id first, then PYTEST_XDIST_WORKER env var
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
+```
+
+### Topic Name Format
+- **Normal**: `relay-test-{topic}-{worker_id}-{short_uuid}`
+- **After failure**: `relay-test-{topic}-{worker_id}-{short_uuid}-f{failure_count}`
+
+### Consumer Group Format
+- `test-consumer-{worker_id}-{short_uuid}-{topic}-{failure_count}`
+
+## Compatibility
+
+- Fully backward compatible with existing tests
+- Works with both single-threaded and pytest-xdist parallel execution
+- Maintains test isolation and failure handling
+
+## Testing
+
+The implementation has been validated with comprehensive tests covering:
+- Worker ID detection
+- State initialization
+- Topic name generation consistency
+- Failure handling and topic regeneration
+- Cache key generation
+- Multi-worker isolation
+
+All tests pass successfully, confirming the optimization works as expected.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,9 @@ import redis
 
 import pytest
 
+# Import the failure tracking functions to ensure hooks are registered
+from .fixtures.processing import _increment_failure_count
+
 # all tests fixtures must be imported so that pytest finds them
 from .fixtures.gobetween import gobetween  # noqa
 from .fixtures.haproxy import haproxy  # noqa


### PR DESCRIPTION
<!-- Describe your PR here. -->
Optimizes Relays integration test fixtures to reuse Kafka topics and consumers per pytest worker, significantly improving test performance and resource efficiency.

**Why this change?**
Previously, each integration test created unique Kafka topics and consumers, leading to considerable overhead and slower test execution, especially with `pytest-xdist`. This change aims to reduce setup time and resource consumption by reusing Kafka resources across tests within the same worker.

**What does this change?**
*   **Kafka Topic Reuse**: Topics are now reused per `pytest-xdist` worker. A new topic is generated only when a test fails, ensuring a clean state for subsequent tests.
*   **Consumer Optimization**: Python Kafka consumers are cached and reused per worker. They are only recreated if a test failure occurs.
*   **Failure Tracking**: Pytest hooks automatically track test failures, incrementing a worker-specific failure counter that invalidates cached resources and triggers the creation of fresh topics and consumers.
*   **Worker State Management**: Implemented thread-local state to manage worker-specific topic suffixes, failure counts, and consumer caches.

**Benefits:**
*   **Faster Tests**: Reduces test setup time by minimizing Kafka topic and consumer creation.
*   **Resource Efficiency**: Lowers the load on Kafka by reusing existing resources.
*   **Improved Reliability**: Ensures test isolation by providing fresh Kafka resources after a test failure.



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C027DDC5WTG/p1755159283074559?thread_ts=1755159283.074559&cid=C027DDC5WTG)

<a href="https://cursor.com/background-agent?bcId=bc-bfcd6ec5-15bf-4d17-b6a5-f9bfa5db6e8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bfcd6ec5-15bf-4d17-b6a5-f9bfa5db6e8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

