### PR TITLE
ref(cli): Rework and test healthcheck command

### DIFF
--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -46,8 +46,6 @@ pub fn execute() -> Result<()> {
         }
     } else if let Some(matches) = matches.subcommand_matches("generate-completions") {
         return generate_completions(matches);
-    } else if let Some(matches) = matches.subcommand_matches("healthcheck") {
-        return healthcheck(matches);
     }
 
     // Commands that need a loaded config:
@@ -66,6 +64,8 @@ pub fn execute() -> Result<()> {
         manage_config(&config, matches)
     } else if let Some(matches) = matches.subcommand_matches("credentials") {
         manage_credentials(config, matches)
+    } else if let Some(matches) = matches.subcommand_matches("healthcheck") {
+        healthcheck(&config, matches)
     } else if let Some(matches) = matches.subcommand_matches("run") {
         // override config with run command args
         let arg_config = extract_config_args(matches);

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -1,5 +1,7 @@
 //! This module implements the definition of the command line app.
 
+use std::net::SocketAddr;
+
 use clap::builder::ValueParser;
 use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint};
 use clap_complete::Shell;
@@ -336,28 +338,11 @@ pub fn make_app() -> Command {
                         .required(false),
                 )
                 .arg(
-                    Arg::new("host")
-                        .long("host")
-                        .short('h')
-                        .help(
-                            "If relay is not running on localhost and there are no config file, \
-                            you can specify the hostname here.",
-                        )
-                        .default_value("localhost")
-                        .value_parser(clap::value_parser!(String))
+                    Arg::new("addr")
+                        .long("addr")
+                        .help("Address where Relay is running. Defaults to the Relay configuration.")
+                        .value_parser(clap::value_parser!(SocketAddr))
                         .required(false),
                 )
-                .arg(
-                    Arg::new("port")
-                        .long("port")
-                        .short('p')
-                        .help(
-                            "If relay is not running on port 3000 and there are no config file, \
-                            you can specify the port here.",
-                        )
-                        .default_value("3000")
-                        .value_parser(clap::value_parser!(u16))
-                        .required(false),
-                ),
         )
 }

--- a/relay/src/healthcheck.rs
+++ b/relay/src/healthcheck.rs
@@ -1,30 +1,32 @@
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use anyhow::{Result, format_err};
 use clap::ArgMatches;
+use relay_config::Config;
 use reqwest::blocking::Client;
 
-pub fn healthcheck(matches: &ArgMatches) -> Result<()> {
+pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
     let mode = matches
         .get_one::<String>("mode")
         .expect("`mode` is required");
+
     let timeout = matches
         .get_one::<u64>("timeout")
         .expect("`timeout` is required");
-    let host = matches
-        .get_one::<String>("host")
-        .expect("`host` is required");
-    let port = matches.get_one::<u16>("port").expect("`port` is required");
+
+    let addr = matches
+        .get_one::<SocketAddr>("addr")
+        .copied()
+        .unwrap_or(config.listen_addr());
 
     let client = Client::builder()
         .timeout(Some(Duration::from_secs(*timeout)))
         .build()
         .unwrap_or_default();
+
     let response = client
-        .get(format!(
-            "http://{}:{}/api/relay/healthcheck/{}/",
-            host, port, mode
-        ))
+        .get(format!("http://{addr}/api/relay/healthcheck/{mode}/"))
         .send();
 
     match response {
@@ -40,7 +42,7 @@ pub fn healthcheck(matches: &ArgMatches) -> Result<()> {
             }
         }
         Err(err) => {
-            relay_log::error!("Relay is unhealthy. Error: {}", err);
+            relay_log::error!("Relay is unhealthy. Error: {err}");
             Err(err.into())
         }
     }


### PR DESCRIPTION
The healthcheck command before was broken:

- it had a clash for `-h` (`--help` and `--host`)
- it did not consider the config as a fallback

Fixes the command and adds some integration tests.