### PR TITLE
fix(monitors): Managed envelope did not emit monitor outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Add Unity Info context to event schema. ([#5155](https://github.com/getsentry/relay/pull/5155))
 - Generate `sentry.name` attributes for spans without names. ([#5143](https://github.com/getsentry/relay/pull/5143))
 
+**Bug Fixes**:
+
+- Emit monitor outcomes when dropping/rejecting an envelope. ([#5177](https://github.com/getsentry/relay/pull/5177))
+
 **Internal**:
 
 - No longer writes Spans as trace items. ([#5152](https://github.com/getsentry/relay/pull/5152))

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -65,6 +65,7 @@ impl Counted for Box<Envelope> {
             ),
             (DataCategory::LogItem, summary.log_item_quantity),
             (DataCategory::LogByte, summary.log_byte_quantity),
+            (DataCategory::Monitor, summary.monitor_quantity),
         ];
 
         for (category, quantity) in data {

--- a/relay-server/src/managed/envelope.rs
+++ b/relay-server/src/managed/envelope.rs
@@ -364,6 +364,14 @@ impl ManagedEnvelope {
             );
         }
 
+        if self.context.summary.monitor_quantity > 0 {
+            self.track_outcome(
+                outcome.clone(),
+                DataCategory::Monitor,
+                self.context.summary.monitor_quantity,
+            );
+        }
+
         if self.context.summary.profile_quantity > 0 {
             self.track_outcome(
                 outcome.clone(),


### PR DESCRIPTION
It is logged in the failure code, but was never emitted.

Also it seems like there should be outcomes, it just was never implemented fully:
https://github.com/getsentry/relay/blob/bd2bd53815e1d7bb6c09928ab4fd6f52273f3b5b/relay-server/src/services/processor.rs#L1307-L1314

Bug found by the new processor's outcome assertions: #5175