### PR TITLE
ref(spans): Enable span extraction unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
-- Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5295))
+- Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5308))
 
 ## 25.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
+- Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5295))
 
 ## 25.10.0
 

--- a/relay-dynamic-config/src/defaults.rs
+++ b/relay-dynamic-config/src/defaults.rs
@@ -12,8 +12,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         .metric_extraction
         .get_or_insert_with(MetricExtractionConfig::empty);
 
-    let features = &project_config.features;
-
     if !config.is_supported() || config._span_metrics_extended {
         return;
     }
@@ -27,10 +25,6 @@ pub fn add_span_metrics(project_config: &mut ProjectConfig) {
         condition: None,
         tags: vec![],
     });
-
-    if !features.produces_spans() {
-        return;
-    }
 
     config
         .global_groups

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -8,6 +8,7 @@ pub const GRADUATED_FEATURE_FLAGS: &[Feature] = &[
     Feature::UserReportV2Ingest,
     Feature::IngestUnsampledProfiles,
     Feature::ScrubMongoDbDescriptions,
+    Feature::DeprecatedExtractSpansFromEvent,
 ];
 
 /// Features exposed by project config.
@@ -90,11 +91,6 @@ pub enum Feature {
     /// Serialized as `organizations:continuous-profiling-beta-ingest`.
     #[serde(rename = "organizations:continuous-profiling-beta-ingest")]
     ContinuousProfilingBetaIngest,
-    /// When enabled, spans will be extracted from a transaction.
-    ///
-    /// Serialized as `organizations:indexed-spans-extraction`.
-    #[serde(rename = "organizations:indexed-spans-extraction")]
-    ExtractSpansFromEvent,
     /// Enable log ingestion for our log product (this is not internal logging).
     ///
     /// Serialized as `organizations:ourlogs-ingestion`.
@@ -134,6 +130,10 @@ pub enum Feature {
     #[doc(hidden)]
     #[serde(rename = "projects:span-metrics-extraction-addons")]
     DeprecatedExtractAddonsSpanMetricsFromEvent,
+    /// This feature has been deprecated and is kept for external Relays.
+    #[doc(hidden)]
+    #[serde(rename = "organizations:indexed-spans-extraction")]
+    DeprecatedExtractSpansFromEvent,
     /// Forward compatibility.
     #[doc(hidden)]
     #[serde(other)]
@@ -153,11 +153,6 @@ impl FeatureSet {
     /// Returns `true` if the given feature is in the set.
     pub fn has(&self, feature: Feature) -> bool {
         self.0.contains(&feature)
-    }
-
-    /// Returns `true` if any spans are produced for this project.
-    pub fn produces_spans(&self) -> bool {
-        self.has(Feature::ExtractSpansFromEvent) || self.has(Feature::StandaloneSpanIngestion)
     }
 }
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -130,7 +130,7 @@ pub enum Feature {
     #[doc(hidden)]
     #[serde(rename = "projects:span-metrics-extraction-addons")]
     DeprecatedExtractAddonsSpanMetricsFromEvent,
-    /// This feature has been deprecated and is kept for external Relays.
+    /// This feature has graduated and is hard-coded for external Relays.
     #[doc(hidden)]
     #[serde(rename = "organizations:indexed-spans-extraction")]
     DeprecatedExtractSpansFromEvent,

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -1289,11 +1289,4 @@ mod tests {
             "c:spans/count_per_root_project@none"
         );
     }
-
-    #[test]
-    fn only_indexed_spans_enabled() {
-        let metrics = extract_span_metrics([Feature::ExtractSpansFromEvent]).project_metrics;
-        assert_eq!(metrics.len(), 75);
-        assert!(metrics.iter().all(|b| &b.name == "c:spans/usage@none"));
-    }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1578,7 +1578,7 @@ impl EnvelopeProcessorService {
                 },
                 device_class_synthesis_config: project_info
                     .has_feature(Feature::DeviceClassSynthesis),
-                enrich_spans: project_info.has_feature(Feature::ExtractSpansFromEvent),
+                enrich_spans: true,
                 max_tag_value_length: self
                     .inner
                     .config
@@ -1922,17 +1922,15 @@ impl EnvelopeProcessorService {
                 spans_extracted,
             )?;
 
-            if ctx.project_info.has_feature(Feature::ExtractSpansFromEvent) {
-                spans_extracted = span::extract_from_event(
-                    managed_envelope,
-                    &event,
-                    ctx.global_config,
-                    ctx.config,
-                    server_sample_rate,
-                    event_metrics_extracted,
-                    spans_extracted,
-                );
-            }
+            spans_extracted = span::extract_from_event(
+                managed_envelope,
+                &event,
+                ctx.global_config,
+                ctx.config,
+                server_sample_rate,
+                event_metrics_extracted,
+                spans_extracted,
+            );
         });
 
         event = self

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -173,16 +173,14 @@ pub async fn process(
 
             extracted_metrics.extend_project_metrics(metrics, Some(sampling_decision));
 
-            if ctx.project_info.config.features.produces_spans() {
-                let bucket = event::create_span_root_counter(
-                    span,
-                    transaction_from_dsc.clone(),
-                    1,
-                    sampling_decision,
-                    project_id,
-                );
-                extracted_metrics.extend_sampling_metrics(bucket, Some(sampling_decision));
-            }
+            let bucket = event::create_span_root_counter(
+                span,
+                transaction_from_dsc.clone(),
+                1,
+                sampling_decision,
+                project_id,
+            );
+            extracted_metrics.extend_sampling_metrics(bucket, Some(sampling_decision));
 
             item.set_metrics_extracted(true);
         }

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -87,17 +87,11 @@ impl<'a> Project<'a> {
             .compute(envelope.envelope_mut(), &scoping)
             .await?;
 
-        let check_nested_spans = state
-            .as_ref()
-            .is_some_and(|s| s.has_feature(Feature::ExtractSpansFromEvent));
-
         // If we can extract spans from the event, we want to try and count the number of nested
         // spans to correctly emit negative outcomes in case the transaction itself is dropped.
-        if check_nested_spans {
-            relay_statsd::metric!(timer(RelayTimers::CheckNestedSpans), {
-                sync_spans_to_enforcement(&envelope, &mut enforcement);
-            });
-        }
+        relay_statsd::metric!(timer(RelayTimers::CheckNestedSpans), {
+            sync_spans_to_enforcement(&envelope, &mut enforcement);
+        });
 
         enforcement.apply_with_outcomes(&mut envelope);
 
@@ -226,9 +220,6 @@ mod tests {
         let project = create_project(
             &config,
             Some(json!({
-                "features": [
-                    "organizations:indexed-spans-extraction"
-                ],
                 "quotas": [{
                    "id": "foo",
                    "categories": ["transaction"],

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use relay_config::Config;
-use relay_dynamic_config::Feature;
 use relay_quotas::{CachedRateLimits, DataCategory, MetricNamespaceScoping, RateLimits};
 use relay_sampling::evaluation::ReservoirCounters;
 

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -305,19 +305,25 @@ class OutcomesConsumer(ConsumerBase):
         timeout=1,
         ignore_other=False,
     ):
+        expected_categories = (
+            {category_value(category) for category in categories}
+            if categories
+            else set()
+        )
         if categories is None:
             outcome = self.get_outcome(timeout=timeout)
             assert isinstance(outcome["category"], int)
             outcomes = [outcome]
         else:
             outcomes = self.get_outcomes(timeout=timeout)
-            expected = {category_value(category) for category in categories}
             actual = {outcome["category"] for outcome in outcomes}
             if ignore_other:
                 actual = actual & set(categories)
-            assert actual == expected, (actual, expected)
+            assert actual == expected_categories, (actual, expected_categories)
 
         for outcome in outcomes:
+            if ignore_other and outcome["category"] not in expected_categories:
+                continue
             assert outcome["outcome"] == 2, outcome
             assert outcome["reason"] == reason, outcome["reason"]
             if key_id is not None:

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -504,7 +504,6 @@ def test_event_with_attachment(
     relay_with_processing,
     attachments_consumer,
     transactions_consumer,
-    outcomes_consumer,
 ):
     project_id = 42
     event_id = "515539018c9b4260a6f999572f1661ee"
@@ -513,7 +512,6 @@ def test_event_with_attachment(
     relay = relay_with_processing()
     attachments_consumer = attachments_consumer()
     transactions_consumer = transactions_consumer()
-    outcomes_consumer = outcomes_consumer()
 
     # event attachments are always sent as chunks, and added to events
     envelope = Envelope(headers=[["event_id", event_id]])

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -629,4 +629,8 @@ def test_filters_are_applied_to_profiles(
         profile, _ = profiles_consumer.get_profile()
         profile = json.loads(profile["payload"])
         assert profile["release"] == "foobar@1.0"
-        outcomes_consumer.assert_empty()
+        assert [
+            outcome
+            for outcome in outcomes_consumer.get_outcomes()
+            if outcome["category"] == data_category
+        ] == []

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -737,8 +737,6 @@ def test_transaction_metrics(
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
 
-    config.setdefault("features", []).append("organizations:indexed-spans-extraction")
-
     timestamp = datetime.now(tz=timezone.utc)
 
     if extract_metrics:

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1806,12 +1806,6 @@ def test_span_outcomes(
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)["config"]
-
-    project_config.setdefault("features", []).extend(
-        [
-            "organizations:indexed-spans-extraction",
-        ]
-    )
     project_config["transactionMetrics"] = {
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -754,7 +754,7 @@ def _get_span_payload():
     "category,outcome_categories",
     [
         ("session", []),
-        ("transaction", ["transaction", "transaction_indexed"]),
+        ("transaction", ["transaction", "transaction_indexed", "span", "span_indexed"]),
         ("user_report_v2", ["user_report_v2"]),
     ],
 )
@@ -1330,6 +1330,15 @@ def test_profile_outcomes(
             "category": DataCategory.SPAN_INDEXED.value,
             "key_id": 123,
             "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            "quantity": 2,
+            "source": "processing-relay",
+        },
+        {
+            "category": DataCategory.SPAN_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
             "outcome": 1,  # Filtered
             "project_id": 42,
             "quantity": 2,
@@ -1406,11 +1415,6 @@ def test_profile_outcomes_invalid(
                 "bucket_interval": 1,
                 "flush_interval": 1,
             },
-            "source": "pop-relay",
-        },
-        "aggregator": {
-            "bucket_interval": 1,
-            "initial_delay": 0,
         },
     }
 
@@ -1440,17 +1444,34 @@ def test_profile_outcomes_invalid(
 
     assert outcomes == [
         {
-            "category": category,
+            "category": DataCategory.PROFILE.value,
             "key_id": 123,
             "org_id": 1,
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": 1,
             "reason": expected_outcome,
-            "source": "pop-relay",
             "timestamp": time_within_delta(),
-        }
-        for category in [DataCategory.PROFILE.value, DataCategory.PROFILE_INDEXED.value]
+        },
+        {
+            "category": DataCategory.PROFILE_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,  # Invalid
+            "project_id": 42,
+            "quantity": 1,
+            "reason": expected_outcome,
+            "timestamp": time_within_delta(),
+        },
+        {
+            "category": DataCategory.SPAN_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            "quantity": 2,
+            "timestamp": time_within_delta(),
+        },
     ]
 
     # Make sure the profile will not be counted as accepted:
@@ -1488,11 +1509,6 @@ def test_profile_outcomes_too_many(
                 "bucket_interval": 1,
                 "flush_interval": 1,
             },
-            "source": "pop-relay",
-        },
-        "aggregator": {
-            "bucket_interval": 1,
-            "initial_delay": 0,
         },
     }
 
@@ -1527,17 +1543,34 @@ def test_profile_outcomes_too_many(
 
     assert outcomes == [
         {
-            "category": category,
+            "category": DataCategory.PROFILE.value,
             "key_id": 123,
             "org_id": 1,
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": 1,
             "reason": "profiling_too_many_profiles",
-            "source": "pop-relay",
             "timestamp": time_within_delta(),
-        }
-        for category in [6, 11]  # Profile, ProfileIndexed
+        },
+        {
+            "category": DataCategory.PROFILE_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,  # Invalid
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "profiling_too_many_profiles",
+            "timestamp": time_within_delta(),
+        },
+        {
+            "category": DataCategory.SPAN_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            "quantity": 2,
+            "timestamp": time_within_delta(),
+        },
     ]
 
     # One profile was accepted
@@ -1577,12 +1610,8 @@ def test_profile_outcomes_rate_limited(
             "batch_interval": 1,
             "aggregator": {
                 "bucket_interval": 1,
-                "flush_interval": 0,
+                "flush_interval": 1,
             },
-        },
-        "aggregator": {
-            "bucket_interval": 1,
-            "initial_delay": 0,
         },
     }
 
@@ -1610,15 +1639,17 @@ def test_profile_outcomes_rate_limited(
     outcomes.sort(key=lambda o: sorted(o.items()))
 
     expected_categories = [
-        DataCategory.PROFILE,
-        DataCategory.PROFILE_INDEXED,
-    ]  # Profile, ProfileIndexed
+        (DataCategory.PROFILE, 1),
+        (DataCategory.PROFILE_INDEXED, 1),
+    ]
     if quota_category == "transaction":
         # Transaction got rate limited as well:
         expected_categories += [
-            DataCategory.TRANSACTION,
-            DataCategory.TRANSACTION_INDEXED,
-        ]  # Transaction, TransactionIndexed
+            (DataCategory.TRANSACTION, 1),
+            (DataCategory.TRANSACTION_INDEXED, 1),
+            (DataCategory.SPAN, 2),
+            (DataCategory.SPAN_INDEXED, 2),
+        ]
     expected_categories.sort()
 
     expected_outcomes = [
@@ -1628,12 +1659,25 @@ def test_profile_outcomes_rate_limited(
             "org_id": 1,
             "outcome": 2,  # RateLimited
             "project_id": 42,
-            "quantity": 1,
+            "quantity": quantity,
             "reason": "profiles_exceeded",
             "timestamp": time_within_delta(),
         }
-        for category in expected_categories
+        for (category, quantity) in expected_categories
     ]
+
+    if quota_category == "profile":
+        expected_outcomes.append(
+            {
+                "category": DataCategory.SPAN_INDEXED,
+                "key_id": 123,
+                "org_id": 1,
+                "outcome": 0,
+                "project_id": 42,
+                "quantity": 2,
+                "timestamp": time_within_delta(),
+            }
+        )
 
     assert outcomes == expected_outcomes, outcomes
 

--- a/tests/integration/test_pii.py
+++ b/tests/integration/test_pii.py
@@ -37,7 +37,7 @@ def test_scrub_span_sentry_tags_advanced_rules(mini_sentry, relay):
     envelope = mini_sentry.captured_events.get(timeout=1)
     event = envelope.get_event()
     assert event["spans"][0]["sentry_tags"]["user.geo.country_code"] == "**"
-    assert event["spans"][0]["sentry_tags"]["user.geo.subregion"] == "**"
+    assert event["spans"][0]["sentry_tags"]["user.geo.subregion"] == "***"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_span_links.py
+++ b/tests/integration/test_span_links.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
@@ -97,6 +98,7 @@ def test_event_with_span_link_in_transaction(relay, mini_sentry):
             "status": "ok",
             "start_timestamp": 1624366926.0,
             "timestamp": 1624366927.0,
+            "sentry_tags": mock.ANY,
             "links": [
                 {
                     "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -51,9 +51,6 @@ def test_span_extraction(
     relay = relay_with_processing(options=TEST_CONFIG)
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "organizations:indexed-spans-extraction",
-    ]
     project_config["config"]["transactionMetrics"] = {
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
@@ -295,9 +292,6 @@ def test_span_extraction_with_sampling(
     relay = relay_with_processing(options=TEST_CONFIG)
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "organizations:indexed-spans-extraction",
-    ]
     project_config["config"]["transactionMetrics"] = {
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
@@ -339,9 +333,6 @@ def test_duplicate_performance_score(mini_sentry, relay):
     relay = relay(mini_sentry, options=TEST_CONFIG)
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "organizations:indexed-spans-extraction",
-    ]
     project_config["config"]["transactionMetrics"] = {
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
@@ -1208,9 +1199,6 @@ def test_rate_limit_consistent_extracted(
     project_config["config"]["transactionMetrics"] = {
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION
     }
-    project_config["config"]["features"] = [
-        "organizations:indexed-spans-extraction",
-    ]
     project_config["config"]["quotas"] = [
         {
             "categories": [category],
@@ -1356,7 +1344,6 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["features"] = [
         "organizations:standalone-span-ingestion",
-        "organizations:indexed-spans-extraction",
     ]
     project_config["config"]["quotas"] = [
         {
@@ -1636,9 +1623,6 @@ def test_scrubs_ip_addresses(
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "organizations:indexed-spans-extraction",
-    ]
     project_config["config"].setdefault("datascrubbingSettings", {})[
         "scrubIpAddresses"
     ] = scrub_ip_addresses

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -55,6 +55,7 @@ def test_span_extraction(
         "version": TRANSACTION_EXTRACT_MIN_SUPPORTED_VERSION,
     }
 
+    project_config["config"].setdefault("features", [])
     if discard_transaction:
         project_config["config"]["features"].append("projects:discard-transaction")
     if performance_issues_spans:


### PR DESCRIPTION
See also: https://github.com/getsentry/getsentry/pull/18704#discussion_r2471861724
Implements: https://linear.app/getsentry/issue/ENG-5783/enable-span-extraction-for-am1

A longterm path to unifying all plans and to give AM1 feature parity.