### PR TITLE
feat(conventions): Match placeholder path segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Extract additional `user.geo.*` attributes on spans. ([#5194](https://github.com/getsentry/relay/pull/5194))
 - Modernize session processing and move to Relay's new processing framework. ([#5201](https://github.com/getsentry/relay/pull/5201))
 - Add TraceMetric data category. ([#5206](https://github.com/getsentry/relay/pull/5206))
+- Match placeholder segments in sentry conventions attributes. ([#5237](https://github.com/getsentry/relay/pull/5237))
 
 ## 25.9.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,43 +3100,43 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -3153,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,7 +3104,9 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.12.1",
+ "serde",
 ]
 
 [[package]]
@@ -3125,6 +3127,19 @@ checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
  "fastrand",
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3297,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -4312,7 +4327,7 @@ dependencies = [
  "rmp-serde",
  "semver",
  "sentry",
- "sentry_protos 0.4.1",
+ "sentry_protos",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -4830,7 +4845,7 @@ checksum = "a8757c054b3dd24d457fb4b0f63a42eac257ec25640f2bdc66332f6f5956be3f"
 dependencies = [
  "jsonschema",
  "prost",
- "sentry_protos 0.3.3",
+ "sentry_protos",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4911,17 +4926,6 @@ dependencies = [
  "time",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "sentry_protos"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2736920441e5f518ac0e79c27b91e2203b7c240afbd6e76771dbf78e208dbc12"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ path-slash = "0.2.1"
 pest = "2.1.3"
 pest_derive = "2.1.0"
 phf = { version = "0.13.1", features = ["macros"] }
-phf_codegen = "0.12"
+phf_codegen = "0.13.1"
 pin-project-lite = "0.2.15"
 pretty-hex = "0.4.1"
 priority-queue = "2.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ parking_lot = "0.12.3"
 path-slash = "0.2.1"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-phf = { version = "0.12", default-features = false }
+phf = { version = "0.13.1", features = ["macros"] }
 phf_codegen = "0.12"
 pin-project-lite = "0.2.15"
 pretty-hex = "0.4.1"

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -1,6 +1,7 @@
 mod name;
 mod raw;
 
+use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -11,9 +12,33 @@ use walkdir::WalkDir;
 const ATTRIBUTE_DIR: &str = "sentry-conventions/model/attributes";
 const NAME_DIR: &str = "sentry-conventions/model/name";
 
+#[derive(Default)]
+struct RawNode {
+    children: BTreeMap<String, RawNode>,
+    info: Option<String>,
+}
+
+impl RawNode {
+    fn build(&self, w: &mut impl std::io::Write) -> Result<(), std::io::Error> {
+        let Self { children, info } = self;
+        write!(w, "AttributeNode {{ info: ")?;
+        match info {
+            Some(info) => write!(w, "Some({})", info)?,
+            None => write!(w, "None")?,
+        };
+        write!(w, ", children: ::phf::phf_map!{{",)?;
+        for (segment, child) in children {
+            write!(w, "\"{segment}\" => ")?;
+            child.build(w)?;
+            write!(w, ",")?;
+        }
+        write!(w, "}} }}")
+    }
+}
+
 fn main() {
     let crate_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
-    let mut map = phf_codegen::Map::new();
+    let mut root = RawNode::default();
 
     for file in WalkDir::new(crate_dir.join(ATTRIBUTE_DIR)) {
         let file = file.unwrap();
@@ -24,19 +49,28 @@ fn main() {
             let contents = std::fs::read_to_string(file.path()).unwrap();
             let attr: raw::Attribute = serde_json::from_str(&contents).unwrap();
             let (key, value) = raw::format_attribute_info(attr);
-            map.entry(key, value);
+
+            let mut node = &mut root;
+            let mut parts = key.split('.').peekable();
+            while let Some(part) = parts.next() {
+                node = node
+                    .children
+                    .entry(part.to_string())
+                    .or_insert_with(RawNode::default);
+                if parts.peek().is_none() {
+                    node.info = Some(value);
+                    break;
+                }
+            }
         }
     }
 
     let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("attribute_map.rs");
     let mut out_file = BufWriter::new(File::create(&out_path).unwrap());
 
-    writeln!(
-        &mut out_file,
-        "static ATTRIBUTES: phf::Map<&'static str, AttributeInfo> = {};",
-        map.build()
-    )
-    .unwrap();
+    write!(&mut out_file, "static ATTRIBUTES: AttributeNode = ",).unwrap();
+    root.build(&mut out_file).unwrap();
+    write!(&mut out_file, ";").unwrap();
 
     write_name_rs(&crate_dir);
 

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -55,7 +55,7 @@ fn main() {
             while let Some(part) = parts.next() {
                 node = node
                     .children
-                    .entry(part.to_string())
+                    .entry(part.to_owned())
                     .or_insert_with(RawNode::default);
                 if parts.peek().is_none() {
                     node.info = Some(value);

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -21,7 +21,7 @@ struct RawNode {
 impl RawNode {
     fn build(&self, w: &mut impl std::io::Write) -> Result<(), std::io::Error> {
         let Self { children, info } = self;
-        write!(w, "AttributeNode {{ info: ")?;
+        write!(w, "Node {{ info: ")?;
         match info {
             Some(info) => write!(w, "Some({})", info)?,
             None => write!(w, "None")?,
@@ -76,7 +76,7 @@ fn main() {
     let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("attribute_map.rs");
     let mut out_file = BufWriter::new(File::create(&out_path).unwrap());
 
-    write!(&mut out_file, "static ATTRIBUTES: AttributeNode = ",).unwrap();
+    write!(&mut out_file, "static ATTRIBUTES: Node<AttributeInfo> = ",).unwrap();
     root.build(&mut out_file).unwrap();
     write!(&mut out_file, ";").unwrap();
 

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -36,6 +36,14 @@ impl RawNode {
     }
 }
 
+/// Parse a path-like attribute key into individual segments.
+///
+/// NOTE: This does not yet support escaped segments, e.g. `"foo.'my.thing'.bar"` will split into
+/// `["foo.'my", "thing'.bar"]`.
+fn parse_segments(key: &str) -> impl Iterator<Item = &str> {
+    key.split('.')
+}
+
 fn main() {
     let crate_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
     let mut root = RawNode::default();
@@ -51,7 +59,7 @@ fn main() {
             let (key, value) = raw::format_attribute_info(attr);
 
             let mut node = &mut root;
-            let mut parts = key.split('.').peekable();
+            let mut parts = parse_segments(&key).peekable();
             while let Some(part) = parts.next() {
                 node = node
                     .children

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -5,7 +5,7 @@ macro_rules! convention_attributes {
         #[test]
         fn test_attributes_defined_in_conventions() {
             $(
-                assert!(crate::ATTRIBUTES.contains_key($name));
+                assert!(crate::attribute_info($name).is_some());
             )*
         }
     };

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Pii {
 }
 
 /// Under which names an attribute should be saved.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub enum WriteBehavior {
     /// Save the attribute under its current name.
     ///
@@ -40,7 +40,7 @@ pub enum WriteBehavior {
 }
 
 /// Information about an attribute, as defined in `sentry-conventions`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct AttributeInfo {
     /// How this attribute should be saved.
     pub write_behavior: WriteBehavior,
@@ -58,12 +58,11 @@ struct AttributeNode {
 /// Returns information about an attribute, as defined in `sentry-conventions`.
 pub fn attribute_info(key: &str) -> Option<&'static AttributeInfo> {
     let mut node = &ATTRIBUTES;
-    let mut parts = key.split('.');
-    while let Some(part) = parts.next() {
+    for part in key.split('.') {
         let (_, child) = node
             .children
             .entries()
-            .find(|(segment, _)| is_match(part, **segment))?;
+            .find(|(segment, _)| is_match(part, segment))?;
         node = child;
     }
     node.info.as_ref()

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -65,7 +65,7 @@ struct Node<T: 'static> {
 
 impl<T> Node<T> {
     fn find(&self, key: &str) -> Option<&T> {
-        if key == "" {
+        if key.is_empty() {
             return self.info.as_ref();
         }
         let (prefix, suffix) = key.split_once('.').unwrap_or((key, ""));

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Pii {
 }
 
 /// Under which names an attribute should be saved.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WriteBehavior {
     /// Save the attribute under its current name.
     ///
@@ -40,7 +40,7 @@ pub enum WriteBehavior {
 }
 
 /// Information about an attribute, as defined in `sentry-conventions`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttributeInfo {
     /// How this attribute should be saved.
     pub write_behavior: WriteBehavior,
@@ -76,6 +76,22 @@ mod tests {
             aliases: [
                 "http.response.body.size",
                 "http.response.header.content-length",
+            ],
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_url_path_parameter() {
+        // See https://github.com/getsentry/sentry-conventions/blob/d80504a40ba3a0a23eb746e2608425cf8d8e68bf/model/attributes/url/url__path__parameter__%5Bkey%5D.json.
+        let info = attribute_info("url.path.parameter.'id=123'").unwrap();
+
+        insta::assert_debug_snapshot!(info, @r###"
+        AttributeInfo {
+            write_behavior: CurrentName,
+            pii: Maybe,
+            aliases: [
+                "params.<key>",
             ],
         }
         "###);

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -60,9 +60,18 @@ pub fn attribute_info(key: &str) -> Option<&'static AttributeInfo> {
     let mut node = &ATTRIBUTES;
     let mut parts = key.split('.');
     while let Some(part) = parts.next() {
-        node = node.children.get(part)?;
+        let (_, child) = node
+            .children
+            .entries()
+            .find(|(segment, _)| is_match(part, **segment))?;
+        node = child;
     }
     node.info.as_ref()
+}
+
+fn is_match(needle: &str, haystack: &str) -> bool {
+    let is_wildcard = haystack.starts_with('<') && haystack.ends_with('>');
+    is_wildcard || needle == haystack
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Attributes in sentry-conventions may contain placeholder segments that match any value, e.g. `sentry.message.parameter.<key>` matches any value for `<key>`.

Fixes INGEST-541.