### PR TITLE
fix(conventions): Use `sentry.profile_id`, not `sentry.profile.id`

### DIFF
--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -19,7 +19,7 @@ use relay_protocol::Error;
 /// * The Sentry span's `exclusive_time` field is set based on the OTEL span's `exclusive_time_nano`
 ///   attribute, or the difference between the start and end timestamp if that attribute is not set.
 /// * The Sentry span's `platform` field is set based on the OTEL span's `sentry.platform` attribute.
-/// * The Sentry span's `profile_id` field is set based on the OTEL span's `sentry.profile.id` attribute.
+/// * The Sentry span's `profile_id` field is set based on the OTEL span's `sentry.profile_id` attribute.
 /// * The Sentry span's `segment_id` field is set based on the OTEL span's `sentry.segment.id` attribute.
 ///
 /// All other attributes are carried over from the OTEL span to the Sentry span's `data`.
@@ -503,7 +503,7 @@ mod tests {
                     }
                 },
                 {
-                    "key" : "sentry.profile.id",
+                    "key" : "sentry.profile_id",
                     "value": {
                         "stringValue": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"
                     }

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -604,7 +604,7 @@ mod tests {
               }
             },
             {
-              "key": "sentry.profile.id",
+              "key": "sentry.profile_id",
               "value": {
                 "stringValue": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"
               }
@@ -729,7 +729,7 @@ mod tests {
               "type": "string",
               "value": "php"
             },
-            "sentry.profile.id": {
+            "sentry.profile_id": {
               "type": "string",
               "value": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"
             },

--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -23,7 +23,7 @@ use url::Url;
 /// * The V1 span's `exclusive_time` field is set based on the V2 span's `exclusive_time_nano`
 ///   attribute, or the difference between the start and end timestamp if that attribute is not set.
 /// * The V1 span's `platform` field is set based on the V2 span's `sentry.platform` attribute.
-/// * The V1 span's `profile_id` field is set based on the V2 span's `sentry.profile.id` attribute.
+/// * The V1 span's `profile_id` field is set based on the V2 span's `sentry.profile_id` attribute.
 /// * The V1 span's `segment_id` field is set based on the V2 span's `sentry.segment.id` attribute.
 ///
 /// All other attributes are carried over from the V2 span to the V1 span's `data`.
@@ -96,7 +96,7 @@ pub fn span_v2_to_span_v1(span_v2: SpanV2) -> SpanV1 {
             "sentry.segment.id" => {
                 segment_id = SpanId::from_value(value);
             }
-            "sentry.profile.id" => {
+            "sentry.profile_id" => {
                 profile_id = EventId::from_value(value);
             }
             _ => {
@@ -595,7 +595,7 @@ mod tests {
                     "value": "php",
                     "type": "string"
                 },
-                "sentry.profile.id": {
+                "sentry.profile_id": {
                     "value": "a0aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab",
                     "type": "string"
                 },


### PR DESCRIPTION
See https://github.com/getsentry/sentry-conventions/blob/d56e0428f4344388f8d4ba8b1356f156ece1e4cd/model/attributes/sentry/sentry__profile_id.json