### PR TITLE
feat(spanv2): Implement otel traces integration

### DIFF
--- a/relay-server/src/envelope/container.rs
+++ b/relay-server/src/envelope/container.rs
@@ -87,11 +87,23 @@ impl<T: ContainerItem> WithHeader<T> {
     ///
     /// This should only be used when creating new items, in most cases existing headers should be
     /// respected and explicitly handled and passed along.
+    ///
+    /// Prefer using [`WithHeader::new`] where possible.
     pub fn just(value: Annotated<T>) -> Self {
         Self {
             header: None,
             value,
         }
+    }
+}
+
+impl<T: ContainerItem<Header = NoHeader>> WithHeader<T> {
+    /// Creates a new [`Self`].
+    ///
+    /// Like [`Self::just`], but providing a type safe way to ensure `T::Header` is always explicitly
+    /// set by only implementing [`Self::new`] for items which have a [`NoHeader`] as header.
+    pub fn new(value: Annotated<T>) -> Self {
+        Self::just(value)
     }
 }
 

--- a/relay-server/src/processing/spans/integrations/otel.rs
+++ b/relay-server/src/processing/spans/integrations/otel.rs
@@ -1,0 +1,47 @@
+use opentelemetry_proto::tonic::trace::v1::TracesData;
+use prost::Message as _;
+use relay_event_schema::protocol::SpanV2;
+
+use crate::integrations::OtelFormat;
+use crate::processing::spans::{Error, Result};
+use crate::services::outcome::DiscardReason;
+
+/// Expands OTeL logs into the [`SpanV2`] format.
+pub fn expand<F>(format: OtelFormat, payload: &[u8], mut produce: F) -> Result<()>
+where
+    F: FnMut(SpanV2),
+{
+    let logs = parse_traces_data(format, payload)?;
+
+    for resource_spans in logs.resource_spans {
+        let resource = resource_spans.resource.as_ref();
+        for scope_spans in resource_spans.scope_spans {
+            let scope = scope_spans.scope.as_ref();
+            for span in scope_spans.spans {
+                let span = relay_spans::otel_to_sentry_span_v2(span, resource, scope);
+                produce(span);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_traces_data(format: OtelFormat, payload: &[u8]) -> Result<TracesData, Error> {
+    match format {
+        OtelFormat::Json => serde_json::from_slice(payload).map_err(|e| {
+            relay_log::debug!(
+                error = &e as &dyn std::error::Error,
+                "Failed to parse traces data as JSON"
+            );
+            Error::Invalid(DiscardReason::InvalidJson)
+        }),
+        OtelFormat::Protobuf => TracesData::decode(payload).map_err(|e| {
+            relay_log::debug!(
+                error = &e as &dyn std::error::Error,
+                "Failed to parse traces data as protobuf"
+            );
+            Error::Invalid(DiscardReason::InvalidProtobuf)
+        }),
+    }
+}

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -45,7 +45,7 @@ use zstd::stream::Encoder as ZstdEncoder;
 use crate::constants::DEFAULT_EVENT_RETENTION;
 use crate::envelope::{self, ContentType, Envelope, EnvelopeError, Item, ItemContainer, ItemType};
 use crate::extractors::{PartialDsn, RequestMeta, RequestTrust};
-use crate::integrations::Integration;
+use crate::integrations::{Integration, SpansIntegration};
 use crate::managed::{InvalidProcessingGroupType, ManagedEnvelope, TypedEnvelope};
 use crate::metrics::{MetricOutcomes, MetricsLimiter, MinimalTrackableBucket};
 use crate::metrics_extraction::transactions::types::ExtractMetricsError;
@@ -314,7 +314,12 @@ impl ProcessingGroup {
         }
 
         if project_info.has_feature(Feature::SpanV2ExperimentalProcessing) {
-            let span_v2_items = envelope.take_items_by(ItemContainer::<SpanV2>::is_container);
+            let span_v2_items = envelope.take_items_by(|item| {
+                matches!(
+                    item.integration(),
+                    Some(Integration::Spans(SpansIntegration::OtelV1 { .. }))
+                ) || ItemContainer::<SpanV2>::is_container(item)
+            });
 
             if !span_v2_items.is_empty() {
                 grouped_envelopes.push((

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -138,7 +138,7 @@ fn convert_traces_data(item: Item, managed_envelope: &mut TypedEnvelope<SpanGrou
     for resource_spans in traces_data.resource_spans {
         for scope_spans in resource_spans.scope_spans {
             for span in scope_spans.spans {
-                let span = relay_spans::otel_to_sentry_span(
+                let span = relay_spans::otel_to_sentry_span_v1(
                     span,
                     resource_spans.resource.as_ref(),
                     scope_spans.scope.as_ref(),
@@ -316,11 +316,12 @@ mod tests {
             "span_key": "span_value"
           },
           "exclusive_time": 0.0,
+          "is_remote": false,
           "links": [],
           "op": "default",
           "span_id": "e342abb1214ca181",
           "start_timestamp": 0.0,
-          "status": "unknown",
+          "status": "ok",
           "timestamp": 0.0,
           "trace_id": "89143b0763095bd9c9955e8175d1fb23"
         }

--- a/relay-spans/src/lib.rs
+++ b/relay-spans/src/lib.rs
@@ -7,7 +7,8 @@
 )]
 
 pub use crate::name::name_for_span;
-pub use crate::otel_to_sentry::otel_to_sentry_span;
+pub use crate::otel_to_sentry::otel_to_sentry_span as otel_to_sentry_span_v1;
+pub use crate::otel_to_sentry_v2::otel_to_sentry_span as otel_to_sentry_span_v2;
 pub use crate::v2_to_v1::span_v2_to_span_v1;
 
 pub use opentelemetry_proto::tonic::trace::v1 as otel_trace;

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -140,6 +140,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_remote": false,
           "status": "ok",
           "description": "GET /home",
           "data": {
@@ -185,7 +186,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -194,7 +195,8 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "description": "middleware - fastify -> @fastify/multipart",
           "data": {
             "sentry.name": "middleware - fastify -> @fastify/multipart"
@@ -202,7 +204,7 @@ mod tests {
           "links": [],
           "kind": "internal"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -219,7 +221,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -228,7 +230,8 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "description": "middleware - fastify -> @fastify/multipart",
           "data": {
             "sentry.name": "middleware - fastify -> @fastify/multipart"
@@ -236,7 +239,7 @@ mod tests {
           "links": [],
           "kind": "internal"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -279,7 +282,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -288,7 +291,8 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
           "data": {
             "db.system": "mysql",
@@ -300,7 +304,7 @@ mod tests {
           "links": [],
           "kind": "client"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -343,7 +347,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -352,7 +356,8 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "description": "index view query",
           "data": {
             "sentry.name": "database query",
@@ -363,7 +368,7 @@ mod tests {
           "links": [],
           "kind": "client"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -394,7 +399,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -403,7 +408,8 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "description": "GET /api/search?q=foobar",
           "data": {
             "sentry.name": "http client request",
@@ -413,7 +419,7 @@ mod tests {
           "links": [],
           "kind": "server"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -462,7 +468,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -471,6 +477,7 @@ mod tests {
           "span_id": "fa90fdead5f74052",
           "parent_span_id": "fa90fdead5f74051",
           "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+          "is_remote": false,
           "status": "ok",
           "description": "cmd.run",
           "data": {
@@ -480,7 +487,7 @@ mod tests {
           },
           "links": []
         }
-        "###);
+        "#);
     }
 
     /// Intended to be synced with `relay-event-schema::protocol::span::convert::tests::roundtrip`.
@@ -616,7 +623,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -626,6 +633,7 @@ mod tests {
           "parent_span_id": "fa90fdead5f74051",
           "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
           "segment_id": "fa90fdead5f74052",
+          "is_remote": false,
           "status": "ok",
           "description": "mydescription",
           "profile_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
@@ -642,7 +650,7 @@ mod tests {
           "links": [],
           "platform": "php"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -658,7 +666,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -668,11 +676,11 @@ mod tests {
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "is_remote": true,
-          "status": "unknown",
+          "status": "ok",
           "data": {},
           "links": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -688,7 +696,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -698,11 +706,11 @@ mod tests {
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "is_remote": false,
-          "status": "unknown",
+          "status": "ok",
           "data": {},
           "links": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -718,7 +726,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -727,12 +735,13 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "data": {},
           "links": [],
           "kind": "client"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -778,7 +787,7 @@ mod tests {
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 0.0,
           "start_timestamp": 0.0,
@@ -786,7 +795,8 @@ mod tests {
           "op": "default",
           "span_id": "e342abb1214ca181",
           "trace_id": "3c79f60c11214eb38604f4ae0781bfb2",
-          "status": "unknown",
+          "is_remote": false,
+          "status": "ok",
           "data": {},
           "links": [
             {
@@ -802,7 +812,7 @@ mod tests {
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -818,7 +828,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 0.0,
           "start_timestamp": 0.0,
@@ -826,12 +836,13 @@ mod tests {
           "op": "default",
           "span_id": "e342abb1214ca181",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_remote": false,
           "status": "internal_error",
           "data": {
             "sentry.status.message": "2 is the error status code"
           },
           "links": []
         }
-        "###);
+        "#);
     }
 }

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -933,7 +933,7 @@ def test_span_ingestion(
                 "sentry.name": {"type": "string", "value": "my 2nd OTel span"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.segment.id": {"type": "string", "value": "d342abb1214ca182"},
-                "sentry.status": {"type": "string", "value": "unknown"},
+                "sentry.status": {"type": "string", "value": "ok"},
                 "user_agent.original": {
                     "type": "string",
                     "value": "python-requests/2.32.4",
@@ -953,7 +953,7 @@ def test_span_ingestion(
             "name": "my 2nd OTel span",
             "span_id": "d342abb1214ca182",
             "start_timestamp": start.timestamp(),
-            "status": "error",
+            "status": "ok",
             "trace_id": "89143b0763095bd9c9955e8175d1fb24",
         },
         {
@@ -1002,7 +1002,7 @@ def test_span_ingestion(
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.name": {"type": "string", "value": "my 3rd protobuf OTel span"},
                 "sentry.op": {"type": "string", "value": "default"},
-                "sentry.status": {"type": "string", "value": "unknown"},
+                "sentry.status": {"type": "string", "value": "ok"},
                 "ui.component_name": {"type": "string", "value": "MyComponent"},
                 "user_agent.original": {
                     "type": "string",
@@ -1026,7 +1026,7 @@ def test_span_ingestion(
             "parent_span_id": "f0f0f0abcdef1234",
             "span_id": "f0b809703e783d00",
             "start_timestamp": start.timestamp(),
-            "status": "error",
+            "status": "ok",
             "trace_id": "89143b0763095bd9c9955e8175d1fb24",
         },
     ]

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -1,0 +1,152 @@
+from datetime import datetime, timezone
+
+from opentelemetry.proto.common.v1.common_pb2 import (
+    AnyValue,
+    InstrumentationScope,
+    KeyValue,
+)
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import (
+    ResourceSpans,
+    ScopeSpans,
+    Span,
+    TracesData,
+)
+
+from .asserts import time_within_delta, time_within
+
+
+def test_span_ingestion(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    spans_consumer,
+    metrics_consumer,
+):
+    spans_consumer = spans_consumer()
+    metrics_consumer = metrics_consumer()
+
+    relay = relay(relay_with_processing())
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:standalone-span-ingestion",
+        "organizations:relay-otlp-traces-endpoint",
+        "projects:span-v2-experimental-processing",
+    ]
+
+    ts = datetime.now(timezone.utc)
+
+    span = Span(
+        trace_id=bytes.fromhex("89143b0763095bd9c9955e8175d1fb24"),
+        span_id=bytes.fromhex("f0b809703e783d00"),
+        parent_span_id=bytes.fromhex("f0f0f0abcdef1234"),
+        name="A Proto Span",
+        start_time_unix_nano=int((ts.timestamp() - 1.0) * 1e9),
+        end_time_unix_nano=int((ts.timestamp() - 0.5) * 1e9),
+        kind=Span.SPAN_KIND_SERVER,
+        attributes=[
+            KeyValue(
+                key="ui.component_name",
+                value=AnyValue(string_value="MyComponent"),
+            ),
+        ],
+        links=[
+            Span.Link(
+                trace_id=bytes.fromhex("89143b0763095bd9c9955e8175d1fb24"),
+                span_id=bytes.fromhex("e0b809703e783d01"),
+                attributes=[
+                    KeyValue(
+                        key="link_str_key",
+                        value=AnyValue(string_value="link_str_value"),
+                    )
+                ],
+            )
+        ],
+    )
+    scope_spans = ScopeSpans(
+        spans=[span], scope=InstrumentationScope(name="my_scope_name", version="13.37")
+    )
+    resource_spans = ResourceSpans(
+        scope_spans=[scope_spans],
+        resource=Resource(
+            attributes=[
+                KeyValue(
+                    key="company",
+                    value=AnyValue(string_value="Relay Corp"),
+                ),
+            ]
+        ),
+    )
+
+    relay.send_otel_span(
+        project_id,
+        bytes=TracesData(resource_spans=[resource_spans]).SerializeToString(),
+        headers={"Content-Type": "application/x-protobuf"},
+    )
+
+    assert spans_consumer.get_span() == {
+        "attributes": {
+            "instrumentation.name": {"type": "string", "value": "my_scope_name"},
+            "instrumentation.version": {"type": "string", "value": "13.37"},
+            "resource.company": {"type": "string", "value": "Relay Corp"},
+            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
+            "sentry.browser.version": {"type": "string", "value": "2.32"},
+            "sentry.observed_timestamp_nanos": {
+                "type": "string",
+                "value": time_within(ts, expect_resolution="ns"),
+            },
+            "ui.component_name": {"type": "string", "value": "MyComponent"},
+        },
+        "downsampled_retention_days": 90,
+        "end_timestamp": time_within(ts.timestamp() - 0.5),
+        "is_remote": False,
+        "key_id": 123,
+        "kind": "server",
+        "links": [
+            {
+                "attributes": {
+                    "link_str_key": {"type": "string", "value": "link_str_value"}
+                },
+                "sampled": False,
+                "span_id": "e0b809703e783d01",
+                "trace_id": "89143b0763095bd9c9955e8175d1fb24",
+            }
+        ],
+        "name": "A Proto Span",
+        "organization_id": 1,
+        "parent_span_id": "f0f0f0abcdef1234",
+        "project_id": 42,
+        "received": time_within(ts),
+        "retention_days": 90,
+        "span_id": "f0b809703e783d00",
+        "start_timestamp": time_within(ts.timestamp() - 1.0),
+        "status": "ok",
+        "trace_id": "89143b0763095bd9c9955e8175d1fb24",
+    }
+
+    assert metrics_consumer.get_metrics(n=2, with_headers=False) == [
+        {
+            "name": "c:spans/count_per_root_project@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {"decision": "keep", "target_project_id": "42"},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+        {
+            "name": "c:spans/usage@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within_delta(),
+            "retention_days": 90,
+            "tags": {},
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+    ]


### PR DESCRIPTION
Implements support for otel traces in the spanv2 processing pipeline.