### PR TITLE
fix(rate-limits): Consistently emit rate limit outcomes for attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Envelopes created from integrations can now be spooled. ([#5284](https://github.com/getsentry/relay/pull/5284))
 - Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))
+- Fix potentially missing attachment outcomes when rate limiting. ([#5301](https://github.com/getsentry/relay/pull/5301))
 - Tag spans' count per root metric with the trace root's transaction instead of the local transaction. ([#5281](https://github.com/getsentry/relay/pull/5281))
 - Use `vercel.path` instead of `url.path` for Vercel Log Drain Transform. ([#5274](https://github.com/getsentry/relay/pull/5274))
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -728,6 +728,10 @@ where
                     summary.attachment_quantity,
                     attachment_byte_limits.longest(),
                 );
+                enforcement.attachment_items = enforcement.attachments.clone_for(
+                    DataCategory::AttachmentItem,
+                    summary.attachment_item_quantity,
+                );
                 attachment_limits.merge(attachment_byte_limits);
             }
             if !attachment_limits.is_limited() && summary.attachment_item_quantity > 0 {
@@ -743,6 +747,9 @@ where
                     summary.attachment_item_quantity,
                     attachment_item_limits.longest(),
                 );
+                enforcement.attachments = enforcement
+                    .attachment_items
+                    .clone_for(DataCategory::Attachment, summary.attachment_quantity);
                 attachment_limits.merge(attachment_item_limits);
             }
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -327,6 +327,16 @@ class OutcomesConsumer(ConsumerBase):
             count = sum(outcome["quantity"] for outcome in outcomes)
             assert count == quantity, (count, quantity)
 
+        if isinstance(categories, dict):
+            aggregated = defaultdict(int)
+            for outcome in outcomes:
+                aggregated[DataCategory(outcome["category"])] += outcome["quantity"]
+            expected = dict(
+                (category_value(category), quantity)
+                for (category, quantity) in categories.items()
+            )
+            assert aggregated == expected, (dict(aggregated), expected)
+
 
 @pytest.fixture
 def consumer_fixture(kafka_consumer):

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -135,13 +135,17 @@ def test_attachments_ratelimit(
     # First attachment returns 200 but is rate limited in processing
     relay.send_attachments(project_id, event_id, attachments)
 
-    outcomes_consumer.assert_rate_limited("static_disabled_quota")
+    outcomes_consumer.assert_rate_limited(
+        "static_disabled_quota", categories=["attachment", "attachment_item"]
+    )
 
     # Second attachment returns 429 in endpoint
     with pytest.raises(HTTPError) as excinfo:
         relay.send_attachments(project_id, event_id, attachments)
     assert excinfo.value.response.status_code == 429
-    outcomes_consumer.assert_rate_limited("static_disabled_quota")
+    outcomes_consumer.assert_rate_limited(
+        "static_disabled_quota", categories=["attachment", "attachment_item"]
+    )
 
 
 def test_attachments_pii(mini_sentry, relay):
@@ -380,7 +384,8 @@ def test_attachments_quotas(
     relay.send_attachments(project_id, event_id, attachments)
 
     outcomes_consumer.assert_rate_limited(
-        "attachments_exceeded", quantity=len(attachment_body)
+        "attachments_exceeded",
+        categories={"attachment": len(attachment_body), "attachment_item": 1},
     )
 
     # Second attachment returns 429 in endpoint
@@ -388,7 +393,8 @@ def test_attachments_quotas(
         relay.send_attachments(42, event_id, attachments)
     assert excinfo.value.response.status_code == 429
     outcomes_consumer.assert_rate_limited(
-        "attachments_exceeded", quantity=len(attachment_body)
+        "attachments_exceeded",
+        categories={"attachment": len(attachment_body), "attachment_item": 1},
     )
 
 
@@ -430,7 +436,8 @@ def test_attachments_quotas_items(
     relay.send_attachments(project_id, event_id, attachments)
 
     outcomes_consumer.assert_rate_limited(
-        "attachments_exceeded", categories=["attachment_item"], quantity=1
+        "attachments_exceeded",
+        categories={"attachment": len(attachment_body), "attachment_item": 1},
     )
 
     # Second attachment returns 429 in endpoint
@@ -439,7 +446,8 @@ def test_attachments_quotas_items(
     assert excinfo.value.response.status_code == 429
 
     outcomes_consumer.assert_rate_limited(
-        "attachments_exceeded", categories=["attachment_item"], quantity=1
+        "attachments_exceeded",
+        categories={"attachment": len(attachment_body), "attachment_item": 1},
     )
 
 

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -164,7 +164,10 @@ ITEM_TYPE_RATE_LIMIT_BEHAVIORS = [
     RateLimitBehavior(
         "attachment",
         PayloadType.BINARY,
-        [{"category": "attachment", "quantity": 100, "reason": "generic"}],
+        [
+            {"category": "attachment", "quantity": 100, "reason": "generic"},
+            {"category": "attachment_item", "quantity": 1, "reason": "generic"},
+        ],
     ),
     RateLimitBehavior(
         "raw_security",


### PR DESCRIPTION
Outcomes in the `attachment` category were not consistently applied to `attachment_item`, but more importantly rate limits in the `attachment_items` category did not generate outcomes in the `attachment` category.