### PR TITLE
ref: Remove ProcessingState::enter_static

### DIFF
--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -129,7 +129,7 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
                 }
             } else {
                 quote! {
-                    __state.enter_static(
+                    __state.enter_borrowed(
                         #field_name,
                         Some(::std::borrow::Cow::Borrowed(&#field_attrs_name)),
                         crate::processor::ValueType::for_field(#ident),

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -346,22 +346,6 @@ impl<'a> ProcessingState<'a> {
         }
     }
 
-    /// Derives a processing state by entering a static key.
-    pub fn enter_static(
-        &'a self,
-        key: &'static str,
-        attrs: Option<Cow<'static, FieldAttrs>>,
-        value_type: impl IntoIterator<Item = ValueType>,
-    ) -> Self {
-        ProcessingState {
-            parent: Some(BoxCow::Borrowed(self)),
-            path_item: Some(PathItem::StaticKey(key)),
-            attrs,
-            value_type: value_type.into_iter().collect(),
-            depth: self.depth + 1,
-        }
-    }
-
     /// Derives a processing state by entering a borrowed key.
     pub fn enter_borrowed(
         &'a self,

--- a/relay-event-schema/tests/test_derive.rs
+++ b/relay-event-schema/tests/test_derive.rs
@@ -57,7 +57,7 @@ mod tests {
         process_value(
             &mut value,
             &mut processor,
-            &ProcessingState::root().enter_static("foo", None, None),
+            &ProcessingState::root().enter_borrowed("foo", None, None),
         )
         .unwrap();
 
@@ -82,7 +82,7 @@ mod tests {
         process_value(
             &mut value,
             &mut processor,
-            &ProcessingState::root().enter_static("foo", None, None),
+            &ProcessingState::root().enter_borrowed("foo", None, None),
         )
         .unwrap();
 

--- a/relay-pii/src/attachments.rs
+++ b/relay-pii/src/attachments.rs
@@ -365,7 +365,7 @@ impl<'a> PiiAttachmentsProcessor<'a> {
         // any init logic into CompiledPiiConfig::new.
 
         let root_state =
-            ProcessingState::root().enter_static("", None, Some(ValueType::Attachments));
+            ProcessingState::root().enter_borrowed("", None, Some(ValueType::Attachments));
 
         PiiAttachmentsProcessor {
             compiled_config,

--- a/relay-pii/src/builtin.rs
+++ b/relay-pii/src/builtin.rs
@@ -437,7 +437,7 @@ mod tests {
     /// }
     /// ```
     fn processing_state() -> ProcessingState<'static> {
-        ProcessingState::root().enter_static(
+        ProcessingState::root().enter_borrowed(
             "value",
             Some(Cow::Owned(FieldAttrs::new().pii(Pii::True))),
             EnumSet::only(ValueType::String),

--- a/relay-pii/src/selector.rs
+++ b/relay-pii/src/selector.rs
@@ -562,9 +562,9 @@ mod tests {
     #[test]
     fn test_matching() {
         let event_state = ProcessingState::new_root(None, Some(ValueType::Event)); // .
-        let user_state = event_state.enter_static("user", None, Some(ValueType::User)); // .user
-        let extra_state = user_state.enter_static("extra", None, Some(ValueType::Object)); // .user.extra
-        let foo_state = extra_state.enter_static("foo", None, Some(ValueType::Array)); // .user.extra.foo
+        let user_state = event_state.enter_borrowed("user", None, Some(ValueType::User)); // .user
+        let extra_state = user_state.enter_borrowed("extra", None, Some(ValueType::Object)); // .user.extra
+        let foo_state = extra_state.enter_borrowed("foo", None, Some(ValueType::Array)); // .user.extra.foo
         let zero_state = foo_state.enter_index(0, None, None); // .user.extra.foo.0
 
         assert_matches_pii_maybe!(
@@ -634,11 +634,11 @@ mod tests {
     #[test]
     fn test_attachments_matching() {
         let event_state = ProcessingState::new_root(None, None);
-        let attachments_state = event_state.enter_static("", None, Some(ValueType::Attachments)); // .
-        let txt_state = attachments_state.enter_static("file.txt", None, Some(ValueType::Binary)); // .'file.txt'
+        let attachments_state = event_state.enter_borrowed("", None, Some(ValueType::Attachments)); // .
+        let txt_state = attachments_state.enter_borrowed("file.txt", None, Some(ValueType::Binary)); // .'file.txt'
         let minidump_state =
-            attachments_state.enter_static("file.dmp", None, Some(ValueType::Minidump)); // .'file.txt'
-        let minidump_state_inner = minidump_state.enter_static("", None, Some(ValueType::Binary)); // .'file.txt'
+            attachments_state.enter_borrowed("file.dmp", None, Some(ValueType::Minidump)); // .'file.txt'
+        let minidump_state_inner = minidump_state.enter_borrowed("", None, Some(ValueType::Binary)); // .'file.txt'
 
         assert_matches_pii_maybe!(attachments_state, "$attachments",);
         assert_matches_pii_maybe!(txt_state, "$attachments.'file.txt'",);
@@ -663,9 +663,10 @@ mod tests {
     #[test]
     fn test_logs_matching() {
         let event_state = ProcessingState::new_root(None, None);
-        let log_state = event_state.enter_static("", None, Some(ValueType::OurLog)); // .
-        let body_state = log_state.enter_static("body", None, Some(ValueType::String));
-        let attributes_state = log_state.enter_static("attributes", None, Some(ValueType::Object));
+        let log_state = event_state.enter_borrowed("", None, Some(ValueType::OurLog)); // .
+        let body_state = log_state.enter_borrowed("body", None, Some(ValueType::String));
+        let attributes_state =
+            log_state.enter_borrowed("attributes", None, Some(ValueType::Object));
 
         assert_matches_pii_maybe!(log_state, "$log",);
         assert_matches_pii_true!(body_state, "$log.body",);

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -143,7 +143,7 @@ fn scrub_log(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
 
     if let Some(ref config) = ctx.project_info.config.pii_config {
         let mut processor = PiiProcessor::new(config.compiled());
-        let root_state = ProcessingState::root().enter_static("", None, Some(ValueType::OurLog));
+        let root_state = ProcessingState::root().enter_borrowed("", None, Some(ValueType::OurLog));
         process_value(log, &mut processor, &root_state)?;
     }
 


### PR DESCRIPTION
The method has the same implementation and return type as `enter_borrowed`, just with a more restrictive signature.