### PR TITLE
ref(relay): Drop once-cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,7 +3650,6 @@ dependencies = [
  "clap_complete",
  "dialoguer",
  "hostname 0.4.0",
- "once_cell",
  "relay-config",
  "relay-kafka",
  "relay-log",
@@ -3699,7 +3698,6 @@ dependencies = [
  "globset",
  "json-forensics",
  "lru",
- "once_cell",
  "regex",
  "relay-auth",
  "relay-base-schema",
@@ -3752,7 +3750,6 @@ version = "25.9.0"
 dependencies = [
  "chrono",
  "criterion",
- "once_cell",
  "regex-lite",
  "relay-pattern",
  "sentry-types",
@@ -3852,7 +3849,6 @@ dependencies = [
  "itertools 0.14.0",
  "maxminddb",
  "md5",
- "once_cell",
  "psl",
  "regex",
  "relay-base-schema",
@@ -3927,7 +3923,6 @@ dependencies = [
  "indexmap",
  "insta",
  "ipnetwork",
- "once_cell",
  "regex",
  "relay-common",
  "relay-conventions",
@@ -4038,7 +4033,6 @@ dependencies = [
  "chrono",
  "hex",
  "insta",
- "once_cell",
  "opentelemetry-proto",
  "relay-common",
  "relay-conventions",
@@ -4076,7 +4070,6 @@ dependencies = [
  "itertools 0.14.0",
  "minidump",
  "num-traits",
- "once_cell",
  "pest",
  "pest_derive",
  "pretty-hex",
@@ -4207,7 +4200,6 @@ dependencies = [
  "criterion",
  "flate2",
  "insta",
- "once_cell",
  "relay-event-schema",
  "relay-log",
  "relay-pii",
@@ -4271,7 +4263,6 @@ dependencies = [
  "mime",
  "minidump",
  "multer",
- "once_cell",
  "opentelemetry-proto",
  "papaya",
  "pin-project-lite",
@@ -4342,7 +4333,6 @@ dependencies = [
  "chrono",
  "hex",
  "insta",
- "once_cell",
  "opentelemetry-proto",
  "relay-conventions",
  "relay-event-schema",
@@ -4370,7 +4360,6 @@ version = "25.9.0"
 dependencies = [
  "futures",
  "insta",
- "once_cell",
  "pin-project-lite",
  "relay-log",
  "relay-statsd",
@@ -4402,7 +4391,6 @@ dependencies = [
 name = "relay-ua"
 version = "25.9.0"
 dependencies = [
- "once_cell",
  "uaparser",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,6 @@ minidump = "0.26.0"
 multer = "3.1.0"
 num-traits = "0.2.19"
 num_cpus = "1.13.1"
-once_cell = "1.13.1"
 opentelemetry-proto = { version = "0.30.0", default-features = false }
 papaya = "0.2.3"
 parking_lot = "0.12.3"

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -21,7 +21,6 @@ chrono = { workspace = true }
 globset = { workspace = true }
 json-forensics = { workspace = true }
 lru = { workspace = true }
-once_cell = { workspace = true }
 regex = { workspace = true }
 relay-auth = { workspace = true }
 relay-base-schema = { workspace = true }

--- a/relay-cabi/src/codeowners.rs
+++ b/relay-cabi/src/codeowners.rs
@@ -1,15 +1,14 @@
 use std::num::NonZeroUsize;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use lru::LruCache;
-use once_cell::sync::Lazy;
 use regex::bytes::Regex;
 
 use crate::core::{RelayBuf, RelayStr};
 
 /// LRU cache for [`Regex`]s in relation to the provided string pattern.
-static CODEOWNERS_CACHE: Lazy<Mutex<LruCache<String, Regex>>> =
-    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(500).unwrap())));
+static CODEOWNERS_CACHE: LazyLock<Mutex<LruCache<String, Regex>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(500).unwrap())));
 
 fn translate_codeowners_pattern(pattern: &str) -> Option<Regex> {
     let mut regex = String::new();

--- a/relay-cabi/src/glob.rs
+++ b/relay-cabi/src/glob.rs
@@ -1,11 +1,10 @@
 //! Binary glob pattern matching for the C-ABI.
 
-use std::borrow::Cow;
 use std::num::NonZeroUsize;
+use std::{borrow::Cow, sync::LazyLock};
 
 use globset::GlobBuilder;
 use lru::LruCache;
-use once_cell::sync::Lazy;
 use regex::bytes::{Regex, RegexBuilder};
 use std::sync::{Mutex, PoisonError};
 
@@ -56,8 +55,8 @@ pub unsafe extern "C" fn relay_is_glob_match(
 }
 
 /// LRU cache for [`Regex`]s in relation to [`GlobOptions`] and the provided string pattern.
-static GLOB_CACHE: Lazy<Mutex<LruCache<(GlobOptions, String), Regex>>> =
-    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(500).unwrap())));
+static GLOB_CACHE: LazyLock<Mutex<LruCache<(GlobOptions, String), Regex>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(500).unwrap())));
 
 /// Controls the options of the globber.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]

--- a/relay-common/Cargo.toml
+++ b/relay-common/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-once_cell = { workspace = true }
 regex-lite = { workspace = true }
 relay-pattern = { workspace = true }
 sentry-types = { workspace = true }

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -19,7 +19,6 @@ dynfmt = { workspace = true, features = ["python", "curly"] }
 itertools = { workspace = true }
 maxminddb = { workspace = true }
 md5 = { workspace = true }
-once_cell = { workspace = true }
 psl = { workspace = true }
 regex = { workspace = true }
 relay-base-schema = { workspace = true }

--- a/relay-event-normalization/src/normalize/contexts.rs
+++ b/relay-event-normalization/src/normalize/contexts.rs
@@ -1,8 +1,8 @@
 //! Computation and normalization of contexts from event data.
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use relay_event_schema::protocol::{
     BrowserContext, Context, Cookies, OsContext, ResponseContext, RuntimeContext,
@@ -10,49 +10,49 @@ use relay_event_schema::protocol::{
 use relay_protocol::{Annotated, Empty, Value};
 
 /// Environment.OSVersion (GetVersionEx) or RuntimeInformation.OSDescription on Windows
-static OS_WINDOWS_REGEX1: Lazy<Regex> = Lazy::new(|| {
+static OS_WINDOWS_REGEX1: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(Microsoft\s+)?Windows\s+(NT\s+)?(?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$")
         .unwrap()
 });
-static OS_WINDOWS_REGEX2: Lazy<Regex> = Lazy::new(|| {
+static OS_WINDOWS_REGEX2: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^Windows\s+\d+\s+\((?P<version>\d+\.\d+\.(?P<build_number>\d+)).*$").unwrap()
 });
 
-static OS_ANDROID_REGEX: Lazy<Regex> = Lazy::new(|| {
+static OS_ANDROID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^Android (OS )?(?P<version>\d+(\.\d+){0,2}) / API-(?P<api>(\d+))").unwrap()
 });
 
 /// Format sent by Unreal Engine on macOS
-static OS_MACOS_REGEX: Lazy<Regex> = Lazy::new(|| {
+static OS_MACOS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$").unwrap()
 });
 
 /// Format sent by Unity on iOS
-static OS_IOS_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^iOS (?P<version>\d+\.\d+\.\d+)").unwrap());
+static OS_IOS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^iOS (?P<version>\d+\.\d+\.\d+)").unwrap());
 
 /// Format sent by Unity on iPadOS
-static OS_IPADOS_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^iPadOS (?P<version>\d+\.\d+\.\d+)").unwrap());
+static OS_IPADOS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^iPadOS (?P<version>\d+\.\d+\.\d+)").unwrap());
 
 /// Specific regex to parse Linux distros
-static OS_LINUX_DISTRO_UNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+static OS_LINUX_DISTRO_UNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^Linux (?P<kernel_version>\d+\.\d+(\.\d+(\.[1-9]+)?)?) (?P<name>[a-zA-Z]+) (?P<version>\d+(\.\d+){0,2})").unwrap()
 });
 
 /// Environment.OSVersion or RuntimeInformation.OSDescription (uname) on Mono and CoreCLR on
 /// macOS, iOS, Linux, etc.
-static OS_UNAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+static OS_UNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(?P<name>[a-zA-Z]+) (?P<kernel_version>\d+\.\d+(\.\d+(\.[1-9]+)?)?)").unwrap()
 });
 
 /// Mono 5.4, .NET Core 2.0
-static RUNTIME_DOTNET_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(?P<name>.*) (?P<version>\d+\.\d+(\.\d+){0,2}).*$").unwrap());
+static RUNTIME_DOTNET_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?P<name>.*) (?P<version>\d+\.\d+(\.\d+){0,2}).*$").unwrap());
 
 /// A hashmap that translates from the android model to the more human-friendly product-names.
 /// E.g. NE2211 -> OnePlus 10 Pro 5G
-static ANDROID_MODEL_NAMES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+static ANDROID_MODEL_NAMES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     let mut map = HashMap::new();
     // Note that windows paths with backslashes '\' won't work on unix systems.
     let android_str = include_str!("android_models.csv");

--- a/relay-event-normalization/src/normalize/span/description/mod.rs
+++ b/relay-event-normalization/src/normalize/span/description/mod.rs
@@ -2,12 +2,12 @@
 mod redis;
 mod resource;
 mod sql;
-use once_cell::sync::Lazy;
 use psl;
 use relay_filter::matches_any_origin;
 use serde_json::Value;
 #[cfg(test)]
 pub use sql::{Mode, scrub_queries};
+use std::sync::LazyLock;
 
 use relay_event_schema::protocol::Span;
 use std::borrow::Cow;
@@ -25,7 +25,7 @@ use crate::span::description::resource::COMMON_PATH_SEGMENTS;
 use crate::span::tag_extraction::HTTP_METHOD_EXTRACTOR_REGEX;
 
 /// Dummy URL used to parse relative URLs.
-static DUMMY_BASE_URL: Lazy<Url> = Lazy::new(|| "http://replace_me".parse().unwrap());
+static DUMMY_BASE_URL: LazyLock<Url> = LazyLock::new(|| "http://replace_me".parse().unwrap());
 
 /// Maximum length of a resource URL segment.
 ///

--- a/relay-event-normalization/src/normalize/span/description/resource.rs
+++ b/relay-event-normalization/src/normalize/span/description/resource.rs
@@ -1,14 +1,14 @@
 //! Code for scrubbing resource span description.
 use std::collections::BTreeSet;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 // TODO: move functions from parent module here.
 
 /// Parts of a resource path that we allowlist.
 ///
 /// By default, all path segments except the last are dropped.
-pub static COMMON_PATH_SEGMENTS: Lazy<BTreeSet<&str>> = Lazy::new(|| {
+pub static COMMON_PATH_SEGMENTS: LazyLock<BTreeSet<&str>> = LazyLock::new(|| {
     BTreeSet::from([
         "_app",
         "_next",

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,7 +1,7 @@
 //! Span normalization logic.
 
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 pub mod ai;
 pub mod country_subregion;
@@ -11,7 +11,7 @@ pub mod reparent_broken_spans;
 pub mod tag_extraction;
 
 /// Regex used to scrub hex IDs and multi-digit numbers from table names and other identifiers.
-pub static TABLE_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static TABLE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?ix)
         [0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12} |

--- a/relay-event-normalization/src/regexes.rs
+++ b/relay-event-normalization/src/regexes.rs
@@ -1,11 +1,12 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 /// Contains multiple capture groups which will be used as a replace placeholder.
 ///
 /// This regex is inspired by one used for grouping:
 /// <https://github.com/getsentry/sentry/blob/6ba59023a78bfe033e48ea4e035b64710a905c6b/src/sentry/grouping/strategies/message.py#L16-L97>
-pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static TRANSACTION_NAME_NORMALIZER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
     (?P<uuid>[^/\\]*
@@ -59,7 +60,7 @@ pub static TRANSACTION_NAME_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
 ///
 /// Slightly modified Regex from
 /// <https://github.com/getsentry/sentry/blob/de5949a9a313d7ef0bf0685f84fe6e981ac38558/src/sentry/utils/performance_issues/base.py#L292-L306>
-pub static RESOURCE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static RESOURCE_NORMALIZER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         # UUIDs.
@@ -75,10 +76,10 @@ pub static RESOURCE_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static DB_SQL_TRANSACTION_CORE_DATA_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?P<int>[0-9]+)").unwrap());
+pub static DB_SQL_TRANSACTION_CORE_DATA_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?P<int>[0-9]+)").unwrap());
 
-pub static DB_SUPABASE_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static DB_SUPABASE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         # UUIDs.
@@ -92,7 +93,7 @@ pub static DB_SUPABASE_REGEX: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static FUNCTION_NORMALIZER_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static FUNCTION_NORMALIZER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         # UUIDs.

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use relay_base_schema::events::EventType;
 use relay_event_schema::processor::{
@@ -348,11 +347,7 @@ pub(crate) fn scrub_identifiers(string: &mut Annotated<String>) {
     scrub_identifiers_with_regex(string, &TRANSACTION_NAME_NORMALIZER_REGEX, "*");
 }
 
-fn scrub_identifiers_with_regex(
-    string: &mut Annotated<String>,
-    pattern: &Lazy<Regex>,
-    replacer: &str,
-) {
+fn scrub_identifiers_with_regex(string: &mut Annotated<String>, pattern: &Regex, replacer: &str) {
     let capture_names = pattern.capture_names().flatten().collect::<Vec<_>>();
 
     let _ = processor::apply(string, |trans, meta| {

--- a/relay-filter/Cargo.toml
+++ b/relay-filter/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 ipnetwork = { workspace = true }
-once_cell = { workspace = true }
 indexmap = { workspace = true }
 regex = { workspace = true }
 relay-common = { workspace = true }

--- a/relay-filter/src/browser_extensions.rs
+++ b/relay-filter/src/browser_extensions.rs
@@ -1,12 +1,13 @@
 //! Implements filtering for events caused by problematic browsers extensions.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 use relay_event_schema::protocol::Exception;
 
 use crate::{FilterConfig, FilterStatKey, Filterable};
 
-static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
+static EXTENSION_EXC_VALUES: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?ix)
         # Random plugins/extensions
@@ -59,7 +60,7 @@ static EXTENSION_EXC_VALUES: Lazy<Regex> = Lazy::new(|| {
     .expect("Invalid browser extensions filter (Exec Vals) Regex")
 });
 
-static EXTENSION_EXC_SOURCES: Lazy<Regex> = Lazy::new(|| {
+static EXTENSION_EXC_SOURCES: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?ix)
         graph\.facebook\.com|                           # Facebook flakiness

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -1,11 +1,12 @@
 //! Filters events coming from user agents known to be web crawlers.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 use crate::{FilterConfig, FilterStatKey, Filterable};
 
-static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
+static WEB_CRAWLERS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?ix)
         Mediapartners-Google|
@@ -49,7 +50,7 @@ static WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
     .expect("Invalid web crawlers filter Regex")
 });
 
-static ALLOWED_WEB_CRAWLERS: Lazy<Regex> = Lazy::new(|| {
+static ALLOWED_WEB_CRAWLERS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?ix)
         Slackbot\s1\.\d+|            # Slack - see https://api.slack.com/robots

--- a/relay-ourlogs/Cargo.toml
+++ b/relay-ourlogs/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 chrono = { workspace = true }
 hex = { workspace = true }
-once_cell = { workspace = true }
 opentelemetry-proto = { workspace = true, features = [
     "gen-tonic",
     "with-serde",

--- a/relay-pii/Cargo.toml
+++ b/relay-pii/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 hmac = { workspace = true }
 minidump = { workspace = true }
 num-traits = { workspace = true }
-once_cell = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }
 regex = { workspace = true }

--- a/relay-pii/src/builtin.rs
+++ b/relay-pii/src/builtin.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::needless_update)]
 use std::collections::BTreeMap;
-
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::{
     AliasRule, MultipleRule, PatternRule, Redaction, ReplaceRedaction, RuleSpec, RuleType,
@@ -9,7 +8,7 @@ use crate::{
 
 macro_rules! declare_builtin_rules {
     ($($rule_id:expr => $spec:expr;)*) => {
-        pub(crate) static BUILTIN_RULES_MAP: Lazy<BTreeMap<&str, RuleSpec>> = Lazy::new(|| {
+        pub(crate) static BUILTIN_RULES_MAP: LazyLock<BTreeMap<&str, RuleSpec>> = LazyLock::new(|| {
             let mut map = BTreeMap::new();
             $(
                 map.insert($rule_id, $spec);

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use relay_event_schema::processor::ValueType;
 
 use crate::selector::{SelectorPathItem, SelectorSpec};
@@ -13,20 +13,20 @@ use crate::{
 ///
 /// We define this list independently of `metastructure(pii = true/false)` because the new PII
 /// scrubber should be able to strip more.
-static DATASCRUBBER_IGNORE: Lazy<SelectorSpec> = Lazy::new(|| {
+static DATASCRUBBER_IGNORE: LazyLock<SelectorSpec> = LazyLock::new(|| {
     "(debug_meta.** | $frame.filename | $frame.abs_path | $logentry.formatted | $error.value | $request.headers.user-agent)"
         .parse()
         .unwrap()
 });
 
 /// Fields that are known to contain IPs. Used for legacy IP scrubbing.
-static KNOWN_IP_FIELDS: Lazy<SelectorSpec> = Lazy::new(|| {
+static KNOWN_IP_FIELDS: LazyLock<SelectorSpec> = LazyLock::new(|| {
     "($request.env.REMOTE_ADDR | $user.ip_address | $sdk.client_ip | $span.sentry_tags.'user.ip')"
         .parse()
         .unwrap()
 });
 
-static SENSITIVE_COOKIES: Lazy<SelectorSpec> = Lazy::new(|| {
+static SENSITIVE_COOKIES: LazyLock<SelectorSpec> = LazyLock::new(|| {
     [
         // Common session cookie names for popular web frameworks
         "*.cookies.sentrysid", // Sentry default session cookie name
@@ -65,7 +65,7 @@ static SENSITIVE_COOKIES: Lazy<SelectorSpec> = Lazy::new(|| {
 ///
 /// This is currently a workaround until we have a more powerful version of the PII processor
 /// in place: <https://github.com/getsentry/relay/issues/5158>.
-static REPLACE_ONLY_SELECTOR: Lazy<SelectorSpec> = Lazy::new(|| {
+static REPLACE_ONLY_SELECTOR: LazyLock<SelectorSpec> = LazyLock::new(|| {
     [
         "$logentry.formatted",
         "$span.data.'gen_ai.prompt'",

--- a/relay-replays/Cargo.toml
+++ b/relay-replays/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 flate2 = { workspace = true }
-once_cell = { workspace = true }
 relay-event-schema = { workspace = true }
 relay-log = { workspace = true }
 relay-pii = { workspace = true }

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -11,16 +11,15 @@
 //! identified by `type: 5`. The scrubber skips all other node types and does not perform any
 //! validation beyond JSON parsing.
 
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt;
 use std::io::Read;
 use std::rc::Rc;
+use std::{borrow::Cow, sync::LazyLock};
 
 use flate2::Compression;
 use flate2::bufread::ZlibDecoder;
 use flate2::write::ZlibEncoder;
-use once_cell::sync::Lazy;
 use relay_event_schema::processor::{FieldAttrs, Pii, ProcessingState, Processor, ValueType};
 use relay_pii::{PiiConfig, PiiProcessor};
 use relay_protocol::Meta;
@@ -32,7 +31,7 @@ use relay_pii::transform::Transform;
 /// Paths to fields on which datascrubbing rules should be applied.
 ///
 /// This is equivalent to marking a field as `pii = true` in an `Annotated` schema.
-static PII_FIELDS: Lazy<[Vec<&str>; 2]> = Lazy::new(|| {
+static PII_FIELDS: LazyLock<[Vec<&str>; 2]> = LazyLock::new(|| {
     [
         vec!["data", "payload", "description"],
         vec!["data", "payload", "data"],

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -56,7 +56,6 @@ liblzma = { workspace = true }
 mime = { workspace = true }
 minidump = { workspace = true, optional = true }
 multer = { workspace = true }
-once_cell = { workspace = true }
 opentelemetry-proto = { workspace = true }
 papaya = { workspace = true }
 pin-project-lite = { workspace = true }

--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -8,13 +8,13 @@ use std::error::Error;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::LazyLock;
 
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::handler::Handler;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
-use once_cell::sync::Lazy;
 use relay_common::glob2::GlobMatcher;
 use relay_config::Config;
 use tokio::sync::oneshot;
@@ -225,7 +225,7 @@ enum SpecialRoute {
 }
 
 /// Glob matcher for special routes.
-static SPECIAL_ROUTES: Lazy<GlobMatcher<SpecialRoute>> = Lazy::new(|| {
+static SPECIAL_ROUTES: LazyLock<GlobMatcher<SpecialRoute>> = LazyLock::new(|| {
     let mut m = GlobMatcher::new();
     // file uploads / legacy dsym uploads
     m.add(

--- a/relay-server/src/middlewares/normalize_path.rs
+++ b/relay-server/src/middlewares/normalize_path.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
+use std::sync::LazyLock;
 use std::task::{Context, Poll};
 
 use axum::http::{Request, Response, Uri};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use tower::Service;
 
@@ -41,7 +41,7 @@ where
 }
 
 fn fold_duplicate_slashes(uri: &mut Uri) {
-    static REPLACE: Lazy<Regex> = Lazy::new(|| Regex::new("/{2,}").unwrap());
+    static REPLACE: LazyLock<Regex> = LazyLock::new(|| Regex::new("/{2,}").unwrap());
 
     let Cow::Owned(new_path) = REPLACE.replace_all(uri.path(), "/") else {
         return;

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -818,10 +818,9 @@ fn validate(span: &mut Annotated<Span>) -> Result<(), ValidationError> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, LazyLock};
 
     use bytes::Bytes;
-    use once_cell::sync::Lazy;
     use relay_event_schema::protocol::{Context, ContextInner, EventId, Timestamp, TraceContext};
     use relay_event_schema::protocol::{Contexts, Event, Span};
     use relay_protocol::get_value;
@@ -1237,7 +1236,7 @@ mod tests {
         assert_eq!(get_value!(span.data.browser_name!), "Opera");
     }
 
-    static GEO_LOOKUP: Lazy<GeoIpLookup> = Lazy::new(|| {
+    static GEO_LOOKUP: LazyLock<GeoIpLookup> = LazyLock::new(|| {
         GeoIpLookup::open("../relay-event-normalization/tests/fixtures/GeoIP2-Enterprise-Test.mmdb")
             .unwrap()
     });

--- a/relay-spans/Cargo.toml
+++ b/relay-spans/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 chrono = { workspace = true }
 hex = { workspace = true }
-once_cell = { workspace = true }
 opentelemetry-proto = { workspace = true, features = [
     "gen-tonic",
     "with-serde",

--- a/relay-spans/src/status_codes.rs
+++ b/relay-spans/src/status_codes.rs
@@ -1,10 +1,9 @@
 use std::collections::BTreeMap;
-
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 /// HTTP maps some HTTP codes to Sentry's span statuses.
 /// See possible mapping in <https://develop.sentry.dev/sdk/event-payloads/span/>.
-pub static HTTP: Lazy<BTreeMap<i64, &str>> = Lazy::new(|| {
+pub static HTTP: LazyLock<BTreeMap<i64, &str>> = LazyLock::new(|| {
     BTreeMap::from([
         (400, "failed_precondition"),
         (401, "unauthenticated"),
@@ -22,7 +21,7 @@ pub static HTTP: Lazy<BTreeMap<i64, &str>> = Lazy::new(|| {
 
 /// GRPC maps some GRPC codes to Sentry's span statuses.
 /// See description in grpc documentation.
-pub static GRPC: Lazy<BTreeMap<i64, &str>> = Lazy::new(|| {
+pub static GRPC: LazyLock<BTreeMap<i64, &str>> = LazyLock::new(|| {
     BTreeMap::from([
         (1, "cancelled"),
         (2, "unknown_error"),

--- a/relay-system/Cargo.toml
+++ b/relay-system/Cargo.toml
@@ -17,7 +17,6 @@ test = []
 
 [dependencies]
 futures = { workspace = true }
-once_cell = { workspace = true }
 relay-log = { workspace = true }
 relay-statsd = { workspace = true }
 tokio = { workspace = true, features = ["rt", "signal", "macros", "sync", "time", "rt-multi-thread"] }

--- a/relay-system/src/controller.rs
+++ b/relay-system/src/controller.rs
@@ -1,7 +1,7 @@
 use std::io;
+use std::sync::LazyLock;
 use std::time::Duration;
 
-use once_cell::sync::Lazy;
 use tokio::sync::watch;
 
 /// Determines how to shut down the Relay system.
@@ -40,10 +40,10 @@ pub struct Shutdown {
 type Channel<T> = (watch::Sender<Option<T>>, watch::Receiver<Option<T>>);
 
 /// Global channel to notify all services of a shutdown.
-static SHUTDOWN: Lazy<Channel<Shutdown>> = Lazy::new(|| watch::channel(None));
+static SHUTDOWN: LazyLock<Channel<Shutdown>> = LazyLock::new(|| watch::channel(None));
 
 /// Internal channel to trigger a manual shutdown via [`Controller::shutdown`].
-static MANUAL_SHUTDOWN: Lazy<Channel<ShutdownMode>> = Lazy::new(|| watch::channel(None));
+static MANUAL_SHUTDOWN: LazyLock<Channel<ShutdownMode>> = LazyLock::new(|| watch::channel(None));
 
 /// Notifies a service about an upcoming shutdown.
 ///

--- a/relay-ua/Cargo.toml
+++ b/relay-ua/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 workspace = true
 
 [dependencies]
-once_cell = { workspace = true }
 uaparser = { workspace = true }
 
 [features]

--- a/relay-ua/src/lib.rs
+++ b/relay-ua/src/lib.rs
@@ -6,7 +6,8 @@
 //! this, integration tests could fail. To fix this, you will need to add a timeout to your
 //! consumer.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use uaparser::{Parser, UserAgentParser};
 
 #[doc(inline)]
@@ -15,7 +16,7 @@ pub use uaparser::{Device, OS, UserAgent};
 /// The global [`UserAgentParser`] already configured with a user agent database.
 ///
 /// For usage, see [`Parser`].
-static UA_PARSER: Lazy<UserAgentParser> = Lazy::new(|| {
+static UA_PARSER: LazyLock<UserAgentParser> = LazyLock::new(|| {
     let ua_regexes = include_bytes!("../uap-core/regexes.yaml");
     UserAgentParser::builder()
         .with_unicode_support(false)
@@ -29,7 +30,7 @@ static UA_PARSER: Lazy<UserAgentParser> = Lazy::new(|| {
 /// agent parser initializes on-demand when using one of the parse methods. This function forces
 /// initialization at a convenient point without introducing unwanted delays.
 pub fn init_parser() {
-    Lazy::force(&UA_PARSER);
+    LazyLock::force(&UA_PARSER);
 }
 
 /// Returns the family and version of a user agent client.

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -24,7 +24,6 @@ clap = { workspace = true, features = ["env", "wrap_help"] }
 clap_complete = { workspace = true }
 dialoguer = { workspace = true }
 hostname = { workspace = true }
-once_cell = { workspace = true }
 relay-config = { workspace = true }
 relay-log = { workspace = true, features = ["init"] }
 relay-server = { workspace = true }

--- a/relay/src/utils.rs
+++ b/relay/src/utils.rs
@@ -1,12 +1,12 @@
 use std::fmt::Display;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use anyhow::Result;
 use dialoguer::Input;
 use dialoguer::theme::{ColorfulTheme, Theme};
-use once_cell::sync::Lazy;
 
-static THEME: Lazy<ColorfulTheme> = Lazy::new(ColorfulTheme::default);
+static THEME: LazyLock<ColorfulTheme> = LazyLock::new(ColorfulTheme::default);
 
 /// Returns the theme to use.
 pub fn get_theme() -> &'static dyn Theme {


### PR DESCRIPTION
`LazyLock` exists since 1.80.