### PR TITLE
ref(schema): Enforce required attributes for EAP item types

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -226,7 +226,7 @@ pub fn normalize_event(event: &mut Annotated<Event>, config: &NormalizationConfi
 
     if !is_renormalize {
         // Check for required and non-empty values
-        let _ = schema::SchemaProcessor.process_event(event, meta, ProcessingState::root());
+        let _ = schema::SchemaProcessor::new().process_event(event, meta, ProcessingState::root());
 
         normalize(event, meta, config);
     }

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -33,7 +33,7 @@ pub use event::{
 pub use normalize::breakdowns::*;
 pub use normalize::*;
 pub use remove_other::RemoveOtherProcessor;
-pub use schema::SchemaProcessor;
+pub use schema::{RequiredMode, SchemaProcessor};
 pub use timestamp::TimestampProcessor;
 pub use transactions::*;
 pub use trimming::TrimmingProcessor;

--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -2,9 +2,37 @@ use relay_event_schema::processor::{
     ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor,
 };
 use relay_protocol::{Array, Empty, Error, ErrorKind, Meta, Object};
+use smallvec::SmallVec;
+
+/// Mode how `required` values should be validated in a [`SchemaProcessor`].
+#[derive(Debug, Default)]
+pub enum RequiredMode {
+    /// The default mode, which only deletes the value and leaves a remark.
+    #[default]
+    DeleteValue,
+    /// Instead of removing the value, the entire container containing the value is removed instead.
+    DeleteParent,
+}
 
 /// Validates constraints such as empty strings or arrays and invalid characters.
-pub struct SchemaProcessor;
+#[derive(Debug, Default)]
+pub struct SchemaProcessor {
+    required: RequiredMode,
+    stack: SmallVec<[SchemaState; 10]>,
+}
+
+impl SchemaProcessor {
+    /// Creates a new [`SchemaProcessor`].
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Configures how `required` values should be validated.
+    pub fn with_required(mut self, mode: RequiredMode) -> Self {
+        self.required = mode;
+        self
+    }
+}
 
 impl Processor for SchemaProcessor {
     fn process_string(
@@ -53,12 +81,66 @@ impl Processor for SchemaProcessor {
         meta: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        if value.is_none() && state.attrs().required && !meta.has_errors() {
-            meta.add_error(ErrorKind::MissingAttribute);
+        match self.required {
+            RequiredMode::DeleteParent => {
+                self.stack.push(SchemaState::default());
+            }
+            RequiredMode::DeleteValue => {
+                if value.is_none() && state.attrs().required && !meta.has_errors() {
+                    meta.add_error(ErrorKind::MissingAttribute);
+                }
+            }
         }
 
         Ok(())
     }
+
+    fn after_process<T: ProcessValue>(
+        &mut self,
+        value: Option<&T>,
+        meta: &mut Meta,
+        state: &ProcessingState<'_>,
+    ) -> ProcessingResult {
+        // The stack is not filled if we're in delete value mode.
+        let Some(current) = self.stack.pop() else {
+            debug_assert!(
+                matches!(self.required, RequiredMode::DeleteValue),
+                "processing stack should always have a value"
+            );
+
+            return Ok(());
+        };
+
+        // There is a require validation if the field is required and the value is `None`, or
+        // the current object had any required validations already.
+        let is_required_violation =
+            state.attrs().required && (value.is_none() || current.has_required_violation);
+
+        if let Some(container) = self.stack.last_mut() {
+            // Propagate the violation to the container, to make sure the container is deleted.
+            if is_required_violation {
+                container.has_required_violation = true;
+            }
+        }
+
+        if is_required_violation && let Some(container) = self.stack.last_mut() {
+            container.has_required_violation = true;
+        }
+
+        // Delete the current value if it is a container containing a violation.
+        match current.has_required_violation {
+            true => {
+                meta.add_error(ErrorKind::MissingAttribute);
+                Err(ProcessingAction::DeleteValueHard)
+            }
+            false => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SchemaState {
+    has_required_violation: bool,
 }
 
 fn value_trim_whitespace(value: &mut String, _meta: &mut Meta, state: &ProcessingState<'_>) {
@@ -125,7 +207,7 @@ mod tests {
         CError, ClientSdkInfo, Event, MachException, Mechanism, MechanismMeta, PosixSignal,
         RawStacktrace, User,
     };
-    use relay_protocol::{Annotated, FromValue, IntoValue};
+    use relay_protocol::{Annotated, FromValue, IntoValue, assert_annotated_snapshot};
     use similar_asserts::assert_eq;
 
     use super::*;
@@ -145,8 +227,12 @@ mod tests {
             bar: Annotated::new(T::default()),
             bar2: Annotated::new(T::default()),
         });
-        processor::process_value(&mut wrapper, &mut SchemaProcessor, ProcessingState::root())
-            .unwrap();
+        processor::process_value(
+            &mut wrapper,
+            &mut SchemaProcessor::new(),
+            ProcessingState::root(),
+        )
+        .unwrap();
 
         assert_eq!(
             wrapper,
@@ -180,7 +266,12 @@ mod tests {
         });
 
         let expected = user.clone();
-        processor::process_value(&mut user, &mut SchemaProcessor, ProcessingState::root()).unwrap();
+        processor::process_value(
+            &mut user,
+            &mut SchemaProcessor::new(),
+            ProcessingState::root(),
+        )
+        .unwrap();
 
         assert_eq!(user, expected);
     }
@@ -192,7 +283,12 @@ mod tests {
             ..Default::default()
         });
 
-        processor::process_value(&mut info, &mut SchemaProcessor, ProcessingState::root()).unwrap();
+        processor::process_value(
+            &mut info,
+            &mut SchemaProcessor::new(),
+            ProcessingState::root(),
+        )
+        .unwrap();
 
         let expected = Annotated::new(ClientSdkInfo {
             name: Annotated::new("sentry.rust".to_owned()),
@@ -227,7 +323,7 @@ mod tests {
 
         processor::process_value(
             &mut mechanism,
-            &mut SchemaProcessor,
+            &mut SchemaProcessor::new(),
             ProcessingState::root(),
         )
         .unwrap();
@@ -263,8 +359,12 @@ mod tests {
     fn test_stacktrace_missing_attribute() {
         let mut stack = Annotated::new(RawStacktrace::default());
 
-        processor::process_value(&mut stack, &mut SchemaProcessor, ProcessingState::root())
-            .unwrap();
+        processor::process_value(
+            &mut stack,
+            &mut SchemaProcessor::new(),
+            ProcessingState::root(),
+        )
+        .unwrap();
 
         let expected = Annotated::new(RawStacktrace {
             frames: Annotated::from_error(ErrorKind::MissingAttribute, None),
@@ -281,8 +381,12 @@ mod tests {
             ..Default::default()
         });
 
-        processor::process_value(&mut event, &mut SchemaProcessor, ProcessingState::root())
-            .unwrap();
+        processor::process_value(
+            &mut event,
+            &mut SchemaProcessor::new(),
+            ProcessingState::root(),
+        )
+        .unwrap();
 
         let expected = Annotated::new(Event {
             release: Annotated::new("42".to_owned().into()),
@@ -290,5 +394,244 @@ mod tests {
         });
 
         assert_eq!(expected, event);
+    }
+
+    #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+    struct TestItem<T> {
+        #[metastructure(required = true, nonempty = true)]
+        req_non_empty: Annotated<T>,
+        #[metastructure(required = true)]
+        req: Annotated<T>,
+        other: Annotated<T>,
+    }
+
+    #[test]
+    fn test_required_delete_parent_top_level_nonempty() {
+        let mut item = Annotated::new(TestItem {
+            req_non_empty: Annotated::new("".to_owned()),
+            req: Annotated::new("something".to_owned()),
+            other: Annotated::new("something".to_owned()),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "_meta": {
+            "": {
+              "err": [
+                "missing_attribute"
+              ]
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_required_delete_parent_top_level_req() {
+        let mut item = Annotated::new(TestItem {
+            req_non_empty: Annotated::new("something".to_owned()),
+            req: Annotated::empty(),
+            other: Annotated::new("something".to_owned()),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "_meta": {
+            "": {
+              "err": [
+                "missing_attribute"
+              ]
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_required_delete_parent_top_level_req_error() {
+        let mut item = Annotated::new(TestItem {
+            req_non_empty: Annotated::new("something".to_owned()),
+            req: Annotated(None, Meta::from_error(Error::expected("something"))),
+            other: Annotated::new("something".to_owned()),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "_meta": {
+            "": {
+              "err": [
+                "missing_attribute"
+              ]
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_required_delete_parent_top_level_okay() {
+        let mut item = Annotated::new(TestItem {
+            req_non_empty: Annotated::new("something".to_owned()),
+            req: Annotated::new("something".to_owned()),
+            other: Annotated::empty(),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "req_non_empty": "something",
+          "req": "something"
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_required_delete_parent_nested_propagated() {
+        let mut item = Annotated::new(TestItem {
+            req_non_empty: Annotated::new(TestItem {
+                req_non_empty: Annotated::new("".to_owned()),
+                req: Annotated::new("something".to_owned()),
+                other: Annotated::new("something".to_owned()),
+            }),
+            req: Annotated::new(TestItem {
+                req_non_empty: Annotated::new("something".to_owned()),
+                req: Annotated::new("something".to_owned()),
+                other: Annotated::new("something".to_owned()),
+            }),
+            other: Annotated::empty(),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "_meta": {
+            "": {
+              "err": [
+                "missing_attribute"
+              ]
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_required_delete_nested_simple_all_the_way() {
+        #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+        struct Foo {
+            #[metastructure(required = true)]
+            bar: Annotated<Bar>,
+            other: Annotated<String>,
+        }
+
+        #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+        struct Bar {
+            #[metastructure(required = true, nonempty = true)]
+            value: Annotated<String>,
+        }
+
+        let mut item = Annotated::new(Foo {
+            bar: Annotated::new(Bar {
+                value: Annotated::new("".to_owned()),
+            }),
+            other: Annotated::new("something".to_owned()),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "_meta": {
+            "": {
+              "err": [
+                "missing_attribute"
+              ]
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_required_delete_nested_simple_one_layer() {
+        #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+        struct Foo {
+            bar: Annotated<Bar>,
+            other: Annotated<String>,
+        }
+
+        #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
+        struct Bar {
+            #[metastructure(required = true, nonempty = true)]
+            value: Annotated<String>,
+        }
+
+        let mut item = Annotated::new(Foo {
+            bar: Annotated::new(Bar {
+                value: Annotated::new("".to_owned()),
+            }),
+            other: Annotated::new("something".to_owned()),
+        });
+
+        processor::process_value(
+            &mut item,
+            &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "bar": null,
+          "other": "something",
+          "_meta": {
+            "bar": {
+              "": {
+                "err": [
+                  "missing_attribute"
+                ]
+              }
+            }
+          }
+        }
+        "#);
     }
 }

--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -142,7 +142,7 @@ pub trait Processor: Sized {
 pub use enumset::{EnumSet, enum_set};
 
 /// A recursively processable value.
-pub trait ProcessValue: FromValue + IntoValue + Debug + Clone {
+pub trait ProcessValue: FromValue + IntoValue + Debug + Clone + std::fmt::Debug {
     /// Returns the type of the value.
     #[inline]
     fn value_type(&self) -> EnumSet<ValueType> {

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -11,14 +11,14 @@ use crate::protocol::{Attributes, OperationType, SpanId, SpanKind, Timestamp, Tr
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 pub struct SpanV2 {
     /// The ID of the trace to which this span belongs.
-    #[metastructure(required = true, trim = false)]
+    #[metastructure(required = true, nonempty = true, trim = false)]
     pub trace_id: Annotated<TraceId>,
 
     /// The ID of the span enclosing this span.
     pub parent_span_id: Annotated<SpanId>,
 
     /// The Span ID.
-    #[metastructure(required = true, trim = false)]
+    #[metastructure(required = true, nonempty = true, trim = false)]
     pub span_id: Annotated<SpanId>,
 
     /// Span type (see `OperationType` docs).

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -581,7 +581,7 @@ fn normalize(
 
     process_value(
         annotated_span,
-        &mut SchemaProcessor,
+        &mut SchemaProcessor::new(),
         ProcessingState::root(),
     )?;
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -733,3 +733,54 @@ def test_spanv2_default_pii_scrubbing_attributes(
     rem_info = meta["rem"]
     assert len(rem_info) == 1
     assert rem_info[0][0] == rule_type
+
+
+def test_spansv2_non_empty_span_id(mini_sentry, relay):
+    """
+    A test asserting proper outcomes are emitted for invalid spans missing required attributes.
+    """
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:standalone-span-ingestion",
+        "projects:span-v2-experimental-processing",
+    ]
+
+    relay = relay(mini_sentry, options=TEST_CONFIG)
+
+    ts = datetime.now(timezone.utc)
+    envelope = envelope_with_spans(
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.5,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "some op",
+        }
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    assert mini_sentry.get_outcomes(2) == [
+        {
+            "timestamp": time_within_delta(),
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 3,
+            "reason": "no_data",
+            "category": DataCategory.SPAN,
+            "quantity": 1,
+        },
+        {
+            "timestamp": time_within_delta(),
+            "org_id": 1,
+            "project_id": 42,
+            "key_id": 123,
+            "outcome": 3,
+            "reason": "no_data",
+            "category": DataCategory.SPAN_INDEXED,
+            "quantity": 1,
+        },
+    ]
+
+    assert mini_sentry.captured_events.empty()

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -713,6 +713,8 @@ def test_spanv2_default_pii_scrubbing_attributes(
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "span_id": "eee19b7ec3c1b174",
             "name": "Test span",
+            "status": "ok",
+            "is_remote": False,
             "attributes": {
                 attribute_key: {"value": attribute_value, "type": "string"},
             },
@@ -721,7 +723,7 @@ def test_spanv2_default_pii_scrubbing_attributes(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get()
+    envelope = mini_sentry.captured_events.get(timeout=3)
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
     attributes = item["attributes"]

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -500,6 +500,7 @@ def test_spanv2_inbound_filters(
             "span_id": "eee19b7ec3c1b175",
             "is_remote": False,
             "name": "some op",
+            "status": "ok",
             "attributes": {
                 "some_integer": {"value": 123, "type": "integer"},
                 "sentry.release": {"value": "foobar@1.0", "type": "string"},
@@ -635,6 +636,7 @@ def test_spanv2_with_string_pii_scrubbing(
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "span_id": "eee19b7ec3c1b174",
             "name": "Test span",
+            "status": "ok",
             "is_remote": False,
             "attributes": {
                 "test_pii": {"value": test_value, "type": "string"},
@@ -644,7 +646,7 @@ def test_spanv2_with_string_pii_scrubbing(
 
     relay.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get()
+    envelope = mini_sentry.captured_events.get(timeout=3)
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
 
@@ -671,13 +673,12 @@ def test_spanv2_with_string_pii_scrubbing(
                     }
                 }
             },
-            "status": {"": {"err": ["missing_attribute"]}},
         },
         "name": "Test span",
         "start_timestamp": time_within(ts),
         "end_timestamp": time_within(ts.timestamp() + 0.5),
         "is_remote": False,
-        "status": None,
+        "status": "ok",
     }
 
 


### PR DESCRIPTION
Enforces the `required` annotation on fields on EAP items.

Implements a new mode in the schema processor to delete the parent when a required field fails validation, instead of just deleting the value.

Enables this new option for EAP based items.

Longterm we can think about enabling it for Errors/Transactions as well.