### PR TITLE
test(spans): Add small bucket aggregation time to avoid random failures

### DIFF
--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -709,7 +709,7 @@ def test_span_ingestion(
         options={
             "aggregator": {
                 "bucket_interval": 1,
-                "initial_delay": 0,
+                "initial_delay": 2,
                 "max_secs_in_past": 2**64 - 1,
                 "shift_key": "none",
             }


### PR DESCRIPTION
Failing quite often in CI now, e.g. https://github.com/getsentry/relay/actions/runs/18158062323/job/51682415358