### PR TITLE
feat(relay-pattern): Add negation pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Add InstallableBuild and SizeAnalysis data categories. ([#5084](https://github.com/getsentry/relay/pull/5084))
 - Add dynamic PII derivation to `metastructure`. ([#5107](https://github.com/getsentry/relay/pull/5107))
+- Add negation pattern matching. ([#5116](https://github.com/getsentry/relay/pull/5116))
 
 **Internal**:
 

--- a/relay-pattern/src/wildmatch.rs
+++ b/relay-pattern/src/wildmatch.rs
@@ -9,11 +9,12 @@ use crate::{Literal, Options, Ranges, Token, Tokens};
 /// of the already pre-processed [`Tokens`] structure and its invariants.
 ///
 /// [Kirk J Krauss]: http://developforperformance.com/MatchingWildcards_AnImprovedAlgorithmForBigData.html
-pub fn is_match(haystack: &str, tokens: &Tokens, options: Options) -> bool {
-    match options.case_insensitive {
-        false => is_match_impl::<_, CaseSensitive>(haystack, tokens.as_slice()),
-        true => is_match_impl::<_, CaseInsensitive>(haystack, tokens.as_slice()),
-    }
+pub fn is_match(haystack: &str, tokens: &Tokens, options: Options, negated: bool) -> bool {
+    negated
+        ^ match options.case_insensitive {
+            false => is_match_impl::<_, CaseSensitive>(haystack, tokens.as_slice()),
+            true => is_match_impl::<_, CaseInsensitive>(haystack, tokens.as_slice()),
+        }
 }
 
 #[inline(always)]
@@ -53,6 +54,7 @@ where
             t_next += 1;
 
             match token {
+                Token::Negated => true,
                 Token::Literal(literal) => match M::is_prefix(h_current, literal) {
                     Some(n) => advance!(n),
                     // The literal does not match, but it may match after backtracking.

--- a/relay-pattern/src/wildmatch.rs
+++ b/relay-pattern/src/wildmatch.rs
@@ -9,12 +9,11 @@ use crate::{Literal, Options, Ranges, Token, Tokens};
 /// of the already pre-processed [`Tokens`] structure and its invariants.
 ///
 /// [Kirk J Krauss]: http://developforperformance.com/MatchingWildcards_AnImprovedAlgorithmForBigData.html
-pub fn is_match(haystack: &str, tokens: &Tokens, options: Options, negated: bool) -> bool {
-    negated
-        ^ match options.case_insensitive {
-            false => is_match_impl::<_, CaseSensitive>(haystack, tokens.as_slice()),
-            true => is_match_impl::<_, CaseInsensitive>(haystack, tokens.as_slice()),
-        }
+pub fn is_match(haystack: &str, tokens: &Tokens, options: Options) -> bool {
+    match options.case_insensitive {
+        false => is_match_impl::<_, CaseSensitive>(haystack, tokens.as_slice()),
+        true => is_match_impl::<_, CaseInsensitive>(haystack, tokens.as_slice()),
+    }
 }
 
 #[inline(always)]


### PR DESCRIPTION
Prefixing `!` before a pattern will negate the pattern that follows. This is designed for use within inbound-filters (specifically release filters) where a customer wants to define an allow-list (as opposed to the current deny-list).