### PR TITLE
ref(replays): Use sample-rate rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Produce transactions on `transactions` Kafka topic, even if they have attachments. ([#5081](https://github.com/getsentry/relay/pull/5081))
 - Removes metric stats from the codebase. ([#5097](https://github.com/getsentry/relay/pull/5097))
 - Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088))
+- Use sample-rate rollout for disabled replay-event publishing. ([#5115](https://github.com/getsentry/relay/pull/5115))
 
 ## 25.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@
 - Introduces a project scope sampling rule type. ([#5077](https://github.com/getsentry/relay/pull/5077)))
 - Produce transactions on `transactions` Kafka topic, even if they have attachments. ([#5081](https://github.com/getsentry/relay/pull/5081))
 - Removes metric stats from the codebase. ([#5097](https://github.com/getsentry/relay/pull/5097))
-- Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088))
-- Use sample-rate rollout for disabled replay-event publishing. ([#5115](https://github.com/getsentry/relay/pull/5115))
+- Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088), [#5115](https://github.com/getsentry/relay/pull/5115))
 
 ## 25.8.0
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -174,14 +174,6 @@ pub struct Options {
 
     /// Disables Relay from sending replay-events to Snuba.
     #[serde(
-        rename = "replay.relay-snuba-publishing-disabled",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub replay_relay_snuba_publish_disabled: bool,
-
-    /// Disables Relay from sending replay-events to Snuba.
-    #[serde(
         rename = "replay.relay-snuba-publishing-disabled.sample-rate",
         deserialize_with = "default_on_error",
         skip_serializing_if = "is_default"

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -180,6 +180,14 @@ pub struct Options {
     )]
     pub replay_relay_snuba_publish_disabled: bool,
 
+    /// Disables Relay from sending replay-events to Snuba.
+    #[serde(
+        rename = "replay.relay-snuba-publishing-disabled.sample-rate",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub replay_relay_snuba_publish_disabled_sample_rate: f32,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -279,11 +279,13 @@ impl StoreService {
         let mut replay_recording = None;
 
         // Whether Relay will submit the replay-event to snuba or not.
-        let replay_relay_snuba_publish_disabled = self
-            .global_config
-            .current()
-            .options
-            .replay_relay_snuba_publish_disabled;
+        let replay_relay_snuba_publish_disabled = utils::sample(
+            self.global_config
+                .current()
+                .options
+                .replay_relay_snuba_publish_disabled_sample_rate,
+        )
+        .is_keep();
 
         for item in envelope.items() {
             match item.ty() {

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -33,9 +33,7 @@ def test_replay_recordings(mini_sentry, relay_chain):
     assert replay_recording.startswith(b"{}\n")  # The body is compressed
 
 
-@pytest.mark.parametrize(
-    "value,expected", [(None, False), (False, False), (True, True)]
-)
+@pytest.mark.parametrize("value,expected", [(1.0, True), (None, False), (0.0, False)])
 def test_nonchunked_replay_recordings_processing(
     mini_sentry,
     relay_with_processing,
@@ -50,9 +48,9 @@ def test_nonchunked_replay_recordings_processing(
     replay_id = "515539018c9b4260a6f999572f1661ee"
 
     if value is not None:
-        mini_sentry.global_config["options"][
-            "replay.relay-snuba-publishing-disabled"
-        ] = value
+        mini_sentry.global_config["options"] = {
+            "replay.relay-snuba-publishing-disabled.sample-rate": value
+        }
     mini_sentry.add_basic_project_config(
         project_id, extra={"config": {"features": ["organizations:session-replay"]}}
     )

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -48,9 +48,9 @@ def test_nonchunked_replay_recordings_processing(
     replay_id = "515539018c9b4260a6f999572f1661ee"
 
     if value is not None:
-        mini_sentry.global_config["options"] = {
-            "replay.relay-snuba-publishing-disabled.sample-rate": value
-        }
+        mini_sentry.global_config["options"][
+            "replay.relay-snuba-publishing-disabled.sample-rate"
+        ] = value
     mini_sentry.add_basic_project_config(
         project_id, extra={"config": {"features": ["organizations:session-replay"]}}
     )

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -87,7 +87,7 @@ def test_nonchunked_replay_recordings_processing(
     assert replay_recording["type"] == "replay_recording_not_chunked"
     assert replay_recording["relay_snuba_publish_disabled"] is expected
 
-    if value is True:
+    if expected is True:
         # Nothing produced.
         with pytest.raises(AssertionError):
             replay_events_consumer.get_replay_event()

--- a/tests/integration/test_replay_videos.py
+++ b/tests/integration/test_replay_videos.py
@@ -7,9 +7,7 @@ import json
 import pytest
 
 
-@pytest.mark.parametrize(
-    "value,expected", [(None, False), (False, False), (True, True)]
-)
+@pytest.mark.parametrize("value,expected", [(None, False), (0.0, False), (1.0, True)])
 def test_replay_recording_with_video(
     mini_sentry,
     relay_with_processing,
@@ -24,7 +22,7 @@ def test_replay_recording_with_video(
     replay_id = "515539018c9b4260a6f999572f1661ee"
     if value is not None:
         mini_sentry.global_config["options"][
-            "replay.relay-snuba-publishing-disabled"
+            "replay.relay-snuba-publishing-disabled.sample-rate"
         ] = value
     mini_sentry.add_basic_project_config(
         project_id,

--- a/tests/integration/test_replay_videos.py
+++ b/tests/integration/test_replay_videos.py
@@ -79,7 +79,7 @@ def test_replay_recording_with_video(
     assert replay_event["type"] == "replay_event"
     assert replay_event["replay_id"] == "515539018c9b4260a6f999572f1661ee"
 
-    if value is True:
+    if expected is True:
         with pytest.raises(AssertionError):
             replay_events_consumer.get_replay_event()  # Nothing produced.
     else:


### PR DESCRIPTION
Rather than a boolean enabled/disabled flag use a rollout flag to limit blast radius in case of error.