### PR TITLE
feat(pii): Add otp and two-factor to default password scrubber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - Add `sentry.origin` attribute to OTLP logs. ([#5190](https://github.com/getsentry/relay/pull/5190))
 - Add new iPhone 17 devices. ([#5203](https://github.com/getsentry/relay/pull/5203))
 - Upgrade sqlparser and improve SQL parsing for span grouping. ([#5211](https://github.com/getsentry/relay/pull/5211))
-- Maps `unknown_error` span status to `internal_error` ([#5202](https://github.com/getsentry/relay/pull/5202))
+- Maps `unknown_error` span status to `internal_error`. ([#5202](https://github.com/getsentry/relay/pull/5202))
+- Add `otp` and `two[-_]factor` to default scrubbing rules. ([#5250](https://github.com/getsentry/relay/pull/5250))
 - Add event merging logic for Playstation crashes. ([#5228](https://github.com/getsentry/relay/pull/5228))
 
 **Bug Fixes**:

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -278,6 +278,9 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
             "a_password_here": "hello",
             "api_key": "secret_key",
             "apiKey": "secret_key",
+            "otp": "otp_code",
+            "two-factor": "otp_code",
+            "two_factor": "otp_code",
         })
     }
 

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -1907,4 +1907,33 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(data);
     }
+
+    #[test]
+    fn test_password_rule_only_full_match_fields() {
+        let mut data = Event::from_value(
+            serde_json::json!({
+                "extra": {
+                    "not-a-two-factor": "I am okay",
+                    "not_a_two_factor": "I am okay",
+                    "footpath": "I am okay",
+                    "idiotproof": "I am okay",
+                }
+            })
+            .into(),
+        );
+
+        let pii_config = simple_enabled_pii_config();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(data, @r#"
+        {
+          "extra": {
+            "footpath": "I am okay",
+            "idiotproof": "I am okay",
+            "not-a-two-factor": "I am okay",
+            "not_a_two_factor": "I am okay"
+          }
+        }
+        "#);
+    }
 }

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -336,7 +336,7 @@ regex!(BEARER_TOKEN_REGEX, r"(?i)\b(Bearer\s+)([^\s]+)");
 
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|token)"
+    r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|token|otp|two[-_]factor)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -336,7 +336,7 @@ regex!(BEARER_TOKEN_REGEX, r"(?i)\b(Bearer\s+)([^\s]+)");
 
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|token|otp|two[-_]factor)"
+    r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|token|^otp$|^two[-_]factor$)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__contexts.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__contexts.snap
@@ -9,8 +9,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "app"
     },
     "biz": {
@@ -18,8 +21,11 @@ expression: data
       "apiKey": "[Filtered]",
       "api_key": "[Filtered]",
       "foo": "bar",
+      "otp": "[Filtered]",
       "password": "[Filtered]",
       "the_secret": "[Filtered]",
+      "two-factor": "[Filtered]",
+      "two_factor": "[Filtered]",
       "type": "biz"
     },
     "browser": {
@@ -27,8 +33,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "browser"
     },
     "device": {
@@ -36,8 +45,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "device"
     },
     "gpu": {
@@ -45,8 +57,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "gpu"
     },
     "monitor": {
@@ -54,8 +69,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "monitor"
     },
     "os": {
@@ -63,8 +81,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "os"
     },
     "runtime": {
@@ -72,8 +93,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "runtime"
     },
     "secret": null,
@@ -82,8 +106,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
       "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code",
       "type": "trace"
     }
   },
@@ -129,6 +156,19 @@ expression: data
             "len": 10
           }
         },
+        "otp": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
         "password": {
           "": {
             "rem": [
@@ -153,6 +193,32 @@ expression: data
               ]
             ],
             "len": 5
+          }
+        },
+        "two-factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
+        "two_factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
           }
         }
       },

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__http.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__http.snap
@@ -9,8 +9,11 @@ expression: data
       "apiKey": "[Filtered]",
       "api_key": "[Filtered]",
       "foo": "bar",
+      "otp": "[Filtered]",
       "password": "[Filtered]",
-      "the_secret": "[Filtered]"
+      "the_secret": "[Filtered]",
+      "two-factor": "[Filtered]",
+      "two_factor": "[Filtered]"
     },
     "cookies": [
       [
@@ -30,11 +33,23 @@ expression: data
         "bar"
       ],
       [
+        "otp",
+        "[Filtered]"
+      ],
+      [
         "password",
         "[Filtered]"
       ],
       [
         "the_secret",
+        "[Filtered]"
+      ],
+      [
+        "two-factor",
+        "[Filtered]"
+      ],
+      [
+        "two_factor",
         "[Filtered]"
       ]
     ],
@@ -56,11 +71,23 @@ expression: data
         "bar"
       ],
       [
+        "Otp",
+        "[Filtered]"
+      ],
+      [
         "Password",
         "[Filtered]"
       ],
       [
         "The_secret",
+        "[Filtered]"
+      ],
+      [
+        "Two-Factor",
+        "[Filtered]"
+      ],
+      [
+        "Two_factor",
         "[Filtered]"
       ]
     ],
@@ -69,8 +96,11 @@ expression: data
       "apiKey": "[Filtered]",
       "api_key": "[Filtered]",
       "foo": "bar",
+      "otp": "[Filtered]",
       "password": "[Filtered]",
