### PR TITLE
build: Update `sentry-conventions`

### DIFF
--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -54,7 +54,6 @@ mod tests {
             aliases: [
                 "http.response.body.size",
                 "http.response.header.content-length",
-                "http.response.header['content-length']",
             ],
         }
         "###);


### PR DESCRIPTION
This updates the `sentry-conventions` submodule from https://github.com/getsentry/sentry-conventions/commit/a57b7e34a55d5f32d80aecfb35b37110f22c7250 to [8cc17b95c560aa3efa5537cb5e40a5734e34c6c8](https://github.com/getsentry/sentry-conventions/commit/8cc17b95c560aa3efa5537cb5e40a5734e34c6c8) to get access to https://github.com/getsentry/sentry-conventions/pull/127.

As of https://github.com/getsentry/sentry-conventions/commit/844fe6687bd64608ba8e5c4d19b8fe2a8707ea57, `deprecation.replacement` is no longer required, so we need to make the field optional.

Fixes INGEST-542.