### PR TITLE
ref(sessions): Implement new sessions processing pipeline

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -194,6 +194,14 @@ pub struct Options {
     )]
     pub span_kafka_v2_sample_rate: f32,
 
+    /// Rollout for Relay's reworked sessions processing.
+    #[serde(
+        rename = "relay.session.processing.rollout",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub session_processing_rollout: f32,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-event-schema/src/protocol/session.rs
+++ b/relay-event-schema/src/protocol/session.rs
@@ -29,7 +29,8 @@ pub enum SessionStatus {
     Unhandled,
     /// Unknown status, for forward compatibility.
     ///
-    /// Adding a new variant still requires bumping the metrics extraction version.
+    /// If you add a new variant here, bump the session metrics extraction version
+    /// to prevent outdated extraction in external Relays.
     Unknown(String),
 }
 
@@ -314,8 +315,8 @@ pub struct SessionAggregateItem {
     /// The number of crashed sessions that ocurred.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub crashed: u32,
-    // Adding a new field here, requires bumping the session metrics extraction
-    // version for external/customer managed Relays.
+    // If you add a new variant here, bump the session metrics extraction version
+    // to prevent outdated extraction in external Relays.
 }
 
 impl SessionLike for SessionAggregateItem {

--- a/relay-event-schema/src/protocol/session.rs
+++ b/relay-event-schema/src/protocol/session.rs
@@ -28,6 +28,8 @@ pub enum SessionStatus {
     /// The session had an unhandled error, but did not crash.
     Unhandled,
     /// Unknown status, for forward compatibility.
+    ///
+    /// Adding a new variant still requires bumping the metrics extraction version.
     Unknown(String),
 }
 
@@ -312,6 +314,8 @@ pub struct SessionAggregateItem {
     /// The number of crashed sessions that ocurred.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub crashed: u32,
+    // Adding a new field here, requires bumping the session metrics extraction
+    // version for external/customer managed Relays.
 }
 
 impl SessionLike for SessionAggregateItem {
@@ -392,6 +396,36 @@ mod tests {
     use similar_asserts::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn test_did_you_bump_session_metrics_extraction_version() {
+        fn _assert_status(status: SessionStatus) {
+            match status {
+                SessionStatus::Ok => todo!(),
+                SessionStatus::Exited => todo!(),
+                SessionStatus::Crashed => todo!(),
+                SessionStatus::Abnormal => todo!(),
+                SessionStatus::Errored => todo!(),
+                SessionStatus::Unhandled => todo!(),
+                SessionStatus::Unknown(_) => todo!(),
+                // If you have to make changes here, you also need to bump the session extraction
+                // metrics version in Sentry and Relay.
+            }
+        }
+        fn _assert_aggregate_item(item: SessionAggregateItem) {
+            let SessionAggregateItem {
+                started: _,
+                distinct_id: _,
+                exited: _,
+                errored: _,
+                abnormal: _,
+                unhandled: _,
+                crashed: _,
+                // If you have to make changes here, you also need to bump the session extraction
+                // metrics version in Sentry and Relay.
+            } = item;
+        }
+    }
 
     #[test]
     fn test_sessionstatus_unknown() {

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -190,6 +190,11 @@ impl<M> EnvelopeHeaders<M> {
             Some(ErrorBoundary::Ok(t)) => Some(t),
         }
     }
+
+    /// Returns the timestamp when the event has been sent, according to the SDK.
+    pub fn sent_at(&self) -> Option<DateTime<Utc>> {
+        self.sent_at
+    }
 }
 
 #[doc(hidden)]

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -1,4 +1,6 @@
-use relay_event_schema::protocol::{OurLog, Span, SpanV2};
+use relay_event_schema::protocol::{
+    OurLog, SessionAggregateItem, SessionAggregates, SessionUpdate, Span, SpanV2,
+};
 use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 use smallvec::SmallVec;
@@ -66,6 +68,7 @@ impl Counted for Box<Envelope> {
             (DataCategory::LogItem, summary.log_item_quantity),
             (DataCategory::LogByte, summary.log_byte_quantity),
             (DataCategory::Monitor, summary.monitor_quantity),
+            (DataCategory::Session, summary.session_quantity),
         ];
 
         for (category, quantity) in data {
@@ -122,6 +125,23 @@ impl Counted for ExtractedMetrics {
         .into_iter()
         .filter(|(_, q)| *q > 0)
         .collect()
+    }
+}
+
+impl Counted for SessionUpdate {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Session, 1)]
+    }
+}
+
+impl Counted for SessionAggregates {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Session, self.aggregates.len())]
+    }
+}
+impl Counted for SessionAggregateItem {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Session, 1)]
     }
 }
 

