### PR TITLE
feat(schema): Add Unity Info Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - No longer writes Spans as trace items. ([#5152](https://github.com/getsentry/relay/pull/5152))
 
+**Features**:
+
+- Add Unity Context Info. ([#5155](https://github.com/getsentry/relay/pull/5155))
+
 ## 25.9.0
 
 **Breaking Changes**:

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -18,6 +18,7 @@ mod response;
 mod runtime;
 mod spring;
 mod trace;
+mod unity;
 mod user_report_v2;
 pub use app::*;
 pub use browser::*;
@@ -38,6 +39,7 @@ pub use response::*;
 pub use runtime::*;
 pub use spring::*;
 pub use trace::*;
+pub use unity::*;
 pub use user_report_v2::*;
 
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
@@ -102,6 +104,8 @@ pub enum Context {
     OTAUpdates(Box<OTAUpdatesContext>),
     /// Chromium Stability Report from minidump.
     ChromiumStabilityReport(Box<StabilityReportContext>),
+    /// Unity information.
+    Unity(Box<UnityContext>),
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(fallback_variant)]
     Other(#[metastructure(pii = "true")] Object<Value>),

--- a/relay-event-schema/src/protocol/contexts/unity.rs
+++ b/relay-event-schema/src/protocol/contexts/unity.rs
@@ -107,7 +107,7 @@ mod tests {
         let json = r#"{
   "type": "unity"
 }"#;
-        let context = Annotated::new(Context::Unity(Box::new(UnityContext::default())));
+        let context = Annotated::new(Context::Unity(Box::default()));
         assert_eq!(context, Annotated::from_json(json).unwrap());
         assert_eq!(json, context.to_json_pretty().unwrap());
     }

--- a/relay-event-schema/src/protocol/contexts/unity.rs
+++ b/relay-event-schema/src/protocol/contexts/unity.rs
@@ -62,6 +62,7 @@ impl super::DefaultContext for UnityContext {
 mod tests {
     use super::*;
     use crate::protocol::Context;
+    use crate::protocol::contexts::DefaultContext;
 
     #[test]
     fn test_unity_context_roundtrip() {

--- a/relay-event-schema/src/protocol/contexts/unity.rs
+++ b/relay-event-schema/src/protocol/contexts/unity.rs
@@ -75,7 +75,9 @@ mod tests {
   "type": "unity"
 }"#;
         let context = Annotated::new(Context::Unity(Box::new(UnityContext {
-            copy_texture_support: Annotated::new("Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture".to_owned()),
+            copy_texture_support: Annotated::new(
+                "Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture".to_owned(),
+            ),
             editor_version: Annotated::new("2022.1.23f1".to_owned()),
             install_mode: Annotated::new("Store".to_owned()),
             rendering_threading_mode: Annotated::new("LegacyJobified".to_owned()),

--- a/relay-event-schema/src/protocol/contexts/unity.rs
+++ b/relay-event-schema/src/protocol/contexts/unity.rs
@@ -1,7 +1,6 @@
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
 
 use crate::processor::ProcessValue;
-use crate::protocol::contexts::DefaultContext;
 
 /// Unity context.
 ///

--- a/relay-event-schema/src/protocol/contexts/unity.rs
+++ b/relay-event-schema/src/protocol/contexts/unity.rs
@@ -1,0 +1,111 @@
+use relay_protocol::{Annotated, Empty, FromValue, IntoValue, Object, Value};
+
+use crate::processor::ProcessValue;
+
+/// Unity context.
+///
+/// The Unity context contains attributes that are specific to Unity applications.
+#[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+pub struct UnityContext {
+    /// Graphics texture copying capabilities.
+    pub copy_texture_support: Annotated<String>,
+
+    /// Unity Editor version.
+    pub editor_version: Annotated<String>,
+
+    /// Distribution method.
+    pub install_mode: Annotated<String>,
+
+    /// Rendering pipeline configuration.
+    pub rendering_threading_mode: Annotated<String>,
+
+    /// Target FPS setting.
+    pub target_frame_rate: Annotated<String>,
+
+    /// Additional arbitrary fields for forwards compatibility.
+    #[metastructure(additional_properties, retain = true, pii = "maybe")]
+    pub other: Object<Value>,
+}
+
+impl super::DefaultContext for UnityContext {
+    fn default_key() -> &'static str {
+        "unity"
+    }
+
+    fn from_context(context: super::Context) -> Option<Self> {
+        match context {
+            super::Context::Unity(c) => Some(*c),
+            _ => None,
+        }
+    }
+
+    fn cast(context: &super::Context) -> Option<&Self> {
+        match context {
+            super::Context::Unity(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    fn cast_mut(context: &mut super::Context) -> Option<&mut Self> {
+        match context {
+            super::Context::Unity(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    fn into_context(self) -> super::Context {
+        super::Context::Unity(Box::new(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::Context;
+
+    #[test]
+    fn test_unity_context_roundtrip() {
+        let json = r#"{
+  "copy_texture_support": "Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture",
+  "editor_version": "2022.1.23f1",
+  "install_mode": "Store",
+  "rendering_threading_mode": "LegacyJobified",
+  "target_frame_rate": "-1",
+  "other": "value",
+  "type": "unity"
+}"#;
+        let context = Annotated::new(Context::Unity(Box::new(UnityContext {
+            copy_texture_support: Annotated::new("Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture".to_owned()),
+            editor_version: Annotated::new("2022.1.23f1".to_owned()),
+            install_mode: Annotated::new("Store".to_owned()),
+            rendering_threading_mode: Annotated::new("LegacyJobified".to_owned()),
+            target_frame_rate: Annotated::new("-1".to_owned()),
+            other: {
+                let mut map = Object::new();
+                map.insert(
+                    "other".to_owned(),
+                    Annotated::new(Value::String("value".to_owned())),
+                );
+                map
+            },
+        })));
+
+        assert_eq!(context, Annotated::from_json(json).unwrap());
+        assert_eq!(json, context.to_json_pretty().unwrap());
+    }
+
+    #[test]
+    fn test_unity_context_default_key() {
+        assert_eq!(UnityContext::default_key(), "unity");
+    }
+
+    #[test]
+    fn test_unity_context_minimal() {
+        let json = r#"{
+  "type": "unity"
+}"#;
+        let context = Annotated::new(Context::Unity(Box::new(UnityContext::default())));
+        assert_eq!(context, Annotated::from_json(json).unwrap());
+        assert_eq!(json, context.to_json_pretty().unwrap());
+    }
+}


### PR DESCRIPTION
Adds a new context to Unity Context related information as suggested in the [comment](https://github.com/getsentry/sentry-docs/pull/14931#issuecomment-3292175034).

