### PR TITLE
build(py): Revert dynamic version, ignore pyproject.toml instead

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,5 +1,8 @@
 [project]
 name = "sentry_relay"
+# see setup.py for versioning; we only have this here to make uv happy
+# which we intend to use for dependency management, not packaging
+version = "0.0.0"
 
 # note: we're using legacy setup.py for building, but the mere presence
 # of this file will have setuptools trying to use it
@@ -9,5 +12,4 @@ dynamic = [
     "description",
     "license",
     "requires-python",
-    "version",
 ]

--- a/py/setup.py
+++ b/py/setup.py
@@ -6,6 +6,7 @@ import shutil
 import zipfile
 import tempfile
 import subprocess
+from contextlib import contextmanager
 from setuptools import setup, find_packages
 from distutils.command.sdist import sdist
 
@@ -43,6 +44,15 @@ class CustomSDist(sdist):
         vendor_rust_deps()
         write_version()
         sdist.run(self)
+
+
+@contextmanager
+def ignore_pyproject(*args, **kwargs):
+    shutil.move("pyproject.toml", "pyproject.toml-bkp")
+    try:
+        yield
+    finally:
+        shutil.move("pyproject.toml-bkp", "pyproject.toml")
 
 
 def build_native(spec):
@@ -99,28 +109,29 @@ def build_native(spec):
     )
 
 
-setup(
-    name="sentry-relay",
-    version=version,
-    packages=find_packages(),
-    author="Sentry",
-    license="FSL-1.0-Apache-2.0",
-    author_email="hello@sentry.io",
-    description="A python library to access sentry relay functionality.",
-    long_description=readme,
-    long_description_content_type="text/markdown",
-    include_package_data=True,
-    package_data={"sentry_relay": ["py.typed", "_lowlevel.pyi"]},
-    zip_safe=False,
-    platforms="any",
-    python_requires=">=3.10",
-    install_requires=["milksnake>=0.1.6"],
-    # Specify transitive dependencies manually that are required for the build because
-    # they are not resolved properly since upgrading to python 3.11 in manylinux.
-    # milksnake -> cffi -> pycparser
-    # milksnake specifies cffi>=1.6.0 as dependency while cffi does not specify a
-    # minimum version for pycparser
-    setup_requires=["milksnake>=0.1.6", "cffi>=1.6.0", "pycparser"],
-    milksnake_tasks=[build_native],
-    cmdclass={"sdist": CustomSDist},  # type: ignore
-)
+with ignore_pyproject():
+    setup(
+        name="sentry-relay",
+        version=version,
+        packages=find_packages(),
+        author="Sentry",
+        license="FSL-1.0-Apache-2.0",
+        author_email="hello@sentry.io",
+        description="A python library to access sentry relay functionality.",
+        long_description=readme,
+        long_description_content_type="text/markdown",
+        include_package_data=True,
+        package_data={"sentry_relay": ["py.typed", "_lowlevel.pyi"]},
+        zip_safe=False,
+        platforms="any",
+        python_requires=">=3.10",
+        install_requires=["milksnake>=0.1.6"],
+        # Specify transitive dependencies manually that are required for the build because
+        # they are not resolved properly since upgrading to python 3.11 in manylinux.
+        # milksnake -> cffi -> pycparser
+        # milksnake specifies cffi>=1.6.0 as dependency while cffi does not specify a
+        # minimum version for pycparser
+        setup_requires=["milksnake>=0.1.6", "cffi>=1.6.0", "pycparser"],
+        milksnake_tasks=[build_native],
+        cmdclass={"sdist": CustomSDist},  # type: ignore
+    )


### PR DESCRIPTION
Partial revert of https://github.com/getsentry/relay/pull/5311: That PR changed the version declared in pyproject.toml to "dynamic". However, this is only valid in metadata version >= 2.2. We write metadata = 2.4, but [setuptools / wheel overrites the version with 2.1](https://github.com/pypa/setuptools/blob/8825a5b948d88b639dd477337b454afec1ae5eee/setuptools/_vendor/wheel/metadata.py#L153).

This leads to a failing pypi upload:

```
twine: Uploading distributions to https://upload.pypi.org/legacy/
twine: ERROR    InvalidDistribution: Invalid distribution metadata: dynamic introduced
twine:          in metadata version 2.2, not 2.1
```

Brute-force solution is to remove pyproject.toml completely when running setup.py.