### PR TITLE
build(dep): Pin tokio dependency to currently max working version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,11 @@ synstructure = { version = "0.13.2" }
 sysinfo = "0.35.1"
 tempfile = "3.23.0"
 thiserror = "2.0.17"
-tokio = { version = "1.42.0", default-features = false }
+# Tokio `1.45.1` is the last working/compatible Tokio version. `1.46` introduced a regression which causes
+# Relay to use excessive amounts of CPU. The issue has been fixed in current master of Tokio, which is expected
+# to release as `1.49.0` or `1.48.1`.
+# See: <https://github.com/tokio-rs/tokio/issues/7692>.
+tokio = { version = "=1.45.1", default-features = false }
 tokio-util = { version = "0.7.13", default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tower-http = { version = "0.6.6", default-features = false }


### PR DESCRIPTION
1.45.1 is currently the last working tokio version which works with Relay, current master version of tokio has a fix (expected 1.48.1 or 1.49.0) but it has not yet been released.