### PR TITLE
feat(profiles): Drop transaction profile context if rate limited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `sentry.origin` attribute to OTLP spans. ([#5294](https://github.com/getsentry/relay/pull/5294))
 - Normalize deprecated attribute names according to `sentry-conventions` for logs and V2 spans. ([#5257](https://github.com/getsentry/relay/pull/5257))
 - Allow sample rate per trace metric. ([#5317](https://github.com/getsentry/relay/pull/5317))
+- Remove the profile context from transactions if profiles are currently rate limited. ([#5346](https://github.com/getsentry/relay/pull/5346))
 - Replace `is_remote` with `is_segment` on the Span V2 schema. ([#5306](https://github.com/getsentry/relay/pull/5306))
 
 **Breaking Changes**:

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1451,6 +1451,7 @@ impl EnvelopeProcessorService {
             ctx.project_info,
         );
         profile::transfer_id(&mut event, profile_id);
+        profile::remove_context_if_rate_limited(&mut event, managed_envelope, ctx);
 
         ctx.sampling_project_info = dynamic_sampling::validate_and_set_dsc(
             managed_envelope,

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -119,7 +119,7 @@ pub fn remove_context_if_rate_limited(
     // to handle here.
     // If it is empty -> do nothing.
     let profile_ctx = event.context::<ProfileContext>();
-    if profile_ctx.is_some_and(|pctx| pctx.profiler_id.is_empty()) {
+    if profile_ctx.is_none_or(|pctx| pctx.profiler_id.is_empty() || !pctx.profile_id.is_empty()) {
         return;
     }
 

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -119,7 +119,7 @@ pub fn remove_context_if_rate_limited(
     // to handle here.
     // If it is empty -> do nothing.
     let profile_ctx = event.context::<ProfileContext>();
-    if profile_ctx.is_none_or(|pctx| pctx.profiler_id.is_empty() || !pctx.profile_id.is_empty()) {
+    if profile_ctx.is_none_or(|pctx| pctx.profiler_id.is_empty()) {
         return;
     }
 

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -113,22 +113,6 @@ pub fn remove_context_if_rate_limited(
         return;
     };
 
-    let contains_profile = envelope
-        .envelope()
-        .items()
-        .any(|item| matches!(*item.ty(), ItemType::ProfileChunk | ItemType::Profile));
-
-    // If the envelope for any reason does still contain a profile, we keep the context alive.
-    //
-    // In most cases this should not happen and a profile is already dropped as the passed limits
-    // have already been enforced.
-    //
-    // It's still possible that we have a rate limit in the `profile_chunk` category but not in the
-    // `profile` category, in which case we definitely want to keep the context.
-    if contains_profile {
-        return;
-    }
-
     // There is always only either a transaction profile or a continuous profile, never both.
     //
     // If the `profiler_id` is set on the context, it is for a continuous profile, the case we want

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -319,15 +319,19 @@ def test_profile_chunk_outcomes_rate_limited_fast(
     "platform, category, filter_context",
     [
         ("cocoa", "profile_chunk_ui", True),
+        ("cocoa", "profile_duration_ui", True),
         ("cocoa", "profile_chunk", False),
+        ("cocoa", "profile_duration", False),
         ("node", "profile_chunk", True),
+        ("node", "profile_duration", True),
         ("node", "profile_chunk_ui", False),
+        ("node", "profile_duration_ui", False),
     ],
 )
 def test_profile_chunk_limited_transaction_context_removed(
     mini_sentry,
     relay,
-    platform, 
+    platform,
     category,
     filter_context,
 ):

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from pathlib import Path
 from datetime import datetime, timezone
 
-from _pytest.config import filter_traceback_for_conftest_import_failure
 import pytest
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
@@ -349,7 +348,7 @@ def test_profile_chunk_limited_transaction_context_removed(
 
     project_config["config"]["quotas"] = [
         {
-            "id": f"test_rate_limiting",
+            "id": "test_rate_limiting",
             "categories": [category],
             "limit": 0,
             "reasonCode": "profile_chunks_exceeded",


### PR DESCRIPTION
Closes: #5071
Closes: RELAY-150

See linked issue for details, when the context should be dropped.

The entire thing is best effort (rate limits permanently change and the entire operation is order dependent), so checking cached rate limits should suffice.

Open questions: The issue mentions `profile chunks` but what about not chunked profiles? I tried to handle this (somewhat) by not checking the rate limit category for profiles and by skipping the removal if there is a profile in the same envelope.