### PR TITLE
ref(buffer): Use tokio watch for observable metrics

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -3,13 +3,3 @@ name = "sentry_relay"
 # see setup.py for versioning; we only have this here to make uv happy
 # which we intend to use for dependency management, not packaging
 version = "0.0.0"
-
-# note: we're using legacy setup.py for building, but the mere presence
-# of this file will have setuptools trying to use it
-dynamic = [
-    "authors",
-    "dependencies",
-    "description",
-    "license",
-    "requires-python",
-]


### PR DESCRIPTION
Use a tokio watch channel to communicate envelope buffer metrics.

This way, tests do not have to rely on flaky sleep timeouts to check the value of the metrics. A tokio watch might be less performant than an Atomic and has the theoretical possibility of deadlocking, but I believe it is sufficient for our use case.

Fixes RELAY-168.