### PR TITLE
ref(redis): Turn CommandExecuted into a timer

### DIFF
--- a/relay-redis/src/statsd.rs
+++ b/relay-redis/src/statsd.rs
@@ -1,15 +1,17 @@
-use relay_statsd::CounterMetric;
+use relay_statsd::TimerMetric;
 
-pub enum RedisCounters {
-    /// Incremented every time a Redis command or pipeline is run.
+pub enum RedisTimers {
+    /// The time from sending a Redis command or pipeline to receiving
+    /// a response.
     ///
     /// This metric is tagged with:
     /// - `result`: The outcome (`ok`, `error`, `timeout`).
     /// - `client`: The name of the Redis client sending the command.
+    /// - `cmd`: The name of the command that was sent (or `"pipeline"` for pipelines).
     CommandExecuted,
 }
 
-impl CounterMetric for RedisCounters {
+impl TimerMetric for RedisTimers {
     fn name(&self) -> &'static str {
         match self {
             Self::CommandExecuted => "redis.command_executed",


### PR DESCRIPTION
This turns the `redis.command_executed` metric from a simple counter into a timer measuring the time between sending a command and receiving a response. Additionally, it is now also tagged with the command name (or `"pipeline"` for pipelines).