### PR TITLE
ref(ourlogs): Remove sentry.timestamp_nanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
+- Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
 
 ## 25.10.0
 

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -187,12 +187,6 @@ fn attributes(
         .unwrap_or_default();
 
     result.insert(
-        "sentry.timestamp_nanos".to_owned(),
-        AnyValue {
-            value: Some(any_value::Value::StringValue(timestamp_nanos.to_string())),
-        },
-    );
-    result.insert(
         "sentry.timestamp_precise".to_owned(),
         AnyValue {
             value: Some(any_value::Value::IntValue(timestamp_nanos)),
@@ -371,13 +365,6 @@ mod tests {
                 value: Some(
                     StringValue(
                         "eee19b7ec3c1b174",
-                    ),
-                ),
-            },
-            "sentry.timestamp_nanos": AnyValue {
-                value: Some(
-                    StringValue(
-                        "946684800000000000",
                     ),
                 ),
             },

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -191,12 +191,6 @@ fn attributes(
         .unwrap_or_default();
 
     result.insert(
-        "sentry.timestamp_nanos".to_owned(),
-        AnyValue {
-            value: Some(any_value::Value::StringValue(timestamp_nanos.to_string())),
-        },
-    );
-    result.insert(
         "sentry.timestamp_precise".to_owned(),
         AnyValue {
             value: Some(any_value::Value::IntValue(timestamp_nanos)),

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -143,14 +143,6 @@ def test_otlp_logs_conversion(
                 "sentry.payload_size_bytes": {"intValue": "385"},
                 "sentry.severity_text": {"stringValue": "info"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
-                "sentry.timestamp_nanos": {
-                    "stringValue": time_within_delta(
-                        ts,
-                        delta=timedelta(seconds=0),
-                        expect_resolution="ns",
-                        precision="us",
-                    )
-                },
                 "sentry.timestamp_precise": {
                     "intValue": time_within_delta(
                         ts,
@@ -263,14 +255,6 @@ def test_otlp_logs_multiple_records(
                 "sentry.payload_size_bytes": {"intValue": mock.ANY},
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
-                "sentry.timestamp_nanos": {
-                    "stringValue": time_within_delta(
-                        ts,
-                        delta=timedelta(seconds=0),
-                        expect_resolution="ns",
-                        precision="us",
-                    )
-                },
                 "sentry.timestamp_precise": {
                     "intValue": time_within_delta(
                         ts,
@@ -304,14 +288,6 @@ def test_otlp_logs_multiple_records(
                 "sentry.payload_size_bytes": {"intValue": mock.ANY},
                 "sentry.severity_text": {"stringValue": "debug"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
-                "sentry.timestamp_nanos": {
-                    "stringValue": time_within_delta(
-                        ts,
-                        delta=timedelta(seconds=0),
-                        expect_resolution="ns",
-                        precision="us",
-                    )
-                },
                 "sentry.timestamp_precise": {
                     "intValue": time_within_delta(
                         ts,

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -46,11 +46,6 @@ def timestamps(ts: datetime):
         "sentry.observed_timestamp_nanos": {
             "stringValue": time_within(ts, expect_resolution="ns")
         },
-        "sentry.timestamp_nanos": {
-            "stringValue": time_within_delta(
-                ts, delta=timedelta(seconds=0), expect_resolution="ns", precision="us"
-            )
-        },
         "sentry.timestamp_precise": {
             "intValue": time_within_delta(
                 ts, delta=timedelta(seconds=0), expect_resolution="ns", precision="us"
@@ -556,14 +551,6 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
             "sentry.payload_size_bytes": mock.ANY,
             "sentry.browser.name": {"stringValue": "Python Requests"},
-            "sentry.timestamp_nanos": {
-                "stringValue": time_within_delta(
-                    ts,
-                    delta=timedelta(seconds=0),
-                    expect_resolution="ns",
-                    precision="us",
-                )
-            },
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(
                     ts,

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -70,14 +70,6 @@ def test_trace_metric_extraction(
             "sentry.metric_name": {"stringValue": "http.request.duration"},
             "sentry.metric_type": {"stringValue": "distribution"},
             "sentry.value": {"doubleValue": 123.45},
-            "sentry.timestamp_nanos": {
-                "stringValue": time_within_delta(
-                    start,
-                    delta=timedelta(seconds=0),
-                    expect_resolution="ns",
-                    precision="us",
-                )
-            },
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(
                     start,
@@ -216,14 +208,6 @@ def test_trace_metric_pii_scrubbing(
             "sentry.metric_name": {"stringValue": "test.metric"},
             "sentry.metric_type": {"stringValue": "counter"},
             "sentry.value": {"doubleValue": 1.0},
-            "sentry.timestamp_nanos": {
-                "stringValue": time_within_delta(
-                    start,
-                    delta=timedelta(seconds=0),
-                    expect_resolution="ns",
-                    precision="us",
-                )
-            },
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(
                     start,

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -64,7 +64,6 @@ EXPECTED_ITEMS = [
         "attributes": {
             "vercel.id": {"stringValue": "1573817187330377061717300000"},
             "sentry.browser.version": {"stringValue": "2.32"},
-            "sentry.timestamp_nanos": {"stringValue": "1573817187330000000"},
             "sentry.origin": {"stringValue": "auto.log_drain.vercel"},
             "server.address": {"stringValue": "my-app-abc123.vercel.app"},
             "vercel.source": {"stringValue": "build"},
@@ -121,7 +120,6 @@ EXPECTED_ITEMS = [
             "vercel.id": {"stringValue": "1573817250283254651097202070"},
             "sentry.environment": {"stringValue": "production"},
             "vercel.proxy.vercel_cache": {"stringValue": "MISS"},
-            "sentry.timestamp_nanos": {"stringValue": "1573817250283000000"},
             "sentry.origin": {"stringValue": "auto.log_drain.vercel"},
             "vercel.source": {"stringValue": "lambda"},
             "vercel.proxy.timestamp": {"intValue": "1573817250172"},


### PR DESCRIPTION
This has been superceded by timestamp_precise and that's what we're using everywhere in the frontend/backend now.


