### PR TITLE
test(integration): Grab captured events with default timeout

### DIFF
--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -203,8 +203,11 @@ class Sentry(SentryLike):
         # must be called before initializing relay fixture
         self.global_config["options"][option_name] = value
 
+    def get_captured_event(self, *, timeout=None):
+        return self.captured_events.get(timeout=timeout or self.timeout)
+
     def get_client_report(self, timeout=None):
-        envelope = self.captured_events.get(timeout=timeout or self.timeout)
+        envelope = self.get_captured_event(timeout=timeout)
         items = envelope.items
         assert len(items) == 1
         item = items[0]
@@ -213,7 +216,7 @@ class Sentry(SentryLike):
         return json.loads(item.payload.bytes)
 
     def get_metrics(self, timeout=None):
-        envelope = self.captured_events.get(timeout=timeout or self.timeout)
+        envelope = self.get_captured_event(timeout=timeout)
         items = envelope.items
         assert len(items) == 1
         item = items[0]

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -172,8 +172,7 @@ def test_attachments_pii(mini_sentry, relay):
         relay.send_attachments(project_id, event_id, [attachment])
 
     payloads = {
-        mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
-        for _ in range(2)
+        mini_sentry.get_captured_event().items[0].payload.bytes for _ in range(2)
     }
     assert payloads == {
         b"here's an IP that should get masked -> ********* <-",
@@ -217,9 +216,7 @@ def test_view_hierarchy_scrubbing(mini_sentry, relay, feature_flags, expected):
     relay.send_envelope(project_id, envelope)
 
     relay.send_envelope(project_id, envelope)
-    payload = json.loads(
-        mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
-    )
+    payload = json.loads(mini_sentry.get_captured_event().items[0].payload.bytes)
     assert payload == {"rendering_system": "UIKIT", "identifier": expected}
 
 
@@ -270,7 +267,7 @@ def test_attachment_scrubbing_with_fallback(
 
     relay.send_envelope(project_id, envelope)
 
-    payload = mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
+    payload = mini_sentry.get_captured_event().items[0].payload.bytes
     assert payload == expected
 
 
@@ -294,9 +291,7 @@ def test_view_hierarchy_not_scrubbed_without_config(mini_sentry, relay):
     )
 
     relay.send_envelope(project_id, envelope)
-    payload = json.loads(
-        mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
-    )
+    payload = json.loads(mini_sentry.get_captured_event().items[0].payload.bytes)
     assert payload == json_payload
 
 
@@ -330,7 +325,7 @@ password=mysupersecretpassword123"""
 
     relay.send_envelope(project_id, envelope)
 
-    scrubbed_payload = mini_sentry.captured_events.get(timeout=5).items[0].payload.bytes
+    scrubbed_payload = mini_sentry.get_captured_event().items[0].payload.bytes
 
     assert (
         scrubbed_payload

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -1,5 +1,4 @@
 import datetime
-import queue
 import os
 import gzip
 import sqlite3
@@ -34,7 +33,7 @@ def test_graceful_shutdown_with_in_memory_buffer(mini_sentry, relay):
 
     # When using the memory envelope buffer, we optimistically do not do anything on shutdown, which means that the
     # buffer will try and pop as always as long as it can (within the shutdown timeout).
-    event = mini_sentry.captured_events.get(timeout=0).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
 
@@ -137,7 +136,7 @@ def test_forced_shutdown(mini_sentry, relay):
         sleep(0.5)  # Give the event time to get stuck
 
         relay.shutdown(sig=signal.SIGINT)
-        pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+        assert mini_sentry.captured_events.empty()
 
         failures = mini_sentry.current_test_failures()
         assert failures
@@ -177,7 +176,7 @@ def test_store_pixel_gif(mini_sentry, relay, input, trailing_slash):
     response.raise_for_status()
     assert response.headers["content-type"] == "image/gif"
 
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"]["formatted"] == "im in ur query params"
 
 
@@ -197,7 +196,7 @@ def test_store_post_trailing_slash(mini_sentry, relay, route):
     )
     response.raise_for_status()
 
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"]["formatted"] == "hi"
 
 
@@ -238,7 +237,7 @@ def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     )
 
     if should_be_allowed:
-        mini_sentry.captured_events.get(timeout=1).get_event()
+        assert mini_sentry.get_captured_event().get_event() is not None
     assert mini_sentry.captured_events.empty()
 
 
@@ -360,7 +359,7 @@ def send_transaction_with_dsc(mini_sentry, relay, project_id, sampling_project_k
         },
     )
 
-    return mini_sentry.captured_events.get(timeout=1).get_transaction_event()
+    return mini_sentry.get_captured_event().get_transaction_event()
 
 
 def test_root_project_disabled(mini_sentry, relay):

--- a/tests/integration/test_clock_drift.py
+++ b/tests/integration/test_clock_drift.py
@@ -37,9 +37,7 @@ def test_clock_drift_applied_when_timestamp_is_too_old(mini_sentry, relay):
 
     relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
 
-    transaction_event = mini_sentry.captured_events.get(
-        timeout=1
-    ).get_transaction_event()
+    transaction_event = mini_sentry.get_captured_event().get_transaction_event()
 
     error_name, error_metadata = transaction_event["_meta"]["timestamp"][""]["err"][0]
     assert error_name == "clock_drift"
@@ -63,9 +61,7 @@ def test_clock_drift_not_applied_when_timestamp_is_recent(mini_sentry, relay):
 
     relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
 
-    transaction_event = mini_sentry.captured_events.get(
-        timeout=1
-    ).get_transaction_event()
+    transaction_event = mini_sentry.get_captured_event().get_transaction_event()
     assert "_meta" not in transaction_event
     assert transaction_event["timestamp"] == five_minutes_ago.timestamp()
 
@@ -84,9 +80,7 @@ def test_clock_drift_not_applied_when_sent_at_is_not_supplied(mini_sentry, relay
 
     relay.send_envelope(project_id, envelope, headers={"Accept-Encoding": "gzip"})
 
-    transaction_event = mini_sentry.captured_events.get(
-        timeout=1
-    ).get_transaction_event()
+    transaction_event = mini_sentry.get_captured_event().get_transaction_event()
     error_name, error_metadata = transaction_event["_meta"]["timestamp"][""]["err"][0]
     # In case clock drift is not run, we expect timestamps normalization to go into effect to mark timestamps as
     # past or future if they surpass a certain threshold.

--- a/tests/integration/test_ephemeral_config.py
+++ b/tests/integration/test_ephemeral_config.py
@@ -87,7 +87,7 @@ def test_store_via_ephemeral_relay(
 
     raw_payload = {"message": "Hello, World!"}
     relay.send_event(project_id, payload=raw_payload)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
 
     if mode == "proxy":
         assert event == raw_payload

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -130,7 +130,7 @@ def test_feedback_events_without_processing(mini_sentry, relay_chain):
     relay = relay_chain(min_relay_version="latest")
     relay.send_user_feedback(project_id, replay_item)
 
-    envelope = mini_sentry.captured_events.get(timeout=20)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
 
     userfeedback = envelope.items[0]

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -413,8 +413,7 @@ def test_localhost_filter_no_local_header_ips(mini_sentry, relay, headers):
     event = {"user": {"ip_address": None}, "request": {"headers": headers}}
     relay.send_event(project_id, event)
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    event = envelope.get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event is not None
 
 

--- a/tests/integration/test_flags.py
+++ b/tests/integration/test_flags.py
@@ -30,7 +30,7 @@ def test_event_with_flags(relay, mini_sentry):
 
     relay.send_envelope(42, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
     assert envelope.items[0].payload.json["contexts"] == {
         "flags": {
@@ -63,7 +63,7 @@ def test_event_with_flags_malformed(relay, mini_sentry):
     relay.send_envelope(42, envelope)
 
     # Malformed fields are removed. Unknown fields are passed through.
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
     assert envelope.items[0].payload.json["contexts"] == {
         "flags": {"values": None, "key": "value", "type": "flags"}
@@ -98,7 +98,7 @@ def test_event_with_flags_malformed_inner_object(relay, mini_sentry):
     relay.send_envelope(42, envelope)
 
     # Malformed fields are removed. Unknown fields are passed through.
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
     assert envelope.items[0].payload.json["contexts"] == {
         "flags": {"values": [{"flag": None, "key": "key"}, None], "type": "flags"}

--- a/tests/integration/test_ingest_path.py
+++ b/tests/integration/test_ingest_path.py
@@ -10,7 +10,7 @@ def test_ingest_path(mini_sentry, relay, relay_with_processing, latest_relay_ver
     project_config["config"]["trustedRelays"] = list(external_keys)
 
     relay.send_event(project_id)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["ingest_path"] == [
         {"version": latest_relay_version, "public_key": key} for key in external_keys
     ]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -107,7 +107,7 @@ def test_metrics_proxy_mode_buckets(mini_sentry, relay):
     }
     relay.send_metrics_buckets(project_id, [bucket])
 
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     payload = envelope.items[0].payload.json[0]
     assert payload["name"] == bucket_name
 
@@ -130,7 +130,7 @@ def test_metrics_proxy_mode_statsd(mini_sentry, relay):
 
     metrics_payload = f"transactions/foo:42|c\ntransactions/bar:17|c|T{now}"
     relay.send_metrics(project_id, metrics_payload)
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
     item = envelope.items[0]
     assert item.type == "statsd"
@@ -149,7 +149,7 @@ def test_metrics(mini_sentry, relay):
     )
     relay.send_metrics(project_id, metrics_payload)
 
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
 
     metrics_item = envelope.items[0]
@@ -186,7 +186,7 @@ def test_metrics_backdated(mini_sentry, relay):
     metrics_payload = f"transactions/foo:42|c|T{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
 
-    envelope = mini_sentry.captured_events.get(timeout=2)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
 
     metrics_item = envelope.items[0]
@@ -249,7 +249,7 @@ def test_metrics_partition_key(mini_sentry, relay, metrics_partitions, expected_
     metrics_payload = "transactions/foo:42|c|T999994711"
     relay.send_metrics(project_id, metrics_payload)
 
-    mini_sentry.captured_events.get(timeout=3)
+    mini_sentry.get_captured_event()
 
     headers, _ = mini_sentry.request_log[-1]
     if expected_header is None:
@@ -286,10 +286,9 @@ def test_metrics_max_batch_size(mini_sentry, relay, max_batch_size, expected_eve
     relay.send_metrics(project_id, metrics_payload)
 
     for _ in range(expected_events):
-        mini_sentry.captured_events.get(timeout=3)
+        mini_sentry.get_captured_event()
 
-    with pytest.raises(queue.Empty):
-        mini_sentry.captured_events.get(timeout=1)
+    assert mini_sentry.captured_events.empty()
 
 
 @pytest.mark.parametrize("ns", [None, "custom", "transactions"])
@@ -385,7 +384,7 @@ def test_global_metrics_no_config(mini_sentry, relay):
         {"buckets": {public_key: metrics}},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     item = envelope.items[0]
     assert item.headers["type"] == "metric_buckets"
     metrics_batch = json.loads(item.payload.get_bytes())
@@ -1005,13 +1004,13 @@ def test_transaction_metrics_extraction_external_relays(
     external.send_transaction(project_id, tx, item_headers, trace_info)
 
     # Client reports.
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
 
     if expect_metrics_extraction:
-        metrics_envelope = mini_sentry.captured_events.get(timeout=3)
+        metrics_envelope = mini_sentry.get_captured_event()
         assert len(metrics_envelope.items) == 1
 
         payload = json.loads(metrics_envelope.items[0].get_bytes().decode())
@@ -1253,7 +1252,7 @@ def test_graceful_shutdown(mini_sentry, relay):
 
     received_metrics = list()
     for _ in range(2):
-        envelope = mini_sentry.captured_events.get(timeout=5)
+        envelope = mini_sentry.get_captured_event()
         assert len(envelope.items) == 1
         metrics_item = envelope.items[0]
         assert metrics_item.type == "metric_buckets"
@@ -1380,12 +1379,12 @@ def test_generic_metric_extraction(mini_sentry, relay):
     relay.send_transaction(PROJECT_ID, transaction)
 
     # Skip client reports
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     assert envelope.get_event() is None
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     assert envelope.get_event() is None
 
-    envelope = mini_sentry.captured_events.get(timeout=3)
+    envelope = mini_sentry.get_captured_event()
     for item in envelope.items:
         # Transaction items should be sampled and not among the envelope items.
         assert item.headers.get("type") != "transaction"
@@ -1492,9 +1491,8 @@ def test_relay_forwards_events_without_extracting_metrics_on_broken_global_filte
         # Processing Relays extract metrics even on broken global filters.
         assert metrics_consumer.get_metrics(timeout=2)
     else:
-        assert mini_sentry.captured_events.get(timeout=2) is not None
-        with pytest.raises(queue.Empty):
-            mini_sentry.captured_metrics.get(timeout=2)
+        assert mini_sentry.get_captured_event() is not None
+        assert mini_sentry.captured_metrics.empty()
 
 
 @pytest.mark.parametrize("is_processing_relay", (False, True))
@@ -1553,9 +1551,8 @@ def test_relay_forwards_events_without_extracting_metrics_on_unsupported_project
         # Processing Relays extract metrics even on unsupported project filters.
         assert metrics_consumer.get_metrics(timeout=2)
     else:
-        assert mini_sentry.captured_events.get(timeout=2)
-        with pytest.raises(queue.Empty):
-            mini_sentry.captured_metrics.get(timeout=2)
+        assert mini_sentry.get_captured_event()
+        assert mini_sentry.captured_metrics.empty()
 
 
 def test_missing_global_filters_enables_metric_extraction(
@@ -1691,7 +1688,7 @@ def test_histogram_outliers(mini_sentry, relay):
 
     tags = {}
     for _ in range(3):
-        envelope = mini_sentry.captured_events.get(timeout=5)
+        envelope = mini_sentry.get_captured_event()
         for item in envelope:
             if item.type == "metric_buckets":
                 buckets = item.payload.json

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -53,7 +53,7 @@ def test_minidump(mini_sentry, relay):
     event_id = UUID(body)
     assert str(event_id) == body
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
 
     # the event id from the response should match the envelope
@@ -89,7 +89,7 @@ def test_minidump_attachments(mini_sentry, relay):
     ]
 
     relay.send_minidump(project_id=project_id, files=attachments)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
 
     # Check that the envelope assumes the given event id
@@ -144,7 +144,7 @@ def test_minidump_multipart(mini_sentry, relay):
     ]
 
     relay.send_minidump(project_id=project_id, files=attachments, params=params)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope)
@@ -173,7 +173,7 @@ def test_minidump_sentry_json(mini_sentry, relay):
     ]
 
     relay.send_minidump(project_id=project_id, files=attachments, params=params)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope)
@@ -201,7 +201,7 @@ def test_minidump_sentry_namespace_json(mini_sentry, relay):
     params = [("sentry", event_json), ("sentry___global", namespace_json)]
 
     relay.send_minidump(project_id=project_id, files=attachments, params=params)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope)
@@ -233,7 +233,7 @@ def test_minidump_sentry_json_chunked(mini_sentry, relay):
     response = relay.send_minidump(
         project_id=project_id, files=attachments, params=params
     )
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope)
@@ -264,7 +264,7 @@ def test_minidump_invalid_json(mini_sentry, relay):
     ]
 
     relay.send_minidump(project_id=project_id, files=attachments, params=params)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope)
@@ -313,7 +313,7 @@ def test_minidump_raw(mini_sentry, relay, content_type):
         data="MDMP content",
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope)
@@ -335,7 +335,7 @@ def test_minidump_nested_formdata(mini_sentry, relay, test_file_name):
     attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", dmp_file)]
 
     relay.send_minidump(project_id=project_id, files=attachments)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     assert envelope
     assert_only_minidump(envelope, assert_payload=False)

--- a/tests/integration/test_monitors.py
+++ b/tests/integration/test_monitors.py
@@ -18,7 +18,7 @@ def test_monitor_ingest(mini_sentry, relay):
     check_in = generate_check_in("my-monitor")
     relay.send_check_in(42, check_in)
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
     item = envelope.items[0]
     assert item.headers["type"] == "check_in"
@@ -163,7 +163,7 @@ def test_monitor_post_json_body(mini_sentry, relay):
     response = relay.post(f"/api/42/cron/my-monitor/{public_key}", json=check_in)
     assert response.status_code == 202, response.text
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
     item = envelope.items[0]
     assert item.headers["type"] == "check_in"

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -13,7 +13,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
 
     relay.send_nel_event(project_id)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
 
     # Time is corrected by the `age` specified in the NEL report
     expected_ts = datetime.now(tz=timezone.utc) - timedelta(milliseconds=1200000)

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -46,7 +46,7 @@ def test_relay_with_full_normalization(mini_sentry, relay, config_full_normaliza
     )
 
     relay.send_event(project_id, input)
-    envelope = mini_sentry.captured_events.get(timeout=10)
+    envelope = mini_sentry.get_captured_event()
 
     if config_full_normalization:
         assert "fully_normalized" in envelope.items[0].headers
@@ -201,7 +201,7 @@ def test_relay_doesnt_normalize_unextracted_unreal_event(
     )
     relay.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=10)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
     assert "fully_normalized" not in envelope.items[0].headers
 
@@ -373,7 +373,7 @@ def test_ip_normalization_with_remove_remark(mini_sentry, relay_chain):
 
     relay.send_event(project_id, {"platform": "javascript"})
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event["user"]["ip_address"] is None
     assert event["user"]["id"] == "AE12FE3B5F129B5CC4CDD2B136B7B7947C4D2741"
@@ -395,7 +395,7 @@ def test_ip_not_extracted_with_setting(mini_sentry, relay, scrub_ip_addresses, u
 
     relay.send_event(project_id, {"user": {"ip_address": "{{auto}}"}})
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) is None
     assert event.get("user", {}).get("id", None) == user_id
@@ -424,7 +424,7 @@ def test_geo_inferred_without_user_ip(
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected_ip
     # Geo is always present
@@ -457,7 +457,7 @@ def test_geo_is_not_overwritten(mini_sentry, relay, scrub_ip_addresses, expected
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected_ip
     # Geo is always present
@@ -495,7 +495,7 @@ def test_infer_ip_setting_javascript(
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected
 
@@ -531,7 +531,7 @@ def test_auto_infer_setting_cocoa(
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected
 
@@ -564,7 +564,7 @@ def test_auto_infer_settings(mini_sentry, relay, user_ip_address, infer_ip, expe
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected
 
@@ -600,7 +600,7 @@ def test_auto_infer_setting_objective_c(
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected
 
@@ -635,7 +635,7 @@ def test_auto_infer_without_user(mini_sentry, relay, platform, infer_ip, expecte
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected
 
@@ -662,7 +662,7 @@ def test_auto_infer_remote_addr_env(mini_sentry, relay, infer_ip, expected):
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) == expected
 
@@ -693,6 +693,6 @@ def test_auto_infer_invalid_setting(mini_sentry, relay):
         headers={"X-Forwarded-For": "2.125.160.216"},
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     event = envelope.get_event()
     assert event.get("user", {}).get("ip_address", None) is None

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -338,7 +338,7 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
 
@@ -415,7 +415,7 @@ def test_ourlog_extraction_default_pii_scrubbing_attributes(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
     attributes = item["attributes"]
@@ -457,7 +457,7 @@ def test_ourlog_default_pii_body(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     log = item_payload["items"][0]
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1746,7 +1746,7 @@ def test_profile_outcomes_rate_limited_when_dynamic_sampling_drops(
         assert mini_sentry.captured_events.empty()
     else:
         # Do not rate limit if there is only a transaction_indexed quota.
-        envelope = mini_sentry.captured_events.get(timeout=10)
+        envelope = mini_sentry.get_captured_event()
         assert envelope.items[0].headers["type"] == "profile"
 
         assert mini_sentry.captured_outcomes.empty()

--- a/tests/integration/test_pii.py
+++ b/tests/integration/test_pii.py
@@ -34,8 +34,7 @@ def test_scrub_span_sentry_tags_advanced_rules(mini_sentry, relay):
         },
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    event = envelope.get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["spans"][0]["sentry_tags"]["user.geo.country_code"] == "**"
     assert event["spans"][0]["sentry_tags"]["user.geo.subregion"] == "***"
 
@@ -81,9 +80,7 @@ def test_logentry_formatted_smart_scrubbing(
         },
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    event = envelope.get_event()
-
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"]["formatted"] == expected_output
 
 
@@ -111,9 +108,7 @@ def test_logentry_formatted_user_rules(mini_sentry, relay):
         },
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    event = envelope.get_event()
-
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"]["formatted"] == "Auth failed with [secret]"
 
 
@@ -136,10 +131,8 @@ def test_logentry_formatted_data_scrubbing_settings(
         },
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    event = envelope.get_event()
+    event = mini_sentry.get_captured_event().get_event()
     formatted_value = event["logentry"]["formatted"]
-
     assert formatted_value == non_destructive.expected_output
 
     if non_destructive.additional_checks:

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -366,8 +366,7 @@ def test_playstation_ignore_large_fields(
         }
     ]
     assert [
-        item.headers["filename"]
-        for item in mini_sentry.captured_events.get(timeout=5).items
+        item.headers["filename"] for item in mini_sentry.get_captured_event().items
     ] == ["playstation.prosperodmp"]
 
 

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -304,7 +304,7 @@ def test_profile_chunk_outcomes_rate_limited_fast(
     upstream.send_envelope(project_id, envelope)
 
     if platform is None:
-        envelope = mini_sentry.captured_events.get(timeout=1)
+        envelope = mini_sentry.get_captured_event()
         assert [item.type for item in envelope.items] == ["profile_chunk"]
     else:
         outcome = mini_sentry.get_client_report()
@@ -381,7 +381,7 @@ def test_profile_chunk_limited_transaction_context_removed(
         },
     )
 
-    event = mini_sentry.captured_events.get(timeout=5).get_transaction_event()
+    event = mini_sentry.get_captured_event().get_transaction_event()
     if filter_context:
         assert "profile" not in event["contexts"]
     else:

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -261,12 +261,12 @@ def test_unparsable_project_config(mini_sentry, relay):
 
     # We should have the previous events through now.
     for _ in range(4):
-        event = mini_sentry.captured_events.get(timeout=1).get_event()
+        event = mini_sentry.get_captured_event().get_event()
         assert event["logentry"] == {"formatted": "Hello, World!"}
 
     # This must succeed, since we will re-request the project state update at this point.
     relay.send_event(project_key)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
     assert mini_sentry.captured_events.empty()
 
@@ -284,11 +284,11 @@ def test_cached_project_config(mini_sentry, relay):
 
     # Once the event is sent the project state is requested and cached.
     relay.send_event(project_key)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
     # send a second event
     relay.send_event(project_key)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
     body = {"publicKeys": [public_key]}

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -96,7 +96,7 @@ def test_query_retry(failure_type, mini_sentry, relay):
     try:
         relay.send_event(42)
 
-        event = mini_sentry.captured_events.get(timeout=12).get_event()
+        event = mini_sentry.get_captured_event(timeout=12).get_event()
         assert event["logentry"] == {"formatted": "Hello, World!"}
         assert retry_count == 3
 
@@ -283,7 +283,7 @@ def test_project_fetch_revision(mini_sentry, relay, with_revision_support):
     project_config_fetch.clear()
     assert not with_rev.is_set()
 
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
     # Wait for project config to expire.
@@ -294,5 +294,5 @@ def test_project_fetch_revision(mini_sentry, relay, with_revision_support):
     assert project_config_fetch.wait(timeout=2)
     assert with_rev.wait(timeout=2)
 
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -131,7 +131,7 @@ def test_replay_events_without_processing(mini_sentry, relay_chain):
 
     relay.send_replay_event(42, replay_item)
 
-    envelope = mini_sentry.captured_events.get(timeout=20)
+    envelope = mini_sentry.get_captured_event(timeout=20)
     assert len(envelope.items) == 1
 
     replay_event = envelope.items[0]

--- a/tests/integration/test_replay_recordings.py
+++ b/tests/integration/test_replay_recordings.py
@@ -23,7 +23,7 @@ def test_replay_recordings(mini_sentry, relay_chain):
 
     relay.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
 
     session_item = envelope.items[0]

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -48,7 +48,7 @@ def test_uses_origins(mini_sentry, relay, json_fixture_provider, allowed_origins
     )
 
     if should_be_allowed:
-        mini_sentry.captured_events.get(timeout=10).get_event()
+        assert mini_sentry.get_captured_event() is not None
     assert mini_sentry.captured_events.empty()
 
 
@@ -266,7 +266,7 @@ def test_security_report(mini_sentry, relay, test_case, json_fixture_provider):
 
     assert resp.status_code == 200
 
-    envelope = mini_sentry.captured_events.get(timeout=10)
+    envelope = mini_sentry.get_captured_event()
     event = get_security_report(envelope)
     for x in ignored_properties:
         event.pop(x, None)
@@ -364,7 +364,7 @@ def test_adds_origin_header(mini_sentry, relay, json_fixture_provider):
         origin="http://valid.com",
     )
 
-    envelope = mini_sentry.captured_events.get(timeout=10)
+    envelope = mini_sentry.get_captured_event()
     event = get_security_report(envelope)
 
     assert ["Origin", "http://valid.com/"] in event["request"]["headers"]

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -36,7 +36,7 @@ def test_sessions(mini_sentry, relay_chain, metric_extraction):
 
     relay.send_session(project_id, session_payload)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
     assert len(envelope.items) == 1
 
     if metric_extraction:

--- a/tests/integration/test_span_links.py
+++ b/tests/integration/test_span_links.py
@@ -67,7 +67,7 @@ def test_event_with_span_link_in_transaction(relay, mini_sentry):
 
     relay.send_envelope(42, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
     assert envelope.items[0].payload.json["contexts"] == {
         "trace": {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -368,7 +368,7 @@ def test_duplicate_performance_score(mini_sentry, relay):
 
     score_total_seen = 0
     for _ in range(3):  # 2 client reports and the actual item we're interested in
-        envelope = mini_sentry.captured_events.get(timeout=5)
+        envelope = mini_sentry.get_captured_event()
         for item in envelope.items:
             if item.type == "metric_buckets":
                 for metric in item.payload.json:

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -765,7 +765,7 @@ def test_spanv2_with_string_pii_scrubbing(
 
     relay.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
 
@@ -846,7 +846,7 @@ def test_spanv2_default_pii_scrubbing_attributes(
 
     relay_instance.send_envelope(project_id, envelope)
 
-    envelope = mini_sentry.captured_events.get(timeout=5)
+    envelope = mini_sentry.get_captured_event()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
     attributes = item["attributes"]
@@ -959,7 +959,7 @@ def test_invalid_spans(mini_sentry, relay):
         },
     ]
 
-    envelope = mini_sentry.captured_events.get(timeout=0.1)
+    envelope = mini_sentry.get_captured_event()
     spans = json.loads(envelope.items[0].payload.bytes.decode())["items"]
 
     assert len(spans) == 1

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -27,7 +27,7 @@ def test_store(mini_sentry, relay_chain):
     mini_sentry.add_basic_project_config(project_id)
 
     relay.send_event(project_id)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
 
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
@@ -48,10 +48,10 @@ def test_store_external_relay(mini_sentry, relay, allowed):
     relay.send_event(42)
 
     if allowed:
-        event = mini_sentry.captured_events.get(timeout=1).get_event()
+        event = mini_sentry.get_captured_event().get_event()
         assert event["logentry"] == {"formatted": "Hello, World!"}
     else:
-        pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+        pytest.raises(queue.Empty, lambda: mini_sentry.get_captured_event(timeout=1))
 
 
 def test_legacy_store(mini_sentry, relay_chain):
@@ -59,12 +59,12 @@ def test_legacy_store(mini_sentry, relay_chain):
     mini_sentry.add_basic_project_config(42)
 
     relay.send_event(42, legacy=True)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
 
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
     relay.send_event(42, legacy=True)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
 
@@ -109,7 +109,7 @@ def test_store_node_base64(mini_sentry, relay_chain):
     )  # noqa
     relay.send_event(project_id, payload)
 
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
 
     assert event["logentry"] == {"formatted": "Error: yo mark"}
 
@@ -121,7 +121,7 @@ def test_store_pii_stripping(mini_sentry, relay):
     mini_sentry.add_basic_project_config(project_id)
     relay.send_event(project_id, {"message": "hi", "extra": {"foo": "test@mail.org"}})
 
-    event = mini_sentry.captured_events.get(timeout=2).get_event()
+    event = mini_sentry.get_captured_event().get_event()
 
     # Email should be stripped:
     assert event["extra"]["foo"] == "[email]"
@@ -160,7 +160,7 @@ def test_store_rate_limit(mini_sentry, relay):
         relay.send_event(project_id, {"message": "invalid"})
 
     # Generated outcome has reason code 'generic':
-    outcome_envelope = mini_sentry.captured_events.get(timeout=1)
+    outcome_envelope = mini_sentry.get_captured_event()
     outcome = json.loads(outcome_envelope.items[0].payload.bytes)
     assert outcome["rate_limited_events"] == [
         {"reason": "generic", "category": "error", "quantity": 1}
@@ -170,7 +170,7 @@ def test_store_rate_limit(mini_sentry, relay):
     sleep(2)
     relay.send_event(project_id, {"message": "correct"})
 
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "correct"}
 
 
@@ -189,7 +189,7 @@ def test_store_proxy_config(mini_sentry, relay):
 
     raw_payload = {"message": "Hello, World!"}
     relay.send_event(project_id, payload=raw_payload)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event == raw_payload
 
 
@@ -203,7 +203,7 @@ def test_store_with_low_memory(mini_sentry, relay):
     try:
         with pytest.raises(HTTPError):
             relay.send_event(project_id, {"message": "pls ignore"})
-        pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+        pytest.raises(queue.Empty, lambda: mini_sentry.get_captured_event(timeout=1))
 
         found_queue_error = False
         for _, error in mini_sentry.current_test_failures():
@@ -926,7 +926,7 @@ def test_events_buffered_before_auth(relay, mini_sentry):
         mini_sentry.app.view_functions["get_challenge"] = old_handler
 
         # now test that we still get the message sent at some point in time (the event is retried)
-        event = mini_sentry.captured_events.get(timeout=3).get_event()
+        event = mini_sentry.get_captured_event().get_event()
         assert event["logentry"] == {"formatted": "Hello, World!"}
     finally:
         # Relay reports authentication errors, which is fine.
@@ -964,7 +964,7 @@ def test_events_are_retried(relay, mini_sentry):
     mini_sentry.app.view_functions["store_event"] = old_handler
 
     # now test that we still get the message sent at some point in time (the event is retried)
-    event = mini_sentry.captured_events.get(timeout=3).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
 
@@ -1041,7 +1041,7 @@ def test_no_auth(relay, mini_sentry):
     relay.send_event(project_id, raw_payload)
 
     # sanity test that we got the event we sent
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event == raw_payload
     # verify that no registration took place (the register flag is not set)
     assert not has_registered[0]
@@ -1149,7 +1149,7 @@ def test_re_auth_failure(relay, mini_sentry):
     # send a message, it should not come through while the authentication has failed
     relay.send_event(project_id, {"message": "123"})
     # sentry should have received nothing
-    pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+    pytest.raises(queue.Empty, lambda: mini_sentry.get_captured_event(timeout=1))
 
     # set back authentication to ok
     registration_should_succeed = True
@@ -1168,7 +1168,7 @@ def test_re_auth_failure(relay, mini_sentry):
     # now we should be re-authenticated and we should have the event
 
     # sanity test that we got the event we sent
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "123"}
 
 
@@ -1280,7 +1280,7 @@ def test_buffer_events_during_outage(relay, mini_sentry):
     is_network_error = False
 
     # sanity test that we got the event we sent
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"] == {"formatted": "123"}
 
 
@@ -1320,7 +1320,7 @@ def test_store_content_encodings_chained(mini_sentry, relay, encoding):
     mini_sentry.add_basic_project_config(project_id)
 
     relay.send_event(project_id)
-    event = mini_sentry.captured_events.get(timeout=1).get_event()
+    event = mini_sentry.get_captured_event().get_event()
 
     assert event["logentry"] == {"formatted": "Hello, World!"}
 
@@ -1345,7 +1345,7 @@ def test_store_project_move(mini_sentry, relay):
     }
 
     relay.send_event(99, headers=headers)
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
 
     # NB: mini_sentry errors on all other URLs than /api/42/store/. All that's left is checking the
     # DSN that is transmitted as part of the Envelope headers.
@@ -1367,7 +1367,7 @@ def test_invalid_project_id(mini_sentry, relay):
     }
 
     relay.send_event(99, headers=headers)
-    pytest.raises(queue.Empty, lambda: mini_sentry.captured_events.get(timeout=1))
+    pytest.raises(queue.Empty, lambda: mini_sentry.get_captured_event(timeout=1))
 
 
 def test_kafka_ssl(relay_with_processing):

--- a/tests/integration/test_trusted_relay.py
+++ b/tests/integration/test_trusted_relay.py
@@ -28,7 +28,7 @@ def test_trusted_relay_chain(mini_sentry, relay, relay_credentials):
     relay.send_event(project_id, {"message": "trusted event"})
 
     for _ in range(2):
-        envelope = mini_sentry.captured_events.get(timeout=1)
+        envelope = mini_sentry.get_captured_event()
         event = envelope.get_event()
         assert event["logentry"]["formatted"] == "trusted event"
 
@@ -58,8 +58,7 @@ def test_send_directly(mini_sentry, relay, relay_credentials):
     # sending to the static relay works
     relay.send_event(project_id, {"message": "trusted event"})
 
-    envelope = mini_sentry.captured_events.get(timeout=1)
-    event = envelope.get_event()
+    event = mini_sentry.get_captured_event().get_event()
     assert event["logentry"]["formatted"] == "trusted event"
 
     # sending directly to the managed relay will be rejected
@@ -137,8 +136,7 @@ def test_internal_relay(mini_sentry, relay, relay_credentials):
     )
 
     for _ in range(2):
-        envelope = mini_sentry.captured_events.get(timeout=1)
-        event = envelope.get_event()
+        event = mini_sentry.get_captured_event().get_event()
         assert event["logentry"]["formatted"] == "trusted event"
 
 
@@ -179,8 +177,7 @@ def test_internal_relays_invalid_signature(mini_sentry, relay, relay_credentials
         headers=headers,
     )
     for _ in range(2):
-        envelope = mini_sentry.captured_events.get(timeout=1)
-        event = envelope.get_event()
+        event = mini_sentry.get_captured_event().get_event()
         assert event["logentry"]["formatted"] == "trusted event"
 
 

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -32,7 +32,7 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, extract_metrics):
     response = relay.send_unreal_request(project_id, unreal_content)
 
     event_id = response.text.replace("-", "")
-    envelope = mini_sentry.captured_events.get(timeout=1)
+    envelope = mini_sentry.get_captured_event()
     assert envelope
     assert event_id == envelope.headers.get("event_id")
     items = envelope.items


### PR DESCRIPTION
This adds a helper `get_captured_event` which replaces `captured_events.get`. The helper automatically configures a timeout, which means it is no longer possible to have tests which never finish.
Additionally tests no longer have to care about setting timeouts.

A lot of fast timeouts have been increased to 5 seconds with this change, this should reduce some flakiness of tests but not increase the overall run duration of tests, as tests awaiting an item will continue as soon as the item is available or fail otherwise.

Some slower timeouts are left in place and others reduced (aka removed) to the default value, the ones which seemed not necessary in the first place. If I am wrong on those we may need to increase them again or increase the now global default.

I changed some usages of `pytest.raises(queue.Empty, ...)` to `mini_sentry.captured_events.empty()` where reasonable (since semantics slightly differ). We should consider in a follow-up to also assert the queue is empty when tests finish (like we do for Kafka).

Closes: #5347