### PR TITLE
fix(spans): Require non-empty timestamps on Span v2

### DIFF
--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -48,11 +48,11 @@ pub struct SpanV2 {
     pub kind: Annotated<SpanKind>,
 
     /// Timestamp when the span started.
-    #[metastructure(required = true)]
+    #[metastructure(required = true, nonempty = true)]
     pub start_timestamp: Annotated<Timestamp>,
 
     /// Timestamp when the span was ended.
-    #[metastructure(required = true)]
+    #[metastructure(required = true, nonempty = true)]
     pub end_timestamp: Annotated<Timestamp>,
 
     /// Links from this span to other spans.


### PR DESCRIPTION
Timestamps are [required by the consumer](https://github.com/getsentry/sentry/blob/7d1e9a6f23ae204ed98084c1c6d3dac12d3f4d68/src/sentry/spans/consumers/process/factory.py#L188-L189):

```python
            assert val["end_timestamp"] is not None
            assert val["start_timestamp"] is not None
```

This also corresponds to validation we do for V1 spans:

https://github.com/getsentry/relay/blob/cf91aa719ae63436e0106071ead642f3281a7120/relay-server/src/services/processor/span/processing.rs#L776-L784