### PR TITLE
test(spans): Test all required fields

### DIFF
--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -164,7 +164,6 @@ impl Processor for SchemaProcessor {
 
         // Propagate the violation to the parent container, to make sure the parent is deleted.
         if is_required_violation && let Some(parent) = self.stack.last_mut() {
-            dbg!(&value, &state);
             parent.has_required_violation = true;
         }
 

--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -164,6 +164,7 @@ impl Processor for SchemaProcessor {
 
         // Propagate the violation to the parent container, to make sure the parent is deleted.
         if is_required_violation && let Some(parent) = self.stack.last_mut() {
+            dbg!(&value, &state);
             parent.has_required_violation = true;
         }
 

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -251,7 +251,6 @@ class Sentry(SentryLike):
                     quantity = outcome.pop("quantity")
                     aggregated[tuple(sorted(outcome.items()))] += quantity
         except Empty:
-            print("Empty")
             outcomes = [
                 {**{k: v for (k, v) in fields}, "quantity": quantity}
                 for (fields, quantity) in aggregated.items()

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import datetime
 import copy
 import zstandard
@@ -237,6 +238,26 @@ class Sentry(SentryLike):
             )
         outcomes.sort(key=lambda x: x["category"])
         return outcomes
+
+    def get_aggregated_outcomes(self, *, timeout=None):
+        aggregated = Counter()
+        try:
+            while True:
+                outcomes = self.captured_outcomes.get(
+                    timeout=timeout or self.timeout
+                ).get("outcomes")
+                timeout = 0.1  # only wait the first time
+                for outcome in outcomes:
+                    quantity = outcome.pop("quantity")
+                    aggregated[tuple(sorted(outcome.items()))] += quantity
+        except Empty:
+            print("Empty")
+            outcomes = [
+                {**{k: v for (k, v) in fields}, "quantity": quantity}
+                for (fields, quantity) in aggregated.items()
+            ]
+            outcomes.sort(key=lambda x: x["category"])
+            return outcomes
 
 
 def _get_project_id(public_key, project_configs):

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1,4 +1,3 @@
-from collections import Counter
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -761,12 +760,17 @@ def test_invalid_spans(mini_sentry, relay):
         "span_id": "eee19b7ec3c1b174",
         "start_timestamp": ts.timestamp(),
         "status": "ok",
-        "trace_id": "5b8ef"
-        "ff798038103d269b633813fc60c",
+        "trace_id": "5b8ef" "ff798038103d269b633813fc60c",
     }
 
     required_keys = valid_span.keys()
-    nonempty_keys = {"end_timestamp", "is_remote", "span_id", "start_timestamp", "trace_id"}
+    nonempty_keys = {
+        "end_timestamp",
+        "is_remote",
+        "span_id",
+        "start_timestamp",
+        "trace_id",
+    }
 
     def without(dct, key):
         dct = dct.copy()

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -772,24 +772,21 @@ def test_invalid_spans(mini_sentry, relay):
         "trace_id",
     }
 
-    def without(dct, key):
-        dct = dct.copy()
-        dct.pop(key)
-        return dct
+    invalid_spans = []
+    for key in required_keys:
+        invalid_span = valid_span.copy()
+        del invalid_span[key]
+        invalid_spans.append(invalid_span)
 
-    invalid_spans = [
-        modify(valid_span)
-        for field in required_keys
-        for modify in [
-            lambda span: without(span, field),
-            lambda span: {**span, field: None},
-        ]
-    ] + [
-        {**valid_span, field: ""}
-        for field in [
-            key for (key, value) in valid_span.items() if key in nonempty_keys
-        ]
-    ]
+    for key in required_keys:
+        invalid_span = valid_span.copy()
+        invalid_span[key] = None
+        invalid_spans.append(invalid_span)
+
+    for key in nonempty_keys:
+        invalid_span = valid_span.copy()
+        invalid_span[key] = ""
+        invalid_spans.append(invalid_span)
 
     envelope = envelope_with_spans(*(invalid_spans + [valid_span]))
     relay.send_envelope(project_id, envelope)

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -738,7 +739,7 @@ def test_spanv2_default_pii_scrubbing_attributes(
     assert rem_info[0][0] == rule_type
 
 
-def test_spansv2_non_empty_span_id(mini_sentry, relay):
+def test_invalid_spans(mini_sentry, relay):
     """
     A test asserting proper outcomes are emitted for invalid spans missing required attributes.
     """
@@ -752,38 +753,72 @@ def test_spansv2_non_empty_span_id(mini_sentry, relay):
     relay = relay(mini_sentry, options=TEST_CONFIG)
 
     ts = datetime.now(timezone.utc)
-    envelope = envelope_with_spans(
-        {
-            "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.5,
-            "trace_id": "5b8efff798038103d269b633813fc60c",
-            "name": "some op",
-        }
-    )
 
+    valid_span = {
+        "end_timestamp": ts.timestamp() + 0.5,
+        "is_remote": False,
+        "name": "some op",
+        "span_id": "eee19b7ec3c1b174",
+        "start_timestamp": ts.timestamp(),
+        "status": "ok",
+        "trace_id": "5b8ef"
+        "ff798038103d269b633813fc60c",
+    }
+
+    required_keys = valid_span.keys()
+    nonempty_keys = {"end_timestamp", "is_remote", "span_id", "start_timestamp", "trace_id"}
+
+    def without(dct, key):
+        dct = dct.copy()
+        dct.pop(key)
+        return dct
+
+    invalid_spans = [
+        modify(valid_span)
+        for field in required_keys
+        for modify in [
+            lambda span: without(span, field),
+            lambda span: {**span, field: None},
+        ]
+    ] + [
+        {**valid_span, field: ""}
+        for field in [
+            key for (key, value) in valid_span.items() if key in nonempty_keys
+        ]
+    ]
+
+    envelope = envelope_with_spans(*(invalid_spans + [valid_span]))
     relay.send_envelope(project_id, envelope)
 
-    assert mini_sentry.get_outcomes(2) == [
+    outcomes = mini_sentry.get_aggregated_outcomes(timeout=3)
+    assert outcomes == [
         {
-            "timestamp": time_within_delta(),
-            "org_id": 1,
-            "project_id": 42,
+            "category": 12,
             "key_id": 123,
+            "org_id": 1,
             "outcome": 3,
+            "project_id": 42,
             "reason": "no_data",
-            "category": DataCategory.SPAN,
-            "quantity": 1,
+            "timestamp": time_within_delta(),
+            "quantity": len(invalid_spans),
         },
         {
-            "timestamp": time_within_delta(),
-            "org_id": 1,
-            "project_id": 42,
+            "category": 16,
             "key_id": 123,
+            "org_id": 1,
             "outcome": 3,
+            "project_id": 42,
             "reason": "no_data",
-            "category": DataCategory.SPAN_INDEXED,
-            "quantity": 1,
+            "timestamp": time_within_delta(),
+            "quantity": len(invalid_spans),
         },
     ]
+
+    envelope = mini_sentry.captured_events.get(timeout=0.1)
+    spans = json.loads(envelope.items[0].payload.bytes.decode())["items"]
+
+    assert len(spans) == 1
+    spans[0].pop("attributes")  # irrelevant for this test
+    assert spans[0] == valid_span
 
     assert mini_sentry.captured_events.empty()


### PR DESCRIPTION
Make sure we do not produce spans that [the consumer does not expect](https://github.com/getsentry/sentry/blob/7d1e9a6f23ae204ed98084c1c6d3dac12d3f4d68/src/sentry/spans/consumers/process/factory.py#L188-L191).

This extends the existing test to cover all required and nonempty fields for Span V2.