### PR TITLE
fix(redis): Correctly size the Redis pools by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 **Bug Fixes**:
 
+- Redis pools being sized too small by default. ([#5358](https://github.com/getsentry/relay/pull/5358))
 - Fix array attributes not being applied to standalone spans. ([#5337](https://github.com/getsentry/relay/pull/5337))
 - Envelopes created from integrations can now be spooled. ([#5284](https://github.com/getsentry/relay/pull/5284))
 - Make referer optional in Vercel Log Drain Transform. ([#5273](https://github.com/getsentry/relay/pull/5273))

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -2530,6 +2530,7 @@ impl Config {
         Some(build_redis_configs(
             redis_configs,
             self.cpu_concurrency() as u32,
+            self.pool_concurrency() as u32,
         ))
     }
 


### PR DESCRIPTION
The Redis pools are still sized without considering async pool concurrency. We're no longer in a Redis connection per thread world, we now have an additional pool concurrency to consider.

This increases right sizes the internal Redis pools with the total (worst case) concurrency in mind.