### PR TITLE
Revert "ref(devservices): Add back relay healthcheck"

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -31,11 +31,12 @@ services:
     ports:
       - 127.0.0.1:7899:7899
     command: [run, --config, /etc/relay]
-    healthcheck:
-      test: ["CMD", "/bin/relay", "--config", "/etc/relay", "healthcheck"]
-      interval: 5s
-      timeout: 5s
-      retries: 3
+    # Temporarily removed, due to a distroless image not having access to curl.
+    # healthcheck:
+    #   test: curl -f http://127.0.0.1:7899/api/relay/healthcheck/live/
+    #   interval: 5s
+    #   timeout: 5s
+    #   retries: 3
     volumes:
       - ./config/relay.yml:/etc/relay/config.yml
       - ./config/devservices-credentials.json:/etc/relay/credentials.json


### PR DESCRIPTION
Reverts getsentry/relay#5066

Breaks Sentry CI: https://github.com/getsentry/getsentry/actions/runs/18277455443/job/52032764645

Maybe just because devservices expects Relay to be up before starting Sentry.