-      "the_secret": "[Filtered]"
+      "the_secret": "[Filtered]",
+      "two-factor": "[Filtered]",
+      "two_factor": "[Filtered]"
     }
   },
   "_meta": {
@@ -132,7 +162,7 @@ expression: data
                   10
                 ]
               ],
-              "len": 5
+              "len": 8
             }
           }
         },
@@ -148,6 +178,51 @@ expression: data
                 ]
               ],
               "len": 5
+            }
+          }
+        },
+        "6": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 5
+            }
+          }
+        },
+        "7": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 8
+            }
+          }
+        },
+        "8": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 8
             }
           }
         }
@@ -192,6 +267,19 @@ expression: data
             "len": 10
           }
         },
+        "otp": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
         "password": {
           "": {
             "rem": [
@@ -216,6 +304,32 @@ expression: data
               ]
             ],
             "len": 5
+          }
+        },
+        "two-factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
+        "two_factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
           }
         }
       },
@@ -259,6 +373,19 @@ expression: data
             "len": 10
           }
         },
+        "otp": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
         "password": {
           "": {
             "rem": [
@@ -283,6 +410,32 @@ expression: data
               ]
             ],
             "len": 5
+          }
+        },
+        "two-factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
+        "two_factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
           }
         }
       },
@@ -343,7 +496,7 @@ expression: data
                   10
                 ]
               ],
-              "len": 5
+              "len": 8
             }
           }
         },
@@ -359,6 +512,51 @@ expression: data
                 ]
               ],
               "len": 5
+            }
+          }
+        },
+        "6": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 5
+            }
+          }
+        },
+        "7": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 8
+            }
+          }
+        },
+        "8": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 8
             }
           }
         }

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__ip_stripped.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__ip_stripped.snap
@@ -11,8 +11,11 @@ expression: data
       "apiKey": "secret_key",
       "api_key": "secret_key",
       "foo": "bar",
+      "otp": "otp_code",
       "password": "hello",
-      "the_secret": "hello"
+      "the_secret": "hello",
+      "two-factor": "otp_code",
+      "two_factor": "otp_code"
     }
   },
   "breadcrumbs": {

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_additional_sensitive_fields.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__sanitize_additional_sensitive_fields.snap
@@ -10,8 +10,11 @@ expression: data
     "fieldy_field": "[Filtered]",
     "foo": "bar",
     "moar_other_field": "[Filtered]",
+    "otp": "[Filtered]",
     "password": "[Filtered]",
-    "the_secret": "[Filtered]"
+    "the_secret": "[Filtered]",
+    "two-factor": "[Filtered]",
+    "two_factor": "[Filtered]"
   },
   "_meta": {
     "extra": {
@@ -80,6 +83,19 @@ expression: data
           "len": 13
         }
       },
+      "otp": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 8
+        }
+      },
       "password": {
         "": {
           "rem": [
@@ -104,6 +120,32 @@ expression: data
             ]
           ],
           "len": 5
+        }
+      },
+      "two-factor": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 8
+        }
+      },
+      "two_factor": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 8
         }
       }
     }

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__stacktrace.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__stacktrace.snap
@@ -11,8 +11,11 @@ expression: data
           "apiKey": "[Filtered]",
           "api_key": "[Filtered]",
           "foo": "bar",
+          "otp": "[Filtered]",
           "password": "[Filtered]",
-          "the_secret": "[Filtered]"
+          "the_secret": "[Filtered]",
+          "two-factor": "[Filtered]",
+          "two_factor": "[Filtered]"
         }
       }
     ]
@@ -61,6 +64,19 @@ expression: data
                 "len": 10
               }
             },
+            "otp": {
+              "": {
+                "rem": [
+                  [
+                    "@password:filter",
+                    "s",
+                    0,
+                    10
+                  ]
+                ],
+                "len": 8
+              }
+            },
             "password": {
               "": {
                 "rem": [
@@ -85,6 +101,32 @@ expression: data
                   ]
                 ],
                 "len": 5
+              }
+            },
+            "two-factor": {
+              "": {
+                "rem": [
+                  [
+                    "@password:filter",
+                    "s",
+                    0,
+                    10
+                  ]
+                ],
+                "len": 8
+              }
+            },
+            "two_factor": {
+              "": {
+                "rem": [
+                  [
+                    "@password:filter",
+                    "s",
+                    0,
+                    10
+                  ]
+                ],
+                "len": 8
               }
             }
           }

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__user.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__user.snap
@@ -11,8 +11,11 @@ expression: data
       "apiKey": "[Filtered]",
       "api_key": "[Filtered]",
       "foo": "bar",
+      "otp": "[Filtered]",
       "password": "[Filtered]",
-      "the_secret": "[Filtered]"
+      "the_secret": "[Filtered]",
+      "two-factor": "[Filtered]",
+      "two_factor": "[Filtered]"
     }
   },
   "_meta": {
@@ -57,6 +60,19 @@ expression: data
             "len": 10
           }
         },
+        "otp": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
         "password": {
           "": {
             "rem": [
@@ -81,6 +97,32 @@ expression: data
               ]
             ],
             "len": 5
+          }
+        },
+        "two-factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
+          }
+        },
+        "two_factor": {
+          "": {
+            "rem": [
+              [
+                "@password:filter",
+                "s",
+                0,
+                10
+              ]
+            ],
+            "len": 8
           }
         }
       },


### PR DESCRIPTION
Feedback from a customer, `otp` and `two[-_]factor` are indicators for sensitive values.