### PR TITLE
feat(ourlogs): Add otel log to sentry log transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,6 +2961,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.1",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 
@@ -3981,6 +3982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "relay-otel"
+version = "25.8.0"
+dependencies = [
+ "insta",
+ "opentelemetry-proto",
+ "relay-event-schema",
+ "relay-protocol",
+ "serde_json",
+]
+
+[[package]]
 name = "relay-ourlogs"
 version = "25.8.0"
 dependencies = [
@@ -3988,8 +4000,10 @@ dependencies = [
  "hex",
  "insta",
  "once_cell",
+ "opentelemetry-proto",
  "relay-common",
  "relay-event-schema",
+ "relay-otel",
  "relay-protocol",
  "serde_json",
 ]
@@ -4290,6 +4304,7 @@ dependencies = [
  "once_cell",
  "opentelemetry-proto",
  "relay-event-schema",
+ "relay-otel",
  "relay-protocol",
  "serde_json",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ relay-kafka = { path = "relay-kafka" }
 relay-log = { path = "relay-log" }
 relay-metrics = { path = "relay-metrics" }
 relay-monitors = { path = "relay-monitors" }
+relay-otel = { path = "relay-otel" }
 relay-ourlogs = { path = "relay-ourlogs" }
 relay-pattern = { path = "relay-pattern" }
 relay-pii = { path = "relay-pii" }

--- a/relay-otel/Cargo.toml
+++ b/relay-otel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "relay-spans"
+name = "relay-otel"
 authors = ["Sentry <oss@sentry.io>"]
-description = "Event normalization and processing"
+description = "OpenTelemetry to Sentry transformation utilities"
 homepage = "https://getsentry.github.io/relay/"
 repository = "https://github.com/getsentry/relay"
 version = "25.8.0"
@@ -13,19 +13,15 @@ publish = false
 workspace = true
 
 [dependencies]
-chrono = { workspace = true }
-hex = { workspace = true }
-once_cell = { workspace = true }
 opentelemetry-proto = { workspace = true, features = [
     "gen-tonic",
     "with-serde",
     "trace",
+    "logs",
 ] }
 relay-event-schema = { workspace = true }
-relay-otel = { workspace = true }
 relay-protocol = { workspace = true }
 serde_json = { workspace = true }
-url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -16,8 +16,7 @@ use relay_protocol::Value;
 /// Converts an OpenTelemetry AnyValue to a Sentry attribute.
 ///
 /// This function handles the conversion of OpenTelemetry attribute values to Sentry attribute types.
-/// Complex types like arrays and key-value lists are serialized to strings for safety and
-/// compatibility.
+/// Complex types like arrays and key-value lists are serialized to strings.
 ///
 /// For array and key-value list values, this function filters out nested complex types
 /// (nested arrays and key-value lists) before serialization to prevent issues with

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -1,0 +1,240 @@
+//! OpenTelemetry to Sentry transformation utilities.
+//!
+//! This crate provides common functionality for converting OpenTelemetry data structures
+//! to Sentry format. It serves as a shared library for both span and log transformations.
+
+#![warn(missing_docs)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png",
+    html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
+)]
+
+use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
+use relay_event_schema::protocol::{Attribute, AttributeType};
+use relay_protocol::Value;
+
+/// Converts an OpenTelemetry AnyValue to a Sentry attribute.
+///
+/// This function handles the conversion of OpenTelemetry attribute values to Sentry attribute types.
+/// Complex types like arrays and key-value lists are serialized to JSON strings for safety and
+/// compatibility.
+///
+/// For array and key-value list values, this function filters out nested complex types
+/// (nested arrays and key-value lists) before serialization to prevent issues with
+/// the OTLP protocol and ensure safe handling.
+pub fn otel_value_to_attribute(otel_value: OtelValue) -> Option<Attribute> {
+    let (ty, value) = match otel_value {
+        OtelValue::StringValue(s) => (AttributeType::String, Value::String(s)),
+        OtelValue::BoolValue(b) => (AttributeType::Boolean, Value::Bool(b)),
+        OtelValue::IntValue(i) => (AttributeType::Integer, Value::I64(i)),
+        OtelValue::DoubleValue(d) => (AttributeType::Double, Value::F64(d)),
+        OtelValue::BytesValue(bytes) => {
+            let s = String::from_utf8(bytes).ok()?;
+            (AttributeType::String, Value::String(s))
+        }
+        OtelValue::ArrayValue(array) => {
+            // Filter out nested arrays and key-value lists for safety.
+            // This is not usually allowed by the OTLP protocol, but we filter
+            // these values out before serializing for robustness.
+            let safe_values: Vec<serde_json::Value> = array
+                .values
+                .into_iter()
+                .filter_map(|v| match v.value? {
+                    OtelValue::StringValue(s) => Some(serde_json::Value::String(s)),
+                    OtelValue::BoolValue(b) => Some(serde_json::Value::Bool(b)),
+                    OtelValue::IntValue(i) => {
+                        Some(serde_json::Value::Number(serde_json::Number::from(i)))
+                    }
+                    OtelValue::DoubleValue(d) => {
+                        serde_json::Number::from_f64(d).map(serde_json::Value::Number)
+                    }
+                    OtelValue::BytesValue(bytes) => {
+                        String::from_utf8(bytes).ok().map(serde_json::Value::String)
+                    }
+                    // Skip nested complex types for safety
+                    OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => None,
+                })
+                .collect();
+
+            // Serialize the array values as a JSON string. Even though there is some nominal
+            // support for array values in Sentry, it's not robust and not ready to be used.
+            // Instead, serialize arrays to a JSON string, and have the UI decode the JSON if
+            // possible.
+            let json = serde_json::to_string(&safe_values).unwrap_or_default();
+            (AttributeType::String, Value::String(json))
+        }
+        OtelValue::KvlistValue(kvlist) => {
+            // Convert key-value list to JSON object and serialize as string.
+            // Key-value pairs are supported by the type definition, but handling
+            // varies between spans and logs, so we serialize to JSON for consistency.
+            let mut json_obj = serde_json::Map::new();
+            for kv in kvlist.values {
+                if let Some(val) = kv.value.and_then(|v| match v.value? {
+                    OtelValue::StringValue(s) => Some(serde_json::Value::String(s)),
+                    OtelValue::BoolValue(b) => Some(serde_json::Value::Bool(b)),
+                    OtelValue::IntValue(i) => {
+                        Some(serde_json::Value::Number(serde_json::Number::from(i)))
+                    }
+                    OtelValue::DoubleValue(d) => {
+                        serde_json::Number::from_f64(d).map(serde_json::Value::Number)
+                    }
+                    OtelValue::BytesValue(bytes) => {
+                        String::from_utf8(bytes).ok().map(serde_json::Value::String)
+                    }
+                    // Skip nested complex types for safety
+                    OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => None,
+                }) {
+                    json_obj.insert(kv.key, val);
+                }
+            }
+            let json = serde_json::to_string(&json_obj).unwrap_or_default();
+            (AttributeType::String, Value::String(json))
+        }
+    };
+
+    Some(Attribute::new(ty, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::common::v1::{
+        AnyValue, ArrayValue, KeyValue, KeyValueList, any_value,
+    };
+
+    #[test]
+    fn test_string_value() {
+        let otel_value = OtelValue::StringValue("test".to_owned());
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::String);
+        if let Value::String(s) = attr.value.value.value().unwrap() {
+            assert_eq!(s, "test");
+        } else {
+            panic!("Expected string value");
+        }
+    }
+
+    #[test]
+    fn test_bool_value() {
+        let otel_value = OtelValue::BoolValue(true);
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::Boolean);
+        if let Value::Bool(b) = attr.value.value.value().unwrap() {
+            assert!(b);
+        } else {
+            panic!("Expected boolean value");
+        }
+    }
+
+    #[test]
+    fn test_int_value() {
+        let otel_value = OtelValue::IntValue(42);
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::Integer);
+        if let Value::I64(i) = attr.value.value.value().unwrap() {
+            assert_eq!(*i, 42);
+        } else {
+            panic!("Expected integer value");
+        }
+    }
+
+    #[test]
+    fn test_double_value() {
+        let otel_value = OtelValue::DoubleValue(3.5);
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::Double);
+        if let Value::F64(f) = attr.value.value.value().unwrap() {
+            assert_eq!(*f, 3.5);
+        } else {
+            panic!("Expected double value");
+        }
+    }
+
+    #[test]
+    fn test_bytes_value() {
+        let otel_value = OtelValue::BytesValue(b"hello".to_vec());
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::String);
+        if let Value::String(s) = attr.value.value.value().unwrap() {
+            assert_eq!(s, "hello");
+        } else {
+            panic!("Expected string value");
+        }
+    }
+
+    #[test]
+    fn test_array_value() {
+        let array = ArrayValue {
+            values: vec![
+                AnyValue {
+                    value: Some(any_value::Value::StringValue("item1".to_owned())),
+                },
+                AnyValue {
+                    value: Some(any_value::Value::IntValue(42)),
+                },
+            ],
+        };
+        let otel_value = OtelValue::ArrayValue(array);
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::String);
+        if let Value::String(s) = attr.value.value.value().unwrap() {
+            // Should be JSON array string
+            assert!(s.contains("item1"));
+            assert!(s.contains("42"));
+        } else {
+            panic!("Expected string value for array");
+        }
+    }
+
+    #[test]
+    fn test_kvlist_value() {
+        let kvlist = KeyValueList {
+            values: vec![KeyValue {
+                key: "key1".to_owned(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue("value1".to_owned())),
+                }),
+            }],
+        };
+        let otel_value = OtelValue::KvlistValue(kvlist);
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::String);
+        if let Value::String(s) = attr.value.value.value().unwrap() {
+            // Should be JSON object string
+            assert!(s.contains("key1"));
+            assert!(s.contains("value1"));
+        } else {
+            panic!("Expected string value for kvlist");
+        }
+    }
+
+    #[test]
+    fn test_span_kvlist_value_works() {
+        let kvlist = KeyValueList {
+            values: vec![KeyValue {
+                key: "key1".to_owned(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue("value1".to_owned())),
+                }),
+            }],
+        };
+        let otel_value = OtelValue::KvlistValue(kvlist);
+        let attr = otel_value_to_attribute(otel_value).unwrap();
+
+        // Should work and return JSON string
+        assert_eq!(attr.value.ty.value().unwrap(), &AttributeType::String);
+        if let Value::String(s) = attr.value.value.value().unwrap() {
+            assert!(s.contains("key1"));
+            assert!(s.contains("value1"));
+        } else {
+            panic!("Expected string value for kvlist");
+        }
+    }
+}

