### PR TITLE
feat(ourlogs): Attach sentry.origin attribute to otlp logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add integration endpoints for OTLP. ([#5176](https://github.com/getsentry/relay/pull/5176))
 - Emit a metric to record keep/drop decisions in Dynamic Sampling. ([#5164](https://github.com/getsentry/relay/pull/5164))
 - Trim event tag keys & values to 200 chars instead of dropping them. ([#5198](https://github.com/getsentry/relay/pull/5198))
+- Add `sentry.origin` attribute to OTLP logs. ([#5190](https://github.com/getsentry/relay/pull/5190))
 
 **Bug Fixes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,6 +4006,7 @@ dependencies = [
  "once_cell",
  "opentelemetry-proto",
  "relay-common",
+ "relay-conventions",
  "relay-event-schema",
  "relay-otel",
  "relay-protocol",

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -29,6 +29,7 @@ convention_attributes!(
     MESSAGING_SYSTEM => "messaging.system",
     OBSERVED_TIMESTAMP_NANOS => "sentry.observed_timestamp_nanos",
     OP => "sentry.op",
+    ORIGIN => "sentry.origin",
     PLATFORM => "sentry.platform",
     PROFILE_ID => "sentry.profile_id",
     RELEASE => "sentry.release",

--- a/relay-ourlogs/Cargo.toml
+++ b/relay-ourlogs/Cargo.toml
@@ -21,6 +21,7 @@ opentelemetry-proto = { workspace = true, features = [
     "with-serde",
     "logs",
 ] }
+relay-conventions = { workspace = true }
 relay-event-schema = { workspace = true }
 relay-otel = { workspace = true }
 relay-protocol = { workspace = true }

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -281,6 +281,10 @@ mod tests {
               "type": "string",
               "value": "test-service"
             },
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.otlp.logs"
+            },
             "string.attribute": {
               "type": "string",
               "value": "some string"
@@ -364,6 +368,10 @@ mod tests {
             "db.type": {
               "type": "string",
               "value": "sql"
+            },
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.otlp.logs"
             }
           }
         }
@@ -445,6 +453,10 @@ mod tests {
           "level": "info",
           "body": "Log without trace context",
           "attributes": {
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.otlp.logs"
+            },
             "test.attribute": {
               "type": "string",
               "value": "test value"
@@ -504,6 +516,10 @@ mod tests {
             "error.type": {
               "type": "string",
               "value": "ValidationError"
+            },
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.otlp.logs"
             }
           },
           "_meta": {
@@ -558,6 +574,10 @@ mod tests {
           "level": "warn",
           "body": "Warning log with invalid trace IDs",
           "attributes": {
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.otlp.logs"
+            },
             "warning.code": {
               "type": "integer",
               "value": 42

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -7,6 +7,7 @@ use chrono::{TimeZone, Utc};
 use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLogRecord;
+use relay_conventions::ORIGIN;
 
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
@@ -88,7 +89,7 @@ pub fn otel_to_sentry_log(
     });
 
     let mut attribute_data = Attributes::default();
-    attribute_data.insert("sentry.origin", "auto.otlp.logs".to_owned());
+    attribute_data.insert(ORIGIN, "auto.otlp.logs".to_owned());
 
     for attribute in resource.into_iter().flat_map(|s| &s.attributes) {
         if let Some(attr) = attribute

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -88,6 +88,7 @@ pub fn otel_to_sentry_log(
     });
 
     let mut attribute_data = Attributes::default();
+    attribute_data.insert("sentry.origin", "auto.otlp.logs".to_owned());
 
     for attribute in resource.into_iter().flat_map(|s| &s.attributes) {
         if let Some(attr) = attribute

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -139,7 +139,8 @@ def test_otlp_logs_conversion(
                 "sentry.observed_timestamp_nanos": {
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
-                "sentry.payload_size_bytes": {"intValue": "358"},
+                "sentry.origin": {"stringValue": "auto.otlp.logs"},
+                "sentry.payload_size_bytes": {"intValue": "385"},
                 "sentry.severity_text": {"stringValue": "info"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_nanos": {
@@ -189,7 +190,7 @@ def test_otlp_logs_conversion(
             "org_id": 1,
             "outcome": 0,
             "project_id": 42,
-            "quantity": 358,
+            "quantity": 385,
         },
     ]
 
@@ -257,6 +258,7 @@ def test_otlp_logs_multiple_records(
                 "sentry.observed_timestamp_nanos": {
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
+                "sentry.origin": {"stringValue": "auto.otlp.logs"},
                 "sentry.payload_size_bytes": {"intValue": mock.ANY},
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
@@ -296,6 +298,7 @@ def test_otlp_logs_multiple_records(
                 "sentry.observed_timestamp_nanos": {
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
+                "sentry.origin": {"stringValue": "auto.otlp.logs"},
                 "sentry.payload_size_bytes": {"intValue": mock.ANY},
                 "sentry.severity_text": {"stringValue": "debug"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
@@ -345,6 +348,6 @@ def test_otlp_logs_multiple_records(
             "org_id": 1,
             "outcome": 0,
             "project_id": 42,
-            "quantity": 251,
+            "quantity": 305,
         },
     ]


### PR DESCRIPTION
We use this field for telemetry analytics internally. This allows us to see what % of logs come from otlp. 