### PR TITLE
fix(processor): Remove the unwraps in the `handle_submit_client_reports`

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2671,9 +2671,19 @@ impl EnvelopeProcessorService {
 
         let mut envelope = Envelope::from_request(None, RequestMeta::outbound(dsn));
         for client_report in client_reports {
-            let mut item = Item::new(ItemType::ClientReport);
-            item.set_payload(ContentType::Json, client_report.serialize().unwrap()); // TODO: unwrap OK?
-            envelope.add_item(item);
+            match client_report.serialize() {
+                Ok(payload) => {
+                    let mut item = Item::new(ItemType::ClientReport);
+                    item.set_payload(ContentType::Json, payload);
+                    envelope.add_item(item);
+                }
+                Err(error) => {
+                    relay_log::error!(
+                        error = &error as &dyn std::error::Error,
+                        "failed to serialize client report"
+                    );
+                }
+            }
         }
 
         let envelope = ManagedEnvelope::new(envelope, self.inner.addrs.outcome_aggregator.clone());

--- a/relay-server/src/services/proxy_processor.rs
+++ b/relay-server/src/services/proxy_processor.rs
@@ -62,9 +62,19 @@ impl ProxyProcessorService {
 
         let mut envelope = Envelope::from_request(None, RequestMeta::outbound(dsn));
         for client_report in client_reports {
-            let mut item = Item::new(ItemType::ClientReport);
-            item.set_payload(ContentType::Json, client_report.serialize().unwrap()); // TODO: unwrap OK?
-            envelope.add_item(item);
+            match client_report.serialize() {
+                Ok(payload) => {
+                    let mut item = Item::new(ItemType::ClientReport);
+                    item.set_payload(ContentType::Json, payload);
+                    envelope.add_item(item);
+                }
+                Err(error) => {
+                    relay_log::error!(
+                        error = &error as &dyn std::error::Error,
+                        "failed to serialize client report"
+                    );
+                }
+            }
         }
 
         let envelope = ManagedEnvelope::new(envelope, self.addrs.outcome_aggregator.clone());


### PR DESCRIPTION
During the recent creation of the `ProxyProcessorService` it was rightfully [pointed out](https://github.com/getsentry/relay/pull/5165#discussion_r2439222285) that we probably want to clean up the unwraps. 
This PR replaces the unwraps, both in the new `ProxyProcessorService` and the `EnvelopeProcessorService`.