### PR TITLE
feat(spans): Introduce a kafka-compatible Span V2

### DIFF
--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -219,6 +219,11 @@ impl Attributes {
         self.0.contains_key(key)
     }
 
+    /// Iterates over this collection's attribute keys and values.
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, Annotated<Attribute>> {
+        self.0.iter()
+    }
+
     /// Iterates mutably over this collection's attribute keys and values.
     pub fn iter_mut(
         &mut self,

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -1,3 +1,4 @@
+mod compat;
 mod convert;
 
 use std::fmt;

--- a/relay-event-schema/src/protocol/span/compat.rs
+++ b/relay-event-schema/src/protocol/span/compat.rs
@@ -1,0 +1,235 @@
+use std::str::FromStr;
+
+use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
+
+use crate::protocol::{EventId, SpanV2, Timestamp};
+
+/// Temporary type that amends a SpansV2 span with fields needed by the sentry span consumer.
+/// This can be removed once the consumer has benn updated to use the new schema.
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue)]
+pub struct CompatSpan {
+    #[metastructure(flatten)]
+    pub span: SpanV2,
+
+    pub data: Annotated<Object<Value>>,
+    pub description: Annotated<String>,
+    pub duration_ms: Annotated<u64>,
+    pub end_timestamp_precise: Annotated<Timestamp>,
+    pub profile_id: Annotated<EventId>,
+    pub segment_id: Annotated<String>,
+    pub start_timestamp_ms: Annotated<u64>, // TODO: remove from kafka schema, no longer used in consumer
+    pub start_timestamp_precise: Annotated<Timestamp>,
+}
+
+impl TryFrom<SpanV2> for CompatSpan {
+    type Error = uuid::Error;
+
+    fn try_from(span: SpanV2) -> Result<Self, uuid::Error> {
+        let mut compat_span = Self::default();
+
+        if let Some(start_timestamp) = span.start_timestamp.value() {
+            let dt = start_timestamp.0;
+            compat_span.start_timestamp_precise = start_timestamp.clone().into();
+            compat_span.start_timestamp_ms = (dt.timestamp_millis() as u64).into();
+        }
+
+        if let Some(end_timestamp) = span.end_timestamp.value() {
+            compat_span.end_timestamp_precise = end_timestamp.clone().into();
+        }
+
+        if let (Some(start_timestamp), Some(end_timestamp)) =
+            (span.start_timestamp.value(), span.end_timestamp.value())
+        {
+            let delta = (*end_timestamp - *start_timestamp).num_milliseconds();
+            compat_span.duration_ms = u64::try_from(delta).unwrap_or(0).into();
+        }
+
+        if let Some(attributes) = span.attributes.value() {
+            for (key, value) in attributes.iter() {
+                if let Some(attribute) = value.value() {
+                    if let Some(value) = attribute.value.value.value() {
+                        // NOTE: This discards `_meta`
+                        compat_span
+                            .data
+                            .get_or_insert_with(Default::default)
+                            .insert(key.clone(), value.clone().into());
+                    }
+                }
+            }
+
+            if let Some(description) = attributes
+                .get_value("sentry.raw_description")
+                .and_then(Value::as_str)
+            {
+                compat_span.description = Annotated::from(description.to_owned());
+            }
+
+            if let Some(profile_id) = attributes
+                .get_value("sentry.profile_id")
+                .and_then(Value::as_str)
+            {
+                compat_span.profile_id = Annotated::from(EventId::from_str(profile_id)?);
+            }
+
+            if let Some(segment_id) = attributes
+                .get_value("sentry.profile_id")
+                .and_then(Value::as_str)
+            {
+                compat_span.segment_id = Annotated::from(segment_id.to_owned());
+            }
+        }
+
+        compat_span.span = span;
+        Ok(compat_span)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::DateTime;
+    use relay_protocol::SerializableAnnotated;
+
+    use super::*;
+
+    #[test]
+    fn basic_conversion() {
+        let json = r#"{
+            "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+            "span_id": "fa90fdead5f74052",
+            "parent_span_id": "fa90fdead5f74051",
+            "start_timestamp": 123,
+            "end_timestamp": 123.5,
+            "name": "myname",
+            "status": "ok",
+            "links": [],
+            "attributes": {
+                "browser.name": {
+                    "value": "Chrome",
+                    "type": "string"
+                },
+                "sentry.description": {
+                    "value": "mydescription",
+                    "type": "string"
+                },
+                "sentry.environment": {
+                    "value": "prod",
+                    "type": "string"
+                },
+                "sentry.op": {
+                    "value": "myop",
+                    "type": "string"
+                },
+                "sentry.platform": {
+                    "value": "php",
+                    "type": "string"
+                },
+                "sentry.profile.id": {
+                    "value": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab",
+                    "type": "string"
+                },
+                "sentry.release": {
+                    "value": "myapp@1.0.0",
+                    "type": "string"
+                },
+                "sentry.sdk.name": {
+                    "value": "sentry.php",
+                    "type": "string"
+                },
+                "sentry.segment.id": {
+                    "value": "FA90FDEAD5F74052",
+                    "type": "string"
+                },
+                "sentry.segment.name": {
+                    "value": "my 1st transaction",
+                    "type": "string"
+                }
+            }
+        }"#;
+
+        let span_v2: SpanV2 = Annotated::from_json(json).unwrap().into_value().unwrap();
+        let compat_span = CompatSpan::try_from(span_v2).unwrap();
+
+        insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::from(compat_span)), @r###"
+        {
+          "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+          "parent_span_id": "fa90fdead5f74051",
+          "span_id": "fa90fdead5f74052",
+          "name": "myname",
+          "status": "ok",
+          "start_timestamp": 123.0,
+          "end_timestamp": 123.5,
+          "links": [],
+          "attributes": {
+            "browser.name": {
+              "type": "string",
+              "value": "Chrome"
+            },
+            "sentry.description": {
+              "type": "string",
+              "value": "mydescription"
+            },
+            "sentry.environment": {
+              "type": "string",
+              "value": "prod"
+            },
+            "sentry.op": {
+              "type": "string",
+              "value": "myop"
+            },
+            "sentry.platform": {
+              "type": "string",
+              "value": "php"
+            },
+            "sentry.profile.id": {
+              "type": "string",
+              "value": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"
+            },
+            "sentry.release": {
+              "type": "string",
+              "value": "myapp@1.0.0"
+            },
+            "sentry.sdk.name": {
+              "type": "string",
+              "value": "sentry.php"
+            },
+            "sentry.segment.id": {
+              "type": "string",
+              "value": "FA90FDEAD5F74052"
+            },
+            "sentry.segment.name": {
+              "type": "string",
+              "value": "my 1st transaction"
+            }
+          },
+          "data": {
+            "browser.name": "Chrome",
+            "sentry.description": "mydescription",
+            "sentry.environment": "prod",
+            "sentry.op": "myop",
+            "sentry.platform": "php",
+            "sentry.profile.id": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab",
+            "sentry.release": "myapp@1.0.0",
+            "sentry.sdk.name": "sentry.php",
+            "sentry.segment.id": "FA90FDEAD5F74052",
+            "sentry.segment.name": "my 1st transaction"
+          },
+          "duration_ms": 500,
+          "end_timestamp_precise": 123.5,
+          "start_timestamp_ms": 123000,
+          "start_timestamp_precise": 123.0
+        }
+        "###);
+    }
+
+    #[test]
+    fn negative_duration() {
+        let span_v2 = SpanV2 {
+            start_timestamp: Timestamp(DateTime::from_timestamp_nanos(100)).into(),
+            end_timestamp: Timestamp(DateTime::from_timestamp_nanos(50)).into(),
+            ..Default::default()
+        };
+
+        let compat_span = CompatSpan::try_from(span_v2).unwrap();
+        assert_eq!(compat_span.duration_ms.value(), Some(&0));
+    }
+}

