### PR TITLE
feat(ai): Add gen_ai_cost_total_tokens field and double write total cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Produce transactions on `transactions` Kafka topic, even if they have attachments. ([#5081](https://github.com/getsentry/relay/pull/5081))
 - Removes metric stats from the codebase. ([#5097](https://github.com/getsentry/relay/pull/5097))
 - Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088), [#5115](https://github.com/getsentry/relay/pull/5115))
+- Add gen_ai_cost_total_tokens attribute and double write total tokens cost. ([#5121](https://github.com/getsentry/relay/pull/5121))
 
 ## 25.8.0
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2324,6 +2324,14 @@ mod tests {
                 .first()
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_total_tokens.value()),
+            Some(&Value::F64(50.0))
+        );
+        assert_eq!(
+            spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_cost_input_tokens.value()),
             Some(&Value::F64(10.0))
         );
@@ -2341,6 +2349,14 @@ mod tests {
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_usage_total_cost.value()),
+            Some(&Value::F64(80.0))
+        );
+        assert_eq!(
+            spans
+                .get(1)
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_total_tokens.value()),
             Some(&Value::F64(80.0))
         );
         assert_eq!(
@@ -2457,6 +2473,10 @@ mod tests {
             Some(&Value::F64(75.0))
         );
         assert_eq!(
+            first_span_data.and_then(|data| data.gen_ai_cost_total_tokens.value()),
+            Some(&Value::F64(75.0))
+        );
+        assert_eq!(
             first_span_data.and_then(|data| data.gen_ai_cost_input_tokens.value()),
             Some(&Value::F64(25.0))
         );
@@ -2475,6 +2495,10 @@ mod tests {
             .and_then(|span| span.data.value());
         assert_eq!(
             second_span_data.and_then(|data| data.gen_ai_usage_total_cost.value()),
+            Some(&Value::F64(190.0))
+        );
+        assert_eq!(
+            second_span_data.and_then(|data| data.gen_ai_cost_total_tokens.value()),
             Some(&Value::F64(190.0))
         );
         assert_eq!(
@@ -2501,6 +2525,10 @@ mod tests {
             .and_then(|span| span.data.value());
         assert_eq!(
             third_span_data.and_then(|data| data.gen_ai_usage_total_cost.value()),
+            Some(&Value::F64(190.0))
+        );
+        assert_eq!(
+            third_span_data.and_then(|data| data.gen_ai_cost_total_tokens.value()),
             Some(&Value::F64(190.0))
         );
         assert_eq!(
@@ -2565,6 +2593,14 @@ mod tests {
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_usage_total_cost.value()),
+            None
+        );
+        assert_eq!(
+            spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_total_tokens.value()),
             None
         );
         // total_tokens shouldn't be set if no tokens are present on span data
@@ -2664,6 +2700,14 @@ mod tests {
                 .first()
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_total_tokens.value()),
+            Some(&Value::F64(65.0))
+        );
+        assert_eq!(
+            spans
+                .first()
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_cost_input_tokens.value()),
             Some(&Value::F64(25.0))
         );
@@ -2681,6 +2725,14 @@ mod tests {
                 .and_then(|span| span.value())
                 .and_then(|span| span.data.value())
                 .and_then(|data| data.gen_ai_usage_total_cost.value()),
+            Some(&Value::F64(190.0))
+        );
+        assert_eq!(
+            spans
+                .get(1)
+                .and_then(|span| span.value())
+                .and_then(|span| span.data.value())
+                .and_then(|data| data.gen_ai_cost_total_tokens.value()),
             Some(&Value::F64(190.0))
         );
         assert_eq!(

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -57,7 +57,11 @@ fn extract_ai_model_cost_data(model_cost: Option<ModelCostV2>, data: &mut SpanDa
     }
 
     let result = input_cost + output_cost;
+    // double write during migration period
+    // 'gen_ai_usage_total_cost' is deprecated and will be removed in the future
     data.gen_ai_usage_total_cost
+        .set_value(Value::F64(result).into());
+    data.gen_ai_cost_total_tokens
         .set_value(Value::F64(result).into());
 
     // Set individual cost components

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -505,6 +505,10 @@ pub struct SpanData {
     #[metastructure(field = "gen_ai.usage.total_cost", legacy_alias = "ai.total_cost")]
     pub gen_ai_usage_total_cost: Annotated<Value>,
 
+    /// The total cost for the tokens used (duplicate field for migration)
+    #[metastructure(field = "gen_ai.cost.total_tokens")]
+    pub gen_ai_cost_total_tokens: Annotated<Value>,
+
     /// The cost for input tokens used
     #[metastructure(field = "gen_ai.cost.input_tokens")]
     pub gen_ai_cost_input_tokens: Annotated<Value>,
@@ -952,6 +956,7 @@ impl Getter for SpanData {
             "gen_ai\\.request\\.max_tokens" => self.gen_ai_request_max_tokens.value()?.into(),
             "gen_ai\\.usage\\.total_tokens" => self.gen_ai_usage_total_tokens.value()?.into(),
             "gen_ai\\.usage\\.total_cost" => self.gen_ai_usage_total_cost.value()?.into(),
+            "gen_ai\\.cost\\.total_tokens" => self.gen_ai_cost_total_tokens.value()?.into(),
             "gen_ai\\.cost\\.input_tokens" => self.gen_ai_cost_input_tokens.value()?.into(),
             "gen_ai\\.cost\\.output_tokens" => self.gen_ai_cost_output_tokens.value()?.into(),
             "http\\.decoded_response_content_length" => {
@@ -1413,6 +1418,7 @@ mod tests {
             gen_ai_response_model: ~,
             gen_ai_request_model: ~,
             gen_ai_usage_total_cost: ~,
+            gen_ai_cost_total_tokens: ~,
             gen_ai_cost_input_tokens: ~,
             gen_ai_cost_output_tokens: ~,
             gen_ai_prompt: ~,

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -165,6 +165,7 @@ mod tests {
                 gen_ai_response_model: ~,
                 gen_ai_request_model: ~,
                 gen_ai_usage_total_cost: ~,
+                gen_ai_cost_total_tokens: ~,
                 gen_ai_cost_input_tokens: ~,
                 gen_ai_cost_output_tokens: ~,
                 gen_ai_prompt: ~,


### PR DESCRIPTION
Introduce `gen_ai_cost_total_tokens` and double write total tokens cost to it and to `gen_ai_usage_total_cost` for the next 90 days (until the data expires).

After that the plan is to completely deprecate `gen_ai_usage_total_cost` field to have all the cost related fields under `gen_ai.cost.*`.

Part of [TET-1100: Update relay and conventions to reduce work scattering](https://linear.app/getsentry/issue/TET-1100/update-relay-and-conventions-to-reduce-work-scattering)
