### PR TITLE
feat(eap): Infer the client ip if set to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Only apply non-destructive PII rules to log bodies by default. ([#5272](https://github.com/getsentry/relay/pull/5272))
+- Infer the client ip when set to `{{auto}}` for EAP items. ([#5304](https://github.com/getsentry/relay/pull/5304))
 - Add `sentry.origin` attribute to OTLP spans. ([#5294](https://github.com/getsentry/relay/pull/5294))
 
 **Breaking Changes**:

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -15,6 +15,7 @@ macro_rules! convention_attributes {
 convention_attributes!(
     BROWSER_NAME => "sentry.browser.name",
     BROWSER_VERSION => "sentry.browser.version",
+    CLIENT_ADDRESS => "client.address",
     DB_QUERY_TEXT => "db.query.text",
     DB_STATEMENT => "db.statement",
     DB_SYSTEM_NAME => "db.system.name",

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -110,6 +110,7 @@ fn scrub_log(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
 fn normalize_log(log: &mut Annotated<OurLog>, meta: &RequestMeta) -> Result<()> {
     if let Some(log) = log.value_mut() {
         eap::normalize_received(&mut log.attributes, meta.received_at());
+        eap::normalize_client_address(&mut log.attributes, meta.client_addr());
         eap::normalize_user_agent(&mut log.attributes, meta.user_agent(), meta.client_hints());
         eap::normalize_attribute_types(&mut log.attributes);
     }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -89,6 +89,7 @@ fn normalize_span(
 
     if let Some(span) = span.value_mut() {
         eap::normalize_received(&mut span.attributes, meta.received_at());
+        eap::normalize_client_address(&mut span.attributes, meta.client_addr());
         eap::normalize_user_agent(&mut span.attributes, meta.user_agent(), meta.client_hints());
         eap::normalize_attribute_types(&mut span.attributes);
         eap::normalize_user_geo(&mut span.attributes, || {

--- a/relay-server/src/processing/trace_metrics/process.rs
+++ b/relay-server/src/processing/trace_metrics/process.rs
@@ -102,6 +102,7 @@ fn scrub_trace_metric(metric: &mut Annotated<TraceMetric>, ctx: Context<'_>) -> 
 fn normalize_trace_metric(metric: &mut Annotated<TraceMetric>, meta: &RequestMeta) -> Result<()> {
     if let Some(metric_value) = metric.value_mut() {
         eap::normalize_received(&mut metric_value.attributes, meta.received_at());
+        eap::normalize_client_address(&mut metric_value.attributes, meta.client_addr());
         eap::normalize_user_agent(
             &mut metric_value.attributes,
             meta.user_agent(),

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -29,7 +29,6 @@ def lcp_cls_inp_differences(mode):
     if mode == "legacy":
         attributes = {
             "browser.name": {"type": "string", "value": "Chrome"},
-            "client.address": {"type": "string", "value": "127.0.0.1"},
             # Legacy behaviour, new field is `sentry.segment.name`
             # Maybe this shouldn't exist since parent and segment information is also removed
             "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
@@ -37,8 +36,6 @@ def lcp_cls_inp_differences(mode):
         fields = {}
     else:
         attributes = {
-            # Not implemented
-            "client.address": {"type": "string", "value": "{{auto}}"},
             # We additionally extract the browser version for EAP items
             "sentry.browser.version": {"type": "string", "value": "141.0.0"},
             # New for EAP items
@@ -127,6 +124,7 @@ def test_lcp_span(
 
     assert spans_consumer.get_span() == {
         "attributes": {
+            "client.address": {"type": "string", "value": "127.0.0.1"},
             "lcp": {"type": "double", "value": 548.0},
             "lcp.loadTime": {"type": "double", "value": 527.5},
             "lcp.renderTime": {"type": "integer", "value": 548},
@@ -297,6 +295,7 @@ def test_cls_span(
 
     assert spans_consumer.get_span() == {
         "attributes": {
+            "client.address": {"type": "string", "value": "127.0.0.1"},
             "cls": {"type": "double", "value": 0.1},
             "cls.source.1": {
                 "type": "string",
@@ -467,6 +466,7 @@ def test_inp_span(
 
     assert spans_consumer.get_span() == {
         "attributes": {
+            "client.address": {"type": "string", "value": "127.0.0.1"},
             "inp": {"type": "double", "value": 104.0},
             "sentry.browser.name": {"type": "string", "value": "Chrome"},
             "sentry.description": {


### PR DESCRIPTION
Mirrors the behaviour we already have for spans, now for all EAP items.

Infers the client ip if the client address attribute is set to `{{auto}}`.