### PR TITLE
feat(ai): Use fuzzy pattern matching as a fallback for matching model name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3846,6 +3846,7 @@ dependencies = [
  "relay-event-schema",
  "relay-filter",
  "relay-log",
+ "relay-pattern",
  "relay-protocol",
  "relay-statsd",
  "relay-ua",

--- a/relay-common/src/glob2.rs
+++ b/relay-common/src/glob2.rs
@@ -1,5 +1,6 @@
 //! Serializable glob patterns for the API.
 
+use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
 use std::{fmt, str};
 
@@ -296,6 +297,12 @@ impl<'de> serde::Deserialize<'de> for LazyGlob {
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(LazyGlob::new)
+    }
+}
+
+impl Hash for LazyGlob {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
     }
 }
 

--- a/relay-common/src/glob2.rs
+++ b/relay-common/src/glob2.rs
@@ -1,6 +1,5 @@
 //! Serializable glob patterns for the API.
 
-use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
 use std::{fmt, str};
 
@@ -297,12 +296,6 @@ impl<'de> serde::Deserialize<'de> for LazyGlob {
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(LazyGlob::new)
-    }
-}
-
-impl Hash for LazyGlob {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.raw.hash(state);
     }
 }
 

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -26,6 +26,7 @@ relay-base-schema = { workspace = true }
 relay-common = { workspace = true }
 relay-event-schema = { workspace = true }
 relay-log = { workspace = true }