--- a/relay-server/src/managed/envelope.rs
+++ b/relay-server/src/managed/envelope.rs
@@ -473,6 +473,14 @@ impl ManagedEnvelope {
             );
         }
 
+        if self.context.summary.session_quantity > 0 {
+            self.track_outcome(
+                outcome.clone(),
+                DataCategory::Session,
+                self.context.summary.session_quantity,
+            );
+        }
+
         self.finish(RelayCounters::EnvelopeRejected, handling);
     }
 

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -248,7 +248,7 @@ impl<T: Counted> Managed<T> {
     /// # type Error = std::convert::Infallible;
     ///
     /// fn process_items(items: &mut Managed<Items>, ctx: Context<'_>) {
-    ///     items.retain(|items| &mut items.items, |item| process(item, ctx));
+    ///     items.retain(|items| &mut items.items, |item, _| process(item, ctx));
     /// }
     ///
     /// fn process(item: &mut Item, ctx: Context<'_>) -> Result<(), Error> {
@@ -259,10 +259,13 @@ impl<T: Counted> Managed<T> {
     where
         S: FnOnce(&mut T) -> &mut Vec<I>,
         I: Counted,
-        U: FnMut(&mut I) -> Result<(), E>,
+        U: FnMut(&mut I, &mut RecordKeeper<'_>) -> Result<(), E>,
         E: OutcomeError,
     {
-        self.retain_with_context(|inner| (select(inner), &()), |item, _| retain(item));
+        self.retain_with_context(
+            |inner| (select(inner), &()),
+            |item, _, records| retain(item, records),
+        );
     }
 
     /// Filters individual items and emits outcomes for them if they are removed.
@@ -294,7 +297,7 @@ impl<T: Counted> Managed<T> {
     /// # type Error = std::convert::Infallible;
     ///
     /// fn process_items(items: &mut Managed<Items>, ctx: Context<'_>) {
-    ///     items.retain_with_context(|items| (&mut items.items, &items.ty), |item, ty| process(item, ty, ctx));
+    ///     items.retain_with_context(|items| (&mut items.items, &items.ty), |item, ty, _| process(item, ty, ctx));
     /// }
     ///
     /// fn process(item: &mut Item, ty: &str, ctx: Context<'_>) -> Result<(), Error> {
@@ -309,12 +312,12 @@ impl<T: Counted> Managed<T> {
         // This is unfortunately a bit limiting but for most of our purposes it is enough.
         for<'a> S: FnOnce(&'a mut T) -> (&'a mut Vec<I>, &'a C),
         I: Counted,
-        U: FnMut(&mut I, &C) -> Result<(), E>,
+        U: FnMut(&mut I, &C, &mut RecordKeeper<'_>) -> Result<(), E>,
         E: OutcomeError,
     {
         self.modify(|inner, records| {
             let (items, ctx) = select(inner);
-            items.retain_mut(|item| match retain(item, ctx) {
+            items.retain_mut(|item| match retain(item, ctx, records) {
                 Ok(()) => true,
                 Err(err) => {
                     records.reject_err(err, &*item);

--- a/relay-server/src/processing/check_ins/mod.rs
+++ b/relay-server/src/processing/check_ins/mod.rs
@@ -120,15 +120,15 @@ impl Forward for CheckInsOutput {
     }
 }
 
-/// Spans in their serialized state, as transported in an envelope.
+/// Check-Ins in their serialized state, as transported in an envelope.
 #[derive(Debug)]
 pub struct SerializedCheckIns {
     /// Original envelope headers.
     headers: EnvelopeHeaders,
 
-    /// A list of spans waiting to be processed.
+    /// A list of check-ins waiting to be processed.
     ///
-    /// All items contained here must be spans.
+    /// All items contained here must be check-ins.
     check_ins: Vec<Item>,
 }
 

--- a/relay-server/src/processing/check_ins/process.rs
+++ b/relay-server/src/processing/check_ins/process.rs
@@ -10,7 +10,7 @@ pub fn normalize(check_ins: &mut Managed<SerializedCheckIns>) {
 
     check_ins.retain(
         |check_ins| &mut check_ins.check_ins,
-        |check_in| {
+        |check_in, _| {
             let payload = check_in.payload();
             let result = relay_monitors::process_check_in(&payload, scoping.project_id)
                 .inspect_err(|err| {

--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -2,6 +2,7 @@ use crate::Envelope;
 use crate::managed::{Managed, Rejected};
 use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::logs::LogsProcessor;
+use crate::processing::sessions::SessionsProcessor;
 use crate::processing::spans::SpansProcessor;
 use crate::processing::{Forward, Processor};
 
@@ -51,4 +52,5 @@ outputs!(
     CheckIns => CheckInsProcessor,
     Logs => LogsProcessor,
     Spans => SpansProcessor,
+    Sessions => SessionsProcessor,
 );

--- a/relay-server/src/processing/logs/filter.rs
+++ b/relay-server/src/processing/logs/filter.rs
@@ -19,7 +19,7 @@ pub fn feature_flag(ctx: Context<'_>) -> Result<()> {
 pub fn filter(logs: &mut Managed<ExpandedLogs>, ctx: Context<'_>) {
     logs.retain_with_context(
         |logs| (&mut logs.logs, logs.headers.meta()),
-        |log, meta| filter_log(log, meta, ctx),
+        |log, meta, _| filter_log(log, meta, ctx),
     );
 }
 

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -49,7 +49,7 @@ pub fn expand(logs: Managed<SerializedLogs>, _ctx: Context<'_>) -> Managed<Expan
 pub fn normalize(logs: &mut Managed<ExpandedLogs>) {
     logs.retain_with_context(
         |logs| (&mut logs.logs, logs.headers.meta()),
-        |log, meta| {
+        |log, meta, _| {
             normalize_log(log, meta).inspect_err(|err| {
                 relay_log::debug!("failed to normalize log: {err}");
             })
@@ -61,7 +61,7 @@ pub fn normalize(logs: &mut Managed<ExpandedLogs>) {
 pub fn scrub(logs: &mut Managed<ExpandedLogs>, ctx: Context<'_>) {
     logs.retain(
         |logs| &mut logs.logs,
-        |log| {
+        |log, _| {
             scrub_log(log, ctx)
                 .inspect_err(|err| relay_log::debug!("failed to scrub pii from log: {err}"))
         },

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -23,6 +23,7 @@ pub use self::limits::*;
 
 pub mod check_ins;
 pub mod logs;
+pub mod sessions;
 pub mod spans;
 
 /// A processor, for an arbitrary unit of work extracted from an envelope.

--- a/relay-server/src/processing/sessions/filter.rs
+++ b/relay-server/src/processing/sessions/filter.rs
@@ -1,0 +1,33 @@
+use relay_filter::Filterable;
+use relay_protocol::Getter;
+
+use crate::extractors::RequestMeta;
+use crate::managed::Managed;
+use crate::processing::Context;
+use crate::processing::sessions::{Error, ExpandedSessions, Result};
+
+/// Applies inbound filters to individual sessions.
+pub fn filter(sessions: &mut Managed<ExpandedSessions>, ctx: Context<'_>) {
+    sessions.retain_with_context(
+        |sessions| (&mut sessions.updates, sessions.headers.meta()),
+        |update, meta, _| filter_session(update, meta, ctx),
+    );
+
+    sessions.retain_with_context(
+        |sessions| (&mut sessions.aggregates, sessions.headers.meta()),
+        |aggregate, meta, _| filter_session(aggregate, meta, ctx),
+    );
+}
+
+fn filter_session<T>(session: &T, meta: &RequestMeta, ctx: Context<'_>) -> Result<()>
+where
+    T: Filterable + Getter,
+{
+    relay_filter::should_filter(
+        session,
+        meta.client_addr(),
+        &ctx.project_info.config.filter_settings,
+        ctx.global_config.filters(),
+    )
+    .map_err(Error::Filtered)
+}

--- a/relay-server/src/processing/sessions/mod.rs
+++ b/relay-server/src/processing/sessions/mod.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+
+use relay_event_schema::protocol::{SessionAggregates, SessionUpdate};
+use relay_quotas::{DataCategory, RateLimits};
+
+use crate::Envelope;
+use crate::envelope::{EnvelopeHeaders, Item, ItemType, Items};
+use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities, Rejected};
+use crate::processing::sessions::process::Expansion;
+use crate::processing::{self, Context, CountRateLimited, Forward, Output, QuotaRateLimiter};
+use crate::services::outcome::Outcome;
+
+mod filter;
+mod process;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The check-ins are rate limited.
+    #[error("rate limited")]
+    RateLimited(RateLimits),
+    /// Sessions filtered due to a filtering rule.
+    #[error("sessions filtered")]
+    Filtered(relay_filter::FilterStatKey),
+    /// The session item is invalid.
+    #[error("invalid sesion item")]
+    Invalid,
+}
+
+impl OutcomeError for Error {
+    type Error = Self;
+
+    fn consume(self) -> (Option<Outcome>, Self::Error) {
+        // Currently/historically sessions do not emit outcomes.
+        (None, self)
+    }
+}
+
+impl From<RateLimits> for Error {
+    fn from(value: RateLimits) -> Self {
+        Self::RateLimited(value)
+    }
+}
+
+/// A processor for sessions, individual updates and aggregates.
+pub struct SessionsProcessor {
+    limiter: Arc<QuotaRateLimiter>,
+}
+
+impl SessionsProcessor {
+    /// Creates a new [`Self`].
+    pub fn new(limiter: Arc<QuotaRateLimiter>) -> Self {
+        Self { limiter }
+    }
+}
+
+impl processing::Processor for SessionsProcessor {
+    type UnitOfWork = SerializedSessions;
+    type Output = SessionsOutput;
+    type Error = Error;
+
+    fn prepare_envelope(
+        &self,
+        envelope: &mut ManagedEnvelope,
+    ) -> Option<Managed<Self::UnitOfWork>> {
+        let headers = envelope.envelope().headers().clone();
+
+        let updates = envelope
+            .envelope_mut()
+            .take_items_by(|item| matches!(*item.ty(), ItemType::Session))
+            .into_vec();
+
+        let aggregates = envelope
+            .envelope_mut()
+            .take_items_by(|item| matches!(*item.ty(), ItemType::Sessions))
+            .into_vec();
+
+        let work = SerializedSessions {
+            headers,
+            updates,
+            aggregates,
+        };
+        Some(Managed::from_envelope(envelope, work))
+    }
+
+    async fn process(
+        &self,
+        sessions: Managed<Self::UnitOfWork>,
+        ctx: Context<'_>,
+    ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
+        let mut sessions = match process::expand(sessions, ctx) {
+            Expansion::Continue(sessions) => sessions,
+            Expansion::Forward(sessions) => return Ok(Output::just(SessionsOutput(sessions))),
+        };
+
+        // We can apply filters before normalization here, as our filters currently do not depend
+        // on any normalization steps. Changes to the filtering in the future may make it necessary
+        // to switch the order of operations.
+        filter::filter(&mut sessions, ctx);
+
+        process::normalize(&mut sessions, ctx);
+
+        self.limiter.enforce_quotas(&mut sessions, ctx).await?;
+
+        let sessions = process::extract(sessions, ctx);
+        Ok(Output::metrics(sessions))
+    }
+}
+
+/// Output produced by the [`SessionsProcessor`].
+#[derive(Debug)]
+pub struct SessionsOutput(Managed<SerializedSessions>);
+
+impl Forward for SessionsOutput {
+    fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+        Ok(self.0.map(|sessions, _| sessions.serialize_envelope()))
+    }
+
+    #[cfg(feature = "processing")]
+    fn forward_store(
+        self,
+        _: &relay_system::Addr<crate::services::store::Store>,
+    ) -> Result<(), Rejected<()>> {
+        let SessionsOutput(sessions) = self;
+        Err(sessions.internal_error("sessions should always be extracted into metrics"))
+    }
+}
+
+/// Spans in their serialized state, as transported in an envelope.
+#[derive(Debug)]
+pub struct SerializedSessions {
+    /// Original envelope headers.
+    headers: EnvelopeHeaders,
+
+    /// A list of sessions waiting to be processed.
+    updates: Vec<Item>,
+    /// A list of session aggregates waiting to be processed.
+    aggregates: Vec<Item>,
+}
+
+impl SerializedSessions {
+    fn serialize_envelope(self) -> Box<Envelope> {
+        let (mut long, short) = match self.updates.len() > self.aggregates.len() {
+            true => (self.updates, self.aggregates),
+            false => (self.aggregates, self.updates),
+        };
+        long.extend(short);
+        Envelope::from_parts(self.headers, Items::from_vec(long))
+    }
+}
+
+impl Counted for SerializedSessions {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(
+            DataCategory::Session,
+            item_count(&self.updates) + item_count(&self.aggregates),
+        )]
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpandedSessions {
+    /// Original envelope headers.
+    headers: EnvelopeHeaders,
+
+    /// A list of parsed session updates.
+    updates: Vec<SessionUpdate>,
+    /// A list of parsed session aggregates.
+    aggregates: Vec<SessionAggregates>,
+}
+
+impl Counted for ExpandedSessions {
+    fn quantities(&self) -> Quantities {
+        let aggregates = self
+            .aggregates
+            .iter()
+            .map(|agg| agg.aggregates.len())
+            .sum::<usize>();
+
+        smallvec::smallvec![(DataCategory::Session, self.updates.len() + aggregates)]
+    }
+}
+
+impl CountRateLimited for Managed<ExpandedSessions> {
+    type Error = Error;
+}
+
+fn item_count(items: &[Item]) -> usize {
+    items
+        .iter()
+        .map(|item| item.item_count().unwrap_or(1) as usize)
+        .sum()
+}

--- a/relay-server/src/processing/sessions/mod.rs
+++ b/relay-server/src/processing/sessions/mod.rs
@@ -17,7 +17,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The check-ins are rate limited.
+    /// The sessions are rate limited.
     #[error("rate limited")]
     RateLimited(RateLimits),
     /// Sessions filtered due to a filtering rule.

--- a/relay-server/src/processing/sessions/process.rs
+++ b/relay-server/src/processing/sessions/process.rs
@@ -1,0 +1,257 @@
+use std::net::IpAddr;
+
+use chrono::{DateTime, Utc};
+use relay_event_normalization::ClockDriftProcessor;
+use relay_event_schema::protocol::{SessionAggregates, SessionAttributes, SessionUpdate};
+use relay_quotas::DataCategory;
+
+use crate::envelope::Item;
+use crate::managed::{Managed, RecordKeeper};
+use crate::metrics_extraction;
+use crate::metrics_extraction::transactions::ExtractedMetrics;
+use crate::processing::Context;
+use crate::processing::sessions::{Error, ExpandedSessions, Result, SerializedSessions};
+use crate::services::processor::MINIMUM_CLOCK_DRIFT;
+use crate::statsd::RelayTimers;
+
+/// Result of [`expand`].
+pub enum Expansion {
+    /// Continue processing with the expanded sessions.
+    Continue(Managed<ExpandedSessions>),
+    /// Do not continue processing, only forward the sessions.
+    Forward(Managed<SerializedSessions>),
+}
+
+pub fn expand(sessions: Managed<SerializedSessions>, ctx: Context<'_>) -> Expansion {
+    let can_extract_metrics = ctx.project_info.config.session_metrics.is_enabled();
+
+    // Always extract metrics in processing Relays, even if the metrics extraction for sessions
+    // is erroneous. In the migration phase from specific session payloads to session metrics,
+    // it was possible to still forward sessions as payloads instead of items, this no longer
+    // exists.
+    //
+    // Having metrics extraction *not* enabled for processing Relays is a misconfiguration.
+    // The alternative to not extracting metrics here is to just drop them, which would be worse
+    // than extracting.
+    if !can_extract_metrics && !ctx.is_processing() {
+        return Expansion::Forward(sessions);
+    }
+
+    let expanded = sessions.map(|sessions, records| {
+        let mut updates = Vec::with_capacity(sessions.updates.len());
+        for item in sessions.updates {
+            match expand_session(&item) {
+                Ok(value) => updates.push(value),
+                Err(err) => drop(records.reject_err(err, item)),
+            }
+        }
+
+        let mut aggregates = Vec::with_capacity(sessions.aggregates.len());
+        for item in sessions.aggregates {
+            match expand_session_aggregates(&item) {
+                Ok(value) => aggregates.push(value),
+                Err(err) => drop(records.reject_err(err, item)),
+            }
+        }
+
+        ExpandedSessions {
+            headers: sessions.headers,
+            updates,
+            aggregates,
+        }
+    });
+
+    Expansion::Continue(expanded)
+}
+
+fn expand_session(item: &Item) -> Result<SessionUpdate> {
+    let payload = item.payload();
+
+    SessionUpdate::parse(&payload).map_err(|err| {
+        relay_log::trace!(
+            error = &err as &dyn std::error::Error,
+            "invalid session aggregate payload"
+        );
+        Error::Invalid
+    })
+}
+
+fn expand_session_aggregates(item: &Item) -> Result<SessionAggregates> {
+    let payload = item.payload();
+
+    SessionAggregates::parse(&payload).map_err(|err| {
+        relay_log::trace!(
+            error = &err as &dyn std::error::Error,
+            "invalid session aggregate payload"
+        );
+        Error::Invalid
+    })
+}
+
+pub fn normalize(sessions: &mut Managed<ExpandedSessions>, ctx: Context<'_>) {
+    let received_at = sessions.received_at();
+    let ctx = NormalizeContext {
+        ctx,
+        clock_drift: ClockDriftProcessor::new(sessions.headers.sent_at(), received_at)
+            .at_least(MINIMUM_CLOCK_DRIFT),
+        received_at,
+        client_addr: sessions.headers.meta().client_addr(),
+    };
+
+    sessions.retain(
+        |sessions| &mut sessions.updates,
+        |update, _| normalize_update(update, &ctx),
+    );
+
+    sessions.retain(
+        |sessions| &mut sessions.aggregates,
+        |aggregates, records| normalize_aggregates(aggregates, &ctx, records),
+    );
+}
+
+struct NormalizeContext<'a> {
+    ctx: Context<'a>,
+    clock_drift: ClockDriftProcessor,
+    received_at: DateTime<Utc>,
+    client_addr: Option<IpAddr>,
+}
+
+impl NormalizeContext<'_> {
+    fn has_delay(&self, ts: DateTime<Utc>) -> Option<std::time::Duration> {
+        let delay = self.received_at - ts;
+        delay.to_std().ok().filter(|delay| delay.as_secs() >= 60)
+    }
+
+    fn validate_session_timestamp(&self, timestamp: DateTime<Utc>) -> Result<()> {
+        let max_age = chrono::Duration::seconds(self.ctx.config.max_session_secs_in_past());
+        if (self.received_at - timestamp) > max_age {
+            relay_log::trace!("skipping session older than {} days", max_age.num_days());
+            return Err(Error::Invalid);
+        }
+
+        let max_future = chrono::Duration::seconds(self.ctx.config.max_secs_in_future());
+        if (timestamp - self.received_at) > max_future {
+            relay_log::trace!(
+                "skipping session more than {}s in the future",
+                max_future.num_seconds()
+            );
+            return Err(Error::Invalid);
+        }
+
+        Ok(())
+    }
+}
+
+fn normalize_update(session: &mut SessionUpdate, ctx: &NormalizeContext<'_>) -> Result<()> {
+    if ctx.clock_drift.is_drifted() {
+        relay_log::trace!("applying clock drift correction to session");
+        ctx.clock_drift.process_datetime(&mut session.started);
+        ctx.clock_drift.process_datetime(&mut session.timestamp);
+    }
+
+    if session.timestamp < session.started {
+        relay_log::trace!("fixing session timestamp to {}", session.timestamp);
+        session.timestamp = session.started;
+    }
+
+    // Log the timestamp delay for all sessions after clock drift correction.
+    if let Some(delay) = ctx.has_delay(session.timestamp) {
+        relay_statsd::metric!(
+            timer(RelayTimers::TimestampDelay) = delay,
+            category = "session",
+        );
+    }
+
+    ctx.validate_session_timestamp(session.timestamp)?;
+    ctx.validate_session_timestamp(session.started)?;
+
+    normalize_attributes(&mut session.attributes, ctx)?;
+
+    Ok(())
+}
+
+fn normalize_aggregates(
+    aggregates: &mut SessionAggregates,
+    ctx: &NormalizeContext<'_>,
+    records: &mut RecordKeeper<'_>,
+) -> Result<()> {
+    if ctx.clock_drift.is_drifted() {
+        relay_log::trace!("applying clock drift correction to session");
+        for aggregate in &mut aggregates.aggregates {
+            ctx.clock_drift.process_datetime(&mut aggregate.started);
+        }
+    }
+
+    aggregates.aggregates.retain(|aggregate| {
+        match ctx.validate_session_timestamp(aggregate.started) {
+            Ok(()) => true,
+            Err(err) => {
+                records.reject_err(err, aggregate);
+                false
+            }
+        }
+    });
+
+    normalize_attributes(&mut aggregates.attributes, ctx)?;
+
+    Ok(())
+}
+
+fn normalize_attributes(attrs: &mut SessionAttributes, ctx: &NormalizeContext<'_>) -> Result<()> {
+    relay_event_normalization::validate_release(&attrs.release).map_err(|_| Error::Invalid)?;
+
+    attrs.environment = attrs
+        .environment
+        .take()
+        .filter(|env| relay_event_normalization::validate_environment(env).is_ok());
+
+    if attrs.ip_address.as_ref().is_some_and(|ip| ip.is_auto()) {
+        attrs.ip_address = ctx.client_addr.map(Into::into);
+    }
+
+    Ok(())
+}
+
+pub fn extract(sessions: Managed<ExpandedSessions>, ctx: Context<'_>) -> Managed<ExtractedMetrics> {
+    let should_extract_abnormal_mechanism = ctx
+        .project_info
+        .config
+        .session_metrics
+        .should_extract_abnormal_mechanism();
+
+    sessions.map(|sessions, records| {
+        let mut metrics = Vec::new();
+        let meta = sessions.headers.meta();
+
+        for update in sessions.updates {
+            records.modify_by(DataCategory::Session, -1);
+            metrics_extraction::sessions::extract_session_metrics(
+                &update.attributes,
+                &update,
+                meta.client(),
+                &mut metrics,
+                should_extract_abnormal_mechanism,
+            );
+        }
+
+        for aggregates in sessions.aggregates {
+            for item in aggregates.aggregates {
+                records.modify_by(DataCategory::Session, -1);
+                metrics_extraction::sessions::extract_session_metrics(
+                    &aggregates.attributes,
+                    &item,
+                    meta.client(),
+                    &mut metrics,
+                    should_extract_abnormal_mechanism,
+                );
+            }
+        }
+
+        records.modify_by(DataCategory::MetricBucket, metrics.len() as isize);
+
+        ExtractedMetrics {
+            project_metrics: metrics,
+            sampling_metrics: Vec::new(),
+        }
+    })
+}

--- a/relay-server/src/processing/spans/filter.rs
+++ b/relay-server/src/processing/spans/filter.rs
@@ -19,7 +19,7 @@ pub fn feature_flag(ctx: Context<'_>) -> Result<()> {
 pub fn filter(spans: &mut Managed<ExpandedSpans>, ctx: Context<'_>) {
     spans.retain_with_context(
         |spans| (&mut spans.spans, spans.headers.meta()),
-        |span, meta| filter_span(span, meta, ctx),
+        |span, meta, _| filter_span(span, meta, ctx),
     );
 }
 

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -47,7 +47,7 @@ fn expand_span(item: &Item) -> Result<ContainerItems<SpanV2>> {
 pub fn normalize(spans: &mut Managed<ExpandedSpans>, geo_lookup: &GeoIpLookup) {
     spans.retain_with_context(
         |spans| (&mut spans.spans, spans.headers.meta()),
-        |span, meta| {
+        |span, meta, _| {
             normalize_span(span, meta, geo_lookup).inspect_err(|err| {
                 relay_log::debug!("failed to normalize span: {err}");
             })

--- a/tests/integration/asserts/__init__.py
+++ b/tests/integration/asserts/__init__.py
@@ -1,7 +1,14 @@
 from typing import Any, Callable
 from .time import time_after, time_within, time_within_delta
+from .protocol import only_items
 
-__all__ = ["time_after", "time_within", "time_within_delta", "matches"]
+__all__ = [
+    "matches",
+    "only_items",
+    "time_after",
+    "time_within",
+    "time_within_delta",
+]
 
 
 class _Matches(object):

--- a/tests/integration/asserts/protocol.py
+++ b/tests/integration/asserts/protocol.py
@@ -1,0 +1,68 @@
+from typing import Any, List
+
+
+def _item_matcher(item):
+    if isinstance(item, str):
+        return _ItemType(item)
+
+    # Assume it's a different matcher
+    return item
+
+
+class _AnyMatcher:
+    def __init__(self, expected: List[Any]) -> None:
+        self._expected = expected
+
+    def __eq__(self, value: object, /) -> bool:
+        return any(expected == value for expected in self._expected)
+
+    def __str__(self) -> str:
+        if len(self._expected) == 1:
+            return str(self._expected[0])
+
+        a = ", ".join(str(m) for m in self._expected)
+        return f"Any({a})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class _ItemType:
+    def __init__(self, expected: str) -> None:
+        self._expected = expected
+
+    def __eq__(self, value) -> bool:
+        print(value)
+        return value.type == self._expected
+
+    def __str__(self) -> str:
+        return f"item.type:{self._expected}"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class _Envelope:
+    def __init__(self, *, items) -> None:
+        self._items = items
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return all(self._items == item for item in other.items)
+
+    def __str__(self) -> str:
+        return f"Envelope(items=all({self._items}))"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+def only_items(*args):
+    """
+    Helper for asserting envelopes.
+
+    Envelope must only contain items which match the passed matchers.
+    """
+    return _Envelope(items=_AnyMatcher([_item_matcher(arg) for arg in args]))

--- a/tests/integration/asserts/protocol.py
+++ b/tests/integration/asserts/protocol.py
@@ -32,7 +32,6 @@ class _ItemType:
         self._expected = expected
 
     def __eq__(self, value) -> bool:
-        print(value)
         return value.type == self._expected
 
     def __str__(self) -> str:

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -531,5 +531,8 @@ GLOBAL_CONFIG = {
         "maxCustomMeasurements": 10,
     },
     "filters": {"version": 1, "filters": []},
-    "options": {"relay.span-usage-metric": True},
+    "options": {
+        "relay.span-usage-metric": True,
+        "relay.session.processing.rollout": 1.0,
+    },
 }

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -145,11 +145,16 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             "http": {"timeout": 2},
             "processing": {"enabled": False, "kafka_config": [], "redis": ""},
             "outcomes": {
-                # Allow fastest possible aggregation:
+                "batch_size": 1,
+                "batch_interval": 1,
                 "aggregator": {
                     "bucket_interval": 1,
                     "flush_interval": 0,
                 },
+            },
+            "aggregator": {
+                "bucket_interval": 1,
+                "initial_delay": 0,
             },
         }
 

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import uuid
 import json
+
+from .asserts import only_items
 from .consts import (
     TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     TRANSACTION_EXTRACT_MAX_SUPPORTED_VERSION,
@@ -252,6 +254,7 @@ def test_it_removes_events(mini_sentry, relay):
     # send the event, the transaction should be removed.
     relay.send_envelope(project_id, envelope)
     # the event should be removed by Relay sampling
+    assert mini_sentry.captured_events.get(timeout=2) == only_items("metric_buckets")
     with pytest.raises(queue.Empty):
         mini_sentry.captured_events.get(timeout=1)
 
@@ -488,6 +491,7 @@ def test_uses_trace_public_key(mini_sentry, relay):
     # send the event, the transaction should be removed.
     relay.send_envelope(project_id2, envelope)
     # the event should be removed by Relay sampling
+    assert mini_sentry.captured_events.get(timeout=2) == only_items("metric_buckets")
     with pytest.raises(queue.Empty):
         mini_sentry.captured_events.get(timeout=1)
 
@@ -566,6 +570,9 @@ def test_multi_item_envelope(mini_sentry, relay, rule_type, event_factory):
         # send the event, the transaction should be removed.
         relay.send_envelope(project_id, envelope)
         # the event should be removed by Relay sampling
+        assert mini_sentry.captured_events.get(timeout=2) == only_items(
+            "metric_buckets"
+        )
         with pytest.raises(queue.Empty):
             mini_sentry.captured_events.get(timeout=1)
 

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -124,7 +124,7 @@ def test_readiness_not_enough_memory_percent(mini_sentry, relay):
 def test_readiness_depends_on_aggregator_being_full_after_metrics(mini_sentry, relay):
     relay = relay(
         mini_sentry,
-        {"aggregator": {"max_total_bucket_bytes": 1}},
+        {"aggregator": {"max_total_bucket_bytes": 1, "initial_delay": 30}},
     )
 
     metrics_payload = "transactions/foo:42|c\ntransactions/bar:17|c"
@@ -138,7 +138,7 @@ def test_readiness_depends_on_aggregator_being_full_after_metrics(mini_sentry, r
             error = str(mini_sentry.test_failures.get(timeout=1))
             assert "Health check probe 'aggregator'" in error
             return
-        time.sleep(0.1)
+        time.sleep(0.2)
 
     assert False, "health check never failed"
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -868,7 +868,6 @@ def test_outcome_to_client_report(relay, mini_sentry):
         mini_sentry.captured_outcomes.get(timeout=3.2),
     ]
     assert mini_sentry.captured_outcomes.qsize() == 0  # we had only one batch
-    assert mini_sentry.captured_events.qsize() == 0
 
     outcomes = list(
         itertools.chain.from_iterable(o.get("outcomes") for o in outcomes_batches)
@@ -1037,7 +1036,6 @@ def test_outcomes_aggregate_dynamic_sampling(relay, mini_sentry):
         mini_sentry.captured_outcomes.get(timeout=1.2),
     ]
     assert mini_sentry.captured_outcomes.qsize() == 0
-    assert mini_sentry.captured_events.qsize() == 0
 
     outcomes = list(
         itertools.chain.from_iterable(o.get("outcomes") for o in outcomes_batches)

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -13,17 +13,7 @@ import pytest
 TEST_CONFIG = {
     "outcomes": {
         "emit_outcomes": True,
-        "batch_size": 1,
-        "batch_interval": 1,
-        "aggregator": {
-            "bucket_interval": 1,
-            "flush_interval": 1,
-        },
-    },
-    "aggregator": {
-        "bucket_interval": 1,
-        "initial_delay": 0,
-    },
+    }
 }
 
 


### PR DESCRIPTION
Implements a new processing pipeline for sessions. It is still hidden behind a rollout global options. All integration tests are running with the new processing enabled.

Now no longer handles `SessionStatus::Unknown`, instead requires bumping the session metrics extraction version when changes are made to the enum, this was already implicitly necessary for session aggregates, it is now explicit/documented behaviour.

Manged (Envelope) now report dropped sessions to outcomes for consistency reasons.

WIll add a changelog entry once the rollout is completed and the old code is removed.
