### PR TITLE
ref(spans): Add support for scoped metadata to otel conversion

### DIFF
--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -77,34 +77,7 @@ pub fn otel_to_sentry_log(
     let mut attribute_data = Attributes::default();
     attribute_data.insert(ORIGIN, "auto.otlp.logs".to_owned());
 
-    for attribute in resource.into_iter().flat_map(|s| &s.attributes) {
-        if let Some(attr) = attribute
-            .value
-            .clone()
-            .and_then(|v| v.value)
-            .and_then(otel_value_to_attribute)
-        {
-            let key = format!("resource.{}", attribute.key);
-            attribute_data.insert_raw(key, Annotated::new(attr));
-        }
-    }
-
-    for attribute in scope.into_iter().flat_map(|s| &s.attributes) {
-        if let Some(attr) = attribute
-            .value
-            .clone()
-            .and_then(|v| v.value)
-            .and_then(otel_value_to_attribute)
-        {
-            let key = format!("instrumentation.{}", attribute.key);
-            attribute_data.insert_raw(key, Annotated::new(attr));
-        }
-    }
-
-    if let Some(scope) = scope {
-        attribute_data.insert("instrumentation.name".to_owned(), scope.name.clone());
-        attribute_data.insert("instrumentation.version".to_owned(), scope.version.clone());
-    }
+    relay_otel::otel_scope_into_attributes(&mut attribute_data, resource, scope);
 
     for attribute in attributes {
         if let Some(attr) = attribute

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -102,7 +102,9 @@ pub async fn process(
     managed_envelope.retain_items(|item| {
         let mut annotated_span = match item.ty() {
             ItemType::OtelSpan => match serde_json::from_slice::<OtelSpan>(&item.payload()) {
-                Ok(otel_span) => Annotated::new(relay_spans::otel_to_sentry_span(otel_span)),
+                Ok(otel_span) => {
+                    Annotated::new(relay_spans::otel_to_sentry_span(otel_span, None, None))
+                }
                 Err(err) => {
                     relay_log::debug!("failed to parse OTel span: {}", err);
                     return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidJson));

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -1,6 +1,8 @@
 use crate::otel_to_sentry_v2;
 use crate::otel_trace::Span as OtelSpan;
 use crate::v2_to_v1;
+use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
+use opentelemetry_proto::tonic::resource::v1::Resource;
 use relay_event_schema::protocol::Span as EventSpan;
 
 /// Transforms an OTEL span to a Sentry span.
@@ -21,8 +23,12 @@ use relay_event_schema::protocol::Span as EventSpan;
 /// * The Sentry span's `segment_id` field is set based on the OTEL span's `sentry.segment.id` attribute.
 ///
 /// All other attributes are carried over from the OTEL span to the Sentry span's `data`.
-pub fn otel_to_sentry_span(otel_span: OtelSpan) -> EventSpan {
-    let span_v2 = otel_to_sentry_v2::otel_to_sentry_span(otel_span);
+pub fn otel_to_sentry_span(
+    otel_span: OtelSpan,
+    resource: Option<&Resource>,
+    scope: Option<&InstrumentationScope>,
+) -> EventSpan {
+    let span_v2 = otel_to_sentry_v2::otel_to_sentry_span(otel_span, resource, scope);
     v2_to_v1::span_v2_to_span_v1(span_v2)
 }
 
@@ -107,7 +113,7 @@ mod tests {
             "droppedLinksCount": 0
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -158,7 +164,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -192,7 +198,7 @@ mod tests {
             "endTimeUnixNano": "1697620454980078800"
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -252,7 +258,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -316,7 +322,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -367,7 +373,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -434,7 +440,7 @@ mod tests {
         }"#;
 
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span = otel_to_sentry_span(otel_span);
+        let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
@@ -588,7 +594,7 @@ mod tests {
         }"#;
 
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span = otel_to_sentry_span(otel_span);
+        let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
@@ -631,7 +637,7 @@ mod tests {
             "flags": 768
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -661,7 +667,7 @@ mod tests {
             "flags": 256
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -691,7 +697,7 @@ mod tests {
             "kind": 3
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
@@ -750,7 +756,7 @@ mod tests {
             ]
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span: EventSpan = otel_to_sentry_span(otel_span);
+        let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
 
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
@@ -791,7 +797,7 @@ mod tests {
           }
         }"#;
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
-        let event_span = otel_to_sentry_span(otel_span);
+        let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {


### PR DESCRIPTION
Add support for otel scoped metadata to span conversion (like we already have for logs).

This already is hacked in when converting otel traces to 'OtelSpan', will clean this up once we remove the `OtelSpan` type.