### PR TITLE
Revert "ref(http): Expose all routes temporarily even with internal ports"

### DIFF
--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -56,7 +56,6 @@ pub fn internal_routes(_: &Config) -> Router<ServiceState>{
 /// Relay's public routes.
 ///
 /// Routes which are public API and must be exposed.
-#[expect(unused, reason = "temporarily unused")]
 pub fn public_routes(config: &Config) -> Router<ServiceState> {
     // Exclude internal routes, they must be configured separately.
     public_routes_raw(config).route("/api/relay/{*not_found}", any(statics::not_found))

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -211,7 +211,7 @@ impl Service for HttpServer {
         relay_statsd::metric!(counter(RelayCounters::ServerStarting) += 1);
 
         if let Some(internal_listener) = internal_listener {
-            let public = make_app(service.clone(), crate::endpoints::all_routes);
+            let public = make_app(service.clone(), crate::endpoints::public_routes);
             let internal = make_app(service, crate::endpoints::internal_routes);
 
             tokio::try_join!(


### PR DESCRIPTION
Reverts getsentry/relay#5361

Postponing the rollout, not needed right now.