--- a/relay-event-schema/src/protocol/span/compat.rs
+++ b/relay-event-schema/src/protocol/span/compat.rs
@@ -7,6 +7,7 @@ use crate::protocol::{EventId, SpanV2, Timestamp};
 /// Temporary type that amends a SpansV2 span with fields needed by the sentry span consumer.
 /// This can be removed once the consumer has benn updated to use the new schema.
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue)]
+#[allow(dead_code)]
 pub struct CompatSpan {
     #[metastructure(flatten)]
     pub span: SpanV2,

--- a/relay-event-schema/src/protocol/span/compat.rs
+++ b/relay-event-schema/src/protocol/span/compat.rs
@@ -30,12 +30,12 @@ impl TryFrom<SpanV2> for CompatSpan {
 
         if let Some(start_timestamp) = span.start_timestamp.value() {
             let dt = start_timestamp.0;
-            compat_span.start_timestamp_precise = start_timestamp.clone().into();
+            compat_span.start_timestamp_precise = (*start_timestamp).into();
             compat_span.start_timestamp_ms = (dt.timestamp_millis() as u64).into();
         }
 
         if let Some(end_timestamp) = span.end_timestamp.value() {
-            compat_span.end_timestamp_precise = end_timestamp.clone().into();
+            compat_span.end_timestamp_precise = (*end_timestamp).into();
         }
 
         if let (Some(start_timestamp), Some(end_timestamp)) =
@@ -47,14 +47,14 @@ impl TryFrom<SpanV2> for CompatSpan {
 
         if let Some(attributes) = span.attributes.value() {
             for (key, value) in attributes.iter() {
-                if let Some(attribute) = value.value() {
-                    if let Some(value) = attribute.value.value.value() {
-                        // NOTE: This discards `_meta`
-                        compat_span
-                            .data
-                            .get_or_insert_with(Default::default)
-                            .insert(key.clone(), value.clone().into());
-                    }
+                if let Some(attribute) = value.value()
+                    && let Some(value) = attribute.value.value.value()
+                {
+                    // NOTE: This discards `_meta`
+                    compat_span
+                        .data
+                        .get_or_insert_with(Default::default)
+                        .insert(key.clone(), value.clone().into());
                 }
             }
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1675,27 +1675,6 @@ struct SpanMeasurement<'a> {
     value: Option<&'a RawValue>,
 }
 
-#[derive(Serialize)]
-struct SpanKafkaMessageV2<'a> {
-    #[serde(flatten)]
-    meta: SpanMeta,
-    #[serde(flatten)]
-    compat_span: &'a RawValue,
-}
-
-#[derive(Serialize)]
-struct SpanMeta {
-    // Required for the buffer to emit outcomes scoped to the DSN.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    key_id: Option<u64>,
-    organization_id: u64,
-    project_id: u64,
-    /// Time at which the event was received by Relay. Not to be confused with `start_timestamp_ms`.
-    received: f64,
-    /// Number of days until these data should be deleted.
-    retention_days: u16,
-}
-
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct SpanKafkaMessage<'a> {
     #[serde(skip_serializing_if = "Option::is_none", borrow)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1675,6 +1675,27 @@ struct SpanMeasurement<'a> {
     value: Option<&'a RawValue>,
 }
 
+#[derive(Serialize)]
+struct SpanKafkaMessageV2<'a> {
+    #[serde(flatten)]
+    meta: SpanMeta,
+    #[serde(flatten)]
+    compat_span: &'a RawValue,
+}
+
+#[derive(Serialize)]
+struct SpanMeta {
+    // Required for the buffer to emit outcomes scoped to the DSN.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key_id: Option<u64>,
+    organization_id: u64,
+    project_id: u64,
+    /// Time at which the event was received by Relay. Not to be confused with `start_timestamp_ms`.
+    received: f64,
+    /// Number of days until these data should be deleted.
+    retention_days: u16,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct SpanKafkaMessage<'a> {
     #[serde(skip_serializing_if = "Option::is_none", borrow)]


### PR DESCRIPTION
First step for migrating Kafka spans to Span V2:

1. **This PR:** Introduce a backward-compatible span format.
2. Enrich `CompatSpan` payloads with Kafka fields (scoping, retention).
3. Write new format to Kafka.
4. Adapt span consumer.
5. Remove `CompatSpan` and send kafka-enriched SpanV2 fields directly.

ref: INGEST-531