### PR TITLE
fix(spansv2): Correctly map the span name from v1 to v2

### DIFF
--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -30,6 +30,11 @@ impl Attribute {
             other: Object::new(),
         }
     }
+
+    /// Returns the string value of this attribute.
+    pub fn into_string(self) -> Option<String> {
+        self.value.value.into_value()?.into_string()
+    }
 }
 
 impl fmt::Debug for Attribute {
@@ -42,8 +47,12 @@ impl fmt::Debug for Attribute {
     }
 }
 
-impl From<AttributeValue> for Attribute {
-    fn from(value: AttributeValue) -> Self {
+impl<T> From<T> for Attribute
+where
+    AttributeValue: From<T>,
+{
+    fn from(value: T) -> Self {
+        let value = value.into();
         Self {
             value,
             other: Default::default(),
@@ -267,6 +276,15 @@ impl Attributes {
         self.0.contains_key(key)
     }
 
+    /// Removes an attribute from this collection.
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<Annotated<Attribute>>
+    where
+        String: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.0.remove(key)
+    }
+
     /// Iterates over this collection's attribute keys and values.
     pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, Annotated<Attribute>> {
         self.0.iter()
@@ -293,6 +311,12 @@ impl IntoIterator for Attributes {
 impl FromIterator<(String, Annotated<Attribute>)> for Attributes {
     fn from_iter<T: IntoIterator<Item = (String, Annotated<Attribute>)>>(iter: T) -> Self {
         Self(Object::from_iter(iter))
+    }
+}
+
+impl<const N: usize> From<[(String, Annotated<Attribute>); N]> for Attributes {
+    fn from(value: [(String, Annotated<Attribute>); N]) -> Self {
+        value.into_iter().collect()
     }
 }
 

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -238,6 +238,17 @@ impl<T> Annotated<T> {
     }
 }
 
+impl<T> Annotated<Option<T>> {
+    /// Transposes an `Annotated` of [`Option`] into a [`Option`] of `Annotated`.
+    pub fn transpose(self) -> Option<Annotated<T>> {
+        match self {
+            Annotated(Some(Some(value)), meta) => Some(Annotated(Some(value), meta)),
+            Annotated(Some(None), _) => None,
+            Annotated(None, meta) => Some(Annotated(None, meta)),
+        }
+    }
+}
+
 impl<T> Annotated<T>
 where
     T: AsRef<str>,

--- a/relay-protocol/src/value.rs
+++ b/relay-protocol/src/value.rs
@@ -70,6 +70,14 @@ impl Value {
         }
     }
 
+    /// Returns the string if this value is a string, otherwise `None`.
+    pub fn into_string(self) -> Option<String> {
+        match self {
+            Value::String(string) => Some(string),
+            _ => None,
+        }
+    }
+
     /// Returns a f64 if the value can be converted to it, otherwise `None`.
     pub fn as_f64(&self) -> Option<f64> {
         match self {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -146,7 +146,6 @@ def test_span_extraction(
         "attributes": {  # Backfilled from `sentry_tags`
             "sentry.category": {"type": "string", "value": "http"},
             "sentry.exclusive_time": {"type": "double", "value": 500.0},
-            "sentry.name": {"type": "string", "value": "http"},
             "sentry.normalized_description": {"type": "string", "value": "GET *"},
             "sentry.group": {"type": "string", "value": "37e3d9fab1ae9162"},
             "sentry.op": {"type": "string", "value": "http"},
@@ -223,7 +222,6 @@ def test_span_extraction(
             "sentry.description": {"type": "string", "value": "hi"},
             "sentry.exclusive_time": {"type": "double", "value": 1500.0},
             "sentry.is_segment": {"type": "boolean", "value": True},
-            "sentry.name": {"type": "string", "value": "hi"},
             "sentry.op": {"type": "string", "value": "hi"},
             "sentry.origin": {"type": "string", "value": "manual"},
             "sentry.platform": {"type": "string", "value": "other"},
@@ -682,7 +680,6 @@ def test_span_ingestion(
                 "sentry.file_extension": {"type": "string", "value": "js"},
                 "sentry.group": {"type": "string", "value": "8a97a9e43588e2bd"},
                 "sentry.is_segment": {"type": "boolean", "value": True},
-                "sentry.name": {"type": "string", "value": "resource.script"},
                 "sentry.normalized_description": {
                     "type": "string",
                     "value": "https://example.com/*/blah.js",
@@ -726,7 +723,6 @@ def test_span_ingestion(
                 },
                 "sentry.exclusive_time": {"type": "double", "value": 345.0},
                 "sentry.is_segment": {"type": "boolean", "value": False},
-                "sentry.name": {"type": "string", "value": "default"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.segment.id": {"type": "string", "value": "968cff94913ebb07"},
                 "user_agent.original": {
@@ -755,7 +751,6 @@ def test_span_ingestion(
                 "sentry.description": {"type": "string", "value": "my 2nd OTel span"},
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.is_segment": {"type": "boolean", "value": True},
-                "sentry.name": {"type": "string", "value": "my 2nd OTel span"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.segment.id": {"type": "string", "value": "d342abb1214ca182"},
                 "sentry.status": {"type": "string", "value": "ok"},
@@ -793,7 +788,6 @@ def test_span_ingestion(
                 "sentry.browser.name": {"type": "string", "value": "Chrome"},
                 "sentry.exclusive_time": {"type": "double", "value": 345.0},
                 "sentry.is_segment": {"type": "boolean", "value": False},
-                "sentry.name": {"type": "string", "value": "default"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.segment.id": {"type": "string", "value": "968cff94913ebb07"},
                 "user_agent.original": {
@@ -825,7 +819,6 @@ def test_span_ingestion(
                     "value": "my 3rd protobuf OTel span",
                 },
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
-                "sentry.name": {"type": "string", "value": "my 3rd protobuf OTel span"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.status": {"type": "string", "value": "ok"},
                 "ui.component_name": {"type": "string", "value": "MyComponent"},


### PR DESCRIPTION
The span name was only mapped but not inferred correctly (like we do for standalone spans).

Also the span name was left in the attributes, when it should've been removed, as it is redundant.

The segment processor in Sentry, then maps the top level `name` field again correctly to a `sentry.name` attribute.