### PR TITLE
test(timeouts): Add timeout to queue.get calls

### DIFF
--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -168,7 +168,8 @@ def test_attachments_pii(mini_sentry, relay):
         relay.send_attachments(project_id, event_id, [attachment])
 
     payloads = {
-        mini_sentry.captured_events.get().items[0].payload.bytes for _ in range(2)
+        mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
+        for _ in range(2)
     }
     assert payloads == {
         b"here's an IP that should get masked -> ********* <-",
@@ -212,7 +213,9 @@ def test_view_hierarchy_scrubbing(mini_sentry, relay, feature_flags, expected):
     relay.send_envelope(project_id, envelope)
 
     relay.send_envelope(project_id, envelope)
-    payload = json.loads(mini_sentry.captured_events.get().items[0].payload.bytes)
+    payload = json.loads(
+        mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
+    )
     assert payload == {"rendering_system": "UIKIT", "identifier": expected}
 
 
@@ -263,7 +266,7 @@ def test_attachment_scrubbing_with_fallback(
 
     relay.send_envelope(project_id, envelope)
 
-    payload = mini_sentry.captured_events.get().items[0].payload.bytes
+    payload = mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
     assert payload == expected
 
 
@@ -287,7 +290,9 @@ def test_view_hierarchy_not_scrubbed_without_config(mini_sentry, relay):
     )
 
     relay.send_envelope(project_id, envelope)
-    payload = json.loads(mini_sentry.captured_events.get().items[0].payload.bytes)
+    payload = json.loads(
+        mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
+    )
     assert payload == json_payload
 
 
@@ -321,7 +326,7 @@ password=mysupersecretpassword123"""
 
     relay.send_envelope(project_id, envelope)
 
-    scrubbed_payload = mini_sentry.captured_events.get().items[0].payload.bytes
+    scrubbed_payload = mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
 
     assert (
         scrubbed_payload

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1693,7 +1693,7 @@ def test_histogram_outliers(mini_sentry, relay):
 
     tags = {}
     for _ in range(3):
-        envelope = mini_sentry.captured_events.get()
+        envelope = mini_sentry.captured_events.get(timeout=5)
         for item in envelope:
             if item.type == "metric_buckets":
                 buckets = item.payload.json

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -340,7 +340,7 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get()
+    envelope = mini_sentry.captured_events.get(timeout=5)
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
 
@@ -418,7 +418,7 @@ def test_ourlog_extraction_default_pii_scrubbing_attributes(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get()
+    envelope = mini_sentry.captured_events.get(timeout=5)
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
     attributes = item["attributes"]

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -279,7 +279,7 @@ def test_playstation_ignore_large_fields(
         PROJECT_ID, playstation_dump, video_content
     )
     assert response.ok
-    assert (mini_sentry.captured_outcomes.get()["outcomes"]) == [
+    assert (mini_sentry.captured_outcomes.get(timeout=5)["outcomes"]) == [
         {
             "timestamp": mock.ANY,
             "project_id": 42,
@@ -290,7 +290,8 @@ def test_playstation_ignore_large_fields(
         }
     ]
     assert [
-        item.headers["filename"] for item in mini_sentry.captured_events.get().items
+        item.headers["filename"]
+        for item in mini_sentry.captured_events.get(timeout=5).items
     ] == ["playstation.prosperodmp"]
 
 

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -376,7 +376,7 @@ def test_duplicate_performance_score(mini_sentry, relay):
 
     score_total_seen = 0
     for _ in range(3):  # 2 client reports and the actual item we're interested in
-        envelope = mini_sentry.captured_events.get()
+        envelope = mini_sentry.captured_events.get(timeout=5)
         for item in envelope.items:
             if item.type == "metric_buckets":
                 for metric in item.payload.json:


### PR DESCRIPTION
Added a 5 second timeout to (almost) all `.get()` calls in the codebase. It's not fun to have a CI which never completes and it's impossible to know why.

Still missing 2 calls in `test_spansv2` but another PR already touches/fixes those.