### PR TITLE
ref(processing): Move extract_transaction_metrics to processing module

### DIFF
--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -10,7 +10,7 @@ use relay_sampling::evaluation::SamplingDecision;
 
 use crate::metrics_extraction::generic::{self, Extractable};
 use crate::metrics_extraction::transactions::ExtractedMetrics;
-use crate::processing::utils::event::extract_transaction_span;
+use crate::processing::utils::transaction::extract_segment_span;
 use crate::statsd::RelayTimers;
 
 impl Extractable for Event {
@@ -81,8 +81,7 @@ fn extract_span_metrics_for_event(
     relay_statsd::metric!(timer(RelayTimers::EventProcessingSpanMetricsExtraction), {
         let mut span_count = 0;
 
-        if let Some(transaction_span) =
-            extract_transaction_span(event, config.max_tag_value_size, &[])
+        if let Some(transaction_span) = extract_segment_span(event, config.max_tag_value_size, &[])
         {
             let metrics = generic::extract_metrics(&transaction_span, config.config);
             output.project_metrics.extend(metrics);

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -12,7 +12,6 @@ use relay_config::Config;
 use relay_config::NormalizationLevel;
 use relay_dynamic_config::Feature;
 use relay_event_normalization::GeoIpLookup;
-use relay_event_normalization::span::tag_extraction;
 use relay_event_normalization::{
     ClockDriftProcessor, normalize_event as normalize_event_inner, validate_event,
 };
@@ -22,7 +21,6 @@ use relay_event_normalization::{
 };
 use relay_event_schema::processor::{self, ProcessingState};
 use relay_event_schema::protocol::IpAddr;
-use relay_event_schema::protocol::Span;
 use relay_event_schema::protocol::{Event, Metrics, OtelContext, RelayInfo};
 use relay_filter::FilterStatKey;
 use relay_metrics::MetricNamespace;
@@ -403,22 +401,6 @@ pub struct EventMetricsExtracted(pub bool);
 /// New type representing whether spans were extracted.
 #[derive(Debug, Copy, Clone)]
 pub struct SpansExtracted(pub bool);
-
-/// Creates a span from the transaction and applies tag extraction on it.
-///
-/// Returns `None` when [`tag_extraction::extract_span_tags`] clears the span, which it shouldn't.
-pub fn extract_transaction_span(
-    event: &Event,
-    max_tag_value_size: usize,
-    span_allowed_hosts: &[String],
-) -> Option<Span> {
-    let mut spans = [Span::from(event).into()];
-
-    tag_extraction::extract_span_tags(event, &mut spans, max_tag_value_size, span_allowed_hosts);
-    tag_extraction::extract_segment_span_tags(event, &mut spans);
-
-    spans.into_iter().next().and_then(Annotated::into_value)
-}
 
 /// Checks if the Event includes unprintable fields.
 fn has_unprintable_fields(event: &Annotated<Event>) -> bool {

--- a/relay-server/src/processing/utils/mod.rs
+++ b/relay-server/src/processing/utils/mod.rs
@@ -2,3 +2,4 @@ pub mod dynamic_sampling;
 pub mod event;
 #[cfg(feature = "processing")]
 pub mod store;
+pub mod transaction;

--- a/relay-server/src/processing/utils/transaction.rs
+++ b/relay-server/src/processing/utils/transaction.rs
@@ -1,0 +1,19 @@
+use relay_event_normalization::span::tag_extraction;
+use relay_event_schema::protocol::{Event, Span};
+use relay_protocol::Annotated;
+
+/// Creates a span from the transaction and applies tag extraction on it.
+///
+/// Returns `None` when [`tag_extraction::extract_span_tags`] clears the span, which it shouldn't.
+pub fn extract_segment_span(
+    event: &Event,
+    max_tag_value_size: usize,
+    span_allowed_hosts: &[String],
+) -> Option<Span> {
+    let mut spans = [Span::from(event).into()];
+
+    tag_extraction::extract_span_tags(event, &mut spans, max_tag_value_size, span_allowed_hosts);
+    tag_extraction::extract_segment_span_tags(event, &mut spans);
+
+    spans.into_iter().next().and_then(Annotated::into_value)
+}

--- a/relay-server/src/processing/utils/transaction.rs
+++ b/relay-server/src/processing/utils/transaction.rs
@@ -1,6 +1,20 @@
+use std::sync::Once;
+
+use relay_base_schema::project::ProjectId;
+use relay_dynamic_config::{
+    CombinedMetricExtractionConfig, ErrorBoundary, Feature, MetricExtractionGroups,
+};
 use relay_event_normalization::span::tag_extraction;
 use relay_event_schema::protocol::{Event, Span};
+use relay_metrics::MetricNamespace;
 use relay_protocol::Annotated;
+use relay_sampling::DynamicSamplingContext;
+use relay_sampling::evaluation::SamplingDecision;
+
+use crate::metrics_extraction::transactions::TransactionExtractor;
+use crate::processing::Context;
+use crate::processing::utils::event::{EventMetricsExtracted, SpansExtracted};
+use crate::services::processor::{ProcessingError, ProcessingExtractedMetrics};
 
 /// Creates a span from the transaction and applies tag extraction on it.
 ///
@@ -16,4 +30,121 @@ pub fn extract_segment_span(
     tag_extraction::extract_segment_span_tags(event, &mut spans);
 
     spans.into_iter().next().and_then(Annotated::into_value)
+}
+
+/// Extract transaction metrics.
+pub fn extract_metrics(
+    dsc: Option<&DynamicSamplingContext>,
+    event: &mut Annotated<Event>,
+    extracted_metrics: &mut ProcessingExtractedMetrics,
+    project_id: ProjectId,
+    ctx: &Context,
+    sampling_decision: SamplingDecision,
+    event_metrics_extracted: EventMetricsExtracted,
+    spans_extracted: SpansExtracted,
+) -> Result<EventMetricsExtracted, ProcessingError> {
+    if event_metrics_extracted.0 {
+        return Ok(event_metrics_extracted);
+    }
+    let Some(event) = event.value_mut() else {
+        return Ok(event_metrics_extracted);
+    };
+
+    // NOTE: This function requires a `metric_extraction` in the project config. Legacy configs
+    // will upsert this configuration from transaction and conditional tagging fields, even if
+    // it is not present in the actual project config payload.
+    let combined_config = {
+        let config = match &ctx.project_info.config.metric_extraction {
+            ErrorBoundary::Ok(config) if config.is_supported() => config,
+            _ => return Ok(event_metrics_extracted),
+        };
+        let global_config = match &ctx.global_config.metric_extraction {
+            ErrorBoundary::Ok(global_config) => global_config,
+            #[allow(unused_variables)]
+            ErrorBoundary::Err(e) => {
+                if cfg!(feature = "processing") && ctx.config.processing_enabled() {
+                    // Config is invalid, but we will try to extract what we can with just the
+                    // project config.
+                    relay_log::error!("Failed to parse global extraction config {e}");
+                    MetricExtractionGroups::EMPTY
+                } else {
+                    // If there's an error with global metrics extraction, it is safe to assume that this
+                    // Relay instance is not up-to-date, and we should skip extraction.
+                    relay_log::debug!("Failed to parse global extraction config: {e}");
+                    return Ok(event_metrics_extracted);
+                }
+            }
+        };
+        CombinedMetricExtractionConfig::new(global_config, config)
+    };
+
+    // Require a valid transaction metrics config.
+    let tx_config = match &ctx.project_info.config.transaction_metrics {
+        Some(ErrorBoundary::Ok(tx_config)) => tx_config,
+        Some(ErrorBoundary::Err(e)) => {
+            relay_log::debug!("Failed to parse legacy transaction metrics config: {e}");
+            return Ok(event_metrics_extracted);
+        }
+        None => {
+            relay_log::debug!("Legacy transaction metrics config is missing");
+            return Ok(event_metrics_extracted);
+        }
+    };
+
+    if !tx_config.is_enabled() {
+        static TX_CONFIG_ERROR: Once = Once::new();
+        TX_CONFIG_ERROR.call_once(|| {
+                if ctx.config.processing_enabled() {
+                    relay_log::error!(
+                        "Processing Relay outdated, received tx config in version {}, which is not supported",
+                        tx_config.version
+                    );
+                }
+            });
+
+        return Ok(event_metrics_extracted);
+    }
+
+    // If spans were already extracted for an event, we rely on span processing to extract metrics.
+    let extract_spans = !spans_extracted.0
+        && crate::utils::sample(
+            ctx.global_config
+                .options
+                .span_extraction_sample_rate
+                .unwrap_or(1.0),
+        )
+        .is_keep();
+
+    let metrics = crate::metrics_extraction::event::extract_metrics(
+        event,
+        crate::metrics_extraction::event::ExtractMetricsConfig {
+            config: combined_config,
+            sampling_decision,
+            target_project_id: project_id,
+            max_tag_value_size: ctx
+                .config
+                .aggregator_config_for(MetricNamespace::Spans)
+                .max_tag_value_length,
+            extract_spans,
+            transaction_from_dsc: dsc.and_then(|dsc| dsc.transaction.as_deref()),
+        },
+    );
+
+    extracted_metrics.extend(metrics, Some(sampling_decision));
+
+    if !ctx.project_info.has_feature(Feature::DiscardTransaction) {
+        let transaction_from_dsc = dsc.and_then(|dsc| dsc.transaction.as_deref());
+
+        let extractor = TransactionExtractor {
+            config: tx_config,
+            generic_config: Some(combined_config),
+            transaction_from_dsc,
+            sampling_decision,
+            target_project_id: project_id,
+        };
+
+        extracted_metrics.extend(extractor.extract(event)?, Some(sampling_decision));
+    }
+
+    Ok(EventMetricsExtracted(true))
 }

--- a/relay-server/src/processing/utils/transaction.rs
+++ b/relay-server/src/processing/utils/transaction.rs
@@ -32,17 +32,31 @@ pub fn extract_segment_span(
     spans.into_iter().next().and_then(Annotated::into_value)
 }
 
+/// Input arguments for [`extract_metrics`].
+pub struct ExtractMetricsContext<'a> {
+    pub dsc: Option<&'a DynamicSamplingContext>,
+    pub project_id: ProjectId,
+    pub ctx: &'a Context<'a>,
+    pub sampling_decision: SamplingDecision,
+    pub event_metrics_extracted: EventMetricsExtracted,
+    pub spans_extracted: SpansExtracted,
+}
+
 /// Extract transaction metrics.
 pub fn extract_metrics(
-    dsc: Option<&DynamicSamplingContext>,
     event: &mut Annotated<Event>,
     extracted_metrics: &mut ProcessingExtractedMetrics,
-    project_id: ProjectId,
-    ctx: &Context,
-    sampling_decision: SamplingDecision,
-    event_metrics_extracted: EventMetricsExtracted,
-    spans_extracted: SpansExtracted,
+    ctx: ExtractMetricsContext,
 ) -> Result<EventMetricsExtracted, ProcessingError> {
+    let ExtractMetricsContext {
+        dsc,
+        project_id,
+        ctx,
+        sampling_decision,
+        event_metrics_extracted,
+        spans_extracted,
+    } = ctx;
+
     if event_metrics_extracted.0 {
         return Ok(event_metrics_extracted);
     }

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -5,7 +5,6 @@ use std::error::Error;
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::managed::{ItemAction, ManagedEnvelope, TypedEnvelope};
 use crate::metrics_extraction::{event, generic};
-use crate::processing::utils::event::extract_transaction_span;
 use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::processor::{
     EventMetricsExtracted, ProcessingError, ProcessingExtractedMetrics, SpanGroup, SpansExtracted,
@@ -383,7 +382,7 @@ pub fn extract_from_event(
         return spans_extracted;
     };
 
-    let Some(transaction_span) = extract_transaction_span(
+    let Some(transaction_span) = processing::utils::transaction::extract_segment_span(
         event,
         config
             .aggregator_config_for(MetricNamespace::Spans)


### PR DESCRIPTION
As in https://github.com/getsentry/relay/pull/5309 and https://github.com/getsentry/relay/pull/5322, move `EnvelopeProcessor::extract_transaction_metrics` to a standalone function in the `processing` module so it can be easily used from a new-style `TransactionsProcessor` in the future.

ref: INGEST-610