### PR TITLE
feat(normalization): Trim tag keys & values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Generate `sentry.name` attributes for spans without names. ([#5143](https://github.com/getsentry/relay/pull/5143))
 - Add integration endpoints for OTLP. ([#5176](https://github.com/getsentry/relay/pull/5176))
 - Emit a metric to record keep/drop decisions in Dynamic Sampling. ([#5164](https://github.com/getsentry/relay/pull/5164))
+- Trim event tag keys & values to 200 chars instead of dropping them. ([#5198](https://github.com/getsentry/relay/pull/5198))
 
 **Bug Fixes**:
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -12,7 +12,6 @@
 ### Various fixes & improvements
 
 - feat(billing): Add retentions to project configs (#5135) by @vbro
->>>>>>> origin/master
 
 ## 0.9.15
 

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Introduces a project scope sampling rule type. ([#5077](https://github.com/getsentry/relay/pull/5077)))
 - Add InstallableBuild and SizeAnalysis data categories. ([#5084](https://github.com/getsentry/relay/pull/5084))
+- Trim event tag keys & values to 200 chars instead of dropping them. ([#5198](https://github.com/getsentry/relay/pull/5198))
 
 ## 0.9.15
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -5221,4 +5221,85 @@ mod tests {
         }
         "###);
     }
+
+    #[test]
+    fn test_tags_are_trimmed() {
+        let json = r#"
+            {
+                "tags": {
+                    "key": "too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_",
+                    "too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_": "value"
+                }
+            }
+        "#;
+
+        let mut event = Annotated::<Event>::from_json(json).unwrap();
+
+        normalize_event(
+            &mut event,
+            &NormalizationConfig {
+                enable_trimming: true,
+                ..NormalizationConfig::default()
+            },
+        );
+
+        insta::assert_debug_snapshot!(get_value!(event.tags!), @r###"
+        Tags(
+            PairList(
+                [
+                    TagEntry(
+                        "key",
+                        Annotated(
+                            "too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__lo...",
+                            Meta {
+                                remarks: [
+                                    Remark {
+                                        ty: Substituted,
+                                        rule_id: "!limit",
+                                        range: Some(
+                                            (
+                                                197,
+                                                200,
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                errors: [],
+                                original_length: Some(
+                                    210,
+                                ),
+                                original_value: None,
+                            },
+                        ),
+                    ),
+                    TagEntry(
+                        Annotated(
+                            "too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__long_too__lo...",
+                            Meta {
+                                remarks: [
+                                    Remark {
+                                        ty: Substituted,
+                                        rule_id: "!limit",
+                                        range: Some(
+                                            (
+                                                197,
+                                                200,
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                errors: [],
+                                original_length: Some(
+                                    210,
+                                ),
+                                original_value: None,
+                            },
+                        ),
+                        "value",
+                    ),
+                ],
+            ),
+        )
+        "###);
+    }
 }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -668,20 +668,16 @@ fn normalize_event_tags(event: &mut Event) {
 
     for tag in tags.iter_mut() {
         let _ = processor::apply(tag, |tag, _| {
-            if let Some(key) = tag.key() {
-                if key.is_empty() {
-                    tag.0 = Annotated::from_error(Error::nonempty(), None);
-                } else if bytecount::num_chars(key.as_bytes()) > MaxChars::TagKey.limit() {
-                    tag.0 = Annotated::from_error(Error::new(ErrorKind::ValueTooLong), None);
-                }
+            if let Some(key) = tag.key()
+                && key.is_empty()
+            {
+                tag.0 = Annotated::from_error(Error::nonempty(), None);
             }
 
-            if let Some(value) = tag.value() {
-                if value.is_empty() {
-                    tag.1 = Annotated::from_error(Error::nonempty(), None);
-                } else if bytecount::num_chars(value.as_bytes()) > MaxChars::TagValue.limit() {
-                    tag.1 = Annotated::from_error(Error::new(ErrorKind::ValueTooLong), None);
-                }
+            if let Some(value) = tag.value()
+                && value.is_empty()
+            {
+                tag.1 = Annotated::from_error(Error::nonempty(), None);
             }
 
             Ok(())

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -49,8 +49,6 @@ pub use sentry_release_parser::{validate_environment, validate_release};
 /// Must be aligned with the `max_chars` field in the metastructure of the
 /// payload's attribute.
 enum MaxChars {
-    TagKey,
-    TagValue,
     Distribution,
     Logger,
 }
@@ -58,8 +56,6 @@ enum MaxChars {
 impl MaxChars {
     pub fn limit(self) -> usize {
         match self {
-            Self::TagKey => 200,
-            Self::TagValue => 200,
             Self::Distribution => 64,
             Self::Logger => 64,
         }

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1284,38 +1284,6 @@ mod tests {
     }
 
     #[test]
-    fn test_too_long_tags() {
-        let mut event = Annotated::new(Event {
-        tags: Annotated::new(Tags(PairList(
-            vec![Annotated::new(TagEntry(
-                Annotated::new("foobar".to_owned()),
-                Annotated::new("...........................................................................................................................................................................................................".to_owned()),
-            )), Annotated::new(TagEntry(
-                Annotated::new("foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo".to_owned()),
-                Annotated::new("bar".to_owned()),
-            ))]),
-        )),
-        ..Event::default()
-    });
-
-        normalize_event(&mut event, &NormalizationConfig::default());
-
-        assert_eq!(
-            get_value!(event.tags!),
-            &Tags(PairList(vec![
-                Annotated::new(TagEntry(
-                    Annotated::new("foobar".to_owned()),
-                    Annotated::from_error(Error::new(ErrorKind::ValueTooLong), None),
-                )),
-                Annotated::new(TagEntry(
-                    Annotated::from_error(Error::new(ErrorKind::ValueTooLong), None),
-                    Annotated::new("bar".to_owned()),
-                )),
-            ]))
-        );
-    }
-
-    #[test]
     fn test_too_long_distribution() {
         let json = r#"{
   "event_id": "52df9022835246eeb317dbd739ccd059",


### PR DESCRIPTION
We've been dropping event tag values when they are too long: https://github.com/getsentry/relay/commit/7af05d4560d90fadfa35b419b6ed1da5c4f68dae

SDKs are removing truncation on their side, so Relay should truncate instead of dropping to create the same end-to-end behavior for the product.

Fixes INGEST-538.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch handling of overlong tag keys/values from dropping to trimming with remarks, and update tests accordingly.
> 
> - **Tag Trimming Behavior**:
>   - Implement trimming (with remarks) for overlong tag keys/values in `TrimmingProcessor` tests, replacing previous behavior that dropped them.
> - **Tests**:
>   - Remove `normalize::tests::test_too_long_tags` that expected drop-on-too-long in `relay-event-normalization/src/normalize/mod.rs`.
>   - Add `trimming::tests::test_too_long_tags` verifying trimmed `Tags` `PairList` snapshots in `relay-event-normalization/src/trimming.rs`.
>   - Adjust imports to include `PairList` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90202859b5e143878d785c7bf28b313e5ac484e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->