### PR TITLE
ref(spans): Removes support for the otel_span item type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 **Internal**:
 
 - No longer writes Spans as trace items. ([#5152](https://github.com/getsentry/relay/pull/5152))
+- Removes support for the `otel_span` envelope item type. ([#5238](https://github.com/getsentry/relay/pull/5238))
 - Produce spans to `ingest-spans` by default. ([#5163](https://github.com/getsentry/relay/pull/5163))
 - Add `retentions` to the project configuration and use them for logs. ([#5135](https://github.com/getsentry/relay/pull/5135))
 - Produce Span V2 Kafka messages. ([#5151](https://github.com/getsentry/relay/pull/5151), [#5173](https://github.com/getsentry/relay/pull/5173), [#5199](https://github.com/getsentry/relay/pull/5199), [#5216](https://github.com/getsentry/relay/pull/5216))

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -139,7 +139,7 @@ impl Item {
             }
             ItemType::ClientReport => smallvec![],
             ItemType::CheckIn => smallvec![(DataCategory::Monitor, item_count)],
-            ItemType::Span | ItemType::OtelSpan => smallvec![(DataCategory::Span, item_count)],
+            ItemType::Span => smallvec![(DataCategory::Span, item_count)],
             // NOTE: semantically wrong, but too expensive to parse.
             ItemType::ProfileChunk => match self.profile_type() {
                 Some(ProfileType::Backend) => smallvec![(DataCategory::ProfileChunk, item_count)],
@@ -437,7 +437,6 @@ impl Item {
             | ItemType::Span
             | ItemType::Nel
             | ItemType::Log
-            | ItemType::OtelSpan
             | ItemType::TraceMetric
             | ItemType::ProfileChunk => false,
 
@@ -477,7 +476,6 @@ impl Item {
             ItemType::Span => false,
             ItemType::Log => false,
             ItemType::TraceMetric => false,
-            ItemType::OtelSpan => false,
             ItemType::ProfileChunk => false,
             ItemType::Integration => false,
 
@@ -554,8 +552,6 @@ pub enum ItemType {
     TraceMetric,
     /// A standalone span.
     Span,
-    /// A standalone OpenTelemetry span serialized as JSON.
-    OtelSpan,
     /// UserReport as an Event
     UserReportV2,
     /// ProfileChunk is a chunk of a profiling session.
@@ -618,7 +614,6 @@ impl ItemType {
             Self::Log => "log",
             Self::TraceMetric => "trace_metric",
             Self::Span => "span",
-            Self::OtelSpan => "otel_span",
             Self::ProfileChunk => "profile_chunk",
             Self::Integration => "integration",
             Self::Unknown(_) => "unknown",
@@ -678,7 +673,6 @@ impl ItemType {
             ItemType::Log => true,
             ItemType::TraceMetric => true,
             ItemType::Span => true,
-            ItemType::OtelSpan => true,
             ItemType::UserReportV2 => false,
             ItemType::ProfileChunk => true,
             ItemType::Integration => false,
@@ -721,7 +715,6 @@ impl std::str::FromStr for ItemType {
             "log" => Self::Log,
             "trace_metric" => Self::TraceMetric,
             "span" => Self::Span,
-            "otel_span" => Self::OtelSpan,
             "profile_chunk" => Self::ProfileChunk,
             // "profile_chunk_ui" is to be treated as an alias for `ProfileChunk`
             // because Android 8.10.0 and 8.11.0 is sending it as the item type.

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -614,8 +614,6 @@ pub enum DiscardItemType {
     TraceMetric,
     /// A standalone span.
     Span,
-    /// A standalone OpenTelemetry span serialized as JSON.
-    OtelSpan,
     /// UserReport as an Event
     UserReportV2,
     /// ProfileChunk is a chunk of a profiling session.
@@ -671,7 +669,6 @@ impl DiscardItemType {
             Self::Log => "log",
             Self::TraceMetric => "trace_metric",
             Self::Span => "span",
-            Self::OtelSpan => "otel_span",
             Self::UserReportV2 => "user_report_v2",
             Self::ProfileChunk => "profile_chunk",
             Self::Integration => "integration",
@@ -704,7 +701,6 @@ impl From<&ItemType> for DiscardItemType {
             ItemType::Log => Self::Log,
             ItemType::TraceMetric => Self::TraceMetric,
             ItemType::Span => Self::Span,
-            ItemType::OtelSpan => Self::OtelSpan,
             ItemType::UserReportV2 => Self::UserReportV2,
             ItemType::ProfileChunk => Self::ProfileChunk,
             ItemType::Integration => Self::Integration,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -326,7 +326,7 @@ impl ProcessingGroup {
 
         // Extract spans.
         let span_items = envelope.take_items_by(|item| {
-            matches!(item.ty(), &ItemType::Span | &ItemType::OtelSpan)
+            matches!(item.ty(), &ItemType::Span)
                 || matches!(item.integration(), Some(Integration::Spans(_)))
         });
 

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -466,7 +466,6 @@ fn is_duplicate(item: &Item, processing_enabled: bool) -> bool {
         ItemType::Log => false,
         ItemType::TraceMetric => false,
         ItemType::Span => false,
-        ItemType::OtelSpan => false,
         ItemType::ProfileChunk => false,
         ItemType::Integration => false,
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -135,7 +135,6 @@ fn infer_event_category(item: &Item) -> Option<DataCategory> {
         ItemType::Log => None,
         ItemType::TraceMetric => None,
         ItemType::Span => None,
-        ItemType::OtelSpan => None,
         ItemType::ProfileChunk => None,
         ItemType::Integration => None,
         ItemType::Unknown(_) => None,
@@ -539,7 +538,7 @@ impl Enforcement {
             ItemType::Log => {
                 !(self.log_items.is_active() || self.log_bytes.is_active())
             }
-            ItemType::Span | ItemType::OtelSpan => !self.spans_indexed.is_active(),
+            ItemType::Span => !self.spans_indexed.is_active(),
             ItemType::ProfileChunk => match item.profile_type() {
                 Some(ProfileType::Backend) => !self.profile_chunks.is_active(),
                 Some(ProfileType::Ui) => !self.profile_chunks_ui.is_active(),
@@ -1770,7 +1769,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_span() {
-        let mut envelope = envelope![Span, OtelSpan];
+        let mut envelope = envelope![Span, Span];
 
         let mock = mock_limiter(Some(DataCategory::Span));
         let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
@@ -1788,7 +1787,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_span_no_indexing_quota() {
-        let mut envelope = envelope![OtelSpan, Span];
+        let mut envelope = envelope![Span, Span];
 
         let mock = mock_limiter(Some(DataCategory::SpanIndexed));
         let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
@@ -1807,7 +1806,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_span_metrics_extracted_no_indexing_quota() {
-        let mut envelope = envelope![Span, OtelSpan];
+        let mut envelope = envelope![Span, Span];
         set_extracted(envelope.envelope_mut(), ItemType::Span);
 
         let mock = mock_limiter(Some(DataCategory::SpanIndexed));

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -85,7 +85,7 @@ pub fn check_envelope_size_limits(
                 trace_metric_count += item.item_count().unwrap_or(1) as usize;
                 config.max_trace_metric_size()
             }
-            ItemType::Span | ItemType::OtelSpan => {
+            ItemType::Span => {
                 span_count += item.item_count().unwrap_or(1) as usize;
                 config.max_span_size()
             }

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1053,7 +1053,7 @@ def test_span_ingestion(
             "tags": {"decision": "keep", "target_project_id": "42"},
             "timestamp": expected_timestamp,
             "type": "c",
-            "value": 4.0,
+            "value": 3.0,
         },
         {
             "name": "c:spans/count_per_root_project@none",
@@ -1074,7 +1074,7 @@ def test_span_ingestion(
             "tags": {},
             "timestamp": expected_timestamp,
             "type": "c",
-            "value": 4.0,
+            "value": 3.0,
             "received_at": time_after(now_timestamp),
         },
         {
@@ -1436,7 +1436,7 @@ def test_rate_limit_indexed_consistent(
     project_config["config"]["quotas"] = [
         {
             "categories": ["span_indexed"],
-            "limit": 6,
+            "limit": 5,
             "window": int(datetime.now(UTC).timestamp()),
             "id": uuid.uuid4(),
             "reasonCode": "indexed_exceeded",
@@ -1460,12 +1460,12 @@ def test_rate_limit_indexed_consistent(
     # First batch passes
     relay.send_envelope(project_id, envelope)
     spans = spans_consumer.get_spans(n=5, timeout=10)
-    assert len(spans) == 6
-    assert summarize_outcomes() == {(16, 0): 6}  # SpanIndexed, Accepted
+    assert len(spans) == 5
+    assert summarize_outcomes() == {(16, 0): 5}  # SpanIndexed, Accepted
 
     # Second batch is limited
     relay.send_envelope(project_id, envelope)
-    assert summarize_outcomes() == {(16, 2): 6}  # SpanIndexed, RateLimited
+    assert summarize_outcomes() == {(16, 2): 5}  # SpanIndexed, RateLimited
 
     spans_consumer.assert_empty()
     outcomes_consumer.assert_empty()


### PR DESCRIPTION
This was used internally, which is no longer necessary.