### PR TITLE
ref(spans): Make otel to sentry span conversion infallible

### DIFF
--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -12,7 +12,7 @@ use relay_conventions::ORIGIN;
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
 use relay_otel::otel_value_to_attribute;
-use relay_protocol::{Annotated, Meta, Object, Remark, RemarkType};
+use relay_protocol::{Annotated, Object};
 
 /// Maps OpenTelemetry severity number to Sentry log level.
 ///
@@ -62,25 +62,11 @@ pub fn otel_to_sentry_log(
         ..
     } = otel_log;
 
-    let span_id = if span_id.is_empty() {
-        Annotated::empty()
-    } else {
-        SpanId::try_from(span_id.as_slice())
-            .map_or_else(|err| Annotated::from_error(err, None), Annotated::new)
+    let span_id = match span_id.is_empty() {
+        true => Annotated::empty(),
+        false => SpanId::try_from(span_id.as_slice()).into(),
     };
-    let trace_id = match TraceId::try_from(trace_id.as_slice()) {
-        Ok(id) => Annotated::new(id),
-        Err(_) => {
-            let mut meta = Meta::default();
-            let rule_id = if trace_id.is_empty() {
-                "trace_id.missing"
-            } else {
-                "trace_id.invalid"
-            };
-            meta.add_remark(Remark::new(RemarkType::Substituted, rule_id));
-            Annotated(Some(TraceId::random()), meta)
-        }
-    };
+    let trace_id = TraceId::try_from_slice_or_random(trace_id.as_slice());
     let timestamp = Utc.timestamp_nanos(time_unix_nano as i64);
     let level = map_severity_to_level(severity_number, &severity_text);
     let body = body.and_then(|v| v.value).and_then(|v| match v {

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -420,6 +420,12 @@ impl<T> From<Option<T>> for Annotated<T> {
     }
 }
 
+impl<T> From<Result<T, Error>> for Annotated<T> {
+    fn from(t: Result<T, Error>) -> Self {
+        t.map_or_else(|err| Annotated::from_error(err, None), Annotated::new)
+    }
+}
+
 impl<T> Default for Annotated<T> {
     fn default() -> Annotated<T> {
         Annotated::empty()

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -102,13 +102,7 @@ pub async fn process(
     managed_envelope.retain_items(|item| {
         let mut annotated_span = match item.ty() {
             ItemType::OtelSpan => match serde_json::from_slice::<OtelSpan>(&item.payload()) {
-                Ok(otel_span) => match relay_spans::otel_to_sentry_span(otel_span) {
-                    Ok(span) => Annotated::new(span),
-                    Err(err) => {
-                        relay_log::debug!("failed to convert OTel span to Sentry span: {:?}", err);
-                        return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidJson));
-                    }
-                },
+                Ok(otel_span) => Annotated::new(relay_spans::otel_to_sentry_span(otel_span)),
                 Err(err) => {
                     relay_log::debug!("failed to parse OTel span: {}", err);
                     return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidJson));

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -2,7 +2,6 @@ use crate::otel_to_sentry_v2;
 use crate::otel_trace::Span as OtelSpan;
 use crate::v2_to_v1;
 use relay_event_schema::protocol::Span as EventSpan;
-use relay_protocol::Error;
 
 /// Transforms an OTEL span to a Sentry span.
 ///
@@ -22,9 +21,9 @@ use relay_protocol::Error;
 /// * The Sentry span's `segment_id` field is set based on the OTEL span's `sentry.segment.id` attribute.
 ///
 /// All other attributes are carried over from the OTEL span to the Sentry span's `data`.
-pub fn otel_to_sentry_span(otel_span: OtelSpan) -> Result<EventSpan, Error> {
-    let span_v2 = otel_to_sentry_v2::otel_to_sentry_span(otel_span)?;
-    Ok(v2_to_v1::span_v2_to_span_v1(span_v2))
+pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
+    let span_v2 = otel_to_sentry_v2::otel_to_sentry_span(otel_span);
+    v2_to_v1::span_v2_to_span_v1(span_v2)
 }
 
 #[cfg(test)]
@@ -108,7 +107,7 @@ mod tests {
             "droppedLinksCount": 0
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -159,7 +158,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -193,7 +192,7 @@ mod tests {
             "endTimeUnixNano": "1697620454980078800"
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -253,7 +252,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -317,7 +316,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -368,7 +367,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -435,7 +434,7 @@ mod tests {
         }"#;
 
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span = otel_to_sentry_span(otel_span).unwrap();
+        let event_span = otel_to_sentry_span(otel_span);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
@@ -589,7 +588,7 @@ mod tests {
         }"#;
 
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span = otel_to_sentry_span(otel_span).unwrap();
+        let event_span = otel_to_sentry_span(otel_span);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
@@ -632,7 +631,7 @@ mod tests {
             "flags": 768
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -662,7 +661,7 @@ mod tests {
             "flags": 256
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -692,7 +691,7 @@ mod tests {
             "kind": 3
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -751,7 +750,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span).unwrap();
+        let event_span: EventSpan = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
 
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
@@ -792,7 +791,7 @@ mod tests {
           }
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span = otel_to_sentry_span(otel_span).unwrap();
+        let event_span = otel_to_sentry_span(otel_span);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {


### PR DESCRIPTION
Similar how we changed the logs conversion. We can make use of `Annotated` to store errors and be lenient for the trace id.