### PR TITLE
fix(dep): Manylinux 2025.08.22 no longer includes setup tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Set the default log retention to 30 days for full fidelity and downsampled data. ([#5065](https://github.com/getsentry/relay/pull/5065))
 - Improved PII Scrubbing for attributes / logs ([#5061](https://github.com/getsentry/relay/pull/5061)))
+- Fix python package release scripts ([#5073](https://github.com/getsentry/relay/pull/5073))
 
 ## 25.8.0
 

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -29,7 +29,7 @@ docker run \
   -v "$(pwd):/work" \
   -e SKIP_RELAY_LIB_BUILD=1 \
   -e CARGO_BUILD_TARGET \
-  quay.io/pypa/manylinux_2_28_${TARGET}:2025.08.15-1 \
+  quay.io/pypa/manylinux_2_28_${TARGET}:2025.08.15-1 \ # Pinned to 2025.08.15-1 since manylinux 2025.08.22 onward removes setuptools
   sh manylinux.sh
 
 # Fix permissions for shared directories

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -29,7 +29,7 @@ docker run \
   -v "$(pwd):/work" \
   -e SKIP_RELAY_LIB_BUILD=1 \
   -e CARGO_BUILD_TARGET \
-  quay.io/pypa/manylinux_2_28_${TARGET} \
+  quay.io/pypa/manylinux_2_28_${TARGET}:2025.08.15-1 \
   sh manylinux.sh
 
 # Fix permissions for shared directories


### PR DESCRIPTION
### Summary
The latest manylinux docker image no longer contains setuptools and is blocking sentry_py releases, this moves the pin back a week for now.


