### PR TITLE
feat(relay-server): Add integration endpoints for otlp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add Thread Pool Info context to event schema. ([#5153](https://github.com/getsentry/relay/pull/5153))
 - Add Unity Info context to event schema. ([#5155](https://github.com/getsentry/relay/pull/5155))
 - Generate `sentry.name` attributes for spans without names. ([#5143](https://github.com/getsentry/relay/pull/5143))
+- Add integration endpoints for OTLP. ([#5176](https://github.com/getsentry/relay/pull/5176))
 
 **Internal**:
 

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -86,8 +86,8 @@ pub fn routes(config: &Config) -> Router<ServiceState>{
         // Integration Endpoints
         // Trailing slash is optional to match otlp specification:
         // https://opentelemetry.io/docs/specs/otlp/#otlphttp-request
-        .route("/api/{project_id}/integration/otlp/v1/traces", otlp_log::route(config))
-        .route("/api/{project_id}/integration/otlp/v1/traces/", otlp_log::route(config))
+        .route("/api/{project_id}/integration/otlp/v1/traces", otlp_traces::route(config))
+        .route("/api/{project_id}/integration/otlp/v1/traces/", otlp_traces::route(config))
         .route("/api/{project_id}/integration/otlp/v1/logs", otlp_log::route(config))
         .route("/api/{project_id}/integration/otlp/v1/logs/", otlp_log::route(config));
         // NOTE: If you add a new (non-experimental) route here, please also list it in

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -83,7 +83,12 @@ pub fn routes(config: &Config) -> Router<ServiceState>{
         // backwards compatibility.
         .route("/api/{project_id}/otlp/v1/traces", otlp_traces::route(config))
         .route("/api/{project_id}/otlp/v1/traces/", otlp_traces::route(config))
-        .route("/api/{project_id}/otlp/v1/logs", otlp_log::route(config));
+        // Integration Endpoints
+        // Trailing slash is optional to match otlp specification https://opentelemetry.io/docs/specs/otlp/#otlphttp-request
+        .route("/api/{project_id}/integration/otlp/v1/traces", otlp_log::route(config))
+        .route("/api/{project_id}/integration/otlp/v1/traces/", otlp_log::route(config))
+        .route("/api/{project_id}/integration/otlp/v1/logs", otlp_log::route(config))
+        .route("/api/{project_id}/integration/otlp/v1/logs/", otlp_log::route(config));
         // NOTE: If you add a new (non-experimental) route here, please also list it in
         // https://github.com/getsentry/sentry-docs/blob/master/docs/product/relay/operating-guidelines.mdx
 

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -84,7 +84,8 @@ pub fn routes(config: &Config) -> Router<ServiceState>{
         .route("/api/{project_id}/otlp/v1/traces", otlp_traces::route(config))
         .route("/api/{project_id}/otlp/v1/traces/", otlp_traces::route(config))
         // Integration Endpoints
-        // Trailing slash is optional to match otlp specification https://opentelemetry.io/docs/specs/otlp/#otlphttp-request
+        // Trailing slash is optional to match otlp specification:
+        // https://opentelemetry.io/docs/specs/otlp/#otlphttp-request
         .route("/api/{project_id}/integration/otlp/v1/traces", otlp_log::route(config))
         .route("/api/{project_id}/integration/otlp/v1/traces/", otlp_log::route(config))
         .route("/api/{project_id}/integration/otlp/v1/logs", otlp_log::route(config))

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -216,7 +216,7 @@ class SentryLike:
         if dsn_key is None:
             dsn_key = self.get_dsn_public_key(project_id, dsn_key_idx)
 
-        url = f"/api/{project_id}/otlp/v1/traces?sentry_key={dsn_key}"
+        url = f"/api/{project_id}/integration/otlp/v1/traces?sentry_key={dsn_key}"
 
         if json:
             headers = {
@@ -243,7 +243,7 @@ class SentryLike:
         if dsn_key is None:
             dsn_key = self.get_dsn_public_key(project_id, dsn_key_idx)
 
-        url = f"/api/{project_id}/otlp/v1/logs?sentry_key={dsn_key}"
+        url = f"/api/{project_id}/integration/otlp/v1/logs?sentry_key={dsn_key}"
 
         if json:
             headers = {


### PR DESCRIPTION
In https://www.notion.so/sentry/Log-Drains-and-other-Integrations-2778b10e4b5d806995e2dac749a323db we decided to move to a new endpoint, `/api/{project_id}/integration/{integration}/{...}` for integrations with other platforms, like OTLP.

This PR adds integration endpoints for otlp logs and traces.

`/api/{project_id}/otlp/v1/logs` is not yet used in production (nor exposed in our internal infra anywhere), so it is safe to remove. We can eventually remove `/api/{project_id}/otlp/v1/traces` and `/api/{project_id}/otlp/v1/traces/` in a future PR.