### PR TITLE
fix(dep): Comment breaking release sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - Set the default log retention to 30 days for full fidelity and downsampled data. ([#5065](https://github.com/getsentry/relay/pull/5065))
 - Improved PII Scrubbing for attributes / logs ([#5061](https://github.com/getsentry/relay/pull/5061)))
-- Fix python package release scripts ([#5073](https://github.com/getsentry/relay/pull/5073))
-- Fix comment breaking release scripts ([#5074](https://github.com/getsentry/relay/pull/5074))
 
 ## 25.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Set the default log retention to 30 days for full fidelity and downsampled data. ([#5065](https://github.com/getsentry/relay/pull/5065))
 - Improved PII Scrubbing for attributes / logs ([#5061](https://github.com/getsentry/relay/pull/5061)))
 - Fix python package release scripts ([#5073](https://github.com/getsentry/relay/pull/5073))
+- Fix comment breaking release scripts ([#5074](https://github.com/getsentry/relay/pull/5074))
 
 ## 25.8.0
 

--- a/scripts/docker-manylinux.sh
+++ b/scripts/docker-manylinux.sh
@@ -23,13 +23,14 @@ docker run \
   bash -c 'cargo build -p relay-cabi --profile release-cabi'
 
 # create a wheel for the correct architecture
+# Pinned to 2025.08.15-1 since manylinux 2025.08.22 onward removes setuptools
 docker run \
   --rm \
   -w /work/py \
   -v "$(pwd):/work" \
   -e SKIP_RELAY_LIB_BUILD=1 \
   -e CARGO_BUILD_TARGET \
-  quay.io/pypa/manylinux_2_28_${TARGET}:2025.08.15-1 \ # Pinned to 2025.08.15-1 since manylinux 2025.08.22 onward removes setuptools
+  quay.io/pypa/manylinux_2_28_${TARGET}:2025.08.15-1 \
   sh manylinux.sh
 
 # Fix permissions for shared directories


### PR DESCRIPTION
### Summary
Put the comment in the wrong spot, it was getting included in the docker entrypoint


