### PR TITLE
fix(ci): Increase sleep and timeout in flakey tests

### DIFF
--- a/tests/integration/test_autoscaling.py
+++ b/tests/integration/test_autoscaling.py
@@ -42,7 +42,7 @@ def test_sqlite_spooling_metrics(mini_sentry, relay):
 
     # Send SIGUSR1 to disable unspooling
     relay.send_signal(signal.SIGUSR1)
-    sleep(0.5)  # Give time for the signal to be processed
+    sleep(1)  # Give time for the signal to be processed
 
     # Send more events while unspooling is disabled
     for i in range(200):

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -13,7 +13,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
 
     relay.send_nel_event(project_id)
 
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.captured_events.get(timeout=5)
 
     # Time is corrected by the `age` specified in the NEL report
     expected_ts = datetime.now(tz=timezone.utc) - timedelta(milliseconds=1200000)


### PR DESCRIPTION
The following tests have been incredibly flakey recently, this PR is an attempt at fixing that:
```
FAILED tests/integration/test_autoscaling.py::test_sqlite_spooling_metrics - requests.exceptions.ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=40733): Max retries exceeded with url: /api/42/store/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff50611af10>: Failed to establish a new connection: [Errno 111] Connection refused'))
FAILED tests/integration/test_nel.py::test_nel_converted_to_logs - _queue.Empty
```