### PR TITLE
ref(server): Remove non-integration otlp endpoints

### DIFF
--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -87,9 +87,6 @@ pub fn routes(config: &Config) -> Router<ServiceState>{
     // configured by users or protocols may force a specific variant.
     let integration_routes = Router::new()
         .nest("/api/{project_id}/integration/otlp", integrations::otlp::routes(config))
-        // Old, pre integration routes to be removed
-        .route("/api/{project_id}/otlp/v1/traces", integrations::otlp::traces::route(config))
-        .route("/api/{project_id}/otlp/v1/traces/", integrations::otlp::traces::route(config))
         .route_layer(middlewares::cors());
 
     // NOTE: If you add a new (non-experimental) route here, please also list it in


### PR DESCRIPTION
They were never released, we decided to go with an integration namesapce which is no accessible. We can remove these now.