### PR TITLE
ref(eap): Extract user agent from user_agent.original

### DIFF
--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -45,6 +45,7 @@ convention_attributes!(
     USER_GEO_COUNTRY_CODE => "user.geo.country_code",
     USER_GEO_REGION => "user.geo.region",
     USER_GEO_SUBDIVISION => "user.geo.subdivision",
+    USER_AGENT_ORIGINAL => "user_agent.original",
 );
 
 /// Attributes which are in use by Relay but are not yet defined in the Sentry conventions.

--- a/relay-filter/src/interface.rs
+++ b/relay-filter/src/interface.rs
@@ -1,6 +1,8 @@
 //! This module contains the trait for items that can be filtered by Inbound Filters, plus
 //! the implementation for [`Event`].
-use relay_conventions::{BROWSER_NAME, BROWSER_VERSION, RELEASE, SEGMENT_NAME};
+use relay_conventions::{
+    BROWSER_NAME, BROWSER_VERSION, RELEASE, SEGMENT_NAME, USER_AGENT_ORIGINAL,
+};
 use url::Url;
 
 use relay_event_schema::protocol::{
@@ -284,5 +286,10 @@ fn user_agent_from_attributes(attributes: &relay_protocol::Annotated<Attributes>
         })
     })();
 
-    UserAgent { raw: None, parsed }
+    let raw = attributes
+        .value()
+        .and_then(|attr| attr.get_value(USER_AGENT_ORIGINAL))
+        .and_then(|ua| ua.as_str());
+
+    UserAgent { raw, parsed }
 }

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -30,7 +30,6 @@ def lcp_cls_inp_differences(mode):
         attributes = {
             "browser.name": {"type": "string", "value": "Chrome"},
             "client.address": {"type": "string", "value": "127.0.0.1"},
-            "sentry.browser.name": {"type": "string", "value": "Chrome"},
             # Legacy behaviour, new field is `sentry.segment.name`
             # Maybe this shouldn't exist since parent and segment information is also removed
             "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
@@ -40,9 +39,8 @@ def lcp_cls_inp_differences(mode):
         attributes = {
             # Not implemented
             "client.address": {"type": "string", "value": "{{auto}}"},
-            # Uses wrong user agent
-            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
-            "sentry.browser.version": {"type": "string", "value": "2.32"},
+            # We additionally extract the browser version for EAP items
+            "sentry.browser.version": {"type": "string", "value": "141.0.0"},
             # New for EAP items
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -137,6 +135,7 @@ def test_lcp_span(
                 "type": "string",
                 "value": "https://s1.sentry-cdn.com/../sentry-loader.svg",
             },
+            "sentry.browser.name": {"type": "string", "value": "Chrome"},
             "sentry.description": {"type": "string", "value": "<unknown>"},
             "sentry.environment": {"type": "string", "value": "prod"},
             "sentry.exclusive_time": {"type": "double", "value": 0.0},
@@ -308,6 +307,7 @@ def test_cls_span(
                 "value": "div.app-1azrk9k.etjky0h0 > AppContainer > BodyContainer > BaseFooter",
             },
             "cls.source.3": {"type": "string", "value": "<unknown>"},
+            "sentry.browser.name": {"type": "string", "value": "Chrome"},
             "sentry.description": {
                 "type": "string",
                 "value": "AppContainer > NavContent > MobileTopbar > StyledButton",
@@ -468,6 +468,7 @@ def test_inp_span(
     assert spans_consumer.get_span() == {
         "attributes": {
             "inp": {"type": "double", "value": 104.0},
+            "sentry.browser.name": {"type": "string", "value": "Chrome"},
             "sentry.description": {
                 "type": "string",
                 "value": "<unknown>",


### PR DESCRIPTION
This considers now `user_agent.original` for extracting browser name and version. It does not yet set the attribute if Relay extracts the attributes from the request user agent.