### PR TITLE
fix(spanv2): Map `error` status to `internal_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Removes metric stats from the codebase. ([#5097](https://github.com/getsentry/relay/pull/5097))
 - Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088), [#5115](https://github.com/getsentry/relay/pull/5115))
 - Add gen_ai_cost_total_tokens attribute and double write total tokens cost. ([#5121](https://github.com/getsentry/relay/pull/5121))
+- Change mapping of incoming OTLP spans with `ERROR` status to Sentry's `internal_error` status. ([#5127](https://github.com/getsentry/relay/pull/5127))
 
 ## 25.8.0
 

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -781,4 +781,34 @@ mod tests {
         }
         "###);
     }
+
+    #[test]
+    fn parse_span_error_status() {
+        let json = r#"{
+          "traceId": "89143b0763095bd9c9955e8175d1fb23",
+          "spanId": "e342abb1214ca181",
+          "status": {
+            "code": 2,
+            "message": "2 is the error status code"
+          }
+        }"#;
+        let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
+        let event_span = otel_to_sentry_span(otel_span).unwrap();
+        let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        {
+          "timestamp": 0.0,
+          "start_timestamp": 0.0,
+          "exclusive_time": 0.0,
+          "op": "default",
+          "span_id": "e342abb1214ca181",
+          "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "status": "error",
+          "data": {
+            "sentry.status.message": "2 is the error status code"
+          },
+          "links": []
+        }
+        "###);
+    }
 }

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -803,7 +803,7 @@ mod tests {
           "op": "default",
           "span_id": "e342abb1214ca181",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "error",
+          "status": "internal_error",
           "data": {
             "sentry.status.message": "2 is the error status code"
           },

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -917,4 +917,35 @@ mod tests {
         }
         "###);
     }
+
+    #[test]
+    fn parse_span_error_status() {
+        let json = r#"{
+          "traceId": "89143b0763095bd9c9955e8175d1fb23",
+          "spanId": "e342abb1214ca181",
+          "status": {
+            "code": 2,
+            "message": "2 is the error status code"
+          }
+        }"#;
+        let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
+        let event_span = otel_to_sentry_span(otel_span).unwrap();
+        let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        {
+          "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "span_id": "e342abb1214ca181",
+          "status": "error",
+          "start_timestamp": 0.0,
+          "end_timestamp": 0.0,
+          "links": [],
+          "attributes": {
+            "sentry.status.message": {
+              "type": "string",
+              "value": "2 is the error status code"
+            }
+          }
+        }
+        "###);
+    }
 }


### PR DESCRIPTION
Currently, OTLP's `ERROR` status (`2`) and SpanV2's `error` status are mapped to the SpanV1 status `unknown`. Since an `error` status means you definitely had an error, the `unknown` status ("We do not know whether the transaction failed or succeeded") does not seem appropriate.

The closest candidate for a generic error in SpanV1's status enum is `internal_error`. Update the V2 to V1 mapping to use that instead.