### PR TITLE
ref(replays): Add flag gating snuba publishing

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -28,6 +28,11 @@ pub enum Feature {
     /// Serialized as `organizations:session-replay-video-disabled`.
     #[serde(rename = "organizations:session-replay-video-disabled")]
     SessionReplayVideoDisabled,
+    /// Disables Relay from sending replay-events to Snuba.
+    ///
+    /// Serialized as `organizations:session-replay-relay-snuba-publishing-disabled`.
+    #[serde(rename = "organizations:session-replay-relay-snuba-publishing-disabled")]
+    SessionReplayRelaySnubaPublishingDisabled,
     /// Enables device.class synthesis
     ///
     /// Enables device.class tag synthesis on mobile events.

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -41,6 +41,7 @@ impl Item {
                 fully_normalized: false,
                 profile_type: None,
                 platform: None,
+                replay_relay_snuba_publish_disabled: false,
             },
             payload: Bytes::new(),
         }
@@ -309,6 +310,17 @@ impl Item {
     /// Sets the fully normalized flag.
     pub fn set_fully_normalized(&mut self, fully_normalized: bool) {
         self.headers.fully_normalized = fully_normalized;
+    }
+
+    /// Returns if the replay-event should be propagated to the snuba consumer or not.
+    #[cfg(feature = "processing")]
+    pub fn replay_relay_snuba_publish_disabled(&self) -> bool {
+        self.headers.replay_relay_snuba_publish_disabled
+    }
+
+    /// Sets the replay_relay_snuba_publish_disabled for this item.
+    pub fn set_replay_relay_snuba_publish_disabled(&mut self, value: bool) {
+        self.headers.replay_relay_snuba_publish_disabled = value;
     }
 
     /// Returns the associated platform.
@@ -816,6 +828,11 @@ pub struct ItemHeaders {
     /// Other attributes for forward compatibility.
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
+
+    /// Indicates that Relay should not publish replay-event data to the Snuba consumer.
+    /// NOTE: This is internal-only and not exposed into the Envelope.
+    #[serde(default, skip)]
+    replay_relay_snuba_publish_disabled: bool,
 }
 
 /// Container for item quantities that the item was derived from.

--- a/relay-server/src/services/processor/replay.rs
+++ b/relay-server/src/services/processor/replay.rs
@@ -83,7 +83,11 @@ pub fn process(
         None
     };
 
+    let snuba_publish_disabled =
+        project_info.has_feature(Feature::SessionReplayRelaySnubaPublishingDisabled);
+
     for item in managed_envelope.envelope_mut().items_mut() {
+        item.set_replay_relay_snuba_publish_disabled(snuba_publish_disabled);
         match item.ty() {
             ItemType::ReplayEvent => {
                 let replay_event = handle_replay_event_item(item.payload(), &rpc)?;


### PR DESCRIPTION
TODO:

- [ ] `getsentry` PR adding the flag.
- [ ] Update `sentry-kafka-schemas` to acknowledge the new field being passed.
- [ ] Update recording consumer to interpret the boolean and perform some action.