### PR TITLE
ref(processing): Read retention from context, cleanup retention code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,6 @@ dependencies = [
  "relay-protocol",
  "relay-quotas",
  "relay-sampling",
- "sentry_protos 0.4.1",
  "serde",
  "serde_json",
  "similar-asserts",

--- a/relay-dynamic-config/Cargo.toml
+++ b/relay-dynamic-config/Cargo.toml
@@ -29,7 +29,6 @@ relay-pii = { workspace = true }
 relay-protocol = { workspace = true }
 relay-quotas = { workspace = true }
 relay-sampling = { workspace = true }
-sentry_protos = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -10,8 +10,6 @@ use relay_sampling::SamplingConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use sentry_protos::snuba::v1::TraceItemType;
-
 use crate::error_boundary::ErrorBoundary;
 use crate::feature::FeatureSet;
 use crate::metrics::{
@@ -20,57 +18,6 @@ use crate::metrics::{
 };
 use crate::trusted_relay::TrustedRelayConfig;
 use crate::{GRADUATED_FEATURE_FLAGS, defaults};
-
-/// Per-Category settings for retention policy.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RetentionSettings {
-    /// Standard / full fidelity retention policy in days.
-    pub standard: u16,
-    /// Downsampled retention policy in days.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub downsampled: Option<u16>,
-}
-
-/// Settings for retention policy.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Retentions {
-    /// Retention settings for logs.
-    /// This will determine when they are removed from storage.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub log: Option<RetentionSettings>,
-    /// Retention settings for spans.
-    /// This will determine when they are removed from storage.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub span: Option<RetentionSettings>,
-    /// Retention settings for metrics.
-    /// This will determine when they are removed from storage.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_metric: Option<RetentionSettings>,
-}
-
-impl Retentions {
-    /// Returns the retentions setting for the trace item type `ty` in the `retentions` object
-    pub fn retention_for_trace_item(&self, ty: TraceItemType) -> Option<&RetentionSettings> {
-        match ty {
-            TraceItemType::Span => {
-                if let Some(span) = &self.span {
-                    Some(span)
-                } else {
-                    None
-                }
-            }
-            TraceItemType::Log => {
-                if let Some(log) = &self.log {
-                    Some(log)
-                } else {
-                    None
-                }
-            }
-            TraceItemType::Metric => self.trace_metric.as_ref(),
-            _ => None,
-        }
-    }
-}
 
 /// Dynamic, per-DSN configuration passed down from Sentry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -101,8 +48,8 @@ pub struct ProjectConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub downsampled_event_retention: Option<u16>,
     /// Retention settings for different products.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub retentions: Option<Retentions>,
+    #[serde(default, skip_serializing_if = "RetentionsConfig::is_empty")]
+    pub retentions: RetentionsConfig,
     /// Usage quotas for this project.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub quotas: Vec<Quota>,
@@ -184,24 +131,6 @@ impl ProjectConfig {
             }
         }
     }
