### PR TITLE
fix(ourlogs): Make referer optional in vercel log drain transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))
+
 **Internal**:
 
 - Add internal attributes to aid searching trace metrics ([#5260](https://github.com/getsentry/relay/pull/5260))

--- a/relay-ourlogs/src/vercel_to_sentry.rs
+++ b/relay-ourlogs/src/vercel_to_sentry.rs
@@ -118,10 +118,10 @@ pub struct VercelProxy {
     pub path: String,
     /// User agent strings of the request.
     pub user_agent: Vec<String>,
-    /// Referer of the request.
-    pub referer: String,
     /// Region where the request is processed.
     pub region: String,
+    /// Referer of the request.
+    pub referer: Option<String>,
     /// HTTP status code of the proxy request.
     pub status_code: Option<i64>,
     /// Client IP address.
@@ -282,13 +282,13 @@ pub fn vercel_log_to_sentry_log(vercel_log: VercelLog) -> OurLog {
         add_attribute!("vercel.proxy.method", method);
         add_attribute!("vercel.proxy.host", host);
         add_attribute!("vercel.proxy.path", path);
-        add_attribute!("vercel.proxy.referer", referer);
         add_attribute!("vercel.proxy.region", region);
 
         if let Ok(user_agent_string) = serde_json::to_string(&user_agent) {
             attributes.insert("vercel.proxy.user_agent", user_agent_string);
         }
 
+        add_optional_attribute!("vercel.proxy.referer", referer);
         add_optional_attribute!("vercel.proxy.status_code", status_code);
         add_optional_attribute!("vercel.proxy.client_ip", client_ip);
         add_optional_attribute!("vercel.proxy.scheme", scheme);
@@ -363,8 +363,8 @@ mod tests {
                 host: "my-app.vercel.app".to_owned(),
                 path: "/api/users?page=1".to_owned(),
                 user_agent: vec!["Mozilla/5.0...".to_owned()],
-                referer: "https://my-app.vercel.app".to_owned(),
                 region: "sfo1".to_owned(),
+                referer: Some("https://my-app.vercel.app".to_owned()),
                 status_code: Some(200),
                 client_ip: Some("120.75.16.101".to_owned()),
                 scheme: Some("https".to_owned()),


### PR DESCRIPTION
ref https://github.com/getsentry/sentry/issues/91728
resolves https://linear.app/getsentry/issue/LOGS-434/investigate-why-logs-from-vercel-log-drain-are-being-marked-as-invalid

I've been testing the vercel log drain internally and I found that we were dropping quite a few logs, 40% of which were marked as invalid.

<img width="1317" height="520" alt="image" src="https://github.com/user-attachments/assets/a1da3afb-ecd7-467a-8da9-217c66441ea2" />

When testing locally, I found that we were hitting an error where the log drain was sending us logs that did not have a `proxy.referer` field, which the vercel docs do say [is required](https://vercel.com/docs/drains/reference/logs):

<img width="607" height="101" alt="image" src="https://github.com/user-attachments/assets/f8440212-30b9-4397-974f-a9a91e354aed" />

```
TRACE relay_server::services::processor: Processing log group
DEBUG relay_server::processing::logs::integrations::vercel: Failed to parse logs data as JSON error=missing field `referer` at line 1 column 564
```

This PR just makes `referer` optional just to unblock ourselves. I'm also following up with Vercel separately to see if what is going on.