### PR TITLE
ci(ci): Run integration tests on arm nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,7 +692,7 @@ jobs:
   test_integration:
     needs: build-setup
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     env:
       RUSTFLAGS:  ${{ needs.build-setup.outputs.rustflags }}


### PR DESCRIPTION
Maybe they run faster/are more stable on an arm runner.