### PR TITLE
feat(PII): Add dynamic PII derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Features**:
 
 - Add InstallableBuild and SizeAnalysis data categories. ([#5084](https://github.com/getsentry/relay/pull/5084))
+- Add dynamic PII derivation to `metastructure`. ([#5107](https://github.com/getsentry/relay/pull/5107))
 
 **Internal**:
 

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -311,16 +311,16 @@ enum Pii {
 impl Pii {
     fn as_tokens(&self) -> TokenStream {
         match self {
-            Pii::True => quote!(crate::processor::PiiExtended::Static(
+            Pii::True => quote!(crate::processor::PiiMode::Static(
                 crate::processor::Pii::True
             )),
-            Pii::False => quote!(crate::processor::PiiExtended::Static(
+            Pii::False => quote!(crate::processor::PiiMode::Static(
                 crate::processor::Pii::False
             )),
-            Pii::Maybe => quote!(crate::processor::PiiExtended::Static(
+            Pii::Maybe => quote!(crate::processor::PiiMode::Static(
                 crate::processor::Pii::Maybe
             )),
-            Pii::Dynamic(fun) => quote!(crate::processor::PiiExtended::Dynamic(#fun)),
+            Pii::Dynamic(fun) => quote!(crate::processor::PiiMode::Dynamic(#fun)),
         }
     }
 }
@@ -386,7 +386,7 @@ impl FieldAttrs {
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
             quote!(#parent_attrs.pii)
         } else {
-            quote!(crate::processor::PiiExtended::Static(
+            quote!(crate::processor::PiiMode::Static(
                 crate::processor::Pii::False
             ))
         };

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -13,7 +13,7 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use syn::meta::ParseNestedMeta;
-use syn::{Ident, Lit, LitBool, LitInt, LitStr};
+use syn::{ExprPath, Ident, Lit, LitBool, LitInt, LitStr};
 use synstructure::decl_derive;
 
 mod utils;
@@ -300,19 +300,27 @@ fn parse_type_attributes(s: &synstructure::Structure<'_>) -> syn::Result<TypeAtt
     Ok(rv)
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 enum Pii {
     True,
     False,
     Maybe,
+    Dynamic(ExprPath),
 }
 
 impl Pii {
-    fn as_tokens(self) -> TokenStream {
+    fn as_tokens(&self) -> TokenStream {
         match self {
-            Pii::True => quote!(crate::processor::Pii::True),
-            Pii::False => quote!(crate::processor::Pii::False),
-            Pii::Maybe => quote!(crate::processor::Pii::Maybe),
+            Pii::True => quote!(crate::processor::PiiExtended::Static(
+                crate::processor::Pii::True
+            )),
+            Pii::False => quote!(crate::processor::PiiExtended::Static(
+                crate::processor::Pii::False
+            )),
+            Pii::Maybe => quote!(crate::processor::PiiExtended::Static(
+                crate::processor::Pii::Maybe
+            )),
+            Pii::Dynamic(fun) => quote!(crate::processor::PiiExtended::Dynamic(#fun)),
         }
     }
 }
@@ -373,12 +381,14 @@ impl FieldAttrs {
             quote!(false)
         };
 
-        let pii = if let Some(pii) = self.pii.or(type_attrs.pii) {
+        let pii = if let Some(pii) = self.pii.as_ref().or(type_attrs.pii.as_ref()) {
             pii.as_tokens()
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
             quote!(#parent_attrs.pii)
         } else {
-            quote!(crate::processor::Pii::False)
+            quote!(crate::processor::PiiExtended::Static(
+                crate::processor::Pii::False
+            ))
         };
 
         let trim = if let Some(trim) = self.trim.or(type_attrs.trim) {
@@ -596,6 +606,8 @@ fn parse_pii_value(value: LitStr, meta: &ParseNestedMeta) -> syn::Result<Option<
         "true" => Pii::True,
         "false" => Pii::False,
         "maybe" => Pii::Maybe,
-        _ => return Err(meta.error("Expected one of `true`, `false`, `maybe`")),
+        _ => Pii::Dynamic(value.parse().map_err(|_| {
+            meta.error("Expected one of `true`, `false`, `maybe`, or a function name")
+        })?),
     }))
 }

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -457,11 +457,10 @@ impl<'a> ProcessingState<'a> {
 
     /// Derives the attrs for recursion.
     pub fn inner_attrs(&self) -> Option<Cow<'_, FieldAttrs>> {
-        match self.attrs().pii {
-            PiiExtended::Static(Pii::True) => Some(Cow::Borrowed(&PII_TRUE_FIELD_ATTRS)),
-            PiiExtended::Static(Pii::False) => None,
-            PiiExtended::Static(Pii::Maybe) => Some(Cow::Borrowed(&PII_MAYBE_FIELD_ATTRS)),
-            PiiExtended::Dynamic(_) => None,
+        match self.pii() {
+            Pii::True => Some(Cow::Borrowed(&PII_TRUE_FIELD_ATTRS)),
+            Pii::False => None,
+            Pii::Maybe => Some(Cow::Borrowed(&PII_MAYBE_FIELD_ATTRS)),
         }
     }
 

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -108,7 +108,7 @@ pub enum Pii {
 
 /// A static or dynamic `Pii` value.
 #[derive(Debug, Clone, Copy)]
-pub enum PiiExtended {
+pub enum PiiMode {
     /// A static value.
     Static(Pii),
     /// A dynamic value, computed based on a `ProcessingState`.
@@ -137,7 +137,7 @@ pub struct FieldAttrs {
     /// The maximum number of bytes of this field.
     pub max_bytes: Option<usize>,
     /// The type of PII on the field.
-    pub pii: PiiExtended,
+    pub pii: PiiMode,
     /// Whether additional properties should be retained during normalization.
     pub retain: bool,
     /// Whether the trimming processor is allowed to shorten or drop this field.
@@ -179,7 +179,7 @@ impl FieldAttrs {
             max_chars_allowance: 0,
             max_depth: None,
             max_bytes: None,
-            pii: PiiExtended::Static(Pii::False),
+            pii: PiiMode::Static(Pii::False),
             retain: false,
             trim: true,
         }
@@ -208,13 +208,13 @@ impl FieldAttrs {
 
     /// Sets whether this field contains PII.
     pub const fn pii(mut self, pii: Pii) -> Self {
-        self.pii = PiiExtended::Static(pii);
+        self.pii = PiiMode::Static(pii);
         self
     }
 
     /// Sets whether this field contains PII dynamically based on the current state.
     pub const fn pii_dynamic(mut self, pii: fn(&ProcessingState) -> Pii) -> Self {
-        self.pii = PiiExtended::Dynamic(pii);
+        self.pii = PiiMode::Dynamic(pii);
         self
     }
 
@@ -471,8 +471,8 @@ impl<'a> ProcessingState<'a> {
     /// it is applied to this state and the output returned.
     pub fn pii(&self) -> Pii {
         match self.attrs().pii {
-            PiiExtended::Static(pii) => pii,
-            PiiExtended::Dynamic(pii_fn) => pii_fn(self),
+            PiiMode::Static(pii) => pii,
+            PiiMode::Dynamic(pii_fn) => pii_fn(self),
         }
     }
 

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -106,6 +106,15 @@ pub enum Pii {
     Maybe,
 }
 
+/// A static or dynamic `Pii` value.
+#[derive(Debug, Clone, Copy)]
+pub enum PiiExtended {
+    /// A static value.
+    Static(Pii),
+    /// A dynamic value, computed based on a `ProcessingState`.
+    Dynamic(fn(&ProcessingState) -> Pii),
+}
+
 /// Meta information about a field.
 #[derive(Debug, Clone, Copy)]
 pub struct FieldAttrs {
@@ -128,7 +137,7 @@ pub struct FieldAttrs {
     /// The maximum number of bytes of this field.
     pub max_bytes: Option<usize>,
     /// The type of PII on the field.
-    pub pii: Pii,
+    pub pii: PiiExtended,
     /// Whether additional properties should be retained during normalization.
     pub retain: bool,
     /// Whether the trimming processor is allowed to shorten or drop this field.
@@ -170,7 +179,7 @@ impl FieldAttrs {
             max_chars_allowance: 0,
             max_depth: None,
             max_bytes: None,
-            pii: Pii::False,
+            pii: PiiExtended::Static(Pii::False),
             retain: false,
             trim: true,
         }
@@ -199,7 +208,13 @@ impl FieldAttrs {
 
     /// Sets whether this field contains PII.
     pub const fn pii(mut self, pii: Pii) -> Self {
-        self.pii = pii;
+        self.pii = PiiExtended::Static(pii);
+        self
+    }
+
+    /// Sets whether this field contains PII dynamically based on the current state.
+    pub const fn pii_dynamic(mut self, pii: fn(&ProcessingState) -> Pii) -> Self {
+        self.pii = PiiExtended::Dynamic(pii);
         self
     }
 
@@ -443,9 +458,18 @@ impl<'a> ProcessingState<'a> {
     /// Derives the attrs for recursion.
     pub fn inner_attrs(&self) -> Option<Cow<'_, FieldAttrs>> {
         match self.attrs().pii {
-            Pii::True => Some(Cow::Borrowed(&PII_TRUE_FIELD_ATTRS)),
-            Pii::False => None,
-            Pii::Maybe => Some(Cow::Borrowed(&PII_MAYBE_FIELD_ATTRS)),
+            PiiExtended::Static(Pii::True) => Some(Cow::Borrowed(&PII_TRUE_FIELD_ATTRS)),
+            PiiExtended::Static(Pii::False) => None,
+            PiiExtended::Static(Pii::Maybe) => Some(Cow::Borrowed(&PII_MAYBE_FIELD_ATTRS)),
+            PiiExtended::Dynamic(_) => None,
+        }
+    }
+
+    /// Returns the PII status for this state.
+    pub fn pii(&self) -> Pii {
+        match self.attrs().pii {
+            PiiExtended::Static(pii) => pii,
+            PiiExtended::Dynamic(pii_fn) => pii_fn(self),
         }
     }
 
@@ -561,6 +585,11 @@ impl Path<'_> {
         self.0.attrs()
     }
 
+    /// Returns the PII status for this path.
+    pub fn pii(&self) -> Pii {
+        self.0.pii()
+    }
+
     /// Iterates through the states in this path.
     pub fn iter(&self) -> ProcessingStateIter<'_> {
         self.0.iter()
@@ -583,5 +612,68 @@ impl fmt::Display for Path<'_> {
             write!(f, "{item}")?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, SerializableAnnotated};
+
+    use crate::processor::attrs::ROOT_STATE;
+    use crate::processor::{Pii, ProcessValue, ProcessingState, Processor, process_value};
+
+    fn pii_from_item_name(state: &ProcessingState) -> Pii {
+        match state.path_item().and_then(|p| p.key()) {
+            Some("true_item") => Pii::True,
+            Some("false_item") => Pii::False,
+            _ => Pii::Maybe,
+        }
+    }
+
+    #[derive(Debug, Clone, Empty, IntoValue, FromValue, ProcessValue)]
+    #[metastructure(pii = "pii_from_item_name")]
+    struct TestValue(String);
+
+    struct TestProcessor;
+
+    impl Processor for TestProcessor {
+        fn process_string(
+            &mut self,
+            value: &mut String,
+            _meta: &mut relay_protocol::Meta,
+            state: &ProcessingState<'_>,
+        ) -> crate::processor::ProcessingResult where {
+            match state.pii() {
+                Pii::True => *value = "true".to_owned(),
+                Pii::False => *value = "false".to_owned(),
+                Pii::Maybe => *value = "maybe".to_owned(),
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_dynamic_pii() {
+        let mut object: Annotated<Object<TestValue>> = Annotated::from_json(
+            r#"
+        {
+          "false_item": "replace me",
+          "other_item": "replace me",
+          "true_item": "replace me"
+        }
+        "#,
+        )
+        .unwrap();
+
+        process_value(&mut object, &mut TestProcessor, &ROOT_STATE).unwrap();
+
+        insta::assert_json_snapshot!(SerializableAnnotated(&object), @r###"
+        {
+          "false_item": "false",
+          "other_item": "maybe",
+          "true_item": "true"
+        }
+        "###);
     }
 }

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -466,6 +466,10 @@ impl<'a> ProcessingState<'a> {
     }
 
     /// Returns the PII status for this state.
+    ///
+    /// If the state's `FieldAttrs` contain a fixed PII status,
+    /// it is returned. If they contain a dynamic PII status (a function),
+    /// it is applied to this state and the output returned.
     pub fn pii(&self) -> Pii {
         match self.attrs().pii {
             PiiExtended::Static(pii) => pii,

--- a/relay-pii/src/attachments.rs
+++ b/relay-pii/src/attachments.rs
@@ -395,7 +395,7 @@ impl<'a> PiiAttachmentsProcessor<'a> {
         state: &ProcessingState<'_>,
         encodings: ScrubEncodings,
     ) -> bool {
-        let pii = state.attrs().pii;
+        let pii = state.pii();
         if pii == Pii::False {
             return false;
         }

--- a/relay-pii/src/generate_selectors.rs
+++ b/relay-pii/src/generate_selectors.rs
@@ -35,7 +35,7 @@ impl Processor for GenerateSelectorsProcessor {
         // The following skip-conditions are in sync with what the PiiProcessor does.
         if state.value_type().contains(ValueType::Boolean)
             || value.is_none()
-            || state.attrs().pii == Pii::False
+            || state.pii() == Pii::False
         {
             return Ok(());
         }

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -38,7 +38,7 @@ impl<'a> PiiProcessor<'a> {
         state: &ProcessingState<'_>,
         mut value: Option<&mut String>,
     ) -> ProcessingResult {
-        let pii = state.attrs().pii;
+        let pii = state.pii();
         if pii == Pii::False {
             return Ok(());
         }

--- a/relay-pii/src/selector.rs
+++ b/relay-pii/src/selector.rs
@@ -197,7 +197,7 @@ impl SelectorSpec {
     /// This walks both the selector and the path starting at the end and towards the root
     /// to determine if the selector matches the current path.
     pub fn matches_path(&self, path: &Path) -> bool {
-        let pii = path.attrs().pii;
+        let pii = path.pii();
         if pii == Pii::False {
             return false;
         }


### PR DESCRIPTION
This adds the ability to "dynamically" define PII to `metastructure`. It works like this: if `compute_pii` is a function `fn(&ProcessingState) -> Pii`, you can annotate a container or field with `#[metastructure(pii = "compute_pii")]` (in addition to the existing values of `"true"`, `"false"`, and `"maybe"`) which will cause the PII value of the field/container to depend on the current `ProcessingState`. See the new `test_dynamic_pii` test for a simple example of this feature in action.

The intended use of this is to allow the PII status  of `AttributeValue::value` to be fetched from `relay-conventions` based on the attribute's name.

ref: #5096. ref: RELAY-152.