### PR TITLE
build(py): Manually install setuptools

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release-library/**
+      - test-release-library/** # For testing the release build
 
 env:
   CARGO_TERM_COLOR: always
@@ -75,7 +76,7 @@ jobs:
 
       - name: Build Wheel
         run: |
-          pip install wheel
+          pip install setuptools wheel
           python setup.py bdist_wheel -p ${{ matrix.py-platform }}
         working-directory: py
         env:

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -105,7 +105,9 @@ jobs:
           python-version: "3.13"
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: |
+          pip install setuptools wheel
+          python setup.py sdist
         working-directory: py
 
       - uses: actions/upload-artifact@v5

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install setuptools wheel
+          pip install setuptools
           python setup.py sdist
         working-directory: py
 


### PR DESCRIPTION
Necessary for Python 3.13. See https://github.com/getsentry/sentry-kafka-schemas/pull/452.