### PR TITLE
feat(otlp): Attach sentry.origin attribute to otlp spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Only apply non-destructive PII rules to log bodies by default. ([#5272](https://github.com/getsentry/relay/pull/5272))
+- Add `sentry.origin` attribute to OTLP spans. ([#5294](https://github.com/getsentry/relay/pull/5294))
 
 **Breaking Changes**:
 

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -239,13 +239,14 @@ mod tests {
             .expect("converted span missing from envelope");
 
         let payload = serde_json::from_slice::<serde_json::Value>(&item.payload()).unwrap();
-        insta::assert_json_snapshot!(payload, @r#"
+        insta::assert_json_snapshot!(payload, @r###"
         {
           "data": {
             "instrumentation.name": "test_instrumentation",
             "instrumentation.scope_key": "scope_value",
             "instrumentation.version": "0.0.1",
             "resource.resource_key": "resource_value",
+            "sentry.origin": "auto.otlp.spans",
             "span_key": "span_value"
           },
           "exclusive_time": 0.0,
@@ -258,6 +259,6 @@ mod tests {
           "timestamp": 0.0,
           "trace_id": "89143b0763095bd9c9955e8175d1fb23"
         }
-        "#);
+        "###);
     }
 }

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -239,7 +239,7 @@ mod tests {
             .expect("converted span missing from envelope");
 
         let payload = serde_json::from_slice::<serde_json::Value>(&item.payload()).unwrap();
-        insta::assert_json_snapshot!(payload, @r###"
+        insta::assert_json_snapshot!(payload, @r#"
         {
           "data": {
             "instrumentation.name": "test_instrumentation",
@@ -259,6 +259,6 @@ mod tests {
           "timestamp": 0.0,
           "trace_id": "89143b0763095bd9c9955e8175d1fb23"
         }
-        "###);
+        "#);
     }
 }

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -131,7 +131,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, Some(&resource), Some(&scope));
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -154,6 +154,7 @@ mod tests {
             "instrumentation.version": "123.42",
             "plugin.name": "fastify -> @fastify/multipart",
             "resource.service.name": 42,
+            "sentry.origin": "auto.otlp.spans",
             "sentry.parentSampled": true,
             "sentry.sample_rate": 1,
             "sentry.status.message": "test"
@@ -161,7 +162,7 @@ mod tests {
           "links": [],
           "kind": "server"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -186,7 +187,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -199,12 +200,13 @@ mod tests {
           "status": "ok",
           "description": "middleware - fastify -> @fastify/multipart",
           "data": {
-            "sentry.name": "middleware - fastify -> @fastify/multipart"
+            "sentry.name": "middleware - fastify -> @fastify/multipart",
+            "sentry.origin": "auto.otlp.spans"
           },
           "links": [],
           "kind": "internal"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -221,7 +223,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -234,12 +236,13 @@ mod tests {
           "status": "ok",
           "description": "middleware - fastify -> @fastify/multipart",
           "data": {
-            "sentry.name": "middleware - fastify -> @fastify/multipart"
+            "sentry.name": "middleware - fastify -> @fastify/multipart",
+            "sentry.origin": "auto.otlp.spans"
           },
           "links": [],
           "kind": "internal"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -282,7 +285,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -299,12 +302,13 @@ mod tests {
             "sentry.name": "database query",
             "db.name": "database",
             "db.statement": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
-            "db.type": "sql"
+            "db.type": "sql",
+            "sentry.origin": "auto.otlp.spans"
           },
           "links": [],
           "kind": "client"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -347,7 +351,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -363,12 +367,13 @@ mod tests {
             "sentry.name": "database query",
             "db.name": "database",
             "db.statement": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
-            "db.type": "sql"
+            "db.type": "sql",
+            "sentry.origin": "auto.otlp.spans"
           },
           "links": [],
           "kind": "client"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -399,7 +404,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -414,12 +419,13 @@ mod tests {
           "data": {
             "sentry.name": "http client request",
             "http.request.method": "GET",
+            "sentry.origin": "auto.otlp.spans",
             "url.path": "/api/search?q=foobar"
           },
           "links": [],
           "kind": "server"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -468,7 +474,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -483,11 +489,12 @@ mod tests {
           "data": {
             "sentry.name": "cmd.run",
             "process.args": "[\"node\",\"--require\",\"preflight.cjs\"]",
-            "process.info": "[41]"
+            "process.info": "[41]",
+            "sentry.origin": "auto.otlp.spans"
           },
           "links": []
         }
-        "#);
+        "###);
     }
 
     /// Intended to be synced with `relay-event-schema::protocol::span::convert::tests::roundtrip`.
@@ -623,7 +630,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -645,12 +652,13 @@ mod tests {
             "sentry.sdk.name": "sentry.php",
             "sentry.name": "myname",
             "sentry.metrics_summary.some_metric": "[]",
+            "sentry.origin": "auto.otlp.spans",
             "sentry.status.message": "foo"
           },
           "links": [],
           "platform": "php"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -666,7 +674,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -677,10 +685,12 @@ mod tests {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "is_remote": true,
           "status": "ok",
-          "data": {},
+          "data": {
+            "sentry.origin": "auto.otlp.spans"
+          },
           "links": []
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -696,7 +706,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -707,10 +717,12 @@ mod tests {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "is_remote": false,
           "status": "ok",
-          "data": {},
+          "data": {
+            "sentry.origin": "auto.otlp.spans"
+          },
           "links": []
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -726,7 +738,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -737,11 +749,13 @@ mod tests {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "is_remote": false,
           "status": "ok",
-          "data": {},
+          "data": {
+            "sentry.origin": "auto.otlp.spans"
+          },
           "links": [],
           "kind": "client"
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -787,7 +801,7 @@ mod tests {
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 0.0,
           "start_timestamp": 0.0,
@@ -797,7 +811,9 @@ mod tests {
           "trace_id": "3c79f60c11214eb38604f4ae0781bfb2",
           "is_remote": false,
           "status": "ok",
-          "data": {},
+          "data": {
+            "sentry.origin": "auto.otlp.spans"
+          },
           "links": [
             {
               "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
@@ -812,7 +828,7 @@ mod tests {
             }
           ]
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -828,7 +844,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
         {
           "timestamp": 0.0,
           "start_timestamp": 0.0,
@@ -839,10 +855,11 @@ mod tests {
           "is_remote": false,
           "status": "internal_error",
           "data": {
+            "sentry.origin": "auto.otlp.spans",
             "sentry.status.message": "2 is the error status code"
           },
           "links": []
         }
-        "#);
+        "###);
     }
 }

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -131,7 +131,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, Some(&resource), Some(&scope));
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -162,7 +162,7 @@ mod tests {
           "links": [],
           "kind": "server"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -206,7 +206,7 @@ mod tests {
           "links": [],
           "kind": "internal"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -223,7 +223,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -242,7 +242,7 @@ mod tests {
           "links": [],
           "kind": "internal"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -285,7 +285,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -308,7 +308,7 @@ mod tests {
           "links": [],
           "kind": "client"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -351,7 +351,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -373,7 +373,7 @@ mod tests {
           "links": [],
           "kind": "client"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -404,7 +404,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 1697620454.980079,
           "start_timestamp": 1697620454.98,
@@ -425,7 +425,7 @@ mod tests {
           "links": [],
           "kind": "server"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -474,7 +474,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -494,7 +494,7 @@ mod tests {
           },
           "links": []
         }
-        "###);
+        "#);
     }
 
     /// Intended to be synced with `relay-event-schema::protocol::span::convert::tests::roundtrip`.
@@ -630,7 +630,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -658,7 +658,7 @@ mod tests {
           "links": [],
           "platform": "php"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -674,7 +674,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -690,7 +690,7 @@ mod tests {
           },
           "links": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -706,7 +706,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -722,7 +722,7 @@ mod tests {
           },
           "links": []
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -738,7 +738,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 123.5,
           "start_timestamp": 123.0,
@@ -755,7 +755,7 @@ mod tests {
           "links": [],
           "kind": "client"
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -801,7 +801,7 @@ mod tests {
         let event_span: EventSpan = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 0.0,
           "start_timestamp": 0.0,
@@ -828,7 +828,7 @@ mod tests {
             }
           ]
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -844,7 +844,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<EventSpan> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "timestamp": 0.0,
           "start_timestamp": 0.0,
@@ -860,6 +860,6 @@ mod tests {
           },
           "links": []
         }
-        "###);
+        "#);
     }
 }

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -260,7 +260,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, Some(&resource), Some(&scope));
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -323,7 +323,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -348,7 +348,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -371,7 +371,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -408,7 +408,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -439,7 +439,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -482,7 +482,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -517,7 +517,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -548,7 +548,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -575,7 +575,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     /// Intended to be synced with `relay-event-schema::protocol::span::convert::tests::roundtrip`.
@@ -714,7 +714,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
 
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
           "parent_span_id": "fa90fdead5f74051",
@@ -780,7 +780,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -796,7 +796,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -813,7 +813,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -829,7 +829,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -846,7 +846,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -862,7 +862,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "parent_span_id": "0c7a7dea069bf5a6",
@@ -880,7 +880,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -926,7 +926,7 @@ mod tests {
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "3c79f60c11214eb38604f4ae0781bfb2",
           "span_id": "e342abb1214ca181",
@@ -966,7 +966,7 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -982,7 +982,7 @@ mod tests {
         let otel_span: OtelSpan = serde_json::from_str(json).unwrap();
         let event_span = otel_to_sentry_span(otel_span, None, None);
         let annotated_span: Annotated<SentrySpanV2> = Annotated::new(event_span);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r###"
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span), @r#"
         {
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
           "span_id": "e342abb1214ca181",
@@ -1002,6 +1002,6 @@ mod tests {
             }
           }
         }
-        "###);
+        "#);
     }
 }

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -758,6 +758,7 @@ def test_span_ingestion(
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.is_segment": {"type": "boolean", "value": True},
                 "sentry.op": {"type": "string", "value": "default"},
+                "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
                 "sentry.segment.id": {"type": "string", "value": "d342abb1214ca182"},
                 "sentry.status": {"type": "string", "value": "ok"},
                 "user_agent.original": {
@@ -826,6 +827,7 @@ def test_span_ingestion(
                 },
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.op": {"type": "string", "value": "default"},
+                "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
                 "sentry.status": {"type": "string", "value": "ok"},
                 "ui.component_name": {"type": "string", "value": "MyComponent"},
                 "user_agent.original": {

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -97,6 +97,7 @@ def test_span_ingestion(
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),
             },
+            "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
             "ui.component_name": {"type": "string", "value": "MyComponent"},
         },
         "downsampled_retention_days": 90,


### PR DESCRIPTION
Modelled after https://github.com/getsentry/relay/pull/5190, and for the same reason - so that we can internally tell how many spans are ingested via OTLP vs other means. (It is hidden by the many snapshot changes, but the actual change is a one-liner in `relay-spans/src/otel_to_sentry_v2.rs`.)

Fixes ENG-5768.