### PR TITLE
ref(redis): Tag connections with client name

### DIFF
--- a/relay-cardinality/benches/redis_impl.rs
+++ b/relay-cardinality/benches/redis_impl.rs
@@ -21,7 +21,7 @@ fn build_redis_client() -> AsyncRedisClient {
     let url =
         std::env::var("RELAY_REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_owned());
 
-    AsyncRedisClient::single(&url, &RedisConfigOptions::default()).unwrap()
+    AsyncRedisClient::single("bench", &url, &RedisConfigOptions::default()).unwrap()
 }
 
 async fn build_limiter(client: AsyncRedisClient, reset_redis: bool) -> RedisSetLimiter {

--- a/relay-cardinality/src/redis/limiter.rs
+++ b/relay-cardinality/src/redis/limiter.rs
@@ -290,7 +290,7 @@ mod tests {
             max_connections: 1,
             ..Default::default()
         };
-        let redis = AsyncRedisClient::single(&url, &opts).unwrap();
+        let redis = AsyncRedisClient::single("test", &url, &opts).unwrap();
 
         RedisSetLimiter::new(
             RedisSetLimiterOptions {

--- a/relay-cardinality/src/redis/script.rs
+++ b/relay-cardinality/src/redis/script.rs
@@ -226,7 +226,7 @@ mod tests {
             max_connections: 1,
             ..Default::default()
         };
-        AsyncRedisClient::single(&url, &opts).unwrap()
+        AsyncRedisClient::single("test", &url, &opts).unwrap()
     }
 
     fn keys(prefix: Uuid, keys: &[&str]) -> impl Iterator<Item = String> {

--- a/relay-quotas/src/global.rs
+++ b/relay-quotas/src/global.rs
@@ -297,7 +297,7 @@ mod tests {
         let url = std::env::var("RELAY_REDIS_URL")
             .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_owned());
 
-        AsyncRedisClient::single(&url, &RedisConfigOptions::default()).unwrap()
+        AsyncRedisClient::single("test", &url, &RedisConfigOptions::default()).unwrap()
     }
 
     fn build_quota(window: u64, limit: impl Into<Option<u64>>) -> Quota {

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -411,7 +411,8 @@ mod tests {
     fn build_rate_limiter() -> RedisRateLimiter<MockGlobalLimiter> {
         let url = std::env::var("RELAY_REDIS_URL")
             .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_owned());
-        let client = AsyncRedisClient::single(&url, &RedisConfigOptions::default()).unwrap();
+        let client =
+            AsyncRedisClient::single("test", &url, &RedisConfigOptions::default()).unwrap();
 
         let global_limiter = MockGlobalLimiter {
             client: client.clone(),

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -90,6 +90,7 @@ impl AsyncRedisClient {
     /// The client uses a custom cluster manager that implements a specific connection recycling
     /// strategy, ensuring optimal performance and reliability in cluster environments.
     pub fn cluster<'a>(
+        name: &'static str,
         servers: impl IntoIterator<Item = &'a str>,
         opts: &RedisConfigOptions,
     ) -> Result<Self, RedisError> {
@@ -100,7 +101,7 @@ impl AsyncRedisClient {
 
         // We use our custom cluster manager which performs recycling in a different way from the
         // default manager.
-        let manager = pool::CustomClusterManager::new(servers, false, opts.clone())
+        let manager = pool::CustomClusterManager::new(name, servers, false, opts.clone())
             .map_err(RedisError::Redis)?;
 
         let pool = Self::build_pool(manager, opts)?;
@@ -115,11 +116,15 @@ impl AsyncRedisClient {
     ///
     /// The client uses a custom single manager that implements a specific connection recycling
     /// strategy, ensuring optimal performance and reliability in single-instance environments.
-    pub fn single(server: &str, opts: &RedisConfigOptions) -> Result<Self, RedisError> {
+    pub fn single(
+        name: &'static str,
+        server: &str,
+        opts: &RedisConfigOptions,
+    ) -> Result<Self, RedisError> {
         // We use our custom single manager which performs recycling in a different way from the
         // default manager.
-        let manager =
-            pool::CustomSingleManager::new(server, opts.clone()).map_err(RedisError::Redis)?;
+        let manager = pool::CustomSingleManager::new(name, server, opts.clone())
+            .map_err(RedisError::Redis)?;
 
         let pool = Self::build_pool(manager, opts)?;
 

--- a/relay-redis/src/statsd.rs
+++ b/relay-redis/src/statsd.rs
@@ -5,6 +5,7 @@ pub enum RedisCounters {
     ///
     /// This metric is tagged with:
     /// - `result`: The outcome (`ok`, `error`, `timeout`).
+    /// - `client`: The name of the Redis client sending the command.
     CommandExecuted,
 }
 

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -441,9 +441,14 @@ impl ServiceState {
 /// is created for each use case.
 #[cfg(feature = "processing")]
 pub fn create_redis_clients(configs: RedisConfigsRef<'_>) -> Result<RedisClients, RedisError> {
+    const CARDINALITY_REDIS_CLIENT: &str = "cardinality";
+    const PROJECT_CONFIG_REDIS_CLIENT: &str = "projectconfig";
+    const QUOTA_REDIS_CLIENT: &str = "quotas";
+    const UNIFIED_REDIS_CLIENT: &str = "unified";
+
     match configs {
         RedisConfigsRef::Unified(unified) => {
-            let client = create_async_redis_client(&unified)?;
+            let client = create_async_redis_client(UNIFIED_REDIS_CLIENT, &unified)?;
 
             Ok(RedisClients {
                 project_configs: client.clone(),
@@ -456,9 +461,10 @@ pub fn create_redis_clients(configs: RedisConfigsRef<'_>) -> Result<RedisClients
             cardinality,
             quotas,
         } => {
-            let project_configs = create_async_redis_client(&project_configs)?;
-            let cardinality = create_async_redis_client(&cardinality)?;
-            let quotas = create_async_redis_client(&quotas)?;
+            let project_configs =
+                create_async_redis_client(PROJECT_CONFIG_REDIS_CLIENT, &project_configs)?;
+            let cardinality = create_async_redis_client(CARDINALITY_REDIS_CLIENT, &cardinality)?;
+            let quotas = create_async_redis_client(QUOTA_REDIS_CLIENT, &quotas)?;
 
             Ok(RedisClients {
                 project_configs,
@@ -470,13 +476,18 @@ pub fn create_redis_clients(configs: RedisConfigsRef<'_>) -> Result<RedisClients
 }
 
 #[cfg(feature = "processing")]
-fn create_async_redis_client(config: &RedisConfigRef<'_>) -> Result<AsyncRedisClient, RedisError> {
+fn create_async_redis_client(
+    name: &'static str,
+    config: &RedisConfigRef<'_>,
+) -> Result<AsyncRedisClient, RedisError> {
     match config {
         RedisConfigRef::Cluster {
             cluster_nodes,
             options,
-        } => AsyncRedisClient::cluster(cluster_nodes.iter().map(|s| s.as_str()), options),
-        RedisConfigRef::Single { server, options } => AsyncRedisClient::single(server, options),
+        } => AsyncRedisClient::cluster(name, cluster_nodes.iter().map(|s| s.as_str()), options),
+        RedisConfigRef::Single { server, options } => {
+            AsyncRedisClient::single(name, server, options)
+        }
     }
 }
 

--- a/relay-server/src/services/global_rate_limits.rs
+++ b/relay-server/src/services/global_rate_limits.rs
@@ -190,7 +190,7 @@ mod tests {
         let url = std::env::var("RELAY_REDIS_URL")
             .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_owned());
 
-        AsyncRedisClient::single(&url, &RedisConfigOptions::default()).unwrap()
+        AsyncRedisClient::single("test", &url, &RedisConfigOptions::default()).unwrap()
     }
 
     fn build_quota(window: u64, limit: impl Into<Option<u64>>) -> Quota {


### PR DESCRIPTION
This adds a client name to Redis connection pools and connections, which can then be used to tag Redis metrics.

If the Redis configuration is split between the different use cases (project configs/cardinality/quotas), each client will have its own name. If the configuration is unified, they will all have the same name. We might revisit this in a future PR.