--- a/relay-ourlogs/Cargo.toml
+++ b/relay-ourlogs/Cargo.toml
@@ -16,7 +16,13 @@ workspace = true
 chrono = { workspace = true }
 hex = { workspace = true }
 once_cell = { workspace = true }
+opentelemetry-proto = { workspace = true, features = [
+    "gen-tonic",
+    "with-serde",
+    "logs",
+] }
 relay-event-schema = { workspace = true }
+relay-otel = { workspace = true }
 relay-protocol = { workspace = true }
 relay-common = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-ourlogs/src/lib.rs
+++ b/relay-ourlogs/src/lib.rs
@@ -6,6 +6,8 @@
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
 
+mod otel_to_sentry;
 mod size;
 
+pub use self::otel_to_sentry::otel_to_sentry_log;
 pub use self::size::calculate_size;

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -1,0 +1,340 @@
+//! Transforms OpenTelemetry logs to Sentry logs.
+//!
+//! This module provides functionality to convert OpenTelemetry log records
+//! into Sentry's internal log format (`OurLog`).
+
+use chrono::{TimeZone, Utc};
+use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
+use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLogRecord;
+
+use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
+use relay_otel::otel_value_to_attribute;
+use relay_protocol::{Annotated, Error, Object};
+
+fn otel_value_to_string(value: Option<opentelemetry_proto::tonic::common::v1::AnyValue>) -> String {
+    value
+        .and_then(|v| v.value)
+        .and_then(|v| match v {
+            OtelValue::StringValue(s) => Some(s),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Maps OpenTelemetry severity number to Sentry log level.
+///
+/// This function maps OpenTelemetry severity numbers according to the OpenTelemetry specification:
+/// - 1-4: Trace
+/// - 5-8: Debug
+/// - 9-12: Info
+/// - 13-16: Warn
+/// - 17-20: Error
+/// - 21-24: Fatal
+///
+/// If the severity number is out of range, it falls back to parsing the severity text.
+fn map_severity_to_level(severity_number: i32, severity_text: &str) -> OurLogLevel {
+    match severity_number {
+        1..=4 => OurLogLevel::Trace,
+        5..=8 => OurLogLevel::Debug,
+        9..=12 => OurLogLevel::Info,
+        13..=16 => OurLogLevel::Warn,
+        17..=20 => OurLogLevel::Error,
+        21..=24 => OurLogLevel::Fatal,
+        _ => match severity_text.to_lowercase().as_str() {
+            "trace" => OurLogLevel::Trace,
+            "debug" => OurLogLevel::Debug,
+            "info" | "information" => OurLogLevel::Info,
+            "warn" | "warning" => OurLogLevel::Warn,
+            "error" => OurLogLevel::Error,
+            "fatal" => OurLogLevel::Fatal,
+            _ => OurLogLevel::Info, // Default fallback
+        },
+    }
+}
+
+/// Transforms an OpenTelemetry log record to a Sentry log.
+pub fn otel_to_sentry_log(otel_log: OtelLogRecord) -> Result<OurLog, Error> {
+    let OtelLogRecord {
+        time_unix_nano,
+        severity_number,
+        severity_text,
+        body,
+        attributes,
+        trace_id,
+        span_id,
+        ..
+    } = otel_log;
+
+    let span_id = SpanId::try_from(span_id.as_slice())?;
+    let trace_id = TraceId::try_from(trace_id.as_slice())?;
+    let timestamp = Utc.timestamp_nanos(time_unix_nano as i64);
+    let level = map_severity_to_level(severity_number, &severity_text);
+    let body = otel_value_to_string(body);
+
+    let mut attribute_data = Attributes::default();
+    for attribute in attributes {
+        if let Some(value) = attribute.value.and_then(|v| v.value)
+            && let Some(attr) = otel_value_to_attribute(value)
+        {
+            attribute_data.insert_raw(attribute.key, Annotated::new(attr));
+        }
+    }
+
+    let ourlog = OurLog {
+        timestamp: Annotated::new(Timestamp(timestamp)),
+        trace_id: Annotated::new(trace_id),
+        span_id: Annotated::new(span_id),
+        level: Annotated::new(level),
+        body: Annotated::new(body),
+        attributes: Annotated::new(attribute_data),
+        other: Object::default(),
+    };
+
+    Ok(ourlog)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relay_protocol::{SerializableAnnotated, get_path};
+
+    #[test]
+    fn parse_otel_log() {
+        // https://github.com/open-telemetry/opentelemetry-proto/blob/c4214b8168d0ce2a5236185efb8a1c8950cccdd6/examples/logs.json
+        let json = r#"{
+            "timeUnixNano": "1544712660300000000",
+            "observedTimeUnixNano": "1544712660300000000",
+            "severityNumber": 10,
+            "severityText": "Information",
+            "traceId": "5B8EFFF798038103D269B633813FC60C",
+            "spanId": "EEE19B7EC3C1B174",
+            "body": {
+                "stringValue": "Example log record"
+            },
+            "attributes": [
+                {
+                    "key": "string.attribute",
+                    "value": {
+                        "stringValue": "some string"
+                    }
+                },
+                {
+                    "key": "boolean.attribute",
+                    "value": {
+                        "boolValue": true
+                    }
+                },
+                {
+                    "key": "int.attribute",
+                    "value": {
+                        "intValue": "10"
+                    }
+                },
+                {
+                    "key": "double.attribute",
+                    "value": {
+                        "doubleValue": 637.704
+                    }
+                },
+                {
+                    "key": "array.attribute",
+                    "value": {
+                        "arrayValue": {
+                            "values": [
+                                {
+                                    "stringValue": "many"
+                                },
+                                {
+                                    "stringValue": "values"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "key": "map.attribute",
+                    "value": {
+                        "kvlistValue": {
+                            "values": [
+                                {
+                                    "key": "some.map.key",
+                                    "value": {
+                                        "stringValue": "some value"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }"#;
+
+        let otel_log: OtelLogRecord = serde_json::from_str(json).unwrap();
+        let our_log: OurLog = otel_to_sentry_log(otel_log).unwrap();
+        let annotated_log: Annotated<OurLog> = Annotated::new(our_log);
+
+        assert_eq!(
+            get_path!(annotated_log.body),
+            Some(&Annotated::new("Example log record".into()))
+        );
+
+        // Snapshot test for comprehensive validation
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_log), @r###"
+        {
+          "timestamp": 1544712660.3,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "span_id": "eee19b7ec3c1b174",
+          "level": "info",
+          "body": "Example log record",
+          "attributes": {
+            "array.attribute": {
+              "type": "string",
+              "value": "[\"many\",\"values\"]"
+            },
+            "boolean.attribute": {
+              "type": "boolean",
+              "value": true
+            },
+            "double.attribute": {
+              "type": "double",
+              "value": 637.704
+            },
+            "int.attribute": {
+              "type": "integer",
+              "value": 10
+            },
+            "map.attribute": {
+              "type": "string",
+              "value": "{\"some.map.key\":\"some value\"}"
+            },
+            "string.attribute": {
+              "type": "string",
+              "value": "some string"
+            }
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn parse_otel_log_with_db_attributes() {
+        let json = r#"{
+            "timeUnixNano": "1544712660300000000",
+            "observedTimeUnixNano": "1544712660300000000",
+            "severityNumber": 10,
+            "severityText": "Information",
+            "traceId": "5B8EFFF798038103D269B633813FC60C",
+            "spanId": "EEE19B7EC3C1B174",
+            "body": {
+                "stringValue": "Database query executed"
+            },
+            "attributes": [
+                {
+                    "key": "db.name",
+                    "value": {
+                        "stringValue": "database"
+                    }
+                },
+                {
+                    "key": "db.type",
+                    "value": {
+                        "stringValue": "sql"
+                    }
+                },
+                {
+                    "key": "db.statement",
+                    "value": {
+                        "stringValue": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s"
+                    }
+                }
+            ]
+        }"#;
+
+        let otel_log: OtelLogRecord = serde_json::from_str(json).unwrap();
+        let our_log = otel_to_sentry_log(otel_log).unwrap();
+        let annotated_log: Annotated<OurLog> = Annotated::new(our_log);
+
+        assert_eq!(
+            get_path!(annotated_log.body),
+            Some(&Annotated::new("Database query executed".into()))
+        );
+        assert_eq!(
+            annotated_log
+                .value()
+                .unwrap()
+                .attributes
+                .value()
+                .unwrap()
+                .get_value("db.statement")
+                .unwrap()
+                .as_str(),
+            Some("SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s")
+        );
+
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_log), @r#"
+        {
+          "timestamp": 1544712660.3,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "span_id": "eee19b7ec3c1b174",
+          "level": "info",
+          "body": "Database query executed",
+          "attributes": {
+            "db.name": {
+              "type": "string",
+              "value": "database"
+            },
+            "db.statement": {
+              "type": "string",
+              "value": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s"
+            },
+            "db.type": {
+              "type": "string",
+              "value": "sql"
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn parse_otel_log_severity_mapping() {
+        let test_cases = vec![
+            (1, "trace", OurLogLevel::Trace),
+            (5, "debug", OurLogLevel::Debug),
+            (9, "info", OurLogLevel::Info),
+            (13, "warn", OurLogLevel::Warn),
+            (17, "error", OurLogLevel::Error),
+            (21, "fatal", OurLogLevel::Fatal),
+            (0, "warning", OurLogLevel::Warn), // fallback to text
+            (0, "unknown", OurLogLevel::Info), // default fallback
+        ];
+
+        for (severity_number, severity_text, expected_level) in test_cases {
+            let json = format!(
+                r#"{{
+                "timeUnixNano": "1544712660300000000",
+                "severityNumber": {},
+                "severityText": "{}",
+                "traceId": "5B8EFFF798038103D269B633813FC60C",
+                "spanId": "EEE19B7EC3C1B174",
+                "body": {{
+                    "stringValue": "Test log"
+                }}
+            }}"#,
+                severity_number, severity_text
+            );
+
+            let otel_log: OtelLogRecord = serde_json::from_str(&json).unwrap();
+            let our_log = otel_to_sentry_log(otel_log).unwrap();
+
+            assert_eq!(
+                our_log.level.value().unwrap(),
+                &expected_level,
+                "Severity {} with text '{}' should map to {:?}",
+                severity_number,
+                severity_text,
+                expected_level
+            );
+        }
+    }
+}

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -1,8 +1,8 @@
 use chrono::{TimeZone, Utc};
-use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use opentelemetry_proto::tonic::trace::v1::span::Link as OtelLink;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind as OtelSpanKind;
-use relay_event_schema::protocol::{Attribute, AttributeType, Attributes, SpanV2Kind};
+use relay_event_schema::protocol::{Attributes, SpanV2Kind};
+use relay_otel::otel_value_to_attribute;
 use relay_protocol::ErrorKind;
 
 use crate::otel_trace::{
@@ -74,7 +74,7 @@ pub fn otel_to_sentry_span(otel_span: OtelSpan) -> Result<SentrySpanV2, Error> {
             _ => (),
         }
 
-        if let Some(v) = otel_value_to_attr(value) {
+        if let Some(v) = otel_value_to_attribute(value) {
             sentry_attributes.insert_raw(key, Annotated::new(v));
         }
     }
@@ -136,56 +136,7 @@ fn otel_to_sentry_status(status_code: i32) -> SpanV2Status {
     }
 }
 
-fn otel_value_to_attr(otel_value: OtelValue) -> Option<Attribute> {
-    let (ty, value) = match otel_value {
-        OtelValue::StringValue(s) => (AttributeType::String, Value::String(s)),
-        OtelValue::BoolValue(b) => (AttributeType::Boolean, Value::Bool(b)),
-        OtelValue::IntValue(i) => (AttributeType::Integer, Value::I64(i)),
-        OtelValue::DoubleValue(d) => (AttributeType::Double, Value::F64(d)),
-        OtelValue::BytesValue(bytes) => {
-            let s = String::from_utf8(bytes).ok()?;
-            (AttributeType::String, Value::String(s))
-        }
-        OtelValue::ArrayValue(array) => {
-            // Technically, `ArrayValue` can contain other arrays, or nested key-value lists. This
-            // is not usually allowed by the OTLP protocol, but for safety we filter those values
-            // out before serializing.
-            let safe_values: Vec<serde_json::Value> = array
-                .values
-                .into_iter()
-                .filter_map(|v| match v.value? {
-                    OtelValue::StringValue(s) => Some(serde_json::Value::String(s)),
-                    OtelValue::BoolValue(b) => Some(serde_json::Value::Bool(b)),
-                    OtelValue::IntValue(i) => {
-                        Some(serde_json::Value::Number(serde_json::Number::from(i)))
-                    }
-                    OtelValue::DoubleValue(d) => {
-                        serde_json::Number::from_f64(d).map(serde_json::Value::Number)
-                    }
-                    OtelValue::BytesValue(bytes) => {
-                        String::from_utf8(bytes).ok().map(serde_json::Value::String)
-                    }
-                    OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => None,
-                })
-                .collect();
-
-            // Serialize the arrays values as a JSON string. Even though there is some nominal
-            // support for array values in Sentry, it's not robust and not ready to be used.
-            // Instead, serialize arrays to a JSON string, and have the UI decode the JSON if
-            // possible.
-            let json = serde_json::to_string(&safe_values).unwrap_or_default();
-            (AttributeType::String, Value::String(json))
-        }
-        OtelValue::KvlistValue(_) => {
-            // Key-value pairs are supported by the type definition, but the OTLP protocol does
-            // _not_ allow setting this kind of value on a span, so we don't need to handle this
-            // case
-            return None;
-        }
-    };
-
-    Some(Attribute::new(ty, value))
-}
+// This function has been moved to relay-otel crate as otel_value_to_attribute
 
 fn otel_to_sentry_link(otel_link: OtelLink) -> Result<SpanV2Link, Error> {
     // See the W3C trace context specification:
@@ -194,7 +145,7 @@ fn otel_to_sentry_link(otel_link: OtelLink) -> Result<SpanV2Link, Error> {
 
     let attributes = Attributes::from_iter(otel_link.attributes.into_iter().filter_map(|kv| {
         let value = kv.value?.value?;
-        let attr_value = otel_value_to_attr(value)?;
+        let attr_value = otel_value_to_attribute(value)?;
         Some((kv.key, Annotated::new(attr_value)))
     }));
 


### PR DESCRIPTION
#skip-changelog

As per https://github.com/getsentry/relay/issues/5111, we'd like to add an OTLP logs endpoint to Relay. More details on the motivation can be found in this internal notion doc: https://www.notion.so/sentry/Logs-OTLP-Endpoint-2638b10e4b5d8050a147d0dd46df1915 (contains screenshots so can't put them in GH).

Before we implement the endpoint itself, this PR adds a `otel_to_sentry_log` to the `relay-ourlogs` crate. `otel_to_sentry_log` is a cleaned up version of the otel log to sentry log transform we had previously implemented and then removed in https://github.com/getsentry/relay/pull/5082.

To make the `otel_to_sentry_log`, I extracted out a `otel_value_to_attr` from the `relay-spans` crate into a `relay-otel` crate. Not sure if this is the correct level of abstraction, would appreciate feedback.

Skipping changelog as this does not expose any user facing changes, only new methods and refactors. Once I add the endpoint in a future PR, I will add a changelog there.