### PR TITLE
fix(spans): Fix spanv1 -> spanv2 conversion for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 **Bug Fixes**:
 
+- Fix array attributes not being applied to standalone spans. ([#5337](https://github.com/getsentry/relay/pull/5337))
 - Envelopes created from integrations can now be spooled. ([#5284](https://github.com/getsentry/relay/pull/5284))
 - Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))
 - Fix potentially missing attachment outcomes when rate limiting. ([#5301](https://github.com/getsentry/relay/pull/5301))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ dependencies = [
  "relay-event-schema",
  "relay-otel",
  "relay-protocol",
+ "serde",
  "serde_json",
  "url",
 ]

--- a/relay-spans/Cargo.toml
+++ b/relay-spans/Cargo.toml
@@ -25,6 +25,7 @@ relay-event-schema = { workspace = true }
 relay-otel = { workspace = true }
 relay-protocol = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Arrays didn't work. Now they do.

Happy to bikeshed on naming, I just put it into the conversion code because I don't think this is something that should be used elsewhere in Relay.