### PR TITLE
build(py): Remove py/pyproject.toml altogether

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,5 +1,0 @@
-[project]
-name = "sentry_relay"
-# see setup.py for versioning; we only have this here to make uv happy
-# which we intend to use for dependency management, not packaging
-version = "0.0.0"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -3,13 +3,3 @@ name = "sentry_relay"
 # see setup.py for versioning; we only have this here to make uv happy
 # which we intend to use for dependency management, not packaging
 version = "0.0.0"
-
-# note: we're using legacy setup.py for building, but the mere presence
-# of this file will have setuptools trying to use it
-dynamic = [
-    "authors",
-    "dependencies",
-    "description",
-    "license",
-    "requires-python",
-]

--- a/py/setup.py
+++ b/py/setup.py
@@ -6,7 +6,6 @@ import shutil
 import zipfile
 import tempfile
 import subprocess
-from contextlib import contextmanager
 from setuptools import setup, find_packages
 from distutils.command.sdist import sdist
 
@@ -44,15 +43,6 @@ class CustomSDist(sdist):
         vendor_rust_deps()
         write_version()
         sdist.run(self)
-
-
-@contextmanager
-def ignore_pyproject(*args, **kwargs):
-    shutil.move("pyproject.toml", "pyproject.toml-bkp")
-    try:
-        yield
-    finally:
-        shutil.move("pyproject.toml-bkp", "pyproject.toml")
 
 
 def build_native(spec):
@@ -109,29 +99,28 @@ def build_native(spec):
     )
 
 
-with ignore_pyproject():
-    setup(
-        name="sentry-relay",
-        version=version,
-        packages=find_packages(),
-        author="Sentry",
-        license="FSL-1.0-Apache-2.0",
-        author_email="hello@sentry.io",
-        description="A python library to access sentry relay functionality.",
-        long_description=readme,
-        long_description_content_type="text/markdown",
-        include_package_data=True,
-        package_data={"sentry_relay": ["py.typed", "_lowlevel.pyi"]},
-        zip_safe=False,
-        platforms="any",
-        python_requires=">=3.10",
-        install_requires=["milksnake>=0.1.6"],
-        # Specify transitive dependencies manually that are required for the build because
-        # they are not resolved properly since upgrading to python 3.11 in manylinux.
-        # milksnake -> cffi -> pycparser
-        # milksnake specifies cffi>=1.6.0 as dependency while cffi does not specify a
-        # minimum version for pycparser
-        setup_requires=["milksnake>=0.1.6", "cffi>=1.6.0", "pycparser"],
-        milksnake_tasks=[build_native],
-        cmdclass={"sdist": CustomSDist},  # type: ignore
-    )
+setup(
+    name="sentry-relay",
+    version=version,
+    packages=find_packages(),
+    author="Sentry",
+    license="FSL-1.0-Apache-2.0",
+    author_email="hello@sentry.io",
+    description="A python library to access sentry relay functionality.",
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    include_package_data=True,
+    package_data={"sentry_relay": ["py.typed", "_lowlevel.pyi"]},
+    zip_safe=False,
+    platforms="any",
+    python_requires=">=3.10",
+    install_requires=["milksnake>=0.1.6"],
+    # Specify transitive dependencies manually that are required for the build because
+    # they are not resolved properly since upgrading to python 3.11 in manylinux.
+    # milksnake -> cffi -> pycparser
+    # milksnake specifies cffi>=1.6.0 as dependency while cffi does not specify a
+    # minimum version for pycparser
+    setup_requires=["milksnake>=0.1.6", "cffi>=1.6.0", "pycparser"],
+    milksnake_tasks=[build_native],
+    cmdclass={"sdist": CustomSDist},  # type: ignore
+)


### PR DESCRIPTION
pypi upload is still failing due to "dynamic" in metadata. Remove pyproject.toml altogether.

https://github.com/getsentry/publish/actions/runs/18940642216/job/54078275279#step:12:326