### PR TITLE
feat(redis): Add counter for commands run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,6 +4275,7 @@ dependencies = [
  "deadpool-redis",
  "futures",
  "redis",
+ "relay-statsd",
  "relay-system",
  "serde",
  "thiserror 2.0.17",

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -30,8 +30,9 @@ serde = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 thiserror = { workspace = true }
 
+relay-statsd = { workspace = true, optional = true }
 relay-system = { workspace = true }
 
 [features]
 default = []
-impl = ["dep:deadpool", "dep:deadpool-redis", "dep:redis"]
+impl = ["dep:deadpool", "dep:deadpool-redis", "dep:relay-statsd", "dep:redis"]

--- a/relay-redis/src/lib.rs
+++ b/relay-redis/src/lib.rs
@@ -25,6 +25,9 @@ mod scripts;
 #[cfg(feature = "impl")]
 pub use self::scripts::*;
 
+#[cfg(feature = "impl")]
+mod statsd;
+
 #[cfg(not(feature = "impl"))]
 mod noop;
 

--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -5,7 +5,6 @@ use futures::FutureExt;
 use std::ops::{Deref, DerefMut};
 
 use crate::redis;
-use crate::redis;
 use crate::redis::aio::MultiplexedConnection;
 use crate::redis::cluster_async::ClusterConnection;
 use crate::redis::{

--- a/relay-redis/src/statsd.rs
+++ b/relay-redis/src/statsd.rs
@@ -1,0 +1,17 @@
+use relay_statsd::CounterMetric;
+
+pub enum RedisCounters {
+    /// Incremented every time a Redis command or pipeline is run.
+    ///
+    /// This metric is tagged with:
+    /// - `result`: The outcome (`ok`, `error`, `timeout`).
+    CommandExecuted,
+}
+
+impl CounterMetric for RedisCounters {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::CommandExecuted => "redis.command_executed",
+        }
+    }
+}


### PR DESCRIPTION
This adds a counter for Redis commands run that is automatically emitted by our `TrackedConnection`.

Questions:
* Should this counter differentiate between individual commands and pipelines?
* Should we count the individual commands in a pipeline? My instinct is no, because we ultimately want to know how many requests to Redis succeeded/failed and not how many commands were in those requests.
* Is the naming acceptable? It was somewhat off the cuff.