### PR TITLE
docs: Rust 1.91

### DIFF
--- a/relay-cabi/src/lib.rs
+++ b/relay-cabi/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```
 //!
 //! If your machine already has `cbindgen` installed, check the header of
-//! [`include/relay.h`] for the minimum version required. This can be verified by
+//! `include/relay.h` for the minimum version required. This can be verified by
 //! running `cbindgen --version`. It is generally advisable to keep `cbindgen`
 //! updated to its latest version, and always check in cbindgen updates separate
 //! from changes to the public interface.

--- a/relay-sampling/src/redis_sampling.rs
+++ b/relay-sampling/src/redis_sampling.rs
@@ -18,7 +18,7 @@ impl ReservoirRuleKey {
 
 /// Increments the reservoir count for a given rule in redis.
 ///
-/// - INCR docs: [`https://redis.io/commands/incr/`]
+/// - INCR docs: <https://redis.io/commands/incr/>.
 /// - If the counter doesn't exist in redis, a new one will be inserted.
 pub async fn increment_redis_reservoir_count(
     connection: &mut AsyncRedisConnection,

--- a/relay-server/src/extractors/forwarded_for.rs
+++ b/relay-server/src/extractors/forwarded_for.rs
@@ -9,7 +9,7 @@ use axum::http::request::Parts;
 pub struct ForwardedFor(String);
 
 impl ForwardedFor {
-    /// The defacto standard header for identifying the originating IP address of a client, [`X-Forwarded-For`].
+    /// The defacto standard header for identifying the originating IP address of a client, `X-Forwarded-For`.
     ///
     /// [`X-Forwarded-For`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
     const FORWARDED_HEADER: &'static str = "X-Forwarded-For";
@@ -20,11 +20,11 @@ impl ForwardedFor {
     ///
     /// The Sentry SaaS infrastructure sets this header.
     const SENTRY_FORWARDED_HEADER: &'static str = "X-Sentry-Forwarded-For";
-    /// Vercel forwards the client ip in its own [`X-Vercel-Forwarded-For`] header.
+    /// Vercel forwards the client ip in its own `X-Vercel-Forwarded-For` header.
     ///
     /// [`X-Vercel-Forwarded-For`](https://vercel.com/docs/concepts/edge-network/headers#x-vercel-forwarded-for)
     const VERCEL_FORWARDED_HEADER: &'static str = "X-Vercel-Forwarded-For";
-    /// Cloudflare forwards the client ip in its own [`CF-Connecting-IP`] header.
+    /// Cloudflare forwards the client ip in its own `CF-Connecting-IP` header.
     ///
     /// [`CF-Connecting-IP`](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip)
     const CLOUDFLARE_FORWARDED_HEADER: &'static str = "CF-Connecting-IP";

--- a/relay-server/src/utils/param_parser.rs
+++ b/relay-server/src/utils/param_parser.rs
@@ -84,7 +84,7 @@ fn get_indexes(full_string: &str) -> Result<Vec<&str>, ()> {
     Ok(ret_vals)
 }
 
-/// Extracts indexes from a param of the form 'sentry[XXX][...]'
+/// Extracts indexes from a param of the form `sentry[XXX][...]`.
 pub fn get_sentry_entry_indexes(param_name: &str) -> Option<Vec<&str>> {
     if param_name.starts_with("sentry[") {
         get_indexes(param_name).ok()

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -32,4 +32,3 @@ relay-kafka = { workspace = true, optional = true }
 uuid = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "native-tls-vendored"] }
 mimalloc = { workspace = true, features = ["v3", "override", "debug_in_debug"] }
-

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -38,7 +38,7 @@
 //!  - [`relay-cogs`]: Break down the cost of Relay by its features.
 //!  - [`relay-common`]: Common utilities and crate re-exports.
 //!  - [`relay-config`]: Static configuration for the CLI and server.
-//!  - [`relay-conventions`]: Attribute definitions extracted from [`sentry-conventions`](https://github.com/getsentry/sentry-conventions).
+//!  - `relay-conventions`: Attribute definitions extracted from [`sentry-conventions`](https://github.com/getsentry/sentry-conventions).
 //!  - [`relay-crash`]: Crash reporting for the Relay server.
 //!  - [`relay-dynamic-config`]: Dynamic configuration passed from Sentry.
 //!  - [`relay-event-derive`]: Derive for visitor traits on the Event schema.
@@ -64,7 +64,6 @@
 //!  - [`relay-statsd`]: High-level StatsD metric client for internal measurements.
 //!  - [`relay-system`]: Foundational system components for Relay's services.
 //!  - [`relay-test`]: Helpers for testing the web server and services.
-//!  - [`relay-threading`]: Threading code that is used by Relay.
 //!  - [`relay-ua`]: User agent parser with built-in rules.
 //!
 //! # Tools


### PR DESCRIPTION
Resolve `cargo doc` complains with rust version 1.91.