### PR TITLE
ref(logs): Change logic for scrubbing attributes

### DIFF
--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -114,7 +114,7 @@ pub trait Processor: Sized {
     process_method!(process_trace_context, crate::protocol::TraceContext);
     process_method!(process_native_image_path, crate::protocol::NativeImagePath);
     process_method!(process_contexts, crate::protocol::Contexts);
-    process_method!(process_attributes, crate::protocol::Attributes);
+    process_method!(process_attribute, crate::protocol::Attribute);
 
     fn process_other(
         &mut self,

--- a/relay-pii/src/utils.rs
+++ b/relay-pii/src/utils.rs
@@ -1,12 +1,9 @@
-use std::borrow::Cow;
-
 use hmac::{Hmac, Mac};
 
 use relay_event_schema::processor::{
-    self, FieldAttrs, Pii, ProcessValue, ProcessingResult, ProcessingState, Processor, ValueType,
-    enum_set,
+    self, ProcessValue, ProcessingResult, ProcessingState, Processor, ValueType,
 };
-use relay_event_schema::protocol::{AsPair, Attributes, PairList};
+use relay_event_schema::protocol::{AsPair, PairList};
 use sha1::Sha1;
 
 pub fn process_pairlist<P: Processor, T: ProcessValue + AsPair>(
@@ -38,46 +35,6 @@ pub fn process_pairlist<P: Processor, T: ProcessValue + AsPair>(
         }
     }
 
-    Ok(())
-}
-
-pub fn process_attributes<P: Processor>(
-    value: &mut Attributes,
-    slf: &mut P,
-    state: &ProcessingState,
-) -> ProcessingResult {
-    // Check if we're in default rules (no root ValueType)
-    // This is a workaround to support explicit selectors eg. $log.attributes.KEY.value to work but keep implicit selectors for default rules.
-    let is_advanced_rules = state
-        .iter()
-        .nth(1)
-        .is_some_and(|s| s.value_type().contains(ValueType::OurLog));
-
-    for (key, annotated_attribute) in value.iter_mut() {
-        if let Some(attribute) = annotated_attribute.value_mut() {
-            if is_advanced_rules {
-                // Process normally to allow explicit selectors like $log.attributes.KEY.value to work
-                let field_value_type = ValueType::for_field(annotated_attribute);
-                let key_state = state.enter_borrowed(key, state.inner_attrs(), field_value_type);
-                processor::process_value(annotated_attribute, slf, &key_state)?;
-            } else {
-                // For the default rules, we want Pii::True since we want them to always be scrubbed.
-                let attrs = FieldAttrs::new().pii(Pii::True);
-                let inner_value = &mut attribute.value.value;
-                let inner_value_type = ValueType::for_field(inner_value);
-                let entered =
-                    state.enter_borrowed(key, Some(Cow::Borrowed(&attrs)), inner_value_type);
-                processor::process_value(inner_value, slf, &entered)?;
-
-                let object_value_type = enum_set!(ValueType::Object);
-                for (key, value) in attribute.other.iter_mut() {
-                    let other_state =
-                        state.enter_borrowed(key, Some(Cow::Borrowed(&attrs)), object_value_type);
-                    processor::process_value(value, slf, &other_state)?;
-                }
-            }
-        }
-    }
     Ok(())
 }
 

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -142,7 +142,7 @@ fn scrub_log(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
         let mut processor = PiiProcessor::new(config.compiled())
             // For advanced rules we want to treat attributes as objects.
             .attribute_mode(AttributeMode::Object);
-        process_value(log, &mut processor, &ProcessingState::root())?;
+        process_value(log, &mut processor, ProcessingState::root())?;
     }
 
     if let Some(config) = pii_config_from_scrubbing {


### PR DESCRIPTION
This is an alternative to https://github.com/getsentry/relay/pull/5061.

Instead of hooking into scrubbing `Attributes` (via a new `process_attributes` method), we do it at the level of individual `Attribute` values (via a new `process_attribute` method). For common scrubbing rules, we just apply them to the attribute's value. For advanced scrubbing rules, we treat attributes as objects and delegate to their fields.

The differentiation between the two ways to treat attributes is controlled by a field `attribute_mode` of type `AttributeMode` on `PiiProcessor`. This decouples the logic from logs and makes it explicit what is happening.

TODO: Handle `other` in `ValueOnly` mode.

ref: #5096 ref: RELAY-152