### PR TITLE
build(py): Use dynamic version

### DIFF
--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -21,4 +21,4 @@ requireNames:
   - /^sentry_relay-.*-py2\.py3-none-macosx_14_0_arm64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux_2_28_x86_64.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux_2_28_aarch64.*\.whl$/
-  - /^sentry-relay-.*\.tar\.gz$/
+  - /^sentry_relay-.*\.tar\.gz$/

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
 - Introduces a project scope sampling rule type. ([#5077](https://github.com/getsentry/relay/pull/5077))
 - Add InstallableBuild and SizeAnalysis data categories. ([#5084](https://github.com/getsentry/relay/pull/5084))

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,9 +1,13 @@
 [project]
 name = "sentry_relay"
-# see setup.py for versioning; we only have this here to make uv happy
-# which we intend to use for dependency management, not packaging
-version = "0.0.0"
 
 # note: we're using legacy setup.py for building, but the mere presence
 # of this file will have setuptools trying to use it
-dynamic = ["authors", "dependencies", "description", "license", "requires-python"]
+dynamic = [
+    "authors",
+    "dependencies",
+    "description",
+    "license",
+    "requires-python",
+    "version",
+]


### PR DESCRIPTION
The python library release is failing: https://github.com/getsentry/publish/actions/runs/18933411793/job/54054586968

```
[info] Available artifacts: 
┌────────────────────────────────────────────────────────────┬──────────┬─────────┬─────────────┐
│ File Name                                                  │ Size     │ Updated │ ContentType │
├────────────────────────────────────────────────────────────┼──────────┼─────────┼─────────────┤
│ sentry_relay-0.0.0-py2.py3-none-macosx_13_0_x86_64.whl     │ 7.13 MB  │         │             │
├────────────────────────────────────────────────────────────┼──────────┼─────────┼─────────────┤
│ sentry_relay-0.0.0-py2.py3-none-macosx_14_0_arm64.whl      │ 6.50 MB  │         │             │
├────────────────────────────────────────────────────────────┼──────────┼─────────┼─────────────┤
│ sentry_relay-0.0.0-py2.py3-none-manylinux_2_28_aarch64.whl │ 6.57 MB  │         │             │
├────────────────────────────────────────────────────────────┼──────────┼─────────┼─────────────┤
│ sentry_relay-0.0.0-py2.py3-none-manylinux_2_28_x86_64.whl  │ 7.20 MB  │         │             │
├────────────────────────────────────────────────────────────┼──────────┼─────────┼─────────────┤
│ sentry_relay-0.0.0.tar.gz                                  │ 16.25 MB │         │             │
└────────────────────────────────────────────────────────────┴──────────┴─────────┴─────────────┘

Error:  No matching artifact found for the required pattern: /^sentry-relay-.*\.tar\.gz$/
```

This PR:

1. Marks `"version"` as dynamic in pyproject.toml so it is taken from `setup.py`,
2. Changes the search pattern to an underscore so the tar archive can be found.

Local output:

```shell
$ python setup.py sdist
$ ls dist
sentry_relay-0.9.17.tar.gz
```