### PR TITLE
test(pytest): Add a default timeout to all integration tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@ pytest-localserver==0.8.1
 pytest-sentry==0.3.0
 pytest-xdist==3.5.0
 pytest==7.4.3
+pytest-timeout==2.2.0
 PyYAML==6.0.2
 redis==4.5.4
 requests==2.32.4

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -243,7 +243,8 @@ def json_fixture_provider():
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    """This handles the extra_failure_checks mark to perform further assertions.
+    """
+    This handles the extra_failure_checks mark to perform further assertions.
 
     The mark can be added e.g. by a fixture that wants to run
     something that can raise pytest.fail.Exception after the test has
@@ -257,6 +258,15 @@ def pytest_runtest_call(item):
     for marker in item.iter_markers("extra_failure_checks"):
         for check_func in marker.kwargs.get("checks", []):
             check_func()
+
+
+def pytest_collection_modifyitems(items):
+    """
+    This hook adds a timeout marker to all tests which do not already have a timeout.
+    """
+    for item in items:
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(60))
 
 
 @pytest.fixture


### PR DESCRIPTION
This [integration test](https://github.com/getsentry/relay/actions/runs/18584364051/attempts/1) ran until cancelled by github actions. It is not clear which test took up all that time.

This adds a timeout of 1 minute to all tests as an upper bound. Tests which require more time, can still override the timeout manually.

Ideally we will now see in CI which test(s) never terminate and then go fix them.