### PR TITLE
fix(span): Apply name generation to extracted spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Bug Fixes**:
 
 - Emit monitor outcomes when dropping/rejecting an envelope. ([#5177](https://github.com/getsentry/relay/pull/5177))
+- Apply span name generation to spans extracted from transaction events. ([#5191](https://github.com/getsentry/relay/pull/5191))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,7 @@ dependencies = [
  "relay-log",
  "relay-pattern",
  "relay-protocol",
+ "relay-spans",
  "relay-statsd",
  "relay-ua",
  "sentry-release-parser",

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -29,6 +29,7 @@ relay-event-schema = { workspace = true }
 relay-log = { workspace = true }
 relay-pattern = { workspace = true, features = ["serde"] }
 relay-protocol = { workspace = true }
+relay-spans = { workspace = true }
 relay-statsd = { workspace = true }
 relay-ua = { workspace = true }
 relay-filter = { workspace = true }

--- a/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__cache_extraction.snap
+++ b/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__cache_extraction.snap
@@ -33,7 +33,8 @@ expression: event.to_json_pretty().unwrap()
         "cache.hit": "true",
         "cache.key": "[\"my_key\"]",
         "thread.name": "Thread-4 (process_request_thread)",
-        "thread.id": "6286962688"
+        "thread.id": "6286962688",
+        "name": "cache.get_item"
       },
       "measurements": {
         "cache.item_size": {
@@ -73,7 +74,8 @@ expression: event.to_json_pretty().unwrap()
         "cache.hit": "false",
         "cache.key": "[\"my_key\",\"my_key_2\"]",
         "thread.name": "Thread-4 (process_request_thread)",
-        "thread.id": "6286962688"
+        "thread.id": "6286962688",
+        "name": "cache.get_item"
       },
       "measurements": {
         "cache.item_size": {
@@ -112,7 +114,8 @@ expression: event.to_json_pretty().unwrap()
         "cache.hit": "false",
         "cache.key": "[\"my_key_2\"]",
         "thread.name": "Thread-4 (process_request_thread)",
-        "thread.id": "6286962688"
+        "thread.id": "6286962688",
+        "name": "cache.get"
       },
       "measurements": {
         "cache.item_size": {

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -355,6 +355,7 @@ pub struct SentryTags {
     pub user_country_code: Annotated<String>,
     #[metastructure(field = "user.geo.subregion")]
     pub user_subregion: Annotated<String>,
+    pub name: Annotated<String>,
     // no need for an `other` entry here because these fields are added server-side.
     // If an upstream relay does not recognize a field it will be dropped.
 }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -413,6 +413,7 @@ impl Getter for SentryTags {
             "messaging.operation.name" => &self.messaging_operation_name,
             "messaging.operation.type" => &self.messaging_operation_type,
             "mobile" => &self.mobile,
+            "name" => &self.name,
             "op" => &self.op,
             "os.name" => &self.os_name,
             "platform" => &self.platform,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -137,6 +137,7 @@ def test_span_extraction(
     expected_child_span = {
         "data": {  # Backfilled from `sentry_tags`
             "sentry.category": "http",
+            "sentry.name": "http",
             "sentry.normalized_description": "GET *",
             "sentry.group": "37e3d9fab1ae9162",
             "sentry.op": "http",
@@ -174,6 +175,7 @@ def test_span_extraction(
             "category": "http",
             "description": "GET *",
             "group": "37e3d9fab1ae9162",
+            "name": "http",
             "op": "http",
             "platform": "other",
             "sdk.name": "raven-node",
@@ -216,6 +218,7 @@ def test_span_extraction(
             "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
             # Backfilled from `sentry_tags`:
+            "sentry.name": "hi",
             "sentry.op": "hi",
             "sentry.platform": "other",
             "sentry.status": "ok",
@@ -245,6 +248,7 @@ def test_span_extraction(
         "retention_days": 90,
         "segment_id": "968cff94913ebb07",
         "sentry_tags": {
+            "name": "hi",
             "op": "hi",
             "platform": "other",
             "sdk.name": "raven-node",
@@ -831,6 +835,7 @@ def test_span_ingestion(
             "sentry_tags": {
                 "browser.name": "Chrome",
                 "category": "db",
+                "name": "my 1st OTel span",
                 "op": "default",
                 "status": "unknown",
             },
@@ -876,6 +881,7 @@ def test_span_ingestion(
             "sentry_tags": {
                 "browser.name": "Chrome",
                 "category": "db",
+                "name": "my 1st V2 span",
                 "op": "default",
                 "status": "unknown",
             },
@@ -933,6 +939,7 @@ def test_span_ingestion(
                 "domain": "example.com",
                 "file_extension": "js",
                 "group": "8a97a9e43588e2bd",
+                "name": "resource.script",
                 "op": "resource.script",
             },
             "span_id": "b0429c44b67a3eb1",
@@ -987,6 +994,7 @@ def test_span_ingestion(
                 "domain": "example.com",
                 "file_extension": "js",
                 "group": "8a97a9e43588e2bd",
+                "name": "resource.script",
                 "op": "resource.script",
                 "status": "ok",
             },
@@ -1019,7 +1027,11 @@ def test_span_ingestion(
             "key_id": 123,
             "retention_days": 90,
             "segment_id": "968cff94913ebb07",
-            "sentry_tags": {"browser.name": "Chrome", "op": "default"},
+            "sentry_tags": {
+                "browser.name": "Chrome",
+                "name": "default",
+                "op": "default",
+            },
             "span_id": "cd429c44b67a3eb1",
             "start_timestamp_ms": int(start.timestamp() * 1e3),
             "start_timestamp_precise": start.timestamp(),
@@ -1061,6 +1073,7 @@ def test_span_ingestion(
             "segment_id": "d342abb1214ca182",
             "sentry_tags": {
                 "browser.name": "Python Requests",
+                "name": "my 2nd OTel span",
                 "op": "default",
                 "status": "unknown",
             },
@@ -1094,6 +1107,7 @@ def test_span_ingestion(
             "segment_id": "968cff94913ebb07",
             "sentry_tags": {
                 "browser.name": "Chrome",
+                "name": "default",
                 "op": "default",
             },
             "span_id": "ed429c44b67a3eb1",
@@ -1139,6 +1153,7 @@ def test_span_ingestion(
             "retention_days": 90,
             "sentry_tags": {
                 "browser.name": "Python Requests",
+                "name": "my 3rd protobuf OTel span",
                 "op": "default",
                 "category": "ui",
                 "status": "unknown",
@@ -1731,6 +1746,7 @@ def test_span_ingestion_with_performance_scores(
             "retention_days": 90,
             "sentry_tags": {
                 "browser.name": "Python Requests",
+                "name": "ui.interaction.click",
                 "op": "ui.interaction.click",
             },
             "span_id": "bd429c44b67a3eb1",
@@ -1814,6 +1830,7 @@ def test_span_ingestion_with_performance_scores(
             "retention_days": 90,
             "sentry_tags": {
                 "browser.name": "Python Requests",
+                "name": "ui.interaction.click",
                 "op": "ui.interaction.click",
                 "transaction": "/page/with/click/interaction/*/*",
                 "replay_id": "8477286c8e5148b386b71ade38374d58",
@@ -2447,6 +2464,7 @@ def test_scrubs_ip_addresses(
             "sentry.category": "http",
             "sentry.normalized_description": "GET *",
             "sentry.group": "37e3d9fab1ae9162",
+            "sentry.name": "http",
             "sentry.op": "http",
             "sentry.platform": "other",
             "sentry.sdk.name": "raven-node",
@@ -2481,6 +2499,7 @@ def test_scrubs_ip_addresses(
             "category": "http",
             "description": "GET *",
             "group": "37e3d9fab1ae9162",
+            "name": "http",
             "op": "http",
             "platform": "other",
             "sdk.name": "raven-node",
@@ -2530,6 +2549,7 @@ def test_scrubs_ip_addresses(
             "sentry.sdk.version": "2.6.3",
             "sentry.segment.name": "hi",
             # Backfilled from `sentry_tags`:
+            "sentry.name": "hi",
             "sentry.op": "hi",
             "sentry.platform": "other",
             "sentry.status": "unknown",
@@ -2555,6 +2575,7 @@ def test_scrubs_ip_addresses(
         "retention_days": 90,
         "segment_id": "968cff94913ebb07",
         "sentry_tags": {
+            "name": "hi",
             "op": "hi",
             "platform": "other",
             "sdk.name": "raven-node",


### PR DESCRIPTION
My change in https://github.com/getsentry/relay/pull/5143 unintentionally only applied to standalone and OTLP spans, but not spans extracted from transactions. Spans from transactions are the most important use case though, since they're the spans lacking a native `name` field.

Moved the name generation logic out of `span::process` (which is only called for standalone/OTLP spans) and into `tag_extraction::extract_tags`, which runs on all spans. By writing to the `name` sentry tag, it is extracted into the correct `sentry.name` attribute downstream.