### PR TITLE
build(makefile): Dont setup venv on every format and lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ lint-rust: setup-git ## run lint on Rust code using clippy
 	cargo +stable clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 .PHONY: lint-rust
 
-lint-python: setup-venv-light ## run lint on Python code using flake8
+lint-python: ## run lint on Python code using flake8
 	.venv/bin/pre-commit run flake8 -a
 	.venv/bin/pre-commit run mypy -a
 .PHONY: lint-python
@@ -125,7 +125,7 @@ format-rust: ## format the Rust code
 	cargo +stable fmt --all
 .PHONY: format-rust
 
-format-python: setup-venv-light ## format the Python code
+format-python: ## format the Python code
 	.venv/bin/pre-commit run black -a
 .PHONY: format-python
 
@@ -145,10 +145,6 @@ setup-venv: uv.lock ## create a Python virtual environment with development requ
 	devenv sync
 	RELAY_DEBUG=1 uv pip install -v -e py
 .PHONY: setup-venv
-
-setup-venv-light: uv.lock
-	devenv sync
-.PHONY: setup-venv-light
 
 clean-target-dir:
 	if [ "$$(du -s target/ | cut -f 1)" -gt 4000000 ]; then \


### PR DESCRIPTION
The setup runs everytime you run `make format-python` which runs `devenv sync` and rebuilds `uv` which removes `sentry-relay` from the `venv`. So after running `make format-python` integration tests don't work again.

Ideally the setup is skipped if it is not necessary (what used to happen) but somehow the triggers don't work anymore and I couldn't figure out why.

So for now you need to setup the venv first, then run the actions (like what happens on commit).