### PR TITLE
fix(ourlogs): Use vercel.path in vercel log drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 **Bug Fixes**:
 
 - Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))
+- Use `vercel.path` instead of `url.path` for Vercel Log Drain Transform. ([#5274](https://github.com/getsentry/relay/pull/5274))
 
 **Internal**:
 
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
-
 
 ## 25.10.0
 

--- a/relay-ourlogs/src/vercel_to_sentry.rs
+++ b/relay-ourlogs/src/vercel_to_sentry.rs
@@ -3,7 +3,7 @@
 use std::str::FromStr;
 
 use chrono::{TimeZone, Utc};
-use relay_conventions::{ENVIRONMENT, ORIGIN, SERVER_ADDRESS, URL_PATH};
+use relay_conventions::{ENVIRONMENT, ORIGIN, SERVER_ADDRESS};
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
 use relay_protocol::{Annotated, Meta, Remark, RemarkType};
 use serde::{Deserialize, Deserializer};
@@ -243,7 +243,7 @@ pub fn vercel_log_to_sentry_log(vercel_log: VercelLog) -> OurLog {
     add_optional_attribute!("vercel.build_id", build_id);
     add_optional_attribute!("vercel.entrypoint", entrypoint);
     add_optional_attribute!("vercel.destination", destination);
-    add_optional_attribute!(URL_PATH, path);
+    add_optional_attribute!("vercel.path", path);
     add_optional_attribute!("vercel.log_type", ty);
     add_optional_attribute!("vercel.status_code", status_code);
     add_optional_attribute!("vercel.request_id", request_id);
@@ -402,10 +402,6 @@ mod tests {
               "type": "string",
               "value": "my-app-abc123.vercel.app"
             },
-            "url.path": {
-              "type": "string",
-              "value": "/api/users"
-            },
             "vercel.branch": {
               "type": "string",
               "value": "main"
@@ -449,6 +445,10 @@ mod tests {
             "vercel.log_type": {
               "type": "string",
               "value": "stdout"
+            },
+            "vercel.path": {
+              "type": "string",
+              "value": "/api/users"
             },
             "vercel.project_id": {
               "type": "string",
@@ -614,10 +614,6 @@ mod tests {
               "type": "string",
               "value": "my-app-abc123.vercel.app"
             },
-            "url.path": {
-              "type": "string",
-              "value": "/api/users"
-            },
             "vercel.deployment_id": {
               "type": "string",
               "value": "dpl_233NRGRjVZX1caZrXWtz5g1TAksD"
@@ -633,6 +629,10 @@ mod tests {
             "vercel.id": {
               "type": "string",
               "value": "1573817250283254651097202070"
+            },
+            "vercel.path": {
+              "type": "string",
+              "value": "/api/users"
             },
             "vercel.project_id": {
               "type": "string",

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -129,7 +129,7 @@ EXPECTED_ITEMS = [
             "vercel.proxy.status_code": {"intValue": "200"},
             "sentry.observed_timestamp_nanos": {"stringValue": mock.ANY},
             "sentry.timestamp_precise": {"intValue": "1573817250283000000"},
-            "sentry.payload_size_bytes": {"intValue": "886"},
+            "sentry.payload_size_bytes": {"intValue": "889"},
             "vercel.proxy.region": {"stringValue": "sfo1"},
         },
         "clientSampleRate": 1.0,
@@ -186,7 +186,7 @@ def test_vercel_logs_json_array(
             "org_id": 1,
             "outcome": 0,
             "project_id": 42,
-            "quantity": 1322,
+            "quantity": 1325,
         },
     ]
 
@@ -234,6 +234,6 @@ def test_vercel_logs_ndjson(
             "org_id": 1,
             "outcome": 0,
             "project_id": 42,
-            "quantity": 1322,
+            "quantity": 1325,
         },
     ]

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -97,7 +97,7 @@ EXPECTED_ITEMS = [
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "timestamp": mock.ANY,
         "attributes": {
-            "url.path": {"stringValue": "/api/users"},
+            "vercel.path": {"stringValue": "/api/users"},
             "sentry.browser.version": {"stringValue": "2.32"},
             "vercel.proxy.scheme": {"stringValue": "https"},
             "vercel.entrypoint": {"stringValue": "api/index.js"},


### PR DESCRIPTION
When implementing the vercel log drain transform in https://github.com/getsentry/relay/pull/5209, I initially used `url.path` to represent the path property.

<img width="819" height="136" alt="image" src="https://github.com/user-attachments/assets/37ddda0d-2d8d-47fc-b125-a47701c44385" />

Unfortunately it seems like this also includes some non path like values, like 404, which breaks the semantic convention of `url.path`.

<img width="1526" height="301" alt="image" src="https://github.com/user-attachments/assets/5f9c5175-d753-45bf-bb59-2baa2a3db0f7" />

This PR changes the attribute to be `vercel.path` instead.