### PR TITLE
ref(server): Use references instead of Arcs, introduce ForwardContext

### DIFF
--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -1,5 +1,6 @@
 use crate::Envelope;
 use crate::managed::{Managed, Rejected};
+use crate::processing::ForwardContext;
 use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::logs::LogsProcessor;
 use crate::processing::sessions::SessionsProcessor;
@@ -18,10 +19,10 @@ macro_rules! outputs {
         }
 
         impl Forward for Outputs {
-            fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+            fn serialize_envelope(self, ctx: ForwardContext<'_>) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
                 match self {
                     $(
-                        Self::$variant(output) => output.serialize_envelope()
+                        Self::$variant(output) => output.serialize_envelope(ctx)
                     ),*
                 }
             }
@@ -30,10 +31,11 @@ macro_rules! outputs {
             fn forward_store(
                 self,
                 s: &relay_system::Addr<crate::services::store::Store>,
+                ctx: ForwardContext<'_>,
             ) -> Result<(), Rejected<()>> {
                 match self {
                     $(
-                        Self::$variant(output) => output.forward_store(s)
+                        Self::$variant(output) => output.forward_store(s, ctx)
                     ),*
                 }
             }

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -170,7 +170,10 @@ pub enum LogOutput {
 }
 
 impl Forward for LogOutput {
-    fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+    fn serialize_envelope(
+        self,
+        _: processing::ForwardContext<'_>,
+    ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
         let logs = match self {
             Self::NotProcessed(logs) => logs,
             Self::Processed(logs) => logs.try_map(|logs, r| {
@@ -191,6 +194,7 @@ impl Forward for LogOutput {
     fn forward_store(
         self,
         s: &relay_system::Addr<crate::services::store::Store>,
+        _: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let logs = match self {
             LogOutput::NotProcessed(logs) => {

--- a/relay-server/src/processing/sessions/mod.rs
+++ b/relay-server/src/processing/sessions/mod.rs
@@ -113,7 +113,10 @@ impl processing::Processor for SessionsProcessor {
 pub struct SessionsOutput(Managed<SerializedSessions>);
 
 impl Forward for SessionsOutput {
-    fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+    fn serialize_envelope(
+        self,
+        _: processing::ForwardContext<'_>,
+    ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
         Ok(self.0.map(|sessions, _| sessions.serialize_envelope()))
     }
 
@@ -121,6 +124,7 @@ impl Forward for SessionsOutput {
     fn forward_store(
         self,
         _: &relay_system::Addr<crate::services::store::Store>,
+        _: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let SessionsOutput(sessions) = self;
         Err(sessions.internal_error("sessions should always be extracted into metrics"))

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -150,7 +150,10 @@ pub enum SpanOutput {
 }
 
 impl Forward for SpanOutput {
-    fn serialize_envelope(self) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+    fn serialize_envelope(
+        self,
+        _: processing::ForwardContext<'_>,
+    ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
         let spans = match self {
             Self::NotProcessed(spans) => spans,
             Self::Processed(spans) => spans.try_map(|spans, _| {
@@ -168,6 +171,7 @@ impl Forward for SpanOutput {
     fn forward_store(
         self,
         s: &relay_system::Addr<crate::services::store::Store>,
+        _: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         use crate::envelope::ContentType;
         use crate::services::store::StoreEnvelope;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -4008,27 +4008,27 @@ mod tests {
             public_key: ProjectKey::parse("e12d836b15bb49d7bbf99e64295d995b").unwrap(),
             numeric_id: Some(1),
         });
-        let project_info = Arc::new(project_info);
+
+        let config = serde_json::json!({
+            "processing": {
+                "enabled": true,
+                "kafka_config": [],
+            }
+        });
 
         let message = ProcessEnvelopeGrouped {
             group: ProcessingGroup::Transaction,
             envelope: managed_envelope,
             ctx: processing::Context {
+                config: &Config::from_json_value(config.clone()).unwrap(),
                 project_info: &project_info,
+                sampling_project_info: Some(&project_info),
                 ..processing::Context::for_test()
             },
             reservoir_counters: &ReservoirCounters::default(),
         };
 
-        let config = Config::from_json_value(serde_json::json!({
-            "processing": {
-                "enabled": true,
-                "kafka_config": [],
-            }
-        }))
-        .unwrap();
-
-        let processor = create_test_processor(config).await;
+        let processor = create_test_processor(Config::from_json_value(config).unwrap()).await;
         let Ok(Some(Submit::Envelope(envelope))) =
             processor.process(&mut Token::noop(), message).await
         else {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -907,11 +907,14 @@ impl ProcessingResult {
     clippy::large_enum_variant,
     reason = "until we have a better solution to combat the excessive growth of Item, see #4819"
 )]
-enum Submit {
+enum Submit<'a> {
     /// A processed envelope.
     Envelope(TypedEnvelope<Processed>),
     /// The output of a [`processing::Processor`].
-    Output(Outputs),
+    Output {
+        output: Outputs,
+        ctx: processing::ForwardContext<'a>,
+    },
 }
 
 /// Applies processing to all contents of the given envelope.
@@ -939,19 +942,15 @@ pub struct ProcessEnvelope {
 
 /// Like a [`ProcessEnvelope`], but with an envelope which has been grouped.
 #[derive(Debug)]
-struct ProcessEnvelopeGrouped {
+struct ProcessEnvelopeGrouped<'a> {
     /// The group the envelope belongs to.
     pub group: ProcessingGroup,
     /// Envelope to process.
     pub envelope: ManagedEnvelope,
-    /// The project info.
-    pub project_info: Arc<ProjectInfo>,
-    /// Currently active cached rate limits for this project.
-    pub rate_limits: Arc<RateLimits>,
-    /// Root sampling project info.
-    pub sampling_project_info: Option<Arc<ProjectInfo>>,
+    /// The processing context.
+    pub ctx: processing::Context<'a>,
     /// Sampling reservoir counters.
-    pub reservoir_counters: ReservoirCounters,
+    pub reservoir_counters: &'a ReservoirCounters,
 }
 
 /// Parses a list of metrics or metric buckets and pushes them to the project's aggregator.
@@ -1316,21 +1315,12 @@ impl EnvelopeProcessorService {
         managed_envelope: &mut TypedEnvelope<Group>,
         event: Annotated<Event>,
         extracted_metrics: &mut ProcessingExtractedMetrics,
-        project_info: &ProjectInfo,
-        rate_limits: &RateLimits,
+        ctx: processing::Context<'_>,
     ) -> Result<Annotated<Event>, ProcessingError> {
-        let global_config = self.inner.global_config.current();
         // Cached quotas first, they are quick to evaluate and some quotas (indexed) are not
         // applied in the fast path, all cached quotas can be applied here.
         let cached_result = RateLimiter::Cached
-            .enforce(
-                managed_envelope,
-                event,
-                extracted_metrics,
-                &global_config,
-                project_info,
-                rate_limits,
-            )
+            .enforce(managed_envelope, event, extracted_metrics, ctx)
             .await?;
 
         if_processing!(self.inner.config, {
@@ -1345,9 +1335,7 @@ impl EnvelopeProcessorService {
                     managed_envelope,
                     cached_result.event,
                     extracted_metrics,
-                    &global_config,
-                    project_info,
-                    rate_limits,
+                    ctx
                 )
                 .await?;
 
@@ -1372,7 +1360,7 @@ impl EnvelopeProcessorService {
         event: &mut Annotated<Event>,
         extracted_metrics: &mut ProcessingExtractedMetrics,
         project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
+        project_info: &ProjectInfo,
         sampling_decision: SamplingDecision,
         event_metrics_extracted: EventMetricsExtracted,
         spans_extracted: SpansExtracted,
@@ -1483,7 +1471,7 @@ impl EnvelopeProcessorService {
         managed_envelope: &mut TypedEnvelope<Group>,
         event: &mut Annotated<Event>,
         project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
+        project_info: &ProjectInfo,
         mut event_fully_normalized: EventFullyNormalized,
     ) -> Result<EventFullyNormalized, ProcessingError> {
         if event.value().is_empty() {
@@ -1625,9 +1613,7 @@ impl EnvelopeProcessorService {
         &self,
         managed_envelope: &mut TypedEnvelope<ErrorGroup>,
         project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
-        mut sampling_project_info: Option<Arc<ProjectInfo>>,
-        rate_limits: Arc<RateLimits>,
+        mut ctx: processing::Context<'_>,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut event_fully_normalized = EventFullyNormalized::new(managed_envelope.envelope());
         let mut metrics = Metrics::default();
@@ -1639,7 +1625,7 @@ impl EnvelopeProcessorService {
         if_processing!(self.inner.config, {
             unreal::expand(managed_envelope, &self.inner.config)?;
             #[cfg(sentry)]
-            playstation::expand(managed_envelope, &self.inner.config, &project_info)?;
+            playstation::expand(managed_envelope, &self.inner.config, ctx.project_info)?;
             nnswitch::expand(managed_envelope)?;
         });
 
@@ -1659,7 +1645,7 @@ impl EnvelopeProcessorService {
             }
             #[cfg(sentry)]
             if let Some(inner_event_fully_normalized) =
-                playstation::process(managed_envelope, &mut event, &project_info)?
+                playstation::process(managed_envelope, &mut event, ctx.project_info)?
             {
                 event_fully_normalized = inner_event_fully_normalized;
             }
@@ -1670,11 +1656,11 @@ impl EnvelopeProcessorService {
             }
         });
 
-        sampling_project_info = dynamic_sampling::validate_and_set_dsc(
+        ctx.sampling_project_info = dynamic_sampling::validate_and_set_dsc(
             managed_envelope,
             &mut event,
-            project_info.clone(),
-            sampling_project_info,
+            ctx.project_info,
+            ctx.sampling_project_info,
         );
         event::finalize(
             managed_envelope,
@@ -1686,13 +1672,13 @@ impl EnvelopeProcessorService {
             managed_envelope,
             &mut event,
             project_id,
-            project_info.clone(),
+            ctx.project_info,
             event_fully_normalized,
         )?;
         let filter_run = event::filter(
             managed_envelope,
             &mut event,
-            project_info.clone(),
+            ctx.project_info,
             &self.inner.global_config.current(),
         )?;
 
@@ -1700,24 +1686,18 @@ impl EnvelopeProcessorService {
             dynamic_sampling::tag_error_with_sampling_decision(
                 managed_envelope,
                 &mut event,
-                sampling_project_info,
+                ctx.sampling_project_info,
                 &self.inner.config,
             )
             .await;
         }
 
         event = self
-            .enforce_quotas(
-                managed_envelope,
-                event,
-                &mut extracted_metrics,
-                &project_info,
-                &rate_limits,
-            )
+            .enforce_quotas(managed_envelope, event, &mut extracted_metrics, ctx)
             .await?;
 
         if event.value().is_some() {
-            event::scrub(&mut event, project_info.clone())?;
+            event::scrub(&mut event, ctx.project_info)?;
             event::serialize(
                 managed_envelope,
                 &mut event,
@@ -1728,7 +1708,7 @@ impl EnvelopeProcessorService {
             event::emit_feedback_metrics(managed_envelope.envelope());
         }
 
-        attachment::scrub(managed_envelope, project_info);
+        attachment::scrub(managed_envelope, ctx.project_info);
 
         if self.inner.config.processing_enabled() && !event_fully_normalized.0 {
             relay_log::error!(
@@ -1748,20 +1728,15 @@ impl EnvelopeProcessorService {
         &self,
         managed_envelope: &mut TypedEnvelope<TransactionGroup>,
         cogs: &mut Token,
-        config: Arc<Config>,
         project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
-        mut sampling_project_info: Option<Arc<ProjectInfo>>,
-        rate_limits: Arc<RateLimits>,
-        reservoir_counters: ReservoirCounters,
+        mut ctx: processing::Context<'_>,
+        reservoir_counters: &ReservoirCounters,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut event_fully_normalized = EventFullyNormalized::new(managed_envelope.envelope());
         let mut event_metrics_extracted = EventMetricsExtracted(false);
         let mut spans_extracted = SpansExtracted(false);
         let mut metrics = Metrics::default();
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
-
-        let global_config = self.inner.global_config.current();
 
         // We extract the main event from the envelope.
         let extraction_result = event::extract(
@@ -1785,17 +1760,17 @@ impl EnvelopeProcessorService {
         let profile_id = profile::filter(
             managed_envelope,
             &event,
-            config.clone(),
+            ctx.config,
             project_id,
-            &project_info,
+            ctx.project_info,
         );
         profile::transfer_id(&mut event, profile_id);
 
-        sampling_project_info = dynamic_sampling::validate_and_set_dsc(
+        ctx.sampling_project_info = dynamic_sampling::validate_and_set_dsc(
             managed_envelope,
             &mut event,
-            project_info.clone(),
-            sampling_project_info,
+            ctx.project_info,
+            ctx.sampling_project_info,
         );
 
         event::finalize(
@@ -1809,15 +1784,15 @@ impl EnvelopeProcessorService {
             managed_envelope,
             &mut event,
             project_id,
-            project_info.clone(),
+            ctx.project_info,
             event_fully_normalized,
         )?;
 
         let filter_run = event::filter(
             managed_envelope,
             &mut event,
-            project_info.clone(),
-            &self.inner.global_config.current(),
+            ctx.project_info,
+            ctx.global_config,
         )?;
 
         // Always run dynamic sampling on processing Relays,
@@ -1835,9 +1810,9 @@ impl EnvelopeProcessorService {
                 dynamic_sampling::run(
                     managed_envelope,
                     &mut event,
-                    config.clone(),
-                    project_info.clone(),
-                    sampling_project_info,
+                    ctx.config,
+                    ctx.project_info,
+                    ctx.sampling_project_info,
                     &reservoir,
                 )
                 .await
@@ -1860,9 +1835,9 @@ impl EnvelopeProcessorService {
             profile::process(
                 managed_envelope,
                 &mut event,
-                &global_config,
-                config.clone(),
-                project_info.clone(),
+                ctx.global_config,
+                ctx.config,
+                ctx.project_info,
             );
             // Extract metrics here, we're about to drop the event/transaction.
             event_metrics_extracted = self.extract_transaction_metrics(
@@ -1870,7 +1845,7 @@ impl EnvelopeProcessorService {
                 &mut event,
                 &mut extracted_metrics,
                 project_id,
-                project_info.clone(),
+                ctx.project_info,
                 SamplingDecision::Drop,
                 event_metrics_extracted,
                 spans_extracted,
@@ -1892,8 +1867,7 @@ impl EnvelopeProcessorService {
                     managed_envelope,
                     Annotated::empty(),
                     &mut extracted_metrics,
-                    &project_info,
-                    &rate_limits,
+                    ctx,
                 )
                 .await?;
 
@@ -1905,19 +1879,19 @@ impl EnvelopeProcessorService {
         // Need to scrub the transaction before extracting spans.
         //
         // Unconditionally scrub to make sure PII is removed as early as possible.
-        event::scrub(&mut event, project_info.clone())?;
+        event::scrub(&mut event, ctx.project_info)?;
 
         // TODO: remove once `relay.drop-transaction-attachments` has graduated.
-        attachment::scrub(managed_envelope, project_info.clone());
+        attachment::scrub(managed_envelope, ctx.project_info);
 
         if_processing!(self.inner.config, {
             // Process profiles before extracting metrics, to make sure they are removed if they are invalid.
             let profile_id = profile::process(
                 managed_envelope,
                 &mut event,
-                &global_config,
-                config.clone(),
-                project_info.clone(),
+                ctx.global_config,
+                ctx.config,
+                ctx.project_info,
             );
             profile::transfer_id(&mut event, profile_id);
             profile::scrub_profiler_id(&mut event);
@@ -1928,18 +1902,18 @@ impl EnvelopeProcessorService {
                 &mut event,
                 &mut extracted_metrics,
                 project_id,
-                project_info.clone(),
+                ctx.project_info,
                 SamplingDecision::Keep,
                 event_metrics_extracted,
                 spans_extracted,
             )?;
 
-            if project_info.has_feature(Feature::ExtractSpansFromEvent) {
+            if ctx.project_info.has_feature(Feature::ExtractSpansFromEvent) {
                 spans_extracted = span::extract_from_event(
                     managed_envelope,
                     &event,
-                    &global_config,
-                    config,
+                    ctx.global_config,
+                    ctx.config,
                     server_sample_rate,
                     event_metrics_extracted,
                     spans_extracted,
@@ -1948,17 +1922,11 @@ impl EnvelopeProcessorService {
         });
 
         event = self
-            .enforce_quotas(
-                managed_envelope,
-                event,
-                &mut extracted_metrics,
-                &project_info,
-                &rate_limits,
-            )
+            .enforce_quotas(managed_envelope, event, &mut extracted_metrics, ctx)
             .await?;
 
         if_processing!(self.inner.config, {
-            event = span::maybe_discard_transaction(managed_envelope, event, project_info);
+            event = span::maybe_discard_transaction(managed_envelope, event, ctx.project_info);
         });
 
         // Event may have been dropped because of a quota and the envelope can be empty.
@@ -1986,17 +1954,16 @@ impl EnvelopeProcessorService {
     async fn process_profile_chunks(
         &self,
         managed_envelope: &mut TypedEnvelope<ProfileChunkGroup>,
-        project_info: Arc<ProjectInfo>,
-        rate_limits: Arc<RateLimits>,
+        ctx: processing::Context<'_>,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
-        profile_chunk::filter(managed_envelope, project_info.clone());
+        profile_chunk::filter(managed_envelope, ctx.project_info);
 
         if_processing!(self.inner.config, {
             profile_chunk::process(
                 managed_envelope,
-                &project_info,
-                &self.inner.global_config.current(),
-                &self.inner.config,
+                ctx.project_info,
+                ctx.global_config,
+                ctx.config,
             );
         });
 
@@ -2004,8 +1971,7 @@ impl EnvelopeProcessorService {
             managed_envelope,
             Annotated::empty(),
             &mut ProcessingExtractedMetrics::new(),
-            &project_info,
-            &rate_limits,
+            ctx,
         )
         .await?;
 
@@ -2016,10 +1982,8 @@ impl EnvelopeProcessorService {
     async fn process_standalone(
         &self,
         managed_envelope: &mut TypedEnvelope<StandaloneGroup>,
-        config: Arc<Config>,
         project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
-        rate_limits: Arc<RateLimits>,
+        ctx: processing::Context<'_>,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
@@ -2028,22 +1992,21 @@ impl EnvelopeProcessorService {
         profile::filter(
             managed_envelope,
             &Annotated::empty(),
-            config,
+            ctx.config,
             project_id,
-            &project_info,
+            ctx.project_info,
         );
 
         self.enforce_quotas(
             managed_envelope,
             Annotated::empty(),
             &mut extracted_metrics,
-            &project_info,
-            &rate_limits,
+            ctx,
         )
         .await?;
 
         report::process_user_reports(managed_envelope);
-        attachment::scrub(managed_envelope, project_info);
+        attachment::scrub(managed_envelope, ctx.project_info);
 
         Ok(Some(extracted_metrics))
     }
@@ -2052,9 +2015,7 @@ impl EnvelopeProcessorService {
     async fn process_client_reports(
         &self,
         managed_envelope: &mut TypedEnvelope<ClientReportGroup>,
-        config: Arc<Config>,
-        project_info: Arc<ProjectInfo>,
-        rate_limits: Arc<RateLimits>,
+        ctx: processing::Context<'_>,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
@@ -2062,15 +2023,14 @@ impl EnvelopeProcessorService {
             managed_envelope,
             Annotated::empty(),
             &mut extracted_metrics,
-            &project_info,
-            &rate_limits,
+            ctx,
         )
         .await?;
 
         report::process_client_reports(
             managed_envelope,
-            &config,
-            &project_info,
+            ctx.config,
+            ctx.project_info,
             self.inner.addrs.outcome_aggregator.clone(),
         );
 
@@ -2081,17 +2041,15 @@ impl EnvelopeProcessorService {
     async fn process_replays(
         &self,
         managed_envelope: &mut TypedEnvelope<ReplayGroup>,
-        config: Arc<Config>,
-        project_info: Arc<ProjectInfo>,
-        rate_limits: Arc<RateLimits>,
+        ctx: processing::Context<'_>,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
         replay::process(
             managed_envelope,
-            &self.inner.global_config.current(),
-            &config,
-            &project_info,
+            ctx.global_config,
+            ctx.config,
+            ctx.project_info,
             &self.inner.geoip_lookup,
         )?;
 
@@ -2099,8 +2057,7 @@ impl EnvelopeProcessorService {
             managed_envelope,
             Annotated::empty(),
             &mut extracted_metrics,
-            &project_info,
-            &rate_limits,
+            ctx,
         )
         .await?;
 
@@ -2156,21 +2113,17 @@ impl EnvelopeProcessorService {
     async fn process_standalone_spans(
         &self,
         managed_envelope: &mut TypedEnvelope<SpanGroup>,
-        config: Arc<Config>,
         _project_id: ProjectId,
-        project_info: Arc<ProjectInfo>,
-        _sampling_project_info: Option<Arc<ProjectInfo>>,
-        rate_limits: Arc<RateLimits>,
-        _reservoir_counters: ReservoirCounters,
+        ctx: processing::Context<'_>,
+        _reservoir_counters: &ReservoirCounters,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
         span::expand_v2_spans(managed_envelope)?;
-        span::filter(managed_envelope, config.clone(), project_info.clone());
+        span::filter(managed_envelope, ctx.config, ctx.project_info);
         span::convert_otel_traces_data(managed_envelope);
 
         if_processing!(self.inner.config, {
-            let global_config = self.inner.global_config.current();
             let reservoir = self.new_reservoir_evaluator(
                 managed_envelope.scoping().organization_id,
                 _reservoir_counters,
@@ -2180,11 +2133,8 @@ impl EnvelopeProcessorService {
                 managed_envelope,
                 &mut Annotated::empty(),
                 &mut extracted_metrics,
-                &global_config,
-                config,
                 _project_id,
-                project_info.clone(),
-                _sampling_project_info,
+                ctx,
                 &self.inner.geoip_lookup,
                 &reservoir,
             )
@@ -2195,8 +2145,7 @@ impl EnvelopeProcessorService {
             managed_envelope,
             Annotated::empty(),
             &mut extracted_metrics,
-            &project_info,
-            &rate_limits,
+            ctx,
         )
         .await?;
 
@@ -2207,19 +2156,17 @@ impl EnvelopeProcessorService {
         &self,
         cogs: &mut Token,
         project_id: ProjectId,
-        message: ProcessEnvelopeGrouped,
+        message: ProcessEnvelopeGrouped<'_>,
     ) -> Result<ProcessingResult, ProcessingError> {
         let ProcessEnvelopeGrouped {
             group,
             envelope: mut managed_envelope,
-            project_info,
-            rate_limits,
-            sampling_project_info,
+            ctx,
             reservoir_counters,
         } = message;
 
         // Pre-process the envelope headers.
-        if let Some(sampling_state) = sampling_project_info.as_ref() {
+        if let Some(sampling_state) = ctx.sampling_project_info {
             // Both transactions and standalone span envelopes need a normalized DSC header
             // to make sampling rules based on the segment/transaction name work correctly.
             managed_envelope
@@ -2229,13 +2176,13 @@ impl EnvelopeProcessorService {
 
         // Set the event retention. Effectively, this value will only be available in processing
         // mode when the full project config is queried from the upstream.
-        if let Some(retention) = project_info.config.event_retention {
+        if let Some(retention) = ctx.project_info.config.event_retention {
             managed_envelope.envelope_mut().set_retention(retention);
         }
 
         // Set the event retention. Effectively, this value will only be available in processing
         // mode when the full project config is queried from the upstream.
-        if let Some(retention) = project_info.config.downsampled_event_retention {
+        if let Some(retention) = ctx.project_info.config.downsampled_event_retention {
             managed_envelope
                 .envelope_mut()
                 .set_downsampled_retention(retention);
@@ -2272,34 +2219,16 @@ impl EnvelopeProcessorService {
             };
         }
 
-        let global_config = self.inner.global_config.current();
-        let ctx = processing::Context {
-            config: &self.inner.config,
-            global_config: &global_config,
-            project_info: &project_info,
-            sampling_project_info: sampling_project_info.as_deref(),
-            rate_limits: &rate_limits,
-        };
-
         relay_log::trace!("Processing {group} group", group = group.variant());
 
         match group {
-            ProcessingGroup::Error => run!(
-                process_errors,
-                project_id,
-                project_info,
-                sampling_project_info,
-                rate_limits
-            ),
+            ProcessingGroup::Error => run!(process_errors, project_id, ctx),
             ProcessingGroup::Transaction => {
                 run!(
                     process_transactions,
                     cogs,
-                    self.inner.config.clone(),
                     project_id,
-                    project_info,
-                    sampling_project_info,
-                    rate_limits,
+                    ctx,
                     reservoir_counters
                 )
             }
@@ -2307,26 +2236,10 @@ impl EnvelopeProcessorService {
                 self.process_with_processor(&self.inner.processing.sessions, managed_envelope, ctx)
                     .await
             }
-            ProcessingGroup::Standalone => run!(
-                process_standalone,
-                self.inner.config.clone(),
-                project_id,
-                project_info,
-                rate_limits
-            ),
-            ProcessingGroup::ClientReport => run!(
-                process_client_reports,
-                self.inner.config.clone(),
-                project_info,
-                rate_limits
-            ),
+            ProcessingGroup::Standalone => run!(process_standalone, project_id, ctx),
+            ProcessingGroup::ClientReport => run!(process_client_reports, ctx),
             ProcessingGroup::Replay => {
-                run!(
-                    process_replays,
-                    self.inner.config.clone(),
-                    project_info,
-                    rate_limits
-                )
+                run!(process_replays, ctx)
             }
             ProcessingGroup::CheckIn => {
                 self.process_with_processor(&self.inner.processing.check_ins, managed_envelope, ctx)
@@ -2351,15 +2264,12 @@ impl EnvelopeProcessorService {
             }
             ProcessingGroup::Span => run!(
                 process_standalone_spans,
-                self.inner.config.clone(),
                 project_id,
-                project_info,
-                sampling_project_info,
-                rate_limits,
+                ctx,
                 reservoir_counters
             ),
             ProcessingGroup::ProfileChunk => {
-                run!(process_profile_chunks, project_info, rate_limits)
+                run!(process_profile_chunks, ctx)
             }
             // Currently is not used.
             ProcessingGroup::Metrics => {
@@ -2403,15 +2313,14 @@ impl EnvelopeProcessorService {
     /// Returns `Some` if the envelope passed inbound filtering and rate limiting. Invalid items are
     /// removed from the envelope. Otherwise, if the envelope is empty or the entire envelope needs
     /// to be dropped, this is `None`.
-    async fn process(
+    async fn process<'a>(
         &self,
         cogs: &mut Token,
-        mut message: ProcessEnvelopeGrouped,
-    ) -> Result<Option<Submit>, ProcessingError> {
+        mut message: ProcessEnvelopeGrouped<'a>,
+    ) -> Result<Option<Submit<'a>>, ProcessingError> {
         let ProcessEnvelopeGrouped {
             ref mut envelope,
-            ref project_info,
-            ref sampling_project_info,
+            ctx,
             ..
         } = message;
 
@@ -2421,7 +2330,8 @@ impl EnvelopeProcessorService {
         //
         // Neither ID can be available in proxy mode on the /store/ endpoint. This is not supported,
         // since we cannot process an envelope without project ID, so drop it.
-        let Some(project_id) = project_info
+        let Some(project_id) = ctx
+            .project_info
             .project_id
             .or_else(|| envelope.envelope().meta().project_id())
         else {
@@ -2438,7 +2348,7 @@ impl EnvelopeProcessorService {
         let sampling_key = envelope
             .envelope()
             .sampling_key()
-            .filter(|_| sampling_project_info.is_some());
+            .filter(|_| ctx.sampling_project_info.is_some());
 
         // We set additional information on the scope, which will be removed after processing the
         // envelope.
@@ -2496,7 +2406,8 @@ impl EnvelopeProcessorService {
                     });
                 }
 
-                Ok(main.map(Submit::Output))
+                let ctx = ctx.to_forward();
+                Ok(main.map(|output| Submit::Output { output, ctx }))
             }
             Err(err) => Err(err),
         };
@@ -2533,13 +2444,21 @@ impl EnvelopeProcessorService {
                 ManagedEnvelope::new(envelope, self.inner.addrs.outcome_aggregator.clone());
             envelope.scope(scoping);
 
+            let global_config = self.inner.global_config.current();
+
+            let ctx = processing::Context {
+                config: &self.inner.config,
+                global_config: &global_config,
+                project_info: &message.project_info,
+                sampling_project_info: message.sampling_project_info.as_deref(),
+                rate_limits: &message.rate_limits,
+            };
+
             let message = ProcessEnvelopeGrouped {
                 group,
                 envelope,
-                project_info: Arc::clone(&message.project_info),
-                rate_limits: Arc::clone(&message.rate_limits),
-                sampling_project_info: message.sampling_project_info.as_ref().map(Arc::clone),
-                reservoir_counters: Arc::clone(&message.reservoir_counters),
+                ctx,
+                reservoir_counters: &message.reservoir_counters,
             };
 
             let result = metric!(
@@ -2667,7 +2586,7 @@ impl EnvelopeProcessorService {
         }
     }
 
-    fn submit_upstream(&self, cogs: &mut Token, submit: Submit) {
+    fn submit_upstream(&self, cogs: &mut Token, submit: Submit<'_>) {
         let _submit = cogs.start_category("submit");
 
         #[cfg(feature = "processing")]
@@ -2676,8 +2595,8 @@ impl EnvelopeProcessorService {
         {
             match submit {
                 Submit::Envelope(envelope) => store_forwarder.send(StoreEnvelope { envelope }),
-                Submit::Output(output) => output
-                    .forward_store(store_forwarder)
+                Submit::Output { output, ctx } => output
+                    .forward_store(store_forwarder, ctx)
                     .unwrap_or_else(|err| err.into_inner()),
             }
             return;
@@ -2685,7 +2604,7 @@ impl EnvelopeProcessorService {
 
         let mut envelope = match submit {
             Submit::Envelope(envelope) => envelope,
-            Submit::Output(output) => match output.serialize_envelope() {
+            Submit::Output { output, ctx } => match output.serialize_envelope(ctx) {
                 Ok(envelope) => ManagedEnvelope::from(envelope).into_processed(),
                 Err(_) => {
                     relay_log::error!("failed to serialize output to an envelope");
@@ -3304,10 +3223,10 @@ impl EnvelopeProcessorService {
     fn new_reservoir_evaluator(
         &self,
         _organization_id: OrganizationId,
-        reservoir_counters: ReservoirCounters,
+        reservoir_counters: &ReservoirCounters,
     ) -> ReservoirEvaluator<'_> {
         #[cfg_attr(not(feature = "processing"), expect(unused_mut))]
-        let mut reservoir = ReservoirEvaluator::new(reservoir_counters);
+        let mut reservoir = ReservoirEvaluator::new(Arc::clone(reservoir_counters));
 
         #[cfg(feature = "processing")]
         if let Some(quotas_client) = self.inner.quotas_client.as_ref() {
@@ -3367,15 +3286,13 @@ impl RateLimiter {
         managed_envelope: &mut TypedEnvelope<Group>,
         event: Annotated<Event>,
         _extracted_metrics: &mut ProcessingExtractedMetrics,
-        global_config: &GlobalConfig,
-        project_info: &ProjectInfo,
-        rate_limits: &RateLimits,
+        ctx: processing::Context<'_>,
     ) -> Result<EnforcementResult, ProcessingError> {
         if managed_envelope.envelope().is_empty() && event.value().is_none() {
             return Ok(EnforcementResult::new(event, RateLimits::default()));
         }
 
-        let quotas = CombinedQuotas::new(global_config, project_info.get_quotas());
+        let quotas = CombinedQuotas::new(ctx.global_config, ctx.project_info.get_quotas());
         if quotas.is_empty() {
             return Ok(EnforcementResult::new(event, RateLimits::default()));
         }
@@ -3388,11 +3305,9 @@ impl RateLimiter {
         // When invoking the rate limiter, capture if the event item has been rate limited to also
         // remove it from the processing state eventually.
         let this = self.clone();
-        let rate_limits_clone = rate_limits.clone();
         let mut envelope_limiter =
             EnvelopeLimiter::new(CheckLimits::All, move |item_scope, _quantity| {
                 let this = this.clone();
-                let rate_limits_clone = rate_limits_clone.clone();
 
                 async move {
                     match this {
@@ -3403,7 +3318,7 @@ impl RateLimiter {
                                 .await?,
                         ),
                         _ => Ok::<_, ProcessingError>(
-                            rate_limits_clone.check_with_quotas(quotas, item_scope),
+                            ctx.rate_limits.check_with_quotas(quotas, item_scope),
                         ),
                     }
                 }
@@ -4021,10 +3936,11 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            project_info: Arc::new(project_info),
-            rate_limits: Default::default(),
-            sampling_project_info: None,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context {
+                project_info: &project_info,
+                ..processing::Context::for_test()
+            },
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let Ok(Some(Submit::Envelope(mut new_envelope))) =
@@ -4097,10 +4013,11 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group: ProcessingGroup::Transaction,
             envelope: managed_envelope,
-            project_info: project_info.clone(),
-            rate_limits: Default::default(),
-            sampling_project_info: Some(project_info),
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context {
+                project_info: &project_info,
+                ..processing::Context::for_test()
+            },
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let config = Config::from_json_value(serde_json::json!({

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -1,7 +1,6 @@
 //! Attachments processor code.
 
 use std::error::Error;
-use std::sync::Arc;
 use std::time::Instant;
 
 use relay_pii::{PiiAttachmentsProcessor, SelectorPathItem, SelectorSpec};
@@ -59,7 +58,7 @@ pub fn create_placeholders(
 /// This only applies the new PII rules that explicitly select `ValueType::Binary` or one of the
 /// attachment types. When special attachments are detected, these are scrubbed with custom
 /// logic; otherwise the entire attachment is treated as a single binary blob.
-pub fn scrub<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: Arc<ProjectInfo>) {
+pub fn scrub<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: &ProjectInfo) {
     let envelope = managed_envelope.envelope_mut();
     if let Some(ref config) = project_info.config.pii_config {
         let view_hierarchy_scrubbing_enabled = project_info

--- a/relay-server/src/services/processor/dynamic_sampling.rs
+++ b/relay-server/src/services/processor/dynamic_sampling.rs
@@ -1,6 +1,5 @@
 //! Dynamic sampling processor related code.
 use std::ops::ControlFlow;
-use std::sync::Arc;
 
 use chrono::Utc;
 use relay_config::Config;
@@ -45,12 +44,12 @@ use crate::utils::{self, SamplingResult};
 /// The function will return the sampling project information of the root project for the event. If
 /// no sampling project information is specified, the project information of the event’s project
 /// will be returned.
-pub fn validate_and_set_dsc<T>(
+pub fn validate_and_set_dsc<'a, T>(
     managed_envelope: &mut TypedEnvelope<T>,
     event: &mut Annotated<Event>,
-    project_info: Arc<ProjectInfo>,
-    sampling_project_info: Option<Arc<ProjectInfo>>,
-) -> Option<Arc<ProjectInfo>> {
+    project_info: &'a ProjectInfo,
+    sampling_project_info: Option<&'a ProjectInfo>,
+) -> Option<&'a ProjectInfo> {
     let original_dsc = managed_envelope.envelope().dsc();
     if original_dsc.is_some() && sampling_project_info.is_some() {
         return sampling_project_info;
@@ -68,7 +67,7 @@ pub fn validate_and_set_dsc<T>(
         dsc.sample_rate = dsc.sample_rate.or(original_sample_rate);
 
         managed_envelope.envelope_mut().set_dsc(dsc);
-        return Some(project_info.clone());
+        return Some(project_info);
     }
 
     // If we cannot compute a new DSC but the old one is incorrect, we need to remove it.
@@ -80,15 +79,15 @@ pub fn validate_and_set_dsc<T>(
 pub async fn run<Group>(
     managed_envelope: &mut TypedEnvelope<Group>,
     event: &mut Annotated<Event>,
-    config: Arc<Config>,
-    project_info: Arc<ProjectInfo>,
-    sampling_project_info: Option<Arc<ProjectInfo>>,
+    config: &Config,
+    project_info: &ProjectInfo,
+    sampling_project_info: Option<&ProjectInfo>,
     reservoir: &ReservoirEvaluator<'_>,
 ) -> SamplingResult
 where
     Group: Sampling,
 {
-    if !Group::supports_sampling(&project_info) {
+    if !Group::supports_sampling(project_info) {
         return SamplingResult::Pending;
     }
 
@@ -241,7 +240,7 @@ async fn compute_sampling_decision(
 pub async fn tag_error_with_sampling_decision<Group: EventProcessing>(
     managed_envelope: &mut TypedEnvelope<Group>,
     event: &mut Annotated<Event>,
-    sampling_project_info: Option<Arc<ProjectInfo>>,
+    sampling_project_info: Option<&ProjectInfo>,
     config: &Config,
 ) {
     let (Some(dsc), Some(event)) = (managed_envelope.envelope().dsc(), event.value_mut()) else {
@@ -302,6 +301,7 @@ mod tests {
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
     use crate::managed::ManagedEnvelope;
+    use crate::processing;
     use crate::services::processor::{ProcessEnvelopeGrouped, ProcessingGroup, SpanGroup, Submit};
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::{create_test_processor, new_envelope, state_with_rule_and_condition};
@@ -349,7 +349,7 @@ mod tests {
     /// Always sets the processing item type to event.
     async fn process_envelope_with_root_project_state(
         envelope: Box<Envelope>,
-        sampling_project_info: Option<Arc<ProjectInfo>>,
+        sampling_project_info: Option<&ProjectInfo>,
     ) -> Envelope {
         let processor = create_test_processor(Default::default()).await;
         let outcome_aggregator = Addr::dummy();
@@ -361,10 +361,11 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope: ManagedEnvelope::new(envelope, outcome_aggregator),
-            project_info: Arc::new(ProjectInfo::default()),
-            rate_limits: Default::default(),
-            sampling_project_info,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context {
+                sampling_project_info,
+                ..processing::Context::for_test()
+            },
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let Ok(Some(Submit::Envelope(envelope))) =
@@ -507,9 +508,6 @@ mod tests {
                 .unwrap();
 
             let event = Annotated::from(event);
-
-            let project_info = Arc::new(project_info);
-
             (managed_envelope, event, project_info)
         };
 
@@ -520,8 +518,8 @@ mod tests {
         let sampling_result = run(
             &mut managed_envelope,
             &mut event,
-            config.clone(),
-            project_info,
+            &config,
+            &project_info,
             None,
             &reservoir,
         )
@@ -533,8 +531,8 @@ mod tests {
         let sampling_result = run(
             &mut managed_envelope,
             &mut event,
-            config.clone(),
-            project_info,
+            &config,
+            &project_info,
             None,
             &reservoir,
         )
@@ -546,8 +544,8 @@ mod tests {
         let sampling_result = run(
             &mut managed_envelope,
             &mut event,
-            config.clone(),
-            project_info,
+            &config,
+            &project_info,
             None,
             &reservoir,
         )
@@ -588,7 +586,7 @@ mod tests {
         let sampling_project_state = project_state_with_single_rule(1.0);
         let new_envelope = process_envelope_with_root_project_state(
             envelope.clone(),
-            Some(Arc::new(sampling_project_state)),
+            Some(&sampling_project_state),
         )
         .await;
         let event = extract_first_event_from_envelope(new_envelope);
@@ -597,11 +595,8 @@ mod tests {
 
         // We test with sample rate equal to 0%.
         let sampling_project_state = project_state_with_single_rule(0.0);
-        let new_envelope = process_envelope_with_root_project_state(
-            envelope,
-            Some(Arc::new(sampling_project_state)),
-        )
-        .await;
+        let new_envelope =
+            process_envelope_with_root_project_state(envelope, Some(&sampling_project_state)).await;
         let event = extract_first_event_from_envelope(new_envelope);
         let trace_context = event.context::<TraceContext>().unwrap();
         assert!(!trace_context.sampled.value().unwrap());
@@ -642,11 +637,8 @@ mod tests {
         );
         envelope.add_item(item);
         let sampling_project_state = project_state_with_single_rule(0.0);
-        let new_envelope = process_envelope_with_root_project_state(
-            envelope,
-            Some(Arc::new(sampling_project_state)),
-        )
-        .await;
+        let new_envelope =
+            process_envelope_with_root_project_state(envelope, Some(&sampling_project_state)).await;
         let event = extract_first_event_from_envelope(new_envelope);
         let trace_context = event.context::<TraceContext>().unwrap();
         assert!(trace_context.sampled.value().unwrap());
@@ -764,14 +756,14 @@ mod tests {
                 version: 1,
                 ..Default::default()
             }));
-            Arc::new(info)
+            info
         };
 
         let bytes = Bytes::from(
             r#"{"dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","trace":{"trace_id":"89143b0763095bd9c9955e8175d1fb23","public_key":"e12d836b15bb49d7bbf99e64295d995b"}}"#,
         );
         let envelope = Envelope::parse_bytes(bytes).unwrap();
-        let config = Arc::new(Config::default());
+        let config = Config::default();
 
         let mut managed_envelope: TypedEnvelope<Group> = (
             ManagedEnvelope::new(envelope, Addr::dummy()),
@@ -809,16 +801,16 @@ mod tests {
                 ],
                 rules_v2: vec![],
             }));
-            Some(Arc::new(state))
+            Some(state)
         };
 
         let reservoir = dummy_reservoir();
         run::<Group>(
             &mut managed_envelope,
             &mut event,
-            config,
-            project_info,
-            sampling_project_info,
+            &config,
+            &project_info,
+            sampling_project_info.as_ref(),
             &reservoir,
         )
         .await

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -1,7 +1,7 @@
 //! Event processor related code.
 
 use std::error::Error;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use chrono::Duration as SignedDuration;
 use relay_auth::RelayVersion;
@@ -296,7 +296,7 @@ pub enum FiltersStatus {
 pub fn filter<Group: EventProcessing>(
     managed_envelope: &mut TypedEnvelope<Group>,
     event: &mut Annotated<Event>,
-    project_info: Arc<ProjectInfo>,
+    project_info: &ProjectInfo,
     global_config: &GlobalConfig,
 ) -> Result<FiltersStatus, ProcessingError> {
     let event = match event.value_mut() {
@@ -338,7 +338,7 @@ pub fn filter<Group: EventProcessing>(
 /// This uses both the general `datascrubbing_settings`, as well as the the PII rules.
 pub fn scrub(
     event: &mut Annotated<Event>,
-    project_info: Arc<ProjectInfo>,
+    project_info: &ProjectInfo,
 ) -> Result<(), ProcessingError> {
     let config = &project_info.config;
 

--- a/relay-server/src/services/processor/profile_chunk.rs
+++ b/relay-server/src/services/processor/profile_chunk.rs
@@ -1,7 +1,6 @@
 //! Profile chunks processor code.
 
 use relay_dynamic_config::Feature;
-use std::sync::Arc;
 
 use crate::envelope::ItemType;
 use crate::managed::{ItemAction, TypedEnvelope};
@@ -18,7 +17,7 @@ use {
 };
 
 /// Removes profile chunks from the envelope if the feature is not enabled.
-pub fn filter<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: Arc<ProjectInfo>) {
+pub fn filter<Group>(managed_envelope: &mut TypedEnvelope<Group>, project_info: &ProjectInfo) {
     let continuous_profiling_enabled =
         if project_info.has_feature(Feature::ContinuousProfilingBetaIngest) {
             project_info.has_feature(Feature::ContinuousProfilingBeta)

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -294,7 +294,7 @@ mod tests {
         }))
         .unwrap();
 
-        let processor = create_test_processor(config).await;
+        let processor = create_test_processor(Default::default()).await;
 
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
@@ -326,7 +326,10 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            ctx: processing::Context::for_test(),
+            ctx: processing::Context {
+                config: &config,
+                ..processing::Context::for_test()
+            },
             reservoir_counters: &ReservoirCounters::default(),
         };
 
@@ -351,7 +354,7 @@ mod tests {
         }))
         .unwrap();
 
-        let processor = create_test_processor(config).await;
+        let processor = create_test_processor(Default::default()).await;
 
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
@@ -383,7 +386,10 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            ctx: processing::Context::for_test(),
+            ctx: processing::Context {
+                config: &config,
+                ..processing::Context::for_test()
+            },
             reservoir_counters: &ReservoirCounters::default(),
         };
 
@@ -416,7 +422,7 @@ mod tests {
         }))
         .unwrap();
 
-        let processor = create_test_processor(config).await;
+        let processor = create_test_processor(Default::default()).await;
 
         let dsn = "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"
             .parse()
@@ -448,7 +454,10 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            ctx: processing::Context::for_test(),
+            ctx: processing::Context {
+                config: &config,
+                ..processing::Context::for_test()
+            },
             reservoir_counters: &ReservoirCounters::default(),
         };
 

--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -266,9 +266,6 @@ fn outcome_from_parts(field: ClientReportField, reason: &str) -> Result<Outcome,
 
 #[cfg(test)]
 mod tests {
-
-    use std::sync::Arc;
-
     use relay_cogs::Token;
     use relay_config::Config;
     use relay_event_schema::protocol::EventId;
@@ -277,9 +274,9 @@ mod tests {
     use crate::envelope::{Envelope, Item};
     use crate::extractors::RequestMeta;
     use crate::managed::ManagedEnvelope;
+    use crate::processing;
     use crate::services::outcome::RuleCategory;
     use crate::services::processor::{ProcessEnvelopeGrouped, ProcessingGroup, Submit};
-    use crate::services::projects::project::ProjectInfo;
     use crate::testutils::create_test_processor;
 
     use super::*;
@@ -329,10 +326,8 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            project_info: Arc::new(ProjectInfo::default()),
-            rate_limits: Default::default(),
-            sampling_project_info: None,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context::for_test(),
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let envelope = processor
@@ -388,10 +383,8 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            project_info: Arc::new(ProjectInfo::default()),
-            rate_limits: Default::default(),
-            sampling_project_info: None,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context::for_test(),
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let Ok(Some(Submit::Envelope(new_envelope))) =
@@ -455,10 +448,8 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            project_info: Arc::new(ProjectInfo::default()),
-            rate_limits: Default::default(),
-            sampling_project_info: None,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context::for_test(),
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let envelope = processor
@@ -500,10 +491,8 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            project_info: Arc::new(ProjectInfo::default()),
-            rate_limits: Default::default(),
-            sampling_project_info: None,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context::for_test(),
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let Ok(Some(Submit::Envelope(new_envelope))) =
@@ -553,10 +542,8 @@ mod tests {
         let message = ProcessEnvelopeGrouped {
             group,
             envelope,
-            project_info: Arc::new(ProjectInfo::default()),
-            rate_limits: Default::default(),
-            sampling_project_info: None,
-            reservoir_counters: ReservoirCounters::default(),
+            ctx: processing::Context::for_test(),
+            reservoir_counters: &ReservoirCounters::default(),
         };
 
         let Ok(Some(Submit::Envelope(new_envelope))) =

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -1,7 +1,5 @@
 //! Processor code related to standalone spans.
 
-use std::sync::Arc;
-
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use prost::Message;
@@ -29,11 +27,11 @@ use super::ProcessingError;
 
 pub fn filter(
     managed_envelope: &mut TypedEnvelope<SpanGroup>,
-    config: Arc<Config>,
-    project_info: Arc<ProjectInfo>,
+    config: &Config,
+    project_info: &ProjectInfo,
 ) {
-    let disabled = should_filter(&config, &project_info, Feature::StandaloneSpanIngestion);
-    let otel_disabled = should_filter(&config, &project_info, Feature::OtelEndpoint);
+    let disabled = should_filter(config, project_info, Feature::StandaloneSpanIngestion);
+    let otel_disabled = should_filter(config, project_info, Feature::OtelEndpoint);
 
     managed_envelope.retain_items(|item| {
         if disabled && item.is_span() {


### PR DESCRIPTION
- Changes all useless uses of `Arc<Config>` to just `&Config`
- Introduces a `ForwardContext` which is passed to `Forward` trait methods, in preparation for extracting the sample rates and other information which now has to be passed in from the `Processor::Output` which is quite annoying.
- Introduces `Context::for_test()` returning `Context<'static>` (basically a `Default`).

Closes: #4878