### PR TITLE
feat(ai): Breakdown cost per input and output tokens

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2320,11 +2320,43 @@ mod tests {
         );
         assert_eq!(
             spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(10.0))
+        );
+        assert_eq!(
+            spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(40.0))
+        );
+        assert_eq!(
+            spans
                 .get(1)
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_usage_total_cost.value()),
             Some(&Value::F64(80.0))
+        );
+        assert_eq!(
+            spans
+                .get(1)
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(20.0)) // 1000 * 0.02
+        );
+        assert_eq!(
+            spans
+                .get(1)
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(60.0)) // 2000 * 0.03
         );
     }
 
@@ -2424,6 +2456,14 @@ mod tests {
             Some(&Value::F64(75.0))
         );
         assert_eq!(
+            first_span_data.and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(25.0))
+        );
+        assert_eq!(
+            first_span_data.and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(50.0))
+        );
+        assert_eq!(
             first_span_data.and_then(|data| data.gen_ai_response_tokens_per_second.value()),
             Some(&Value::F64(2000.0))
         );
@@ -2435,6 +2475,14 @@ mod tests {
         assert_eq!(
             second_span_data.and_then(|data| data.gen_ai_usage_total_cost.value()),
             Some(&Value::F64(190.0))
+        );
+        assert_eq!(
+            second_span_data.and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(90.0))
+        );
+        assert_eq!(
+            second_span_data.and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(100.0))
         );
         assert_eq!(
             second_span_data.and_then(|data| data.gen_ai_usage_total_tokens.value()),
@@ -2453,6 +2501,14 @@ mod tests {
         assert_eq!(
             third_span_data.and_then(|data| data.gen_ai_usage_total_cost.value()),
             Some(&Value::F64(190.0))
+        );
+        assert_eq!(
+            third_span_data.and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(90.0))
+        );
+        assert_eq!(
+            third_span_data.and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(100.0))
         );
     }
 
@@ -2604,11 +2660,43 @@ mod tests {
         );
         assert_eq!(
             spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(25.0))
+        );
+        assert_eq!(
+            spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(40.0))
+        );
+        assert_eq!(
+            spans
                 .get(1)
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_usage_total_cost.value()),
             Some(&Value::F64(190.0))
+        );
+        assert_eq!(
+            spans
+                .get(1)
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_input_tokens.value()),
+            Some(&Value::F64(90.0)) // 1000 * 0.09
+        );
+        assert_eq!(
+            spans
+                .get(1)
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_output_tokens.value()),
+            Some(&Value::F64(100.0)) // 2000 * 0.05
         );
         assert_eq!(
             spans

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -505,6 +505,14 @@ pub struct SpanData {
     #[metastructure(field = "gen_ai.usage.total_cost", legacy_alias = "ai.total_cost")]
     pub gen_ai_usage_total_cost: Annotated<Value>,
 
+    /// The cost for input tokens used
+    #[metastructure(field = "gen_ai.cost.input_tokens")]
+    pub gen_ai_cost_input_tokens: Annotated<Value>,
+
+    /// The cost for output tokens used
+    #[metastructure(field = "gen_ai.cost.output_tokens")]
+    pub gen_ai_cost_output_tokens: Annotated<Value>,
+
     /// Prompt passed to LLM (Vercel AI SDK)
     #[metastructure(field = "gen_ai.prompt", pii = "maybe")]
     pub gen_ai_prompt: Annotated<Value>,
@@ -944,6 +952,8 @@ impl Getter for SpanData {
             "gen_ai\\.request\\.max_tokens" => self.gen_ai_request_max_tokens.value()?.into(),
             "gen_ai\\.usage\\.total_tokens" => self.gen_ai_usage_total_tokens.value()?.into(),
             "gen_ai\\.usage\\.total_cost" => self.gen_ai_usage_total_cost.value()?.into(),
+            "gen_ai\\.cost\\.input_tokens" => self.gen_ai_cost_input_tokens.value()?.into(),
+            "gen_ai\\.cost\\.output_tokens" => self.gen_ai_cost_output_tokens.value()?.into(),
             "http\\.decoded_response_content_length" => {
                 self.http_decoded_response_content_length.value()?.into()
             }
@@ -1403,6 +1413,8 @@ mod tests {
             gen_ai_response_model: ~,
             gen_ai_request_model: ~,
             gen_ai_usage_total_cost: ~,
+            gen_ai_cost_input_tokens: ~,
+            gen_ai_cost_output_tokens: ~,
             gen_ai_prompt: ~,
             gen_ai_request_messages: ~,
             gen_ai_tool_input: ~,

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -165,6 +165,8 @@ mod tests {
                 gen_ai_response_model: ~,
                 gen_ai_request_model: ~,
                 gen_ai_usage_total_cost: ~,
+                gen_ai_cost_input_tokens: ~,
+                gen_ai_cost_output_tokens: ~,
                 gen_ai_prompt: ~,
                 gen_ai_request_messages: ~,
                 gen_ai_tool_input: ~,


### PR DESCRIPTION
Adds two new fields to have more detailed breakdown of the cost per input and output tokens. 

Closes [TET-1004: User Feedback: Show token costs for input and output separately](https://linear.app/getsentry/issue/TET-1004/user-feedback-show-token-costs-for-input-and-output-separately)
