### PR TITLE
ref(processing): Adds nothing output

### DIFF
--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -3,7 +3,7 @@ use crate::managed::{Managed, Rejected};
 use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::logs::LogsProcessor;
 use crate::processing::spans::SpansProcessor;
-use crate::processing::{Forward, Processor};
+use crate::processing::{Forward, Nothing, Processor};
 
 macro_rules! outputs {
     ($($variant:ident => $ty:ty,)*) => {
@@ -52,3 +52,9 @@ outputs!(
     Logs => LogsProcessor,
     Spans => SpansProcessor,
 );
+
+impl From<Nothing> for Outputs {
+    fn from(value: Nothing) -> Self {
+        match value {}
+    }
+}

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -154,3 +154,22 @@ pub trait Forward {
         s: &relay_system::Addr<crate::services::store::Store>,
     ) -> Result<(), Rejected<()>>;
 }
+
+/// The [`Nothing`] output.
+///
+/// Some processors may only produce by-products and not have any output of their own.
+pub struct Nothing(std::convert::Infallible);
+
+impl Forward for Nothing {
+    fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+        match self {}
+    }
+
+    #[cfg(feature = "processing")]
+    fn forward_store(
+        self,
+        _: &relay_system::Addr<crate::services::store::Store>,
+    ) -> Result<(), Rejected<()>> {
+        match self {}
+    }
+}


### PR DESCRIPTION
Currently not in use, an initial implementation of the sessions processing needed it, but it was no longer necessary for that.

But in general a `Nothing` output makes sense and I expect it to likely require it in the future for items which are converted from A->B, like NEL or other browser reports which will conditionally convert to other processor inputs (by-products) but will not have an output itself.