### PR TITLE
feat(ai): Add ai_operation_type_map to global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088), [#5115](https://github.com/getsentry/relay/pull/5115))
 - Add gen_ai_cost_total_tokens attribute and double write total tokens cost. ([#5121](https://github.com/getsentry/relay/pull/5121))
 - Change mapping of incoming OTLP spans with `ERROR` status to Sentry's `internal_error` status. ([#5127](https://github.com/getsentry/relay/pull/5127))
+- Add `ai_operation_type_map` to global config ([#5125](https://github.com/getsentry/relay/pull/5125))
 
 ## 25.8.0
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -5,7 +5,9 @@ use std::io::BufReader;
 use std::path::Path;
 
 use relay_base_schema::metrics::MetricNamespace;
-use relay_event_normalization::{MeasurementsConfig, ModelCosts, SpanOpDefaults};
+use relay_event_normalization::{
+    AiOperationTypeMap, MeasurementsConfig, ModelCosts, SpanOpDefaults,
+};
 use relay_filter::GenericFiltersConfig;
 use relay_quotas::Quota;
 use serde::{Deserialize, Serialize, de};
@@ -49,6 +51,10 @@ pub struct GlobalConfig {
     /// Configuration for AI span measurements.
     #[serde(skip_serializing_if = "is_model_costs_empty")]
     pub ai_model_costs: ErrorBoundary<ModelCosts>,
+
+    /// Configuration to derive the `gen_ai.operation.type` field from other fields
+    #[serde(skip_serializing_if = "is_ai_operation_type_map_empty")]
+    pub ai_operation_type_map: ErrorBoundary<AiOperationTypeMap>,
 
     /// Configuration to derive the `span.op` from other span fields.
     #[serde(
@@ -332,6 +338,10 @@ fn is_ok_and_empty(value: &ErrorBoundary<MetricExtractionGroups>) -> bool {
 
 fn is_model_costs_empty(value: &ErrorBoundary<ModelCosts>) -> bool {
     matches!(value, ErrorBoundary::Ok(model_costs) if model_costs.is_empty())
+}
+
+fn is_ai_operation_type_map_empty(value: &ErrorBoundary<AiOperationTypeMap>) -> bool {
+    matches!(value, ErrorBoundary::Ok(ai_operation_type_map) if ai_operation_type_map.is_empty())
 }
 
 #[cfg(test)]

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -339,11 +339,11 @@ impl AiOperationTypeMap {
     }
 
     /// Gets the AI operation type for the given span operation, if defined.
-    pub fn get_operation_type(&self, span_op: &str) -> Option<&String> {
+    pub fn get_operation_type(&self, span_op: &str) -> Option<&str> {
         if !self.is_enabled() {
             return None;
         }
-        self.operation_types.get(span_op)
+        self.operation_types.get(span_op).map(String::as_str)
     }
 }
 #[cfg(test)]

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -298,7 +298,54 @@ pub struct ModelCostV2 {
     /// The cost per input cached token
     pub input_cached_per_token: f64,
 }
+/// A mapping of AI operation types from span.op to gen_ai.operation.type.
+///
+/// This struct uses a dictionary-based mapping structure with exact span operation keys
+/// and corresponding AI operation type values.
+///
+/// Example JSON:
+/// ```json
+/// {
+///   "version": 1,
+///   "operation_types": {
+///     "gen_ai.execute_tool": "tool",
+///     "gen_ai.handoff": "handoff",
+///     "gen_ai.invoke_agent": "agent",
+///   }
+/// }
+/// ```
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiOperationTypeMap {
+    /// The version of the operation type mapping struct
+    pub version: u16,
 
+    /// The mappings of span.op => gen_ai.operation.type as a dictionary
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub operation_types: HashMap<String, String>,
+}
+
+impl AiOperationTypeMap {
+    const SUPPORTED_VERSION: u16 = 1;
+
+    /// `true` if the operation type mapping is empty and the version is supported.
+    pub fn is_empty(&self) -> bool {
+        self.operation_types.is_empty() || !self.is_enabled()
+    }
+
+    /// `false` if operation type mapping should be skipped.
+    pub fn is_enabled(&self) -> bool {
+        self.version == Self::SUPPORTED_VERSION
+    }
+
+    /// Gets the AI operation type for the given span operation, if defined.
+    pub fn get_operation_type(&self, span_op: &str) -> Option<&String> {
+        if !self.is_enabled() {
+            return None;
+        }
+        self.operation_types.get(span_op)
+    }
+}
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};


### PR DESCRIPTION
### Description

In relay, we want to infer the `gen_ai.operation.type` attribute (it's a newly added attribute) from `gen_ai.operation.name`.

This will be used in UI to easier query and plot data based on operation type. Currently we have a [long list](https://github.com/getsentry/sentry/blob/fd9d6f63b991bd4170defb3da1e0f18e7283cfd6/static/app/views/insights/agents/utils/query.tsx#L3) of attributes that we query for one operation type, but as that list grows, it is becoming harder and harder to pass all the parameters as query param in a request to EAP.

### Implementation plan

PRs will be separated to make it easier to review. The mapping will be defined in sentry, and it will be propagated to relays as a part of global config to make it easier for us to change and extend the mappings.

(in relay):
- [x] add `ai_operation_type_map` to global config (this PR)
- [ ] implement inference of the operation type from name and add tests

(in sentry):
- [ ] during global config generation, generate `ai_operation_type_map` from defined list of attributes


Part of [TET-1092: Introduce `gen_ai.operation.type` attribute](https://linear.app/getsentry/issue/TET-1092/introduce-gen-aioperationtype-attribute)
