### PR TITLE
fix(ci): Nightly publish for ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,7 +471,7 @@ jobs:
 
       - name: Build and push to ghcr.io
         if: "!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'"
-        uses: getsentry/action-build-and-push-images@f6e4a98f7ed028edcfb1159f3a2905b30e51f1fd
+        uses: getsentry/action-build-and-push-images@b172ab61a5f7eabd58bd42ce231b517e79947c01
         with:
           image_name: ${{ matrix.image_name }}
           platforms: ${{ env.PLATFORMS }}
@@ -484,7 +484,7 @@ jobs:
 
       - name: Build and publish docker artifact
         if: "github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'"
-        uses: getsentry/action-build-and-push-images@f6e4a98f7ed028edcfb1159f3a2905b30e51f1fd
+        uses: getsentry/action-build-and-push-images@b172ab61a5f7eabd58bd42ce231b517e79947c01
         with:
           image_name: ${{ matrix.image_name }}
           platforms: ${{ env.PLATFORMS }}
@@ -559,7 +559,7 @@ jobs:
           done
 
       - name: Build and push to Internal AR
-        uses: getsentry/action-build-and-push-images@f6e4a98f7ed028edcfb1159f3a2905b30e51f1fd
+        uses: getsentry/action-build-and-push-images@b172ab61a5f7eabd58bd42ce231b517e79947c01
         with:
           image_name: ${{ matrix.image_name }}
           platforms: ${{ env.PLATFORMS }}


### PR DESCRIPTION
Looks like composite action for building and publishing images is not tagging nightly even when `tag_nightly` is set to true. https://github.com/getsentry/relay/blob/62787c1b1db6063e49b51f7f696e58ef2fedb9a7/.github/workflows/ci.yml#L480

This picks up https://github.com/getsentry/action-build-and-push-images/pull/19 which uses the very similar logic as tagging latest in an attempt to fix this issue. Note that tagging nightly/latest are restricted to workflows on the default branch, so this cannot be tested on a PR

#skip-changelog