### PR TITLE
fix(server): Internal item types must be parsable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**:
 
+- Envelopes created from integrations can now be spooled. ([#5284](https://github.com/getsentry/relay/pull/5284))
 - Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))
 
 **Internal**:

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -43,6 +43,9 @@ pub enum BadStoreRequest {
     #[error("empty request body")]
     EmptyBody,
 
+    #[error("envelope contains internal items")]
+    InternalEnvelope,
+
     #[error("invalid request body")]
     InvalidBody(#[source] std::io::Error),
 

--- a/relay-server/src/endpoints/envelope.rs
+++ b/relay-server/src/endpoints/envelope.rs
@@ -65,7 +65,11 @@ impl EnvelopeParams {
             return Err(BadStoreRequest::EmptyBody);
         }
 
-        Ok(Envelope::parse_request(body, meta)?)
+        let envelope = Envelope::parse_request(body, meta)?;
+        if envelope.is_internal() {
+            return Err(BadStoreRequest::InternalEnvelope);
+        }
+        Ok(envelope)
     }
 }
 

--- a/relay-server/src/endpoints/store.rs
+++ b/relay-server/src/endpoints/store.rs
@@ -113,6 +113,9 @@ async fn handle_post(
         envelope::CONTENT_TYPE => Envelope::parse_request(body, meta)?,
         _ => parse_event(body, meta, state.config())?,
     };
+    if envelope.is_internal() {
+        return Err(BadStoreRequest::InternalEnvelope);
+    }
 
     let id = common::handle_envelope(&state, envelope).await?;
     Ok(axum::Json(PostResponse { id }).into_response())

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -68,10 +68,6 @@ impl Item {
             Some(Ok(headers)) => headers,
         };
 
-        if headers.ty.is_internal() {
-            return Err(EnvelopeError::InternalItemType);
-        }
-
         // Each header is terminated by a UNIX newline.
         let headers_end = stream.byte_offset();
         super::require_termination(slice, headers_end)?;
@@ -973,16 +969,6 @@ mod tests {
         item.set_source_quantities(source_quantities);
 
         assert_eq!(item.source_quantities(), Some(source_quantities));
-    }
-
-    #[test]
-    fn test_internal_item_type_does_not_parse() {
-        let err = Item::parse(Bytes::from_static(
-            br#"{"type":"integration","content_type":"application/vnd.sentry.integration.otel.logs+json"}"#,
-        ))
-        .unwrap_err();
-
-        assert!(matches!(err, EnvelopeError::InternalItemType));
     }
 
     #[test]

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -74,8 +74,6 @@ pub enum EnvelopeError {
     HeaderMismatch(&'static str),
     #[error("invalid item header")]
     InvalidItemHeader(#[source] serde_json::Error),
-    #[error("internal/reserved item type used")]
-    InternalItemType,
     #[error("failed to write header")]
     HeaderIoFailed(#[source] serde_json::Error),
     #[error("failed to write payload")]
@@ -301,6 +299,11 @@ impl Envelope {
     /// Returns `true` if this envelope does not contain any items.
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
+    }
+
+    /// Returns `true` if the envelope contains an [internal item](ItemType::is_internal).
+    pub fn is_internal(&self) -> bool {
+        self.items().any(|item| item.ty().is_internal())
     }
 
     /// Unique identifier of the event associated to this envelope.


### PR DESCRIPTION
Fixes [POP-RELAY-35Y](https://sentry.my.sentry.io/organizations/sentry/issues/2275260).

An internal item may be serialized and de-serialized again when spooling to disk. Previously after storing the envelope, it would not be possible to parse it again.

This change moves the validation from parsing to higher level endpoints (store and envelope).