### PR TITLE
build(py): Upgrade python to 3.13

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -40,9 +40,9 @@ jobs:
         with:
           name: artifact-linux-${{ matrix.build-arch }}
           path: py/dist/*
-          if-no-files-found: 'error'
+          if-no-files-found: "error"
           # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
+          compression-level: "0"
 
   macos:
     strategy:
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Build Wheel
         run: |
@@ -86,9 +86,9 @@ jobs:
         with:
           name: artifact-macos-${{ matrix.py-platform }}
           path: py/dist/*
-          if-no-files-found: 'error'
+          if-no-files-found: "error"
           # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
+          compression-level: "0"
 
   sdist:
     name: Python sdist
@@ -101,7 +101,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Build sdist
         run: python setup.py sdist
@@ -111,9 +111,9 @@ jobs:
         with:
           name: artifact-sdist
           path: py/dist/*
-          if-no-files-found: 'error'
+          if-no-files-found: "error"
           # since this artifact will be merged, compression is not necessary
-          compression-level: '0'
+          compression-level: "0"
 
   merge:
     name: Create Release Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install Rust Toolchain
         run: |
@@ -216,7 +216,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install Dependencies
         run: pip install -U pytest
@@ -751,7 +751,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - run: make test-integration
         env:

--- a/py/.craft.yml
+++ b/py/.craft.yml
@@ -21,4 +21,4 @@ requireNames:
   - /^sentry_relay-.*-py2\.py3-none-macosx_14_0_arm64.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux_2_28_x86_64.*\.whl$/
   - /^sentry_relay-.*-py2\.py3-none-.*manylinux_2_28_aarch64.*\.whl$/
-  - /^sentry-relay-.*\.tar\.gz$/
+  - /^sentry_relay-.*\.tar\.gz$/

--- a/py/setup.py
+++ b/py/setup.py
@@ -7,7 +7,7 @@ import zipfile
 import tempfile
 import subprocess
 from setuptools import setup, find_packages
-from distutils.command.sdist import sdist
+from distutils.command.sdist import sdist  # type: ignore
 
 
 _version_re = re.compile(r'(?m)^version\s*=\s*"(.*?)"\s*$')


### PR DESCRIPTION
This should solve

```
  twine:          Filename 'sentry-relay-0.9.18.tar.gz' is invalid, should be
  twine:          'sentry_relay-0.9.18.tar.gz'.
  ```