### PR TITLE
ref(instr): Tag rate limiting time with limiter type

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3039,6 +3039,7 @@ impl RateLimiter {
     fn name(&self) -> &'static str {
         match self {
             Self::Cached => "cached",
+            #[cfg(feature = "processing")]
             Self::Consistent(_) => "consistent",
         }
     }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3014,12 +3014,11 @@ impl RateLimiter {
         }
 
         let scoping = managed_envelope.scoping();
-        let (enforcement, rate_limits) =
-            metric!(timer(RelayTimers::EventProcessingRateLimiting), {
-                envelope_limiter
-                    .compute(managed_envelope.envelope_mut(), &scoping)
-                    .await
-            })?;
+        let (enforcement, rate_limits) = metric!(timer(RelayTimers::EventProcessingRateLimiting), type = self.name(), {
+            envelope_limiter
+                .compute(managed_envelope.envelope_mut(), &scoping)
+                .await
+        })?;
         let event_active = enforcement.is_event_active();
 
         // Use the same rate limits as used for the envelope on the metrics.
@@ -3035,6 +3034,13 @@ impl RateLimiter {
         }
 
         Ok(EnforcementResult::new(event, rate_limits))
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Cached => "cached",
+            Self::Consistent(_) => "consistent",
+        }
     }
 }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -386,6 +386,9 @@ pub enum RelayTimers {
     /// Not all events reach this point. After an event is rate limited for the first time, the rate
     /// limit is cached. Events coming in after this will be discarded earlier in the request queue
     /// and do not reach the processing queue.
+    ///
+    /// This metric is tagged with:
+    ///  - `type`: The type of limiter executed, `cached` or `consistent`.
     EventProcessingRateLimiting,
     /// Time in milliseconds spent in data scrubbing for the current event. Data scrubbing happens
     /// last before serializing the event back to JSON.


### PR DESCRIPTION
To get clean metrics (e.g. averages) between consistent (redis) and cached.