### PR TITLE
ref: Remove some methods from `Attributes`

### DIFF
--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -25,7 +25,7 @@ pub fn normalize_attribute_types(attributes: &mut Annotated<Attributes>) {
         return;
     };
 
-    let attributes = attributes.iter_mut().map(|(_, attr)| attr);
+    let attributes = attributes.0.values_mut();
     for attribute in attributes {
         use AttributeType::*;
 
@@ -185,7 +185,7 @@ fn normalize_attribute_names_inner(
         return;
     };
 
-    let attribute_names: Vec<_> = attributes.keys().cloned().collect();
+    let attribute_names: Vec<_> = attributes.0.keys().cloned().collect();
 
     for name in attribute_names {
         let Some(attribute_info) = attribute_info(&name) else {
@@ -195,7 +195,7 @@ fn normalize_attribute_names_inner(
         match attribute_info.write_behavior {
             WriteBehavior::CurrentName => continue,
             WriteBehavior::NewName(new_name) => {
-                let Some(old_attribute) = attributes.get_raw_mut(&name) else {
+                let Some(old_attribute) = attributes.0.get_mut(&name) else {
                     continue;
                 };
 
@@ -205,14 +205,14 @@ fn normalize_attribute_names_inner(
                 let new_attribute = std::mem::replace(old_attribute, Annotated(None, meta));
 
                 if !attributes.contains_key(new_name) {
-                    attributes.insert_raw(new_name.to_owned(), new_attribute);
+                    attributes.0.insert(new_name.to_owned(), new_attribute);
                 }
             }
             WriteBehavior::BothNames(new_name) => {
                 if !attributes.contains_key(new_name)
-                    && let Some(current_attribute) = attributes.get_raw(&name).cloned()
+                    && let Some(current_attribute) = attributes.0.get(&name).cloned()
                 {
-                    attributes.insert_raw(new_name.to_owned(), current_attribute);
+                    attributes.0.insert(new_name.to_owned(), current_attribute);
                 }
             }
         }

--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -236,24 +236,6 @@ impl Attributes {
         Some(&self.0.get(key)?.value()?.value.value)
     }
 
-    /// Returns the annotated attribute with the given key.
-    pub fn get_raw<Q>(&self, key: &Q) -> Option<&Annotated<Attribute>>
-    where
-        String: Borrow<Q>,
-        Q: Ord + ?Sized,
-    {
-        self.0.get(key)
-    }
-
-    /// Mutably returns the annotated attribute with the given key.
-    pub fn get_raw_mut<Q>(&mut self, key: &Q) -> Option<&mut Annotated<Attribute>>
-    where
-        String: Borrow<Q>,
-        Q: Ord + ?Sized,
-    {
-        self.0.get_mut(key)
-    }
-
     /// Inserts an attribute with the given value into this collection.
     pub fn insert<K: Into<String>, V: Into<AttributeValue>>(&mut self, key: K, value: V) {
         fn inner(slf: &mut Attributes, key: String, value: AttributeValue) {
@@ -261,7 +243,7 @@ impl Attributes {
                 value,
                 other: Default::default(),
             });
-            slf.insert_raw(key, attribute);
+            slf.0.insert(key, attribute);
         }
         let value = value.into();
         if !value.value.is_empty() {
@@ -280,11 +262,6 @@ impl Attributes {
         }
     }
 
-    /// Inserts an annotated attribute into this collection.
-    pub fn insert_raw(&mut self, key: String, attribute: Annotated<Attribute>) {
-        self.0.insert(key, attribute);
-    }
-
     /// Checks whether this collection contains an attribute with the given key.
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
@@ -301,31 +278,6 @@ impl Attributes {
         Q: Ord + ?Sized,
     {
         self.0.remove(key)
-    }
-
-    /// Iterates over this collection's attribute keys and values.
-    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, Annotated<Attribute>> {
-        self.0.iter()
-    }
-
-    /// Iterates mutably over this collection's attribute keys and values.
-    pub fn iter_mut(
-        &mut self,
-    ) -> std::collections::btree_map::IterMut<'_, String, Annotated<Attribute>> {
-        self.0.iter_mut()
-    }
-
-    /// Returns an iterator over the keys in this collection.
-    pub fn keys(&self) -> std::collections::btree_map::Keys<'_, String, Annotated<Attribute>> {
-        self.0.keys()
-    }
-
-    /// Provides mutable access to an entry in this collection.
-    pub fn entry(
-        &mut self,
-        key: String,
-    ) -> std::collections::btree_map::Entry<'_, String, Annotated<Attribute>> {
-        self.0.entry(key)
     }
 }
 

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -107,7 +107,7 @@ pub fn otel_scope_into_attributes(
             .and_then(otel_value_to_attribute)
         {
             let key = format!("resource.{}", attribute.key);
-            attributes.insert_raw(key, Annotated::new(attr));
+            attributes.0.insert(key, Annotated::new(attr));
         }
     }
 
@@ -119,7 +119,7 @@ pub fn otel_scope_into_attributes(
             .and_then(otel_value_to_attribute)
         {
             let key = format!("instrumentation.{}", attribute.key);
-            attributes.insert_raw(key, Annotated::new(attr));
+            attributes.0.insert(key, Annotated::new(attr));
         }
     }
 

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -85,7 +85,7 @@ pub fn otel_to_sentry_log(
             .and_then(|v| v.value)
             .and_then(otel_value_to_attribute)
         {
-            attribute_data.insert_raw(attribute.key, Annotated::new(attr));
+            attribute_data.0.insert(attribute.key, Annotated::new(attr));
         }
     }
 

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -284,11 +284,11 @@ mod tests {
                 .add_error(MetaError::expected("something in the body"));
 
             let attributes = get_mut!(log.attributes);
-            attributes.insert_raw(
+            attributes.0.insert(
                 "attr_meta".to_owned(),
                 Annotated(None, Meta::from_error(MetaError::expected("meow"))),
             );
-            attributes.insert_raw(
+            attributes.0.insert(
                 "value_meta".to_owned(),
                 Annotated::new(Attribute {
                     value: AttributeValue {

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -88,7 +88,7 @@ pub fn otel_to_sentry_span(
         }
 
         if let Some(v) = otel_value_to_attribute(value) {
-            sentry_attributes.insert_raw(key, Annotated::new(v));
+            sentry_attributes.0.insert(key, Annotated::new(v));
         }
     }
 

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -78,12 +78,12 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     if let Some(tags) = tags.into_value() {
         for (key, value) in tags {
             if !attributes.contains_key(&key) {
-                attributes.insert_raw(
+                attributes.0.insert(
                     key,
                     value
                         .map_value(|JsonLenientString(s)| AttributeValue::from(s))
                         .and_then(Attribute::from),
-                )
+                );
             }
         }
     }
@@ -96,7 +96,9 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
                 other => Cow::Owned(format!("sentry.{}", other)),
             };
             if !value.is_empty() && !attributes.contains_key(key.as_ref()) {
-                attributes.insert_raw(key.into_owned(), attribute_from_value(value));
+                attributes
+                    .0
+                    .insert(key.into_owned(), attribute_from_value(value));
             }
         }
     }


### PR DESCRIPTION
This removes some methods from the `Attributes` struct that would only immediately delegate to the corresponding method on the underlying `BTreeMap`. The `BTreeMap` is publicly accessible anyway, so it's not like we're hiding implementation details.

I've left `contains_key` and `remove` in place for now; even though they also only delegate to `BTreeMap` methods, they feel like things you ought to be able to do directly on the `Attributes` type.

Another way to handle this would be to implement `Deref/DerefMut` on `Attributes`, but I'm not sure that's appropriate.