### PR TITLE
feat(spanv2): Implement transaction name filter

### DIFF
--- a/relay-filter/src/interface.rs
+++ b/relay-filter/src/interface.rs
@@ -201,6 +201,13 @@ impl Filterable for SpanV2 {
             .as_str()
     }
 
+    fn transaction(&self) -> Option<&str> {
+        self.attributes
+            .value()?
+            .get_value("sentry.segment.name")?
+            .as_str()
+    }
+
     fn user_agent(&self) -> UserAgent<'_> {
         user_agent_from_attributes(&self.attributes)
     }

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -402,6 +402,12 @@ def test_spansv2_ds_root_in_different_org(
             {},
             id="release",
         ),
+        pytest.param(
+            "filtered-transaction",
+            {"ignoreTransactions": {"isEnabled": True, "patterns": ["*health*"]}},
+            {},
+            id="transaction",
+        ),
         # Requires normalization to be implemented.
         # pytest.param(
         #     "legacy-browsers",
@@ -485,6 +491,7 @@ def test_spanv2_inbound_filters(
             "attributes": {
                 "some_integer": {"value": 123, "type": "integer"},
                 "sentry.release": {"value": "foobar@1.0", "type": "string"},
+                "sentry.segment.name": {"value": "/foo/healthz", "type": "string"},
             },
         }
     )


### PR DESCRIPTION
As discussed with @cleptric, SDKs will send the segment name/transaction name as an attribute `sentry.segment.name`, to allow use cases like this.