### PR TITLE
feat(tracemetrics): Allow filtering co-occurring keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+- Add internal attributes to aid searching trace metrics ([#5260]https://github.com/getsentry/relay/pull/5260)
+
 ## 25.10.0
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 **Internal**:
-- Add internal attributes to aid searching trace metrics ([#5260]https://github.com/getsentry/relay/pull/5260)
+- Add internal attributes to aid searching trace metrics ([#5260](https://github.com/getsentry/relay/pull/5260))
 
 ## 25.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 **Internal**:
+
 - Add internal attributes to aid searching trace metrics ([#5260](https://github.com/getsentry/relay/pull/5260))
 
 ## 25.10.0

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -153,7 +153,7 @@ fn attributes(
     result.insert(
         "sentry.metric_name".to_owned(),
         AnyValue {
-            value: Some(any_value::Value::StringValue(metric_name)),
+            value: Some(any_value::Value::StringValue(metric_name.clone())),
         },
     );
 
@@ -161,6 +161,20 @@ fn attributes(
         "sentry.metric_type".to_owned(),
         AnyValue {
             value: Some(any_value::Value::StringValue(metric_type.to_string())),
+        },
+    );
+
+    // Add key names matching metric name and type to workaround current co-occuring attributes limitations.
+    result.insert(
+        format!("sentry._meta.cooccuring.name.{}", metric_name),
+        AnyValue {
+            value: Some(any_value::Value::BoolValue(true)),
+        },
+    );
+    result.insert(
+        format!("sentry._meta.cooccuring.type.{}", metric_type),
+        AnyValue {
+            value: Some(any_value::Value::BoolValue(true)),
         },
     );
 

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -166,7 +166,7 @@ fn attributes(
 
     // Add key names matching metric name and type to workaround current co-occuring attributes limitations.
     result.insert(
-        format!("sentry._meta.cooccuring.name.{}", metric_name),
+        format!("sentry._meta.cooccuring.name.{metric_name}"),
         AnyValue {
             value: Some(any_value::Value::BoolValue(true)),
         },

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -172,7 +172,7 @@ fn attributes(
         },
     );
     result.insert(
-        format!("sentry._meta.cooccuring.type.{}", metric_type),
+        format!("sentry._meta.cooccuring.type.{metric_type}"),
         AnyValue {
             value: Some(any_value::Value::BoolValue(true)),
         },

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -166,13 +166,13 @@ fn attributes(
 
     // Add key names matching metric name and type to workaround current co-occuring attributes limitations.
     result.insert(
-        format!("sentry._meta.cooccuring.name.{metric_name}"),
+        format!("sentry._internal.cooccuring.name.{metric_name}"),
         AnyValue {
             value: Some(any_value::Value::BoolValue(true)),
         },
     );
     result.insert(
-        format!("sentry._meta.cooccuring.type.{metric_type}"),
+        format!("sentry._internal.cooccuring.type.{metric_type}"),
         AnyValue {
             value: Some(any_value::Value::BoolValue(true)),
         },

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -99,6 +99,8 @@ def test_trace_metric_extraction(
             "sentry.browser.version": {"stringValue": mock.ANY},
             "http.method": {"stringValue": "GET"},
             "http.status_code": {"intValue": "200"},
+            "sentry._meta.cooccuring.name.http.request.duration": {"boolValue": True},
+            "sentry._meta.cooccuring.type.distribution": {"boolValue": True},
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 390,
@@ -243,6 +245,8 @@ def test_trace_metric_pii_scrubbing(
             "sentry._meta.fields.attributes.user.ip": {
                 "stringValue": '{"meta":{"value":{"":{"rem":[["strip_ips","x",0,0]],"len":11}}}}'
             },
+            "sentry._meta.cooccuring.name.test.metric": {"boolValue": True},
+            "sentry._meta.cooccuring.type.counter": {"boolValue": True},
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -99,8 +99,10 @@ def test_trace_metric_extraction(
             "sentry.browser.version": {"stringValue": mock.ANY},
             "http.method": {"stringValue": "GET"},
             "http.status_code": {"intValue": "200"},
-            "sentry._meta.cooccuring.name.http.request.duration": {"boolValue": True},
-            "sentry._meta.cooccuring.type.distribution": {"boolValue": True},
+            "sentry._internal.cooccuring.name.http.request.duration": {
+                "boolValue": True
+            },
+            "sentry._internal.cooccuring.type.distribution": {"boolValue": True},
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 390,
@@ -245,8 +247,8 @@ def test_trace_metric_pii_scrubbing(
             "sentry._meta.fields.attributes.user.ip": {
                 "stringValue": '{"meta":{"value":{"":{"rem":[["strip_ips","x",0,0]],"len":11}}}}'
             },
-            "sentry._meta.cooccuring.name.test.metric": {"boolValue": True},
-            "sentry._meta.cooccuring.type.counter": {"boolValue": True},
+            "sentry._internal.cooccuring.name.test.metric": {"boolValue": True},
+            "sentry._internal.cooccuring.type.counter": {"boolValue": True},
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,


### PR DESCRIPTION
### Summary
Trace metrics has a blocker of having the available group-by and autocomplete keys being limited to the metric name selected instead of every attribute key ever ingested. Due to how the trace item filter rpc (and eap tables) are currently setup, this is only currently possible with an 'AND' on the key presence, so this is a workaround adding two temporary meta attributes that will let us experiment with this behaviour before open beta.

more details [here](https://www.notion.so/sentry/Metric-Co-occurring-Attributes-2878b10e4b5d80f5a9e5ca200179b4df)

