### PR TITLE
fix(normalization): Prevent stack overflow in sqlparser visitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,8 +5220,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=ade40826563451cc14c130af9d689f4050dbdb15#ade40826563451cc14c130af9d689f4050dbdb15"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,3 +220,7 @@ utf16string = "0.2.0"
 uuid = { version = "1.11.0", features = ["serde", "v4", "v7"] }
 walkdir = "2.5.0"
 zstd = { version = "0.13.2", features = ["experimental"] }
+
+# Patch until upstream has been updated:
+[patch.crates-io]
+sqlparser_derive = { git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "ade40826563451cc14c130af9d689f4050dbdb15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,7 @@ uuid = { version = "1.11.0", features = ["serde", "v4", "v7"] }
 walkdir = "2.5.0"
 zstd = { version = "0.13.2", features = ["experimental"] }
 
-# Patch until upstream has been updated:
+# Patch until https://github.com/apache/datafusion-sqlparser-rs/pull/2060 has been merged.
+# This prevents stack overflows in span description normalization.
 [patch.crates-io]
 sqlparser_derive = { git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "ade40826563451cc14c130af9d689f4050dbdb15" }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -39,7 +39,6 @@ serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
 smallvec = { workspace = true }
 sqlparser = { workspace = true, features = ["visitor"] }
-
 thiserror = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -870,6 +870,8 @@ impl Dialect for DialectWithParameters {
 
 #[cfg(test)]
 mod tests {
+    use sqlparser::ast::{Visit, Visitor};
+
     use super::*;
 
     #[test]
@@ -879,6 +881,32 @@ mod tests {
             normalize_parsed_queries(None, query).unwrap().0,
             "SELECT .. + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s + %s"
         );
+    }
+
+    #[test]
+    fn visit_deep_expression() {
+        struct TestVisitor;
+        impl Visitor for TestVisitor {
+            type Break = ();
+        }
+        let leaf = || Box::new(Expr::Value(Value::Null.into()));
+        let op = BinaryOperator::And;
+
+        let mut expr = Expr::BinaryOp {
+            left: leaf(),
+            op,
+            right: leaf(),
+        };
+
+        for _ in 0..10_000 {
+            expr = Expr::BinaryOp {
+                left: Box::new(expr),
+                op: BinaryOperator::And,
+                right: leaf(),
+            }
+        }
+
+        let _ = expr.visit(&mut TestVisitor);
     }
 
     #[test]


### PR DESCRIPTION
Patch sub-dependency until https://github.com/apache/datafusion-sqlparser-rs/pull/2060 has been merged.

Fixes [POP-RELAY-37Q](https://sentry.my.sentry.io/organizations/sentry/issues/2423744/).
Fixes INGEST-596.