-
-    /// Returns the standard & downsampled retention period for a trace item type.
-    ///
-    /// Falls back to [`Self::event_retention`] and [`Self::downsampled_event_retention`]
-    /// if no per-item retention is specified.
-    pub fn retentions_for_trace_item(&self, ty: TraceItemType) -> (Option<u16>, Option<u16>) {
-        let specific = self.specific_retentions_for_trace_item(ty);
-        let standard = specific.map(|r| r.standard).or(self.event_retention);
-        let downsampled = specific
-            .and_then(|r| r.downsampled)
-            .or(self.downsampled_event_retention);
-
-        (standard, downsampled)
-    }
-
-    fn specific_retentions_for_trace_item(&self, ty: TraceItemType) -> Option<&RetentionSettings> {
-        self.retentions.as_ref()?.retention_for_trace_item(ty)
-    }
 }
 
 impl Default for ProjectConfig {
@@ -216,7 +145,7 @@ impl Default for ProjectConfig {
             datascrubbing_settings: DataScrubbingConfig::default(),
             event_retention: None,
             downsampled_event_retention: None,
-            retentions: None,
+            retentions: Default::default(),
             quotas: Vec::new(),
             sampling: None,
             measurements: None,
@@ -292,6 +221,42 @@ pub struct LimitedProjectConfig {
     /// relays that might still need them.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub span_description_rules: Option<Vec<SpanDescriptionRule>>,
+}
+
+/// Per-Category settings for retention policy.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    /// Standard / full fidelity retention policy in days.
+    pub standard: u16,
+    /// Downsampled retention policy in days.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downsampled: Option<u16>,
+}
+
+/// Settings for retention policy.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RetentionsConfig {
+    /// Retention settings for logs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log: Option<RetentionConfig>,
+    /// Retention settings for spans.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<RetentionConfig>,
+    /// Retention settings for metrics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_metric: Option<RetentionConfig>,
+}
+
+impl RetentionsConfig {
+    fn is_empty(&self) -> bool {
+        let Self {
+            log,
+            span,
+            trace_metric,
+        } = self;
+
+        log.is_none() && span.is_none() && trace_metric.is_none()
+    }
 }
 
 fn is_false(value: &bool) -> bool {

--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -6,7 +6,7 @@ use crate::processing::logs::LogsProcessor;
 use crate::processing::sessions::SessionsProcessor;
 use crate::processing::spans::SpansProcessor;
 use crate::processing::trace_metrics::TraceMetricsProcessor;
-use crate::processing::{Forward, Nothing, Processor};
+use crate::processing::{Forward, Processor};
 
 macro_rules! outputs {
     ($($variant:ident => $ty:ty,)*) => {
@@ -58,9 +58,3 @@ outputs!(
     Spans => SpansProcessor,
     Sessions => SessionsProcessor,
 );
-
-impl From<Nothing> for Outputs {
-    fn from(value: Nothing) -> Self {
-        match value {}
-    }
-}

--- a/relay-server/src/processing/forward.rs
+++ b/relay-server/src/processing/forward.rs
@@ -1,0 +1,110 @@
+use relay_config::Config;
+use relay_dynamic_config::{GlobalConfig, RetentionConfig, RetentionsConfig};
+
+use crate::Envelope;
+use crate::managed::{Managed, Rejected};
+use crate::services::projects::project::ProjectInfo;
+
+/// A processor output which can be forwarded to a different destination.
+pub trait Forward {
+    /// Serializes the output into an [`Envelope`].
+    ///
+    /// All output must be serializable as an envelope.
+    fn serialize_envelope(
+        self,
+        ctx: ForwardContext<'_>,
+    ) -> Result<Managed<Box<Envelope>>, Rejected<()>>;
+
+    /// Serializes the output into a [`crate::services::store::StoreService`] compatible format.
+    ///
+    /// This function must only be called when Relay is configured to be in processing mode.
+    #[cfg(feature = "processing")]
+    fn forward_store(
+        self,
+        s: &relay_system::Addr<crate::services::store::Store>,
+        ctx: ForwardContext<'_>,
+    ) -> Result<(), Rejected<()>>;
+}
+
+/// Context passed to [`Forward`].
+///
+/// A minified version of [`Context`], which does not contain processing specific information.
+#[derive(Copy, Clone, Debug)]
+pub struct ForwardContext<'a> {
+    /// The Relay configuration.
+    #[expect(unused, reason = "not yet used")]
+    pub config: &'a Config,
+    /// A view of the currently active global configuration.
+    #[expect(unused, reason = "not yet used")]
+    pub global_config: &'a GlobalConfig,
+    /// Project configuration associated with the unit of work.
+    pub project_info: &'a ProjectInfo,
+}
+
+impl ForwardContext<'_> {
+    /// Returns the [`Retention`] for a specific type/product.
+    pub fn retention<F>(&self, f: F) -> Retention
+    where
+        F: FnOnce(&RetentionsConfig) -> Option<&RetentionConfig>,
+    {
+        if let Some(retention) = f(&self.project_info.config.retentions) {
+            return Retention::from(*retention);
+        }
+
+        Retention::from(RetentionConfig {
+            standard: self
+                .project_info
+                .config
+                .event_retention
+                .unwrap_or(crate::constants::DEFAULT_EVENT_RETENTION),
+            downsampled: self.project_info.config.downsampled_event_retention,
+        })
+    }
+}
+
+/// The [`Nothing`] output.
+///
+/// Some processors may only produce by-products and not have any output of their own.
+pub struct Nothing(std::convert::Infallible);
+
+impl Forward for Nothing {
+    fn serialize_envelope(
+        self,
+        _: ForwardContext<'_>,
+    ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+        match self {}
+    }
+
+    #[cfg(feature = "processing")]
+    fn forward_store(
+        self,
+        _: &relay_system::Addr<crate::services::store::Store>,
+        _: ForwardContext<'_>,
+    ) -> Result<(), Rejected<()>> {
+        match self {}
+    }
+}
+
+impl From<Nothing> for crate::processing::Outputs {
+    fn from(value: Nothing) -> Self {
+        match value {}
+    }
+}
+
+/// Full retention settings to apply to specific payloads.
+#[derive(Debug, Copy, Clone)]
+pub struct Retention {
+    /// Standard / full fidelity retention policy in days.
+    pub standard: u16,
+    /// Downsampled retention policy in days.
+    pub downsampled: u16,
+}
+
+impl From<RetentionConfig> for Retention {
+    fn from(value: RetentionConfig) -> Self {
+        Self {
+            standard: value.standard,
+            downsampled: value.downsampled.unwrap_or(value.standard),
+        }
+    }
+}

--- a/relay-server/src/processing/forward.rs
+++ b/relay-server/src/processing/forward.rs
@@ -1,5 +1,7 @@
 use relay_config::Config;
-use relay_dynamic_config::{GlobalConfig, RetentionConfig, RetentionsConfig};
+use relay_dynamic_config::GlobalConfig;
+#[cfg(feature = "processing")]
+use relay_dynamic_config::{RetentionConfig, RetentionsConfig};
 
 use crate::Envelope;
 use crate::managed::{Managed, Rejected};
@@ -28,7 +30,7 @@ pub trait Forward {
 
 /// Context passed to [`Forward`].
 ///
-/// A minified version of [`Context`], which does not contain processing specific information.
+/// A minified version of [`Context`](super::Context), which does not contain processing specific information.
 #[derive(Copy, Clone, Debug)]
 pub struct ForwardContext<'a> {
     /// The Relay configuration.
@@ -38,9 +40,11 @@ pub struct ForwardContext<'a> {
     #[expect(unused, reason = "not yet used")]
     pub global_config: &'a GlobalConfig,
     /// Project configuration associated with the unit of work.
+    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub project_info: &'a ProjectInfo,
 }
 
+#[cfg(feature = "processing")]
 impl ForwardContext<'_> {
     /// Returns the [`Retention`] for a specific type/product.
     pub fn retention<F>(&self, f: F) -> Retention
@@ -93,6 +97,7 @@ impl From<Nothing> for crate::processing::Outputs {
 
 /// Full retention settings to apply to specific payloads.
 #[derive(Debug, Copy, Clone)]
+#[cfg(feature = "processing")]
 pub struct Retention {
     /// Standard / full fidelity retention policy in days.
     pub standard: u16,
@@ -100,6 +105,7 @@ pub struct Retention {
     pub downsampled: u16,
 }
 
+#[cfg(feature = "processing")]
 impl From<RetentionConfig> for Retention {
     fn from(value: RetentionConfig) -> Self {
         Self {

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -151,7 +151,7 @@ impl processing::Processor for LogsProcessor {
         // Fast filters, which do not need expanded logs.
         filter::feature_flag(ctx).reject(&logs)?;
 
-        let mut logs = process::expand(logs, ctx);
+        let mut logs = process::expand(logs);
         process::normalize(&mut logs);
         filter::filter(&mut logs, ctx);
         process::scrub(&mut logs, ctx);
@@ -194,7 +194,7 @@ impl Forward for LogOutput {
     fn forward_store(
         self,
         s: &relay_system::Addr<crate::services::store::Store>,
-        _: processing::ForwardContext<'_>,
+        ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let logs = match self {
             LogOutput::NotProcessed(logs) => {
@@ -205,20 +205,13 @@ impl Forward for LogOutput {
             LogOutput::Processed(logs) => logs,
         };
 
-        let scoping = logs.scoping();
-        let received_at = logs.received_at();
-
-        let (logs, retentions) = logs
-            .split_with_context(|logs| (logs.logs, (logs.retention, logs.downsampled_retention)));
         let ctx = store::Context {
-            scoping,
-            received_at,
-            // Hard-code retentions until we have a per data category retention
-            retention: retentions.0,
-            downsampled_retention: retentions.1,
+            scoping: logs.scoping(),
+            received_at: logs.received_at(),
+            retention: ctx.retention(|r| r.log.as_ref()),
         };
 
-        for log in logs {
+        for log in logs.split(|logs| logs.logs) {
             if let Ok(log) = log.try_map(|log, _| store::convert(log, &ctx)) {
                 s.send(log)
             };
@@ -300,16 +293,6 @@ pub struct ExpandedLogs {
     headers: EnvelopeHeaders,
     /// Expanded and parsed logs.
     logs: ContainerItems<OurLog>,
-
-    // These fields are currently necessary as we don't pass any project config context to the
-    // store serialization. The plan is to get rid of them by giving the serialization context,
-    // including the project info, where these are pulled from: #4878.
-    /// Retention in days.
-    #[cfg(feature = "processing")]
-    retention: Option<u16>,
-    /// Downsampled retention in days.
-    #[cfg(feature = "processing")]
-    downsampled_retention: Option<u16>,
 }
 
 impl Counted for ExpandedLogs {

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -8,11 +8,10 @@ use relay_quotas::Scoping;
 use sentry_protos::snuba::v1::{AnyValue, TraceItem, TraceItemType, any_value};
 use uuid::Uuid;
 
-use crate::constants::DEFAULT_EVENT_RETENTION;
 use crate::envelope::WithHeader;
-use crate::processing::Counted;
 use crate::processing::trace_metrics::{Error, Result};
 use crate::processing::utils::store::{AttributeMeta, extract_meta_attributes};
+use crate::processing::{Counted, Retention};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreTraceItem;
 
@@ -37,10 +36,8 @@ pub struct Context {
     pub received_at: DateTime<Utc>,
     /// Item scoping.
     pub scoping: Scoping,
-    /// Storage retention in days.
-    pub retention: Option<u16>,
-    /// Storage retention for downsampled data in days
-    pub downsampled_retention: Option<u16>,
+    /// Item retention.
+    pub retention: Retention,
 }
 
 pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTraceItem> {
@@ -58,16 +55,14 @@ pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTr
         timestamp,
         span_id: metric.span_id.into_value(),
     };
-    let retention_days = ctx.retention.unwrap_or(DEFAULT_EVENT_RETENTION);
-    let downsampled_retention_days = ctx.downsampled_retention.unwrap_or(retention_days);
 
     let trace_item = TraceItem {
         item_type: TraceItemType::Metric.into(),
         organization_id: ctx.scoping.organization_id.value(),
         project_id: ctx.scoping.project_id.value(),
         received: Some(ts(ctx.received_at)),
-        retention_days: retention_days.into(),
-        downsampled_retention_days: downsampled_retention_days.into(),
+        retention_days: ctx.retention.standard.into(),
+        downsampled_retention_days: ctx.retention.downsampled.into(),
         timestamp: Some(ts(timestamp.0)),
         trace_id: required!(metric.trace_id).to_string(),
         item_id: Uuid::new_v7(timestamp.into()).as_bytes().to_vec(),
@@ -234,8 +229,10 @@ mod tests {
                 project_key: "12333333333333333333333333333333".parse().unwrap(),
                 key_id: Some(3),
             },
-            retention: Some(42),
-            downsampled_retention: Some(42),
+            retention: Retention {
+                standard: 42,
+                downsampled: 43,
+            },
         }
     }
 


### PR DESCRIPTION
- Uses the introduced `ForwardContext` now to read the retention settings
- Cleans up `Retentions` stuff in the dynamic config
  - Align naming (we usually use `Config` suffixes)
  - Simplify access to `retentions` by removing one layer of options
- Move `Forward` related code into a separate module as there are more types now that don't directly fit with `processing/mod.rs`
- Some stray fixes in the trace metrics code
  - Removal of unused types
  - Re-Ordering of types to match other modules.