### PR TITLE
test(logs): Slightly increase timeout to reduce flakes

### DIFF
--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -924,7 +924,7 @@ def test_filters_are_applied_to_logs(
 
     outcomes = []
     for _ in range(2):
-        outcomes.extend(mini_sentry.captured_outcomes.get(timeout=3).get("outcomes"))
+        outcomes.extend(mini_sentry.captured_outcomes.get(timeout=5).get("outcomes"))
     outcomes.sort(key=lambda x: x["category"])
 
     assert outcomes == [


### PR DESCRIPTION
I am not sure why, but sometimes in CI this test just takes longer to setup and we fail because we don't wait long enough.