### PR TITLE
feat(ai): Infer gen_ai_operation_type from span.op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 - Add option gating Snuba publishing to ingest-replay-events for Replays. ([#5088](https://github.com/getsentry/relay/pull/5088), [#5115](https://github.com/getsentry/relay/pull/5115))
 - Add gen_ai_cost_total_tokens attribute and double write total tokens cost. ([#5121](https://github.com/getsentry/relay/pull/5121))
 - Change mapping of incoming OTLP spans with `ERROR` status to Sentry's `internal_error` status. ([#5127](https://github.com/getsentry/relay/pull/5127))
-- Add `ai_operation_type_map` to global config ([#5125](https://github.com/getsentry/relay/pull/5125))
+- Add `ai_operation_type_map` to global config. ([#5125](https://github.com/getsentry/relay/pull/5125))
+- Infer `gen_ai.operation.type` from `span.op`. ([#5129](https://github.com/getsentry/relay/pull/5129))
 
 ## 25.8.0
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -267,8 +267,9 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         max_tag_value_length: usize::MAX,
         span_description_rules: None,
         performance_score: None,
-        geoip_lookup: None,   // only supported in relay
-        ai_model_costs: None, // only supported in relay
+        geoip_lookup: None,          // only supported in relay
+        ai_model_costs: None,        // only supported in relay
+        ai_operation_type_map: None, // only supported in relay
         enable_trimming: config.enable_trimming.unwrap_or_default(),
         measurements: None,
         normalize_spans: config.normalize_spans,

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -344,10 +344,9 @@ impl AiOperationTypeMap {
             return None;
         }
 
-        // First try exact match by creating a Pattern from the span_op
-        let exact_key = Pattern::new(span_op).ok()?;
-        if self.operation_types.contains_key(&exact_key) {
-            return self.operation_types.get(&exact_key).map(String::as_str);
+        // try first direct match with span_op
+        if let Some(value) = self.operation_types.get(span_op) {
+            return Some(value.as_str());
         }
 
         // if there is not a direct match, try to find the match using a pattern

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -196,11 +196,11 @@ fn infer_ai_operation_type(span: &mut Span, operation_type_map: &AiOperationType
         return;
     };
 
-    if let Some(op) = span.op.value() {
-        if let Some(operation_type) = operation_type_map.get_operation_type(op) {
-            data.gen_ai_operation_type
-                .set_value(Some(operation_type.to_owned()));
-        }
+    if let Some(op) = span.op.value()
+        && let Some(operation_type) = operation_type_map.get_operation_type(op)
+    {
+        data.gen_ai_operation_type
+            .set_value(Some(operation_type.to_owned()));
     }
 }
 

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -192,9 +192,7 @@ pub fn enrich_ai_event_data(
 /// This function maps span.op values to gen_ai.operation.type based on the provided
 /// operation type map configuration.
 fn infer_ai_operation_type(span: &mut Span, operation_type_map: &AiOperationTypeMap) {
-    let Some(data) = span.data.value_mut() else {
-        return;
-    };
+    let data = span.data.get_or_insert_with(SpanData::default);
 
     if let Some(op) = span.op.value()
         && let Some(operation_type) = operation_type_map.get_operation_type(op)

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -196,9 +196,11 @@ fn infer_ai_operation_type(span: &mut Span, operation_type_map: &AiOperationType
         return;
     };
 
-    if let Some(operation_type) = operation_type_map.get_operation_type(span.op.value().unwrap()) {
-        data.gen_ai_operation_type
-            .set_value(Some(operation_type.to_owned()));
+    if let Some(op) = span.op.value() {
+        if let Some(operation_type) = operation_type_map.get_operation_type(op) {
+            data.gen_ai_operation_type
+                .set_value(Some(operation_type.to_owned()));
+        }
     }
 }
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -641,6 +641,10 @@ pub struct SpanData {
     #[metastructure(field = "gen_ai.operation.name", pii = "maybe")]
     pub gen_ai_operation_name: Annotated<String>,
 
+    /// The type of the operation being performed.
+    #[metastructure(field = "gen_ai.operation.type", pii = "maybe")]
+    pub gen_ai_operation_type: Annotated<String>,
+
     /// The client's browser name.
     #[metastructure(field = "browser.name")]
     pub browser_name: Annotated<String>,
@@ -1443,6 +1447,7 @@ mod tests {
             gen_ai_system: ~,
             gen_ai_tool_name: ~,
             gen_ai_operation_name: ~,
+            gen_ai_operation_type: ~,
             browser_name: ~,
             code_filepath: String(
                 "task.py",

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -189,6 +189,7 @@ mod tests {
                 gen_ai_system: ~,
                 gen_ai_tool_name: ~,
                 gen_ai_operation_name: ~,
+                gen_ai_operation_type: ~,
                 browser_name: "Chrome",
                 code_filepath: ~,
                 code_lineno: ~,

--- a/relay-pattern/src/lib.rs
+++ b/relay-pattern/src/lib.rs
@@ -37,6 +37,7 @@
 //!
 //! For untrusted user input it is highly recommended to limit the maximum complexity.
 
+use std::borrow::Borrow;
 use std::fmt;
 use std::num::NonZeroUsize;
 
@@ -142,6 +143,12 @@ impl PartialEq for Pattern {
 }
 
 impl Eq for Pattern {}
+
+impl Borrow<str> for Pattern {
+    fn borrow(&self) -> &str {
+        &self.pattern
+    }
+}
 
 impl std::hash::Hash for Pattern {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1519,6 +1519,7 @@ impl EnvelopeProcessorService {
 
         let global_config = self.inner.global_config.current();
         let ai_model_costs = global_config.ai_model_costs.clone().ok();
+        let ai_operation_type_map = global_config.ai_operation_type_map.clone().ok();
         let http_span_allowed_hosts = global_config.options.http_span_allowed_hosts.as_slice();
 
         let retention_days: i64 = project_info
@@ -1591,6 +1592,7 @@ impl EnvelopeProcessorService {
                 span_description_rules: project_info.config.span_description_rules.as_ref(),
                 geoip_lookup: Some(&self.inner.geoip_lookup),
                 ai_model_costs: ai_model_costs.as_ref(),
+                ai_operation_type_map: ai_operation_type_map.as_ref(),
                 enable_trimming: true,
                 measurements: Some(CombinedMeasurementsConfig::new(
                     project_info.config().measurements.as_ref(),

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1518,8 +1518,8 @@ impl EnvelopeProcessorService {
             .aggregator_config_for(MetricNamespace::Transactions);
 
         let global_config = self.inner.global_config.current();
-        let ai_model_costs = global_config.ai_model_costs.clone().ok();
-        let ai_operation_type_map = global_config.ai_operation_type_map.clone().ok();
+        let ai_model_costs = global_config.ai_model_costs.as_ref().ok();
+        let ai_operation_type_map = global_config.ai_operation_type_map.as_ref().ok();
         let http_span_allowed_hosts = global_config.options.http_span_allowed_hosts.as_slice();
 
         let retention_days: i64 = project_info
@@ -1591,8 +1591,8 @@ impl EnvelopeProcessorService {
                 emit_event_errors: full_normalization,
                 span_description_rules: project_info.config.span_description_rules.as_ref(),
                 geoip_lookup: Some(&self.inner.geoip_lookup),
-                ai_model_costs: ai_model_costs.as_ref(),
-                ai_operation_type_map: ai_operation_type_map.as_ref(),
+                ai_model_costs,
+                ai_operation_type_map,
                 enable_trimming: true,
                 measurements: Some(CombinedMeasurementsConfig::new(
                     project_info.config().measurements.as_ref(),

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -481,14 +481,8 @@ impl<'a> NormalizeSpanConfig<'a> {
                 project_config.measurements.as_ref(),
                 global_config.measurements.as_ref(),
             )),
-            ai_model_costs: match &global_config.ai_model_costs {
-                ErrorBoundary::Err(_) => None,
-                ErrorBoundary::Ok(costs) => Some(costs),
-            },
-            ai_operation_type_map: match &global_config.ai_operation_type_map {
-                ErrorBoundary::Err(_) => None,
-                ErrorBoundary::Ok(operation_type_map) => Some(operation_type_map),
-            },
+            ai_model_costs: global_config.ai_model_costs.as_ref().ok(),
+            ai_operation_type_map: global_config.ai_operation_type_map.as_ref().ok(),
             max_name_and_unit_len: aggregator_config
                 .max_name_length
                 .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -21,7 +21,8 @@ use relay_config::Config;
 use relay_dynamic_config::{
     CombinedMetricExtractionConfig, ErrorBoundary, Feature, GlobalConfig, ProjectConfig,
 };
-use relay_event_normalization::span::ai::{extract_ai_data, map_ai_measurements_to_data};
+use relay_event_normalization::AiOperationTypeMap;
+use relay_event_normalization::span::ai::enrich_ai_span_data;
 use relay_event_normalization::{
     BorrowedSpanOpDefaults, ClientHints, CombinedMeasurementsConfig, FromUserAgentInfo,
     GeoIpLookup, MeasurementsConfig, ModelCosts, PerformanceScoreConfig, RawUserAgentInfo,
@@ -435,6 +436,8 @@ struct NormalizeSpanConfig<'a> {
     measurements: Option<CombinedMeasurementsConfig<'a>>,
     /// Configuration for AI model cost calculation
     ai_model_costs: Option<&'a ModelCosts>,
+    /// Configuration to derive the `gen_ai.operation.type` field from other fields
+    ai_operation_type_map: Option<&'a AiOperationTypeMap>,
     /// The maximum length for names of custom measurements.
     ///
     /// Measurements with longer names are removed from the transaction event and replaced with a
@@ -481,6 +484,10 @@ impl<'a> NormalizeSpanConfig<'a> {
             ai_model_costs: match &global_config.ai_model_costs {
                 ErrorBoundary::Err(_) => None,
                 ErrorBoundary::Ok(costs) => Some(costs),
+            },
+            ai_operation_type_map: match &global_config.ai_operation_type_map {
+                ErrorBoundary::Err(_) => None,
+                ErrorBoundary::Ok(operation_type_map) => Some(operation_type_map),
             },
             max_name_and_unit_len: aggregator_config
                 .max_name_length
@@ -544,6 +551,7 @@ fn normalize(
         performance_score,
         measurements,
         ai_model_costs,
+        ai_operation_type_map,
         max_name_and_unit_len,
         tx_name_rules,
         user_agent,
@@ -651,10 +659,7 @@ fn normalize(
 
     normalize_performance_score(span, performance_score);
 
-    map_ai_measurements_to_data(span);
-    if let Some(model_costs_config) = ai_model_costs {
-        extract_ai_data(span, model_costs_config);
-    }
+    enrich_ai_span_data(span, ai_model_costs, ai_operation_type_map);
 
     tag_extraction::extract_measurements(span, is_mobile);
 
@@ -1253,6 +1258,7 @@ mod tests {
             performance_score: None,
             measurements: None,
             ai_model_costs: None,
+            ai_operation_type_map: None,
             max_name_and_unit_len: 200,
             tx_name_rules: &[],
             user_agent: None,


### PR DESCRIPTION
### Description

In relay, we want to infer the `gen_ai.operation.type` attribute (it's a newly added attribute) from `gen_ai.operation.name`.

This will be used in UI to easier query and plot data based on operation type. Currently we have a [long list](https://github.com/getsentry/sentry/blob/fd9d6f63b991bd4170defb3da1e0f18e7283cfd6/static/app/views/insights/agents/utils/query.tsx#L3) of attributes that we query for one operation type, but as that list grows, it is becoming harder and harder to pass all the parameters as query param in a request to EAP.

### Implementation plan

PRs will be separated to make it easier to review. The mapping will be defined in sentry, and it will be propagated to relays as a part of global config to make it easier for us to change and extend the mappings.

(in relay):
- [x] add `ai_operation_type_map` to global config (https://github.com/getsentry/relay/pull/5125)
- [x] **implement inference of the operation type from name and add tests (this PR)**

(in sentry):
- [ ] during global config generation, generate `ai_operation_type_map` from defined list of attributes


Part of [TET-1092: Introduce `gen_ai.operation.type` attribute](https://linear.app/getsentry/issue/TET-1092/introduce-gen-aioperationtype-attribute)
