### PR TITLE
fix(spans): Fix broken routing key on `ingest-spans`

### DIFF
--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -34,6 +34,11 @@ impl TraceId {
     pub fn random() -> Self {
         Self(Uuid::new_v4())
     }
+
+    /// Returns the underlying UUID.
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
 }
 
 relay_common::impl_str_serde!(TraceId, "a trace identifier");

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -34,11 +34,6 @@ impl TraceId {
     pub fn random() -> Self {
         Self(Uuid::new_v4())
     }
-
-    /// Returns the underlying UUID.
-    pub fn as_uuid(&self) -> Uuid {
-        self.0
-    }
 }
 
 relay_common::impl_str_serde!(TraceId, "a trace identifier");

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -279,6 +279,9 @@ fn create_span_item(
                 return Err(());
             }
         };
+        if let Some(trace_id) = compat_span.value().and_then(|s| s.span_v2.trace_id.value()) {
+            new_item.set_routing_hint(trace_id.as_uuid());
+        }
 
         new_item.set_payload(ContentType::CompatSpan, payload);
     } else {

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -280,7 +280,7 @@ fn create_span_item(
             }
         };
         if let Some(trace_id) = compat_span.value().and_then(|s| s.span_v2.trace_id.value()) {
-            new_item.set_routing_hint(trace_id.as_uuid());
+            new_item.set_routing_hint(*trace_id.as_ref());
         }
 
         new_item.set_payload(ContentType::CompatSpan, payload);

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1794,7 +1794,7 @@ impl Message for KafkaMessage<'_> {
             Self::Event(message) => Some(message.event_id.0),
             Self::UserReport(message) => Some(message.event_id.0),
             Self::Span { message, .. } => Some(message.trace_id.0),
-            Self::SpanV2 { routing_key, .. } => routing_key.clone(),
+            Self::SpanV2 { routing_key, .. } => *routing_key,
 
             // Monitor check-ins use the hinted UUID passed through from the Envelope.
             //

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -353,15 +353,14 @@ impl StoreService {
                     let client = envelope.meta().client();
                     self.produce_check_in(scoping.project_id, received_at, client, retention, item)?
                 }
-                ItemType::Span if content_type == Some(&ContentType::Json) => self
-                    .produce_span_v1(
-                        scoping,
-                        received_at,
-                        event_id,
-                        retention,
-                        downsampled_retention,
-                        item,
-                    )?,
+                ItemType::Span if content_type == Some(&ContentType::Json) => self.produce_span(
+                    scoping,
+                    received_at,
+                    event_id,
+                    retention,
+                    downsampled_retention,
+                    item,
+                )?,
                 ItemType::Span if content_type == Some(&ContentType::CompatSpan) => self
                     .produce_span_v2(
                         scoping,
@@ -1017,7 +1016,7 @@ impl StoreService {
         Ok(())
     }
 
-    fn produce_span_v1(
+    fn produce_span(
         &self,
         scoping: Scoping,
         received_at: DateTime<Utc>,

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -571,18 +571,16 @@ class MonitorsConsumer(ConsumerBase):
 
 class SpansConsumer(ConsumerBase):
     def get_span(self):
-        message = self.poll()
-        assert message is not None
-        assert message.error() is None
+        return self.get_spans(timeout=None, n=1)[0]
 
-        return json.loads(message.value())
-
-    def get_spans(self, timeout=None, n=None):
+    def get_spans(self, *, timeout=None, n=None):
         spans = []
 
         for message in self.poll_many(timeout=timeout, n=n):
             assert message.error() is None
-            spans.append(json.loads(message.value()))
+            span = json.loads(message.value())
+            assert message.key() == span["trace_id"]
+            spans.append(span)
 
         return spans
 


### PR DESCRIPTION
The implementation tried to parse a `RawValue` into a UUID, which does not work because of the double quotes. This failed silently, but was not a problem for standalone spans as they are not part of a larger segment.

Without the routing key, the span buffer does not work: https://github.com/getsentry/sentry/blob/d4e2500df369043b653fe9a78e404270ffba6e76/src/sentry/spans/buffer.py#L507-L511

ref: INGEST-531