+relay-pattern = { workspace = true, features = ["serde"] }
 relay-protocol = { workspace = true }
 relay-statsd = { workspace = true }
 relay-ua = { workspace = true }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1514,6 +1514,7 @@ fn normalize_app_start_measurements(measurements: &mut Measurements) {
 #[cfg(test)]
 mod tests {
 
+    use relay_common::glob2::LazyGlob;
     use std::collections::BTreeMap;
     use std::collections::HashMap;
 
@@ -2285,7 +2286,7 @@ mod tests {
                     version: 2,
                     models: HashMap::from([
                         (
-                            "claude-2.1".to_owned(),
+                            LazyGlob::new("claude-2.1"),
                             ModelCostV2 {
                                 input_per_token: 0.01,
                                 output_per_token: 0.02,
@@ -2294,7 +2295,7 @@ mod tests {
                             },
                         ),
                         (
-                            "gpt4-21-04".to_owned(),
+                            LazyGlob::new("gpt4-21-04"),
                             ModelCostV2 {
                                 input_per_token: 0.02,
                                 output_per_token: 0.03,
@@ -2422,7 +2423,7 @@ mod tests {
                     version: 2,
                     models: HashMap::from([
                         (
-                            "claude-2.1".to_owned(),
+                            LazyGlob::new("claude-2.1"),
                             ModelCostV2 {
                                 input_per_token: 0.01,
                                 output_per_token: 0.02,
@@ -2431,7 +2432,7 @@ mod tests {
                             },
                         ),
                         (
-                            "gpt4-21-04".to_owned(),
+                            LazyGlob::new("gpt4-21-04"),
                             ModelCostV2 {
                                 input_per_token: 0.09,
                                 output_per_token: 0.05,
@@ -2541,7 +2542,7 @@ mod tests {
                 ai_model_costs: Some(&ModelCosts {
                     version: 2,
                     models: HashMap::from([(
-                        "claude-2.1".to_owned(),
+                        LazyGlob::new("claude-2.1"),
                         ModelCostV2 {
                             input_per_token: 0.01,
                             output_per_token: 0.02,
@@ -2625,7 +2626,7 @@ mod tests {
                     version: 2,
                     models: HashMap::from([
                         (
-                            "claude-2.1".to_owned(),
+                            LazyGlob::new("claude-2.1"),
                             ModelCostV2 {
                                 input_per_token: 0.01,
                                 output_per_token: 0.02,
@@ -2634,7 +2635,7 @@ mod tests {
                             },
                         ),
                         (
-                            "gpt4-21-04".to_owned(),
+                            LazyGlob::new("gpt4-21-04"),
                             ModelCostV2 {
                                 input_per_token: 0.09,
                                 output_per_token: 0.05,

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -1514,7 +1514,7 @@ fn normalize_app_start_measurements(measurements: &mut Measurements) {
 #[cfg(test)]
 mod tests {
 
-    use relay_common::glob2::LazyGlob;
+    use relay_pattern::Pattern;
     use std::collections::BTreeMap;
     use std::collections::HashMap;
 
@@ -2286,7 +2286,7 @@ mod tests {
                     version: 2,
                     models: HashMap::from([
                         (
-                            LazyGlob::new("claude-2.1"),
+                            Pattern::new("claude-2.1").unwrap(),
                             ModelCostV2 {
                                 input_per_token: 0.01,
                                 output_per_token: 0.02,
@@ -2295,7 +2295,7 @@ mod tests {
                             },
                         ),
                         (
-                            LazyGlob::new("gpt4-21-04"),
+                            Pattern::new("gpt4-21-04").unwrap(),
                             ModelCostV2 {
                                 input_per_token: 0.02,
                                 output_per_token: 0.03,
@@ -2423,7 +2423,7 @@ mod tests {
                     version: 2,
                     models: HashMap::from([
                         (
-                            LazyGlob::new("claude-2.1"),
+                            Pattern::new("claude-2.1").unwrap(),
                             ModelCostV2 {
                                 input_per_token: 0.01,
                                 output_per_token: 0.02,
@@ -2432,7 +2432,7 @@ mod tests {
                             },
                         ),
                         (
-                            LazyGlob::new("gpt4-21-04"),
+                            Pattern::new("gpt4-21-04").unwrap(),
                             ModelCostV2 {
                                 input_per_token: 0.09,
                                 output_per_token: 0.05,
@@ -2542,7 +2542,7 @@ mod tests {
                 ai_model_costs: Some(&ModelCosts {
                     version: 2,
                     models: HashMap::from([(
-                        LazyGlob::new("claude-2.1"),
+                        Pattern::new("claude-2.1").unwrap(),
                         ModelCostV2 {
                             input_per_token: 0.01,
                             output_per_token: 0.02,
@@ -2626,7 +2626,7 @@ mod tests {
                     version: 2,
                     models: HashMap::from([
                         (
-                            LazyGlob::new("claude-2.1"),
+                            Pattern::new("claude-2.1").unwrap(),
                             ModelCostV2 {
                                 input_per_token: 0.01,
                                 output_per_token: 0.02,
@@ -2635,7 +2635,7 @@ mod tests {
                             },
                         ),
                         (
-                            LazyGlob::new("gpt4-21-04"),
+                            Pattern::new("gpt4-21-04").unwrap(),
                             ModelCostV2 {
                                 input_per_token: 0.09,
                                 output_per_token: 0.05,

--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -135,6 +135,41 @@ impl fmt::Display for Pattern {
     }
 }
 
+impl PartialEq for Pattern {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+    }
+}
+
+impl Eq for Pattern {}
+
+impl std::hash::Hash for Pattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pattern.hash(state);
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Pattern {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.pattern)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Pattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let pattern = String::deserialize(deserializer)?;
+        Pattern::new(&pattern).map_err(serde::de::Error::custom)
+    }
+}
+
 /// A collection of [`Pattern`]s sharing the same configuration.
 #[derive(Debug, Clone)]
 pub struct Patterns {


### PR DESCRIPTION
Since snapshots of models change quite often, but the prices remain the same, in case when we don't have exact match for the model name, we might try to match it via glob. When generating global config with prices, we will prepare the data to also include names with `*` pattern, so that it can be used as a fallback.

E.g. `gpt-4-20250131` will also be saved as `gpt-4-*` meaning that all the other snapshots of the models will be covered, even if there is not exact match in the name in our pricing data.
