### PR TITLE
feat(filter): Add Storebot-Google to web crawlers list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))
 - Tag spans' count per root metric with the trace root's transaction instead of the local transaction. ([#5281](https://github.com/getsentry/relay/pull/5281))
 - Use `vercel.path` instead of `url.path` for Vercel Log Drain Transform. ([#5274](https://github.com/getsentry/relay/pull/5274))
+- Add Google Storebot to the crawler filter list. ([#5300](https://github.com/getsentry/relay/pull/5300))
 
 **Internal**:
 

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -119,6 +119,8 @@ mod tests {
             "AdsBot-Google",
             "Googlebot",
             "FeedFetcher-Google",
+            "Storebot-Google",
+            "Mozilla/5.0 (X11; Linux x86_64; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
             "BingBot",
             "BingPreview",
             "Baiduspider",

--- a/relay-filter/src/web_crawlers.rs
+++ b/relay-filter/src/web_crawlers.rs
@@ -13,6 +13,7 @@ static WEB_CRAWLERS: LazyLock<Regex> = LazyLock::new(|| {
         AdsBot-Google|
         Googlebot|
         FeedFetcher-Google|
+        Storebot-Google|
         BingBot|                    # Bing search
         BingPreview|
         Baiduspider|                # Baidu search


### PR DESCRIPTION
This adds the Google Storebot crawler to the list of known web crawlers
https://support.google.com/merchants/answer/13294660?hl=en
`Mozilla/5.0 (X11; Linux x86_64; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
