### PR TITLE
ref(server): Cleanup proxy handling in processing

### DIFF
--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -165,7 +165,7 @@ impl Forward for LogOutput {
     ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
         self.0.try_map(|logs, r| {
             r.lenient(DataCategory::LogByte);
-            logs.serialize()
+            logs.serialize_envelope()
                 .map_err(drop)
                 .with_outcome(Outcome::Invalid(DiscardReason::Internal))
         })
@@ -267,7 +267,7 @@ impl Counted for ExpandedLogs {
 }
 
 impl ExpandedLogs {
-    fn serialize(self) -> Result<Box<Envelope>, ContainerWriteError> {
+    fn serialize_envelope(self) -> Result<Box<Envelope>, ContainerWriteError> {
         let mut logs = Vec::new();
 
         if !self.logs.is_empty() {

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -134,19 +134,10 @@ impl processing::Processor for LogsProcessor {
 
     async fn process(
         &self,
-        mut logs: Managed<Self::UnitOfWork>,
+        logs: Managed<Self::UnitOfWork>,
         ctx: Context<'_>,
     ) -> Result<Output<Self::Output>, Rejected<Error>> {
         validate::container(&logs).reject(&logs)?;
-
-        if ctx.is_proxy() {
-            // If running in proxy mode, just apply cached rate limits and forward without
-            // processing.
-            //
-            // Static mode needs processing, as users can override project settings manually.
-            self.limiter.enforce_quotas(&mut logs, ctx).await?;
-            return Ok(Output::just(LogOutput::NotProcessed(logs)));
-        }
 
         // Fast filters, which do not need expanded logs.
         filter::feature_flag(ctx).reject(&logs)?;
@@ -159,36 +150,25 @@ impl processing::Processor for LogsProcessor {
 
         process::scrub(&mut logs, ctx);
 
-        Ok(Output::just(LogOutput::Processed(logs)))
+        Ok(Output::just(LogOutput(logs)))
     }
 }
 
 /// Output produced by [`LogsProcessor`].
 #[derive(Debug)]
-pub enum LogOutput {
-    NotProcessed(Managed<SerializedLogs>),
-    Processed(Managed<ExpandedLogs>),
-}
+pub struct LogOutput(Managed<ExpandedLogs>);
 
 impl Forward for LogOutput {
     fn serialize_envelope(
         self,
         _: processing::ForwardContext<'_>,
     ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
-        let logs = match self {
-            Self::NotProcessed(logs) => logs,
-            Self::Processed(logs) => logs.try_map(|logs, r| {
-                r.lenient(DataCategory::LogByte);
-                logs.serialize()
-                    .map_err(drop)
-                    .with_outcome(Outcome::Invalid(DiscardReason::Internal))
-            })?,
-        };
-
-        Ok(logs.map(|logs, r| {
+        self.0.try_map(|logs, r| {
             r.lenient(DataCategory::LogByte);
-            logs.serialize_envelope()
-        }))
+            logs.serialize()
+                .map_err(drop)
+                .with_outcome(Outcome::Invalid(DiscardReason::Internal))
+        })
     }
 
     #[cfg(feature = "processing")]
@@ -197,14 +177,7 @@ impl Forward for LogOutput {
         s: &relay_system::Addr<crate::services::store::Store>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
-        let logs = match self {
-            LogOutput::NotProcessed(logs) => {
-                return Err(logs.internal_error(
-                    "logs must be processed before they can be forwarded to the store",
-                ));
-            }
-            LogOutput::Processed(logs) => logs,
-        };
+        let Self(logs) = self;
 
         let ctx = store::Context {
             scoping: logs.scoping(),
@@ -239,21 +212,6 @@ pub struct SerializedLogs {
 }
 
 impl SerializedLogs {
-    fn serialize_envelope(self) -> Box<Envelope> {
-        // `Items` can be constructed with zero cost from a Vec (cap > inline cap).
-        //
-        // We want to minimize the work necessary to copy/merge data.
-        // Both vectors can contain items, but very likely only one does.
-        // We can use the bigger one as a base to copy/allocate less data.
-        // This implicitly also assumes the capacity of the vectors follows the length.
-        let (mut long, short) = match self.logs.len() > self.integrations.len() {
-            true => (self.logs, self.integrations),
-            false => (self.integrations, self.logs),
-        };
-        long.extend(short);
-        Envelope::from_parts(self.headers, Items::from_vec(long))
-    }
-
     fn items(&self) -> impl Iterator<Item = &Item> {
         self.logs.iter().chain(self.integrations.iter())
     }
@@ -309,7 +267,7 @@ impl Counted for ExpandedLogs {
 }
 
 impl ExpandedLogs {
-    fn serialize(self) -> Result<SerializedLogs, ContainerWriteError> {
+    fn serialize(self) -> Result<Box<Envelope>, ContainerWriteError> {
         let mut logs = Vec::new();
 
         if !self.logs.is_empty() {
@@ -320,11 +278,7 @@ impl ExpandedLogs {
             logs.push(item);
         }
 
-        Ok(SerializedLogs {
-            headers: self.headers,
-            logs,
-            integrations: Vec::new(),
-        })
+        Ok(Envelope::from_parts(self.headers, Items::from_vec(logs)))
     }
 }
 

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -77,11 +77,6 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    /// Returns `true` if Relay is running in proxy mode.
-    pub fn is_proxy(&self) -> bool {
-        matches!(self.config.relay_mode(), relay_config::RelayMode::Proxy)
-    }
-
     /// Returns `true` if Relay has processing enabled.
     ///
     /// Processing indicates, this Relay is the final Relay processing this item.

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -166,7 +166,7 @@ impl Forward for SpanOutput {
     ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
         self.0.try_map(|spans, _| {
             spans
-                .serialize()
+                .serialize_envelope()
                 .map_err(drop)
                 .with_outcome(Outcome::Invalid(DiscardReason::Internal))
         })
@@ -248,7 +248,7 @@ pub struct ExpandedSpans {
 }
 
 impl ExpandedSpans {
-    fn serialize(self) -> Result<Box<Envelope>, ContainerWriteError> {
+    fn serialize_envelope(self) -> Result<Box<Envelope>, ContainerWriteError> {
         let mut spans = Vec::new();
 
         if !self.spans.is_empty() {

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -125,20 +125,11 @@ impl processing::Processor for SpansProcessor {
 
     async fn process(
         &self,
-        mut spans: Managed<Self::UnitOfWork>,
+        spans: Managed<Self::UnitOfWork>,
         ctx: Context<'_>,
     ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
         filter::feature_flag(ctx).reject(&spans)?;
         validate::container(&spans).reject(&spans)?;
-
-        if ctx.is_proxy() {
-            // If running in proxy mode, just apply cached rate limits and forward without
-            // processing.
-            //
-            // Static mode needs processing, as users can override project settings manually.
-            self.limiter.enforce_quotas(&mut spans, ctx).await?;
-            return Ok(Output::just(SpanOutput::NotProcessed(spans)));
-        }
 
         dynamic_sampling::validate_configs(ctx);
         let spans = match dynamic_sampling::run(spans, ctx).await {
@@ -158,7 +149,7 @@ impl processing::Processor for SpansProcessor {
         let metrics = dynamic_sampling::create_indexed_metrics(&spans, ctx);
 
         Ok(Output {
-            main: Some(SpanOutput::Processed(spans)),
+            main: Some(SpanOutput(spans)),
             metrics,
         })
     }
@@ -166,27 +157,19 @@ impl processing::Processor for SpansProcessor {
 
 /// Output produced by the [`SpansProcessor`].
 #[derive(Debug)]
-pub enum SpanOutput {
-    NotProcessed(Managed<SerializedSpans>),
-    Processed(Managed<ExpandedSpans>),
-}
+pub struct SpanOutput(Managed<ExpandedSpans>);
 
 impl Forward for SpanOutput {
     fn serialize_envelope(
         self,
         _: processing::ForwardContext<'_>,
     ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
-        let spans = match self {
-            Self::NotProcessed(spans) => spans,
-            Self::Processed(spans) => spans.try_map(|spans, _| {
-                spans
-                    .serialize()
-                    .map_err(drop)
-                    .with_outcome(Outcome::Invalid(DiscardReason::Internal))
-            })?,
-        };
-
-        Ok(spans.map(|spans, _| spans.serialize_envelope()))
+        self.0.try_map(|spans, _| {
+            spans
+                .serialize()
+                .map_err(drop)
+                .with_outcome(Outcome::Invalid(DiscardReason::Internal))
+        })
     }
 
     #[cfg(feature = "processing")]
@@ -195,14 +178,7 @@ impl Forward for SpanOutput {
         s: &relay_system::Addr<crate::services::store::Store>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
-        let spans = match self {
-            SpanOutput::NotProcessed(spans) => {
-                return Err(spans.internal_error(
-                    "spans must be processed before they can be forwarded to the store",
-                ));
-            }
-            SpanOutput::Processed(spans) => spans,
-        };
+        let Self(spans) = self;
 
         let ctx = store::Context {
             server_sample_rate: spans.server_sample_rate,
@@ -241,10 +217,6 @@ impl SerializedSpans {
             server_sample_rate,
         }
     }
-
-    fn serialize_envelope(self) -> Box<Envelope> {
-        Envelope::from_parts(self.headers, Items::from_vec(self.spans))
-    }
 }
 
 impl Counted for SerializedSpans {
@@ -276,7 +248,7 @@ pub struct ExpandedSpans {
 }
 
 impl ExpandedSpans {
-    fn serialize(self) -> Result<SerializedSpans, ContainerWriteError> {
+    fn serialize(self) -> Result<Box<Envelope>, ContainerWriteError> {
         let mut spans = Vec::new();
 
         if !self.spans.is_empty() {
@@ -287,11 +259,7 @@ impl ExpandedSpans {
             spans.push(item);
         }
 
-        Ok(SerializedSpans {
-            headers: self.headers,
-            integrations: Vec::new(),
-            spans,
-        })
+        Ok(Envelope::from_parts(self.headers, Items::from_vec(spans)))
     }
 }
 

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -144,7 +144,7 @@ impl Forward for TraceMetricOutput {
     ) -> Result<Managed<Box<crate::Envelope>>, Rejected<()>> {
         self.0.try_map(|metrics, _| {
             metrics
-                .serialize()
+                .serialize_envelope()
                 .map_err(drop)
                 .with_outcome(Outcome::Invalid(DiscardReason::Internal))
         })
@@ -216,7 +216,7 @@ impl Counted for ExpandedTraceMetrics {
 }
 
 impl ExpandedTraceMetrics {
-    fn serialize(self) -> Result<Box<Envelope>, ContainerWriteError> {
+    fn serialize_envelope(self) -> Result<Box<Envelope>, ContainerWriteError> {
         let mut metrics = Vec::new();
 
         if !self.metrics.is_empty() {


### PR DESCRIPTION
Now that #5165 has landed, we can cleanup the proxy mode handling in the new processing pipelines. 

This simplifies a bunch of code as the output now is always processed. This was always a bit messy and temporary and put in as a reminder to deal with proxy mode properly. Now that it is in, we can clean it up :)