### PR TITLE
feat(ourlogs): Add feature flag for oltp logs endpoint

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -55,7 +55,7 @@ pub enum Feature {
     /// Serialized as `projects:relay-otel-endpoint`.
     #[serde(rename = "projects:relay-otel-endpoint")]
     OtelEndpoint,
-    /// Enable logs integestion via the `/logs/` OTel endpoint.
+    /// Enable logs ingestion via the `/logs/` OTel endpoint.
     ///
     /// Serialized as `organizations:relay-otel-logs-endpoint`.
     #[serde(rename = "organizations:relay-otel-logs-endpoint")]

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -57,8 +57,8 @@ pub enum Feature {
     OtelEndpoint,
     /// Enable logs integestion via the `/logs/` OTel endpoint.
     ///
-    /// Serialized as `projects:relay-otel-logs-endpoint`.
-    #[serde(rename = "projects:relay-otel-logs-endpoint")]
+    /// Serialized as `organizations:relay-otel-logs-endpoint`.
+    #[serde(rename = "organizations:relay-otel-logs-endpoint")]
     OtelLogsEndpoint,
     /// Enable playstation crash dump ingestion via the `/playstation/` endpoint.
     ///

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -55,6 +55,11 @@ pub enum Feature {
     /// Serialized as `projects:relay-otel-endpoint`.
     #[serde(rename = "projects:relay-otel-endpoint")]
     OtelEndpoint,
+    /// Enable logs integestion via the `/logs/` OTel endpoint.
+    ///
+    /// Serialized as `projects:relay-otel-logs-endpoint`.
+    #[serde(rename = "projects:relay-otel-logs-endpoint")]
+    OtelLogsEndpoint,
     /// Enable playstation crash dump ingestion via the `/playstation/` endpoint.
     ///
     /// Serialized as `organizations:relay-playstation-ingestion`.


### PR DESCRIPTION
#skip-changelog

ref https://github.com/getsentry/relay/issues/5111

This PR adds a feature flag to relay that will gate the logs otlp endpoint. `organizations:relay-otel-logs-endpoint`