### PR TITLE
ref(pii): Change attr default/advanced rule logic

### DIFF
--- a/relay-pii/src/utils.rs
+++ b/relay-pii/src/utils.rs
@@ -9,6 +9,8 @@ use relay_event_schema::processor::{
 use relay_event_schema::protocol::{AsPair, Attributes, PairList};
 use sha1::Sha1;
 
+use crate::AttributeMode;
+
 pub fn process_pairlist<P: Processor, T: ProcessValue + AsPair>(
     slf: &mut P,
     value: &mut PairList<T>,
@@ -45,35 +47,36 @@ pub fn process_attributes<P: Processor>(
     value: &mut Attributes,
     slf: &mut P,
     state: &ProcessingState,
+    attribute_mode: AttributeMode,
 ) -> ProcessingResult {
-    // Check if we're in default rules (no root ValueType)
-    // This is a workaround to support explicit selectors eg. $log.attributes.KEY.value to work but keep implicit selectors for default rules.
-    let is_advanced_rules = state
-        .iter()
-        .nth(1)
-        .is_some_and(|s| s.value_type().contains(ValueType::OurLog));
-
     for (key, annotated_attribute) in value.iter_mut() {
         if let Some(attribute) = annotated_attribute.value_mut() {
-            if is_advanced_rules {
-                // Process normally to allow explicit selectors like $log.attributes.KEY.value to work
-                let field_value_type = ValueType::for_field(annotated_attribute);
-                let key_state = state.enter_borrowed(key, state.inner_attrs(), field_value_type);
-                processor::process_value(annotated_attribute, slf, &key_state)?;
-            } else {
-                // For the default rules, we want Pii::True since we want them to always be scrubbed.
-                let attrs = FieldAttrs::new().pii(Pii::True);
-                let inner_value = &mut attribute.value.value;
-                let inner_value_type = ValueType::for_field(inner_value);
-                let entered =
-                    state.enter_borrowed(key, Some(Cow::Borrowed(&attrs)), inner_value_type);
-                processor::process_value(inner_value, slf, &entered)?;
+            match attribute_mode {
+                AttributeMode::Object => {
+                    // Process normally to allow explicit selectors like $log.attributes.KEY.value to work
+                    let field_value_type = ValueType::for_field(annotated_attribute);
+                    let key_state =
+                        state.enter_borrowed(key, state.inner_attrs(), field_value_type);
+                    processor::process_value(annotated_attribute, slf, &key_state)?;
+                }
+                AttributeMode::ValueOnly => {
+                    // For the default rules, we want Pii::True since we want them to always be scrubbed.
+                    let attrs = FieldAttrs::new().pii(Pii::True);
+                    let inner_value = &mut attribute.value.value;
+                    let inner_value_type = ValueType::for_field(inner_value);
+                    let entered =
+                        state.enter_borrowed(key, Some(Cow::Borrowed(&attrs)), inner_value_type);
+                    processor::process_value(inner_value, slf, &entered)?;
 
-                let object_value_type = enum_set!(ValueType::Object);
-                for (key, value) in attribute.other.iter_mut() {
-                    let other_state =
-                        state.enter_borrowed(key, Some(Cow::Borrowed(&attrs)), object_value_type);
-                    processor::process_value(value, slf, &other_state)?;
+                    let object_value_type = enum_set!(ValueType::Object);
+                    for (key, value) in attribute.other.iter_mut() {
+                        let other_state = state.enter_borrowed(
+                            key,
+                            Some(Cow::Borrowed(&attrs)),
+                            object_value_type,
+                        );
+                        processor::process_value(value, slf, &other_state)?;
+                    }
                 }
             }
         }

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -1,7 +1,7 @@
 use relay_event_normalization::{SchemaProcessor, eap};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
 use relay_event_schema::protocol::{OurLog, OurLogHeader};
-use relay_pii::PiiProcessor;
+use relay_pii::{AttributeMode, PiiProcessor};
 use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 
@@ -106,18 +106,20 @@ fn scrub_log(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
         .pii_config()
         .map_err(|e| Error::PiiConfig(e.clone()))?;
 
+    let state = ProcessingState::root().enter_borrowed("", None, [ValueType::OurLog]);
+
     if let Some(ref config) = ctx.project_info.config.pii_config {
-        let mut processor = PiiProcessor::new(config.compiled());
-        let root_state = ProcessingState::root().enter_borrowed("", None, Some(ValueType::OurLog));
-        process_value(log, &mut processor, &root_state)?;
+        let mut processor = PiiProcessor::new(config.compiled())
+            // For advanced rules we want to treat attributes as objects.
+            .attribute_mode(AttributeMode::Object);
+        process_value(log, &mut processor, &state)?;
     }
 
     if let Some(config) = pii_config_from_scrubbing {
-        let mut processor = PiiProcessor::new(config.compiled());
-        // Use empty root (assumed to be Event) for legacy/default scrubbing rules.
-        // process_attributes will collapse Attribute into it's value for the default rules.
-        let root_state = ProcessingState::root();
-        process_value(log, &mut processor, root_state)?;
+        let mut processor = PiiProcessor::new(config.compiled())
+            // For "legacy" rules we want to identify attributes with their values.
+            .attribute_mode(AttributeMode::ValueOnly);
+        process_value(log, &mut processor, &state)?;
     }
 
     Ok(())


### PR DESCRIPTION
This changes how the `PiiProcessor` detects whether attributes should be scrubbed as objects (used for advanced rules) or identified with their `value` field (used for default rules). Previously, this was decided based on the presence of a segment of type `$log` in the processing state. Now there is an explicit mode setting. This doesn't change the behavior of the processor at all, it just makes the logic explicit and applicable to other objects than logs.

ref: #5096. ref: RELAY-152.