### PR TITLE
fix(ci): gocd-artifacts job should depends on publish-to-gcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,7 +625,7 @@ jobs:
 
   gocd-artifacts:
     timeout-minutes: 10
-    needs: [build-setup, build-internal, publish-to-ar-internal]
+    needs: [build-setup, build-internal, publish-to-ar-internal, publish-to-gcr]
 
     name: Upload build artifacts to gocd
     runs-on: ubuntu-latest


### PR DESCRIPTION
The publish-to-ar-internal does nothing, it just build the image and that's it


#skip-changelog

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
