### PR TITLE
feat(tracemetrics): Allow sample rate attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Increase the default size limit for attachments to 200MiB. ([#5310](https://github.com/getsentry/relay/pull/5310))
 - Add `sentry.origin` attribute to OTLP spans. ([#5294](https://github.com/getsentry/relay/pull/5294))
 - Normalize deprecated attribute names according to `sentry-conventions` for logs and V2 spans. ([#5257](https://github.com/getsentry/relay/pull/5257))
+- Allow sample rate per trace metric ([#5317](https://github.com/getsentry/relay/pull/5317))
 
 **Breaking Changes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Increase the default size limit for attachments to 200MiB. ([#5310](https://github.com/getsentry/relay/pull/5310))
 - Add `sentry.origin` attribute to OTLP spans. ([#5294](https://github.com/getsentry/relay/pull/5294))
 - Normalize deprecated attribute names according to `sentry-conventions` for logs and V2 spans. ([#5257](https://github.com/getsentry/relay/pull/5257))
-- Allow sample rate per trace metric ([#5317](https://github.com/getsentry/relay/pull/5317))
+- Allow sample rate per trace metric. ([#5317](https://github.com/getsentry/relay/pull/5317))
 
 **Breaking Changes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
  "relay-cogs",
  "relay-common",
  "relay-config",
+ "relay-conventions",
  "relay-dynamic-config",
  "relay-event-normalization",
  "relay-event-schema",

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -47,6 +47,7 @@ convention_attributes!(
     USER_GEO_REGION => "user.geo.region",
     USER_GEO_SUBDIVISION => "user.geo.subdivision",
     USER_AGENT_ORIGINAL => "user_agent.original",
+    CLIENT_SAMPLE_RATE => "sentry.client_sample_rate",
 );
 
 /// Attributes which are in use by Relay but are not yet defined in the Sentry conventions.

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -86,6 +86,7 @@ relay-protocol = { workspace = true }
 relay-quotas = { workspace = true }
 relay-redis = { workspace = true }
 relay-replays = { workspace = true }
+relay-conventions = { workspace = true }
 relay-sampling = { workspace = true }
 relay-spans = { workspace = true }
 relay-statsd = { workspace = true }

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -226,7 +226,9 @@ mod tests {
 
     use relay_base_schema::organization::OrganizationId;
     use relay_base_schema::project::ProjectId;
+    use relay_event_schema::protocol::{Attribute, AttributeType, AttributeValue};
     use relay_protocol::FromValue;
+    use relay_protocol::Object;
 
     use super::*;
 
@@ -292,10 +294,6 @@ mod tests {
 
     #[test]
     fn test_extract_client_sample_rate_function() {
-        use relay_event_schema::protocol::{Attribute, AttributeType, AttributeValue};
-        use relay_protocol::Object;
-        use std::collections::BTreeMap;
-
         let mut attrs_map = BTreeMap::new();
         let attr = Attribute {
             value: AttributeValue {

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -14,6 +14,7 @@ use crate::processing::utils::store::{AttributeMeta, extract_meta_attributes};
 use crate::processing::{Counted, Retention};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreTraceItem;
+use relay_conventions::CLIENT_SAMPLE_RATE;
 
 macro_rules! required {
     ($value:expr) => {{
@@ -56,6 +57,8 @@ pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTr
         span_id: metric.span_id.into_value(),
     };
 
+    let client_sample_rate = extract_client_sample_rate(&attrs).unwrap_or(1.0);
+
     let trace_item = TraceItem {
         item_type: TraceItemType::Metric.into(),
         organization_id: ctx.scoping.organization_id.value(),
@@ -67,7 +70,7 @@ pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTr
         trace_id: required!(metric.trace_id).to_string(),
         item_id: Uuid::new_v7(timestamp.into()).as_bytes().to_vec(),
         attributes: attributes(meta, attrs, fields),
-        client_sample_rate: 1.0,
+        client_sample_rate,
         server_sample_rate: 1.0,
     };
 
@@ -99,6 +102,13 @@ fn extract_numeric_value(value: Value) -> Result<f64> {
         Value::U64(v) => Ok(v as f64),
         _ => Err(Error::Invalid(DiscardReason::InvalidTraceMetric)),
     }
+}
+
+fn extract_client_sample_rate(attributes: &Attributes) -> Option<f64> {
+    attributes
+        .get_value(CLIENT_SAMPLE_RATE)
+        .and_then(|value| value.as_f64())
+        .filter(|v| (0.0..=1.0).contains(v))
 }
 
 fn attributes(
@@ -277,5 +287,45 @@ mod tests {
         assert!(attributes.contains_key("sentry.value"));
         assert!(attributes.contains_key("http.method"));
         assert!(attributes.contains_key("http.status_code"));
+    }
+
+    #[test]
+    fn test_extract_client_sample_rate_function() {
+        use relay_event_schema::protocol::{Attribute, AttributeType, AttributeValue};
+        use relay_protocol::Object;
+        use std::collections::BTreeMap;
+
+        let mut attrs_map = BTreeMap::new();
+        let attr = Attribute {
+            value: AttributeValue {
+                ty: Annotated::new(AttributeType::Double),
+                value: Annotated::new(Value::F64(0.5)),
+            },
+            other: Object::new(),
+        };
+        attrs_map.insert("sentry.client_sample_rate".to_owned(), Annotated::new(attr));
+        let attrs = Attributes(attrs_map);
+
+        let sample_rate = extract_client_sample_rate(&attrs);
+        assert_eq!(sample_rate, Some(0.5));
+
+        // Without sample rate attribute
+        let empty_attrs = Attributes(BTreeMap::new());
+        let default_rate = extract_client_sample_rate(&empty_attrs);
+        assert_eq!(default_rate, None);
+
+        // Invalid sample rate
+        let invalid_attrs = Attributes(BTreeMap::from([(
+            "sentry.client_sample_rate".to_owned(),
+            Annotated::new(Attribute {
+                value: AttributeValue {
+                    ty: Annotated::new(AttributeType::Double),
+                    value: Annotated::new(Value::F64(2.0)),
+                },
+                other: Object::new(),
+            }),
+        )]));
+        let invalid_rate = extract_client_sample_rate(&invalid_attrs);
+        assert_eq!(invalid_rate, None);
     }
 }

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -108,7 +108,8 @@ fn extract_client_sample_rate(attributes: &Attributes) -> Option<f64> {
     attributes
         .get_value(CLIENT_SAMPLE_RATE)
         .and_then(|value| value.as_f64())
-        .filter(|v| (0.0..=1.0).contains(v))
+        .filter(|v| v > 0.0)
+        .filter(|v| v <= 1.0)        
 }
 
 fn attributes(

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use prost_types::Timestamp;
+use relay_conventions::CLIENT_SAMPLE_RATE;
 use relay_event_schema::protocol::{Attributes, MetricType, SpanId, TraceMetric};
 use relay_protocol::{Annotated, IntoValue, Value};
 use relay_quotas::Scoping;
@@ -14,7 +15,6 @@ use crate::processing::utils::store::{AttributeMeta, extract_meta_attributes};
 use crate::processing::{Counted, Retention};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreTraceItem;
-use relay_conventions::CLIENT_SAMPLE_RATE;
 
 macro_rules! required {
     ($value:expr) => {{
@@ -108,8 +108,8 @@ fn extract_client_sample_rate(attributes: &Attributes) -> Option<f64> {
     attributes
         .get_value(CLIENT_SAMPLE_RATE)
         .and_then(|value| value.as_f64())
-        .filter(|v| v > 0.0)
-        .filter(|v| v <= 1.0)        
+        .filter(|v| *v > 0.0)
+        .filter(|v| *v <= 1.0)
 }
 
 fn attributes(

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -58,6 +58,7 @@ def test_trace_metric_extraction(
         "attributes": {
             "http.method": {"value": "GET", "type": "string"},
             "http.status_code": {"value": 200, "type": "integer"},
+            "sentry.client_sample_rate": {"value": 0.25, "type": "double"},
         },
     }
 
@@ -87,6 +88,7 @@ def test_trace_metric_extraction(
                 )
             },
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
+            "sentry.client_sample_rate": {"doubleValue": 0.25},
             "sentry.browser.name": {"stringValue": mock.ANY},
             "sentry.browser.version": {"stringValue": mock.ANY},
             "http.method": {"stringValue": "GET"},
@@ -96,7 +98,7 @@ def test_trace_metric_extraction(
             },
             "sentry._internal.cooccuring.type.distribution": {"boolValue": True},
         },
-        "clientSampleRate": 1.0,
+        "clientSampleRate": 0.25,
         "downsampledRetentionDays": 390,
         "itemId": mock.ANY,
         "itemType": "TRACE_ITEM_TYPE_METRIC",


### PR DESCRIPTION
### Summary
Allows a client sample rate to be set which will set the sample rate to kafka (which then is calculated for extrapolated values).


