### PR TITLE
ref(check-ins): Move check ins to the new processing

### DIFF
--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -254,13 +254,11 @@ impl Item {
     }
 
     /// Returns the routing_hint of this item.
-    #[cfg(feature = "processing")]
     pub fn routing_hint(&self) -> Option<Uuid> {
         self.headers.routing_hint
     }
 
     /// Set the routing_hint of this item.
-    #[cfg(feature = "processing")]
     pub fn set_routing_hint(&mut self, routing_hint: Uuid) {
         self.headers.routing_hint = Some(routing_hint);
     }

--- a/relay-server/src/processing/check_ins/mod.rs
+++ b/relay-server/src/processing/check_ins/mod.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use relay_quotas::{DataCategory, RateLimits};
+
+use crate::Envelope;
+use crate::envelope::{EnvelopeHeaders, Item, ItemType, Items};
+use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities, Rejected};
+use crate::processing::{self, Context, CountRateLimited, Forward, Output, QuotaRateLimiter};
+use crate::services::outcome::{DiscardReason, Outcome};
+
+mod process;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The check-ins are rate limited.
+    #[error("rate limited")]
+    RateLimited(RateLimits),
+    /// Failed to process the check-in.
+    #[error("failed to process checkin: {0}")]
+    Processing(#[from] relay_monitors::ProcessCheckInError),
+}
+
+impl OutcomeError for Error {
+    type Error = Self;
+
+    fn consume(self) -> (Option<Outcome>, Self::Error) {
+        let outcome = match &self {
+            Self::RateLimited(limits) => {
+                let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
+                Some(Outcome::RateLimited(reason_code))
+            }
+            Self::Processing(relay_monitors::ProcessCheckInError::Json(_)) => {
+                Some(Outcome::Invalid(DiscardReason::InvalidJson))
+            }
+            Self::Processing(_) => Some(Outcome::Invalid(DiscardReason::InvalidCheckIn)),
+        };
+        (outcome, self)
+    }
+}
+
+impl From<RateLimits> for Error {
+    fn from(value: RateLimits) -> Self {
+        Self::RateLimited(value)
+    }
+}
+
+/// A processor for Check-Ins.
+pub struct CheckInsProcessor {
+    limiter: Arc<QuotaRateLimiter>,
+}
+
+impl CheckInsProcessor {
+    /// Creates a new [`Self`].
+    pub fn new(limiter: Arc<QuotaRateLimiter>) -> Self {
+        Self { limiter }
+    }
+}
+
+impl processing::Processor for CheckInsProcessor {
+    type UnitOfWork = SerializedCheckIns;
+    type Output = CheckInsOutput;
+    type Error = Error;
+
+    fn prepare_envelope(
+        &self,
+        envelope: &mut ManagedEnvelope,
+    ) -> Option<Managed<Self::UnitOfWork>> {
+        let headers = envelope.envelope().headers().clone();
+
+        let check_ins = envelope
+            .envelope_mut()
+            .take_items_by(|item| matches!(*item.ty(), ItemType::CheckIn))
+            .into_vec();
+
+        let work = SerializedCheckIns { headers, check_ins };
+        Some(Managed::from_envelope(envelope, work))
+    }
+
+    async fn process(
+        &self,
+        mut check_ins: Managed<Self::UnitOfWork>,
+        ctx: Context<'_>,
+    ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
+        if ctx.is_processing() {
+            process::normalize(&mut check_ins);
+        }
+
+        self.limiter.enforce_quotas(&mut check_ins, ctx).await?;
+
+        Ok(Output::just(CheckInsOutput(check_ins)))
+    }
+}
+
+/// Output produced by the [`CheckInsProcessor`].
+#[derive(Debug)]
+pub struct CheckInsOutput(Managed<SerializedCheckIns>);
+
+impl Forward for CheckInsOutput {
+    fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+        let envelope = self.0.map(|SerializedCheckIns { headers, check_ins }, _| {
+            Envelope::from_parts(headers, Items::from_vec(check_ins))
+        });
+
+        Ok(envelope)
+    }
+
+    #[cfg(feature = "processing")]
+    fn forward_store(
+        self,
+        s: &relay_system::Addr<crate::services::store::Store>,
+    ) -> Result<(), Rejected<()>> {
+        let envelope = self.serialize_envelope()?;
+        let envelope = ManagedEnvelope::from(envelope).into_processed();
+
+        s.send(crate::services::store::StoreEnvelope { envelope });
+
+        Ok(())
+    }
+}
+
+/// Spans in their serialized state, as transported in an envelope.
+#[derive(Debug)]
+pub struct SerializedCheckIns {
+    /// Original envelope headers.
+    headers: EnvelopeHeaders,
+
+    /// A list of spans waiting to be processed.
+    ///
+    /// All items contained here must be spans.
+    check_ins: Vec<Item>,
+}
+
+impl Counted for SerializedCheckIns {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Monitor, self.check_ins.len())]
+    }
+}
+
+impl CountRateLimited for Managed<SerializedCheckIns> {
+    type Error = Error;
+}

--- a/relay-server/src/processing/check_ins/process.rs
+++ b/relay-server/src/processing/check_ins/process.rs
@@ -1,0 +1,29 @@
+use crate::envelope::ContentType;
+use crate::managed::Managed;
+use crate::processing::check_ins::{Error, SerializedCheckIns};
+
+/// Normalizes all check-ins using the [`relay_monitors`] module.
+///
+/// Individual, invalid check-ins will be discarded.
+pub fn normalize(check_ins: &mut Managed<SerializedCheckIns>) {
+    let scoping = check_ins.scoping();
+
+    check_ins.retain(
+        |check_ins| &mut check_ins.check_ins,
+        |check_in| {
+            let payload = check_in.payload();
+            let result = relay_monitors::process_check_in(&payload, scoping.project_id)
+                .inspect_err(|err| {
+                    relay_log::debug!(
+                        error = err as &dyn std::error::Error,
+                        "dropped invalid monitor check-in"
+                    )
+                })?;
+
+            check_in.set_routing_hint(result.routing_hint);
+            check_in.set_payload(ContentType::Json, result.payload);
+
+            Ok::<_, Error>(())
+        },
+    );
+}

--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -1,5 +1,6 @@
 use crate::Envelope;
 use crate::managed::{Managed, Rejected};
+use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::logs::LogsProcessor;
 use crate::processing::spans::SpansProcessor;
 use crate::processing::{Forward, Processor};
@@ -47,6 +48,7 @@ macro_rules! outputs {
 }
 
 outputs!(
+    CheckIns => CheckInsProcessor,
     Logs => LogsProcessor,
     Spans => SpansProcessor,
 );

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -17,11 +17,13 @@ use crate::services::projects::project::ProjectInfo;
 
 mod common;
 mod limits;
-pub mod logs;
-pub mod spans;
 
 pub use self::common::*;
 pub use self::limits::*;
+
+pub mod check_ins;
+pub mod logs;
+pub mod spans;
 
 /// A processor, for an arbitrary unit of work extracted from an envelope.
 ///
@@ -80,7 +82,7 @@ impl Context<'_> {
     ///
     /// Processing indicates, this Relay is the final Relay processing this item.
     pub fn is_processing(&self) -> bool {
-        self.config.processing_enabled()
+        cfg!(feature = "processing") && self.config.processing_enabled()
     }
 
     /// Checks on-off feature flags for envelope items, like profiles and spans.

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -496,6 +496,9 @@ pub enum DiscardReason {
 
     /// (Relay) The signature from a trusted Relay was missing but required.
     MissingSignature,
+
+    /// (Relay) The signature from a trusted Relay was missing but required.
+    InvalidCheckIn,
 }
 
 impl DiscardReason {
@@ -546,6 +549,7 @@ impl DiscardReason {
             DiscardReason::InvalidSpan => "invalid_span",
             DiscardReason::FeatureDisabled(_) => "feature_disabled",
             DiscardReason::TransactionAttachment => "transaction_attachment",
+            DiscardReason::InvalidCheckIn => "invalid_check_in",
         }
     }
 }


### PR DESCRIPTION
Closes: INGEST-516

The new pipeline no longer silently discards normalization errors, which was marked as `TODO` in the old one. Otherwise there are no other functional changes.