### PR TITLE
ref(quotas): Fail open for rate limits on Redis failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
+- Bypass rate limits on Redis failures. ([#5351](https://github.com/getsentry/relay/pull/5351))
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
 - Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5308))
 


### PR DESCRIPTION
With additional timeouts #5329 and in general to improve resilience with Redis, default the behaviour on errors to allow items through instead of dropping them implicitly due to a processing error. As a side effect quota enforcement is no longer fallible.