### PR TITLE
ref(pii): Mark the `event.transaction` field as pii-maybe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add integration endpoints for OTLP. ([#5176](https://github.com/getsentry/relay/pull/5176))
 - Emit a metric to record keep/drop decisions in Dynamic Sampling. ([#5164](https://github.com/getsentry/relay/pull/5164))
 - Trim event tag keys & values to 200 chars instead of dropping them. ([#5198](https://github.com/getsentry/relay/pull/5198))
+- Allow pii scrubbing of the `transaction` field. ([#5205](https://github.com/getsentry/relay/pull/5205))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add integration endpoints for OTLP. ([#5176](https://github.com/getsentry/relay/pull/5176))
 - Emit a metric to record keep/drop decisions in Dynamic Sampling. ([#5164](https://github.com/getsentry/relay/pull/5164))
 - Trim event tag keys & values to 200 chars instead of dropping them. ([#5198](https://github.com/getsentry/relay/pull/5198))
-- Allow pii scrubbing of the `transaction` field. ([#5205](https://github.com/getsentry/relay/pull/5205))
+- Allow pii scrubbing of the `event.transaction` field. ([#5205](https://github.com/getsentry/relay/pull/5205))
 
 **Bug Fixes**:
 

--- a/relay-event-schema/src/protocol/event.rs
+++ b/relay-event-schema/src/protocol/event.rs
@@ -204,7 +204,7 @@ pub struct Event {
     ///
     /// For example, in a web app, this might be the route name (`"/users/<username>/"` or
     /// `UserView`), in a task queue it might be the function + module name.
-    #[metastructure(max_chars = 200, trim_whitespace = true)]
+    #[metastructure(max_chars = 200, trim_whitespace = true, pii = "maybe")]
     pub transaction: Annotated<String>,
 
     /// Additional information about the name of the transaction.


### PR DESCRIPTION
A customer tried to apply the `[Mask] [Usernames in filepaths]` for the transaction but was unable to do so, from local testing it seems to stem from the fact that the field is not marked as `pii = "maybe"`. This PR changes this.

---
[Example](https://tempest-test.sentry.io/explore/traces/trace/011655b58130492db7d7429e5c4ee8ba/?node=span-bdcd5d8eff4b8f1b&project=4509355858395136&source=traces&statsPeriod=1h&targetId=bdcd5d8eff4b8f1b&timestamp=1759422157) of transaction send through local Relay were it now works.