### PR TITLE
ref(store): Produce accepted outcomes for JSON spans

### DIFF
--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1064,21 +1064,23 @@ impl StoreService {
                 retention_days,
                 span.clone(),
             )?;
-
-            self.outcome_aggregator.send(TrackOutcome {
-                category: DataCategory::SpanIndexed,
-                event_id: None,
-                outcome: Outcome::Accepted,
-                quantity: 1,
-                remote_addr: None,
-                scoping,
-                timestamp: received_at,
-            });
         }
 
         if spans_target.is_json() {
             self.inner_produce_json_span(scoping, span)?;
         }
+
+        // XXX: Temporarily produce span outcomes also for JSON spans. Keep in sync with either EAP
+        // or the segments consumer, depending on which will produce outcomes later.
+        self.outcome_aggregator.send(TrackOutcome {
+            category: DataCategory::SpanIndexed,
+            event_id: None,
+            outcome: Outcome::Accepted,
+            quantity: 1,
+            remote_addr: None,
+            scoping,
+            timestamp: received_at,
+        });
 
         Ok(())
     }

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1910,6 +1910,16 @@ def test_span_outcomes(
             "category": DataCategory.SPAN_INDEXED.value,
             "key_id": 123,
             "org_id": 1,
+            "outcome": 0,  # Accepted
+            "project_id": 42,
+            "quantity": 2,
+            "source": "processing-relay",
+        },
+        {
+            "timestamp": time_within_delta(),
+            "category": DataCategory.SPAN_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
             "outcome": 1,  # Filtered
             "project_id": 42,
             "quantity": 2,

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -313,7 +313,20 @@ def test_spansv2_ds_sampled(
         },
     ]
 
-    outcomes_consumer.assert_empty()
+    outcomes = outcomes_consumer.get_outcomes(n=1)
+    outcomes.sort(key=lambda o: sorted(o.items()))
+
+    assert outcomes == [
+        {
+            "category": DataCategory.SPAN_INDEXED.value,
+            "timestamp": time_within_delta(),
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            "quantity": 1,
+        }
+    ]
 
 
 def test_spansv2_ds_root_in_different_org(


### PR DESCRIPTION
Temporarily reverts to tracking accepted outcomes for indexed spans that are sent into the new spans pipeline directly in Relay, instead of tracking them in the segments consumer. This is done to improve aggregation of these outcomes.

See also https://github.com/getsentry/sentry/pull/98584
Requires https://github.com/getsentry/ops/pull/16981