### PR TITLE
fix(logs): Fix a potential memory DoS issue

### DIFF
--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -20,7 +20,7 @@ pub fn expand(logs: Managed<SerializedLogs>, _ctx: Context<'_>) -> Managed<Expan
     logs.map(|logs, records| {
         records.lenient(DataCategory::LogByte);
 
-        let mut all_logs = Vec::with_capacity(logs.count());
+        let mut all_logs = Vec::new();
         for logs in logs.logs {
             let expanded = expand_log_container(&logs, trust);
             let expanded = records.or_default(expanded, logs);


### PR DESCRIPTION
The log count is fine to use for outcomes, but it is not a trusted number we should use for memory allocations. In practice it has already been validated at some point, but we don't want to rely on that.