### PR TITLE
ref(server): Add Managed::retain convenience and add missing documentation

### DIFF
--- a/relay-server/src/lib.rs
+++ b/relay-server/src/lib.rs
@@ -258,7 +258,7 @@ mod endpoints;
 mod envelope;
 mod extractors;
 mod http;
-mod managed;
+pub mod managed;
 mod metrics;
 mod metrics_extraction;
 mod middlewares;

--- a/relay-server/src/managed/envelope.rs
+++ b/relay-server/src/managed/envelope.rs
@@ -63,7 +63,7 @@ struct EnvelopeContext {
     done: bool,
 }
 
-/// Error emitted when converting a [`ManagedEnvelope`] and [`ProcessingGroup`] into a [`TypedEnvelope`].
+/// Error emitted when converting a [`ManagedEnvelope`] and a processing group into a [`TypedEnvelope`].
 #[derive(Debug)]
 pub struct InvalidProcessingGroupType(pub ManagedEnvelope, pub ProcessingGroup);
 
@@ -484,7 +484,7 @@ impl ManagedEnvelope {
         self
     }
 
-    /// Returns the contained original [`RequestMeta`].
+    /// Returns the contained original request meta.
     pub fn meta(&self) -> &RequestMeta {
         self.envelope().meta()
     }

--- a/relay-server/src/managed/envelope.rs
+++ b/relay-server/src/managed/envelope.rs
@@ -1,5 +1,3 @@
-//! Envelope context type and helpers to ensure outcomes.
-
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::mem::size_of;
@@ -65,6 +63,7 @@ struct EnvelopeContext {
     done: bool,
 }
 
+/// Error emitted when converting a [`ManagedEnvelope`] and [`ProcessingGroup`] into a [`TypedEnvelope`].
 #[derive(Debug)]
 pub struct InvalidProcessingGroupType(pub ManagedEnvelope, pub ProcessingGroup);
 
@@ -183,6 +182,7 @@ impl ManagedEnvelope {
         }
     }
 
+    /// An untracked instance which does not emit outcomes, useful for testing.
     #[cfg(test)]
     pub fn untracked(envelope: Box<Envelope>, outcome_aggregator: Addr<TrackOutcome>) -> Self {
         let mut envelope = Self::new(envelope, outcome_aggregator);
@@ -473,15 +473,18 @@ impl ManagedEnvelope {
         self.context.scoping
     }
 
+    /// Returns the partition key, which is set on upstream requests in the `X-Sentry-Relay-Shard` header.
     pub fn partition_key(&self) -> Option<u32> {
         self.context.partition_key
     }
 
+    /// Sets a new [`Self::partition_key`].
     pub fn set_partition_key(&mut self, partition_key: Option<u32>) -> &mut Self {
         self.context.partition_key = partition_key;
         self
     }
 
+    /// Returns the contained original [`RequestMeta`].
     pub fn meta(&self) -> &RequestMeta {
         self.envelope().meta()
     }

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -25,10 +25,6 @@ mod debug;
 mod test;
 
 #[cfg(test)]
-#[expect(
-    unused,
-    reason = "currently unused, but these are testing utilities for all of Relay"
-)]
 pub use self::test::*;
 
 /// An error which can be extracted into an outcome.
@@ -105,6 +101,7 @@ impl<T> Rejected<T> {
     }
 }
 
+/// The [`Managed`] wrapper ensures outcomes are correctly emitted for the contained item.
 pub struct Managed<T: Counted> {
     value: T,
     meta: Arc<Meta>,
@@ -221,6 +218,110 @@ impl<T: Counted> Managed<T> {
             },
             context,
         )
+    }
+
+    /// Filters individual items and emits outcomes for them if they are removed.
+    ///
+    /// This is particularly useful when the managed instance is a container of individual items,
+    /// which need to be processed or filtered on a case by case basis.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use relay_server::managed::{Counted, Managed, Quantities};
+    /// # #[derive(Copy, Clone)]
+    /// # struct Context<'a>(&'a u32);
+    /// # struct Item;
+    /// struct Items {
+    ///     items: Vec<Item>,
+    /// }
+    /// # impl Counted for Items {
+    /// #   fn quantities(&self) -> Quantities {
+    /// #       todo!()
+    /// #   }
+    /// # }
+    /// # impl Counted for Item {
+    /// #   fn quantities(&self) -> Quantities {
+    /// #       todo!()
+    /// #   }
+    /// # }
+    /// # type Error = std::convert::Infallible;
+    ///
+    /// fn process_items(items: &mut Managed<Items>, ctx: Context<'_>) {
+    ///     items.retain(|items| &mut items.items, |item| process(item, ctx));
+    /// }
+    ///
+    /// fn process(item: &mut Item, ctx: Context<'_>) -> Result<(), Error> {
+    ///     todo!()
+    /// }
+    /// ```
+    pub fn retain<S, I, U, E>(&mut self, select: S, mut retain: U)
+    where
+        S: FnOnce(&mut T) -> &mut Vec<I>,
+        I: Counted,
+        U: FnMut(&mut I) -> Result<(), E>,
+        E: OutcomeError,
+    {
+        self.retain_with_context(|inner| (select(inner), &()), |item, _| retain(item));
+    }
+
+    /// Filters individual items and emits outcomes for them if they are removed.
+    ///
+    /// Like [`Self::retain`], but it allows for an additional context extracted from the managed
+    /// object passed to the retain function.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use relay_server::managed::{Counted, Managed, Quantities};
+    /// # #[derive(Copy, Clone)]
+    /// # struct Context<'a>(&'a u32);
+    /// # struct Item;
+    /// struct Items {
+    ///     ty: String,
+    ///     items: Vec<Item>,
+    /// }
+    /// # impl Counted for Items {
+    /// #   fn quantities(&self) -> Quantities {
+    /// #       todo!()
+    /// #   }
+    /// # }
+    /// # impl Counted for Item {
+    /// #   fn quantities(&self) -> Quantities {
+    /// #       todo!()
+    /// #   }
+    /// # }
+    /// # type Error = std::convert::Infallible;
+    ///
+    /// fn process_items(items: &mut Managed<Items>, ctx: Context<'_>) {
+    ///     items.retain_with_context(|items| (&mut items.items, &items.ty), |item, ty| process(item, ty, ctx));
+    /// }
+    ///
+    /// fn process(item: &mut Item, ty: &str, ctx: Context<'_>) -> Result<(), Error> {
+    ///     todo!()
+    /// }
+    /// ```
+    pub fn retain_with_context<S, C, I, U, E>(&mut self, select: S, mut retain: U)
+    where
+        // Returning `&'a C` here is not optimal, ideally we return C here and express the correct
+        // bound of `C: 'a` but this is, to my knowledge, currently not possible to express in stable Rust.
+        //
+        // This is unfortunately a bit limiting but for most of our purposes it is enough.
+        for<'a> S: FnOnce(&'a mut T) -> (&'a mut Vec<I>, &'a C),
+        I: Counted,
+        U: FnMut(&mut I, &C) -> Result<(), E>,
+        E: OutcomeError,
+    {
+        self.modify(|inner, records| {
+            let (items, ctx) = select(inner);
+            items.retain_mut(|item| match retain(item, ctx) {
+                Ok(()) => true,
+                Err(err) => {
+                    records.reject_err(err, &*item);
+                    false
+                }
+            })
+        });
     }
 
     /// Maps a [`Managed<T>`] to [`Managed<S>`] by applying the mapping function `f`.

--- a/relay-server/src/managed/managed/test.rs
+++ b/relay-server/src/managed/managed/test.rs
@@ -51,6 +51,7 @@ impl<T> ManagedTestBuilder<T> {
         }
     }
 
+    /// Creates a new [`Managed`] instance and a [`ManagedTestHandle`] to assert outcomes.
     pub fn build(self) -> (Managed<T>, ManagedTestHandle)
     where
         T: Counted,
@@ -77,6 +78,7 @@ impl<T> ManagedTestBuilder<T> {
     }
 }
 
+/// A testing helper which can make sure the right outcomes have been emitted by the [`Managed`] instance.
 pub struct ManagedTestHandle {
     outcomes: UnboundedReceiver<TrackOutcome>,
     received_at: DateTime<Utc>,

--- a/relay-server/src/managed/mod.rs
+++ b/relay-server/src/managed/mod.rs
@@ -1,3 +1,5 @@
+//! Managed containers and utilities to ensure outcomes are correctly emitted.
+
 mod counted;
 mod envelope;
 #[expect(

--- a/relay-server/src/processing/logs/filter.rs
+++ b/relay-server/src/processing/logs/filter.rs
@@ -17,13 +17,10 @@ pub fn feature_flag(ctx: Context<'_>) -> Result<()> {
 
 /// Applies inbound filters to individual logs.
 pub fn filter(logs: &mut Managed<ExpandedLogs>, ctx: Context<'_>) {
-    logs.modify(|logs, records| {
-        let meta = logs.headers.meta();
-        logs.logs.retain_mut(|log| {
-            let r = filter_log(log, meta, ctx);
-            records.or_default(r.map(|_| true), &*log)
-        })
-    });
+    logs.retain_with_context(
+        |logs| (&mut logs.logs, logs.headers.meta()),
+        |log, meta| filter_log(log, meta, ctx),
+    );
 }
 
 fn filter_log(log: &Annotated<OurLog>, meta: &RequestMeta, ctx: Context<'_>) -> Result<()> {

--- a/relay-server/src/processing/spans/filter.rs
+++ b/relay-server/src/processing/spans/filter.rs
@@ -17,13 +17,10 @@ pub fn feature_flag(ctx: Context<'_>) -> Result<()> {
 
 /// Applies inbound filters to individual spans.
 pub fn filter(spans: &mut Managed<ExpandedSpans>, ctx: Context<'_>) {
-    spans.modify(|spans, records| {
-        let meta = spans.headers.meta();
-        spans.spans.retain_mut(|span| {
-            let r = filter_span(span, meta, ctx);
-            records.or_default(r.map(|_| true), &*span)
-        })
-    });
+    spans.retain_with_context(
+        |spans| (&mut spans.spans, spans.headers.meta()),
+        |span, meta| filter_span(span, meta, ctx),
+    );
 }
 
 fn filter_span(span: &Annotated<SpanV2>, meta: &RequestMeta, ctx: Context<'_>) -> Result<()> {

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -45,16 +45,14 @@ fn expand_span(item: &Item) -> Result<ContainerItems<SpanV2>> {
 
 /// Normalizes individual spans.
 pub fn normalize(spans: &mut Managed<ExpandedSpans>, geo_lookup: &GeoIpLookup) {
-    spans.modify(|spans, records| {
-        let meta = spans.headers.meta();
-        spans.spans.retain_mut(|span| {
-            let r = normalize_span(span, meta, geo_lookup).inspect_err(|err| {
+    spans.retain_with_context(
+        |spans| (&mut spans.spans, spans.headers.meta()),
+        |span, meta| {
+            normalize_span(span, meta, geo_lookup).inspect_err(|err| {
                 relay_log::debug!("failed to normalize span: {err}");
-            });
-
-            records.or_default(r.map(|_| true), &*span)
-        })
-    });
+            })
+        },
+    );
 }
 
 fn normalize_span(


### PR DESCRIPTION
- Adds `Managed::retain` as a convenience method over the rather complicated `Managed::modify + retain` construct currently in use.
- Makes the `managed` module public (and fixes the lints that come with it) to make doc tests possible.