### PR TITLE
feat: Support uploading attachments directly to objectstore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,16 +201,19 @@ jobs:
         ports:
           - 6379:6379
 
-      objectstore:
-        image: ghcr.io/getsentry/objectstore:nightly
-        ports:
-          - 8888:8888
-
     steps:
       - name: Install libcurl-dev
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Start objectstore
+        run: |
+          docker run -d \
+            --name objectstore \
+            -p 8888:8888 \
+            ghcr.io/getsentry/objectstore:nightly \
+            run
 
       - uses: actions/checkout@v5.0.0
         with:
@@ -759,16 +762,19 @@ jobs:
         ports:
           - 9092:9092
 
-      objectstore:
-        image: ghcr.io/getsentry/objectstore:nightly
-        ports:
-          - 8888:8888
-
     steps:
       - name: Install libcurl-dev
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Start objectstore
+        run: |
+          docker run -d \
+            --name objectstore \
+            -p 8888:8888 \
+            ghcr.io/getsentry/objectstore:nightly \
+            run
 
       - uses: actions/checkout@v5.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
         ports:
           - 6379:6379
 
+      objectstore:
+        image: ghcr.io/getsentry/objectstore:nightly
+        ports:
+          - 8888:8888
+
     steps:
       - name: Install libcurl-dev
         run: |
@@ -753,6 +758,11 @@ jobs:
           KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
         ports:
           - 9092:9092
+
+      objectstore:
+        image: ghcr.io/getsentry/objectstore:nightly
+        ports:
+          - 8888:8888
 
     steps:
       - name: Install libcurl-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add `response_timeout` config setting for Redis. ([#5329](https://github.com/getsentry/relay/pull/5329))
 - Remove `projects:discard-transaction` feature flag. ([#5307](https://github.com/getsentry/relay/pull/5307))
 - Add SEER_USER data category. ([#5383](https://github.com/getsentry/relay/pull/5383))
+- Support uploading attachments directly to objectstore. ([#5367](https://github.com/getsentry/relay/pull/5367))
 
 **Bug Fixes**:
 
@@ -41,6 +42,7 @@
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
 - Remove the span kind from the Kafka span schema. ([#5368](https://github.com/getsentry/relay/pull/5368))
 - Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5308))
+
 
 ## 25.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Support uploading attachments directly to objectstore. ([#5367](https://github.com/getsentry/relay/pull/5367))
+
 ## 25.11.0
 
 **Breaking Changes**:
@@ -20,7 +26,6 @@
 - Add `response_timeout` config setting for Redis. ([#5329](https://github.com/getsentry/relay/pull/5329))
 - Remove `projects:discard-transaction` feature flag. ([#5307](https://github.com/getsentry/relay/pull/5307))
 - Add SEER_USER data category. ([#5383](https://github.com/getsentry/relay/pull/5383))
-- Support uploading attachments directly to objectstore. ([#5367](https://github.com/getsentry/relay/pull/5367))
 
 **Bug Fixes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+
+[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2554,12 @@ name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
+name = "mediatype"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
 
 [[package]]
 name = "memchr"
@@ -2965,13 +2977,14 @@ dependencies = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075d441351893f449331bff17f7da12d41dabea37202a7396471deebf9e903f"
+checksum = "3b8042b686597a4697640ac3c5d8541d8510afae1be5fedb12efded9f7e2ca2d"
 dependencies = [
  "async-compression",
  "bytes",
  "futures-util",
+ "infer",
  "objectstore-types",
  "reqwest",
  "sentry-core",
@@ -2984,12 +2997,13 @@ dependencies = [
 
 [[package]]
 name = "objectstore-types"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbc335b5a73008592b413ebc929468d0967b991d3c41600cddfc1adabbb195f"
+checksum = "13e8ef8ad5b9ba35f5f63c2d60bd98d4656ac1d693916667cce6e56409242b9c"
 dependencies = [
  "http",
  "humantime",
+ "mediatype",
  "serde",
  "thiserror 2.0.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,18 +171,15 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
 dependencies = [
- "brotli",
- "flate2",
+ "compression-codecs",
+ "compression-core",
  "futures-core",
- "memchr",
  "pin-project-lite",
  "tokio",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -455,7 +452,18 @@ checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.1",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -463,6 +471,16 @@ name = "brotli-decompressor"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -691,6 +709,26 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "brotli 8.0.2",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
 
 [[package]]
 name = "concurrent-queue"
@@ -1829,6 +1867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9994b79e8c1a39b3166c63ae7823bb2b00831e2a96a31399c50fe69df408eaeb"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +2961,37 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "objectstore-client"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3075d441351893f449331bff17f7da12d41dabea37202a7396471deebf9e903f"
+dependencies = [
+ "async-compression",
+ "bytes",
+ "futures-util",
+ "objectstore-types",
+ "reqwest",
+ "sentry-core",
+ "serde",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "objectstore-types"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbc335b5a73008592b413ebc929468d0967b991d3c41600cddfc1adabbb195f"
+dependencies = [
+ "http",
+ "humantime",
+ "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4320,7 +4395,7 @@ dependencies = [
  "axum-extra",
  "axum-server",
  "backoff",
- "brotli",
+ "brotli 7.0.0",
  "bytecount",
  "bytes",
  "bzip2",
@@ -4342,6 +4417,7 @@ dependencies = [
  "mime",
  "minidump",
  "multer",
+ "objectstore-client",
  "opentelemetry-proto",
  "papaya",
  "pin-project-lite",
@@ -5861,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ minidump = "0.26.0"
 multer = "3.1.0"
 num-traits = "0.2.19"
 num_cpus = "1.17.0"
+objectstore-client = "0.0.9"
 opentelemetry-proto = { version = "0.30.0", default-features = false }
 papaya = "0.2.3"
 parking_lot = "0.12.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ minidump = "0.26.0"
 multer = "3.1.0"
 num-traits = "0.2.19"
 num_cpus = "1.17.0"
-objectstore-client = "0.0.9"
+objectstore-client = "0.0.11"
 opentelemetry-proto = { version = "0.30.0", default-features = false }
 papaya = "0.2.3"
 parking_lot = "0.12.5"

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -15,11 +15,18 @@ x-sentry-service-config:
         repo_name: sentry-shared-kafka
         branch: main
         repo_link: https://github.com/getsentry/sentry-shared-kafka.git
+    objectstore:
+      description: Storage for files and blobs
+      remote:
+        repo_name: objectstore
+        branch: main
+        repo_link: https://github.com/getsentry/objectstore.git
+        mode: containerized
     relay:
       description: Service that pushes some functionality from the Sentry SDKs as well as the Sentry server into a proxy process.
   modes:
-    default: [redis, kafka]
-    containerized: [redis, kafka, relay]
+    default: [redis, kafka, objectstore]
+    containerized: [redis, kafka, objectstore, relay]
 
 x-programs:
   devserver:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "flask>=3.0.3",
     "msgpack>=1.1.0",
     "mypy>=1.10.0",
+    "objectstore-client==0.0.11",
     "opentelemetry-proto>=1.32.1",
     "pre-commit>=4.2.0",
     "pytest>=7.4.3",

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1267,6 +1267,12 @@ impl Default for OutcomeAggregatorConfig {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 pub struct UploadServiceConfig {
+    /// The base URL for the objectstore service.
+    ///
+    /// This defaults to [`None`], which means that the service will be disabled,
+    /// unless a proper configuration is provided.
+    pub objectstore_url: Option<String>,
+
     /// Maximum concurrency of uploads.
     pub max_concurrent_requests: usize,
 
@@ -1277,6 +1283,7 @@ pub struct UploadServiceConfig {
 impl Default for UploadServiceConfig {
     fn default() -> Self {
         Self {
+            objectstore_url: None,
             max_concurrent_requests: 100,
             timeout: 60,
         }

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -186,6 +186,17 @@ pub struct Options {
     )]
     pub replay_relay_snuba_publish_disabled_sample_rate: f32,
 
+    /// Instructs relay to store attachments in objectstore instead of sending chunks via kafka.
+    ///
+    /// Rate needs to be between `0.0` and `1.0`.
+    /// If set to `1.0` all attachments will be stored in objectstore.
+    #[serde(
+        rename = "relay.objectstore-attachments.sample-rate",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub objectstore_attachments_sample_rate: f32,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -57,6 +57,7 @@ liblzma = { workspace = true }
 mime = { workspace = true }
 minidump = { workspace = true, optional = true }
 multer = { workspace = true }
+objectstore-client = { workspace = true }
 opentelemetry-proto = { workspace = true }
 papaya = { workspace = true }
 pin-project-lite = { workspace = true }

--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "processing")]
+use std::time::Duration;
+
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
 
 /// Name of the event attachment.
@@ -31,3 +34,7 @@ pub const MAX_JSON_SIZE: usize = 262_144;
 
 /// The default client used for check ins whenever the incoming request has no client set.
 pub const DEFAULT_CHECK_IN_CLIENT: &str = "relay-http";
+
+/// The default retention for attachment, which defaults to 30 days currently.
+#[cfg(feature = "processing")]
+pub const DEFAULT_ATTACHMENT_RETENTION: Duration = Duration::from_hours(24 * 30);

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -32,6 +32,7 @@ impl Item {
                 attachment_type: None,
                 content_type: None,
                 filename: None,
+                stored_key: None,
                 routing_hint: None,
                 rate_limited: false,
                 source_quantities: None,
@@ -282,6 +283,16 @@ impl Item {
         S: Into<String>,
     {
         self.headers.filename = Some(filename.into());
+    }
+
+    /// Returns the objectstore key, if it is an attachment stored in objectstore.
+    pub fn stored_key(&self) -> Option<&str> {
+        self.headers.stored_key.as_deref()
+    }
+
+    /// Sets the objectstore key of this attachment item.
+    pub fn set_stored_key(&mut self, stored_key: String) {
+        self.headers.stored_key = Some(stored_key);
     }
 
     /// Returns the routing_hint of this item.
@@ -772,6 +783,12 @@ pub struct ItemHeaders {
     /// If this is an attachment item, this may contain the original file name.
     #[serde(skip_serializing_if = "Option::is_none")]
     filename: Option<String>,
+
+    /// If this is an attachment item, this may contain the storage key in case it is uploaded to objectstore.
+    ///
+    /// NOTE: This is internal-only and not exposed into the Envelope.
+    #[serde(default, skip)]
+    stored_key: Option<String>,
 
     /// The platform this item was produced for.
     ///

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -224,7 +224,8 @@ impl ServiceState {
         let store = config
             .processing_enabled()
             .then(|| {
-                let upload = services.start(UploadService::new(config.upload()));
+                let upload_service = UploadService::new(config.upload())?;
+                let upload = upload_service.map(|s| services.start(s));
                 StoreService::create(
                     store_pool.clone(),
                     config.clone(),

--- a/relay-server/src/services/mod.rs
+++ b/relay-server/src/services/mod.rs
@@ -46,6 +46,5 @@ pub mod stats;
 #[cfg(feature = "processing")]
 pub mod store;
 #[cfg(feature = "processing")]
-#[expect(unused)]
 pub mod upload;
 pub mod upstream;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -64,7 +64,6 @@ use crate::services::metrics::{Aggregator, FlushBuckets, MergeBuckets, ProjectBu
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome, TrackOutcome};
 use crate::services::projects::cache::ProjectCacheHandle;
 use crate::services::projects::project::{ProjectInfo, ProjectState};
-#[cfg(feature = "processing")]
 use crate::services::upstream::{
     SendRequest, Sign, SignatureType, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
 };

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -64,6 +64,7 @@ use crate::services::metrics::{Aggregator, FlushBuckets, MergeBuckets, ProjectBu
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome, TrackOutcome};
 use crate::services::projects::cache::ProjectCacheHandle;
 use crate::services::projects::project::{ProjectInfo, ProjectState};
+#[cfg(feature = "processing")]
 use crate::services::upstream::{
     SendRequest, Sign, SignatureType, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
 };
@@ -76,6 +77,7 @@ use {
     crate::services::global_rate_limits::{GlobalRateLimits, GlobalRateLimitsServiceHandle},
     crate::services::processor::nnswitch::SwitchProcessingError,
     crate::services::store::{Store, StoreEnvelope},
+    crate::services::upload::UploadAttachments,
     crate::utils::Enforcement,
     itertools::Itertools,
     relay_cardinality::{
@@ -1104,6 +1106,8 @@ pub struct Addrs {
     pub outcome_aggregator: Addr<TrackOutcome>,
     pub upstream_relay: Addr<UpstreamRelay>,
     #[cfg(feature = "processing")]
+    pub upload: Option<Addr<UploadAttachments>>,
+    #[cfg(feature = "processing")]
     pub store_forwarder: Option<Addr<Store>>,
     pub aggregator: Addr<Aggregator>,
     #[cfg(feature = "processing")]
@@ -1115,6 +1119,8 @@ impl Default for Addrs {
         Addrs {
             outcome_aggregator: Addr::dummy(),
             upstream_relay: Addr::dummy(),
+            #[cfg(feature = "processing")]
+            upload: None,
             #[cfg(feature = "processing")]
             store_forwarder: None,
             aggregator: Addr::dummy(),
@@ -2297,7 +2303,27 @@ impl EnvelopeProcessorService {
             && let Some(store_forwarder) = &self.inner.addrs.store_forwarder
         {
             match submit {
-                Submit::Envelope(envelope) => store_forwarder.send(StoreEnvelope { envelope }),
+                Submit::Envelope(envelope) => {
+                    let envelope_has_attachments = envelope
+                        .envelope()
+                        .items()
+                        .any(|item| *item.ty() == ItemType::Attachment);
+                    // Whether Relay will store this attachment in objectstore or use kafka like before.
+                    let use_objectstore = || {
+                        let options = &self.inner.global_config.current().options;
+                        utils::sample(options.objectstore_attachments_sample_rate).is_keep()
+                    };
+
+                    if let Some(upload) = &self.inner.addrs.upload
+                        && envelope_has_attachments
+                        && use_objectstore()
+                    {
+                        // the `UploadService` will upload all attachments, and then forward the envelope to the `StoreService`.
+                        upload.send(UploadAttachments { envelope })
+                    } else {
+                        store_forwarder.send(StoreEnvelope { envelope })
+                    }
+                }
                 Submit::Output { output, ctx } => output
                     .forward_store(store_forwarder, ctx)
                     .unwrap_or_else(|err| err.into_inner()),

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -1,18 +1,17 @@
 //! Service that uploads attachments.
-use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
+use objectstore_client::{Client, ExpirationPolicy, Session, Usecase};
 use relay_config::UploadServiceConfig;
 use relay_quotas::DataCategory;
 use relay_system::{FromMessage, Interface, NoResponse, Receiver, Recipient, Service};
 use smallvec::smallvec;
-use tokio::sync::Notify;
-use uuid::Uuid;
 
+use crate::constants::DEFAULT_ATTACHMENT_RETENTION;
 use crate::managed::{Counted, Managed, OutcomeError, Quantities, Rejected};
 use crate::services::outcome::DiscardReason;
 use crate::statsd::{RelayCounters, RelayGauges};
@@ -37,7 +36,7 @@ impl Interface for Upload {}
 impl FromMessage<UploadAttachment> for Upload {
     type Response = NoResponse;
 
-    fn from_message(message: UploadAttachment, sender: ()) -> Self {
+    fn from_message(message: UploadAttachment, _sender: ()) -> Self {
         Self::Attachment(message)
     }
 }
@@ -48,7 +47,7 @@ pub struct Attachment {
     /// Attachment metadata.
     pub meta: AttachmentMeta,
     /// The attachment body.
-    payload: Bytes,
+    pub payload: Bytes,
 }
 
 impl Counted for Attachment {
@@ -66,7 +65,7 @@ impl Counted for Attachment {
 /// attachment.
 #[derive(Clone, Debug)]
 pub struct UploadedAttachment {
-    meta: AttachmentMeta,
+    pub stored_id: String,
     uploaded_bytes: usize,
 }
 
@@ -82,8 +81,16 @@ impl Counted for UploadedAttachment {
 /// Metadata of the attachment (stub).
 #[derive(Clone, Debug)]
 pub struct AttachmentMeta {
-    attachment_id: Option<String>,
+    pub attachment_id: Option<String>,
     // TODO: more fields
+    pub scope: AttachmentScope,
+}
+
+/// The attachment scope.
+#[derive(Clone, Debug)]
+pub struct AttachmentScope {
+    pub organization_id: u64,
+    pub project_id: u64,
 }
 
 /// Errors that can occur when trying to upload an attachment.
@@ -121,19 +128,34 @@ pub struct UploadService {
     pending_requests: FuturesUnordered<BoxFuture<'static, Result<(), Rejected<Error>>>>,
     max_concurrent_requests: usize,
     timeout: Duration,
+
+    objectstore_client: Client,
+    attachments_usecase: Usecase,
 }
 
 impl UploadService {
-    pub fn new(config: &UploadServiceConfig) -> Self {
+    pub fn new(config: &UploadServiceConfig) -> anyhow::Result<Option<Self>> {
         let UploadServiceConfig {
+            objectstore_url,
             max_concurrent_requests,
             timeout,
         } = config;
-        Self {
+        let Some(objectstore_url) = objectstore_url else {
+            return Ok(None);
+        };
+
+        let objectstore_client = Client::builder(objectstore_url).build()?;
+        let attachments_usecase = Usecase::new("attachments")
+            .with_expiration(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
+
+        Ok(Some(Self {
             pending_requests: FuturesUnordered::new(),
             max_concurrent_requests: *max_concurrent_requests,
             timeout: Duration::from_secs(*timeout),
-        }
+
+            objectstore_client,
+            attachments_usecase,
+        }))
     }
 
     fn handle_message(&mut self, message: Upload) {
@@ -148,8 +170,17 @@ impl UploadService {
             return;
         }
 
+        let AttachmentScope {
+            organization_id,
+            project_id,
+        } = attachment.meta.scope;
+        let session = self
+            .attachments_usecase
+            .for_project(organization_id, project_id)
+            .session(&self.objectstore_client);
+
         self.pending_requests
-            .push(handle_upload(self.timeout, attachment, respond_to).boxed());
+            .push(handle_upload(self.timeout, session, attachment, respond_to).boxed());
     }
 }
 
@@ -161,7 +192,7 @@ impl Service for UploadService {
         loop {
             relay_log::trace!("Upload loop iteration");
             tokio::select! {
-                //Bias towards handling responses so that there's space for new incoming requests.
+                // Bias towards handling responses so that there's space for new incoming requests.
                 biased;
 
                 Some(result) = self.pending_requests.next() => {
@@ -197,26 +228,36 @@ fn count_upload(result: Result<(), Rejected<Error>>) {
 /// Returns an [`UploadedAttachment`] if the upload was successful.
 async fn handle_upload(
     timeout: Duration,
+    session: Result<Session, objectstore_client::Error>,
     attachment: Managed<Attachment>,
     respond_to: Recipient<Managed<UploadedAttachment>, NoResponse>,
 ) -> Result<(), Rejected<Error>> {
+    let session = session.map_err(|_err| attachment.reject_err(Error::UploadFailed))?;
+
     relay_log::trace!("Starting upload");
     let key = attachment.meta.attachment_id.as_deref();
-    let new_key = tokio::time::timeout(timeout, async { upload(key, &attachment.payload).await })
+
+    let mut put_request = session.put(attachment.payload.clone());
+    if let Some(key) = key {
+        put_request = put_request.key(key);
+    }
+    let future = async {
+        let result = put_request.send().await?;
+        Ok(result.key)
+    };
+
+    let new_key = tokio::time::timeout(timeout, future)
         .await
         .map_err(|_elapsed| attachment.reject_err(Error::Timeout))?
-        .map_err(|_error| attachment.reject_err(Error::UploadFailed))?;
+        .map_err(|_error: objectstore_client::Error| attachment.reject_err(Error::UploadFailed))?;
 
     if key.is_some_and(|key| key != new_key) {
         return Err(attachment.reject_err(Error::KeyMismatch));
     }
 
-    let uploaded_attachment = attachment.map(|Attachment { mut meta, payload }, _| {
-        meta.attachment_id = Some(new_key);
-        UploadedAttachment {
-            meta,
-            uploaded_bytes: payload.len(),
-        }
+    let uploaded_attachment = attachment.map(|Attachment { payload, .. }, _| UploadedAttachment {
+        stored_id: new_key,
+        uploaded_bytes: payload.len(),
     });
 
     respond_to.send(uploaded_attachment);
@@ -224,19 +265,8 @@ async fn handle_upload(
     Ok(())
 }
 
-/// Uploads the payload to the objectstore and returns the key under which it is stored.
-///
-/// - If `key` is `None`, the objectstore will assign a key.
-/// - If `key` is not `None`, write to objectstore with the given key.
-async fn upload(key: Option<&str>, payload: &[u8]) -> Result<String, ()> {
-    // TODO: call objectstore
-    Ok(key.unwrap_or_default().to_owned())
-}
-
 #[cfg(test)]
 mod tests {
-    use relay_redis::redis::FromRedisValue;
-    use relay_system::Addr;
 
     use super::*;
 
@@ -245,14 +275,21 @@ mod tests {
         let upload_service = UploadService::new(&UploadServiceConfig {
             max_concurrent_requests: 2,
             timeout: 1,
+            objectstore_url: Some("http://127.0.0.1:8888/".into()),
         })
+        .unwrap()
+        .unwrap()
         .start_detached();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let (attachment, mut managed_handle) = Managed::for_test(Attachment {
+        let (attachment, mut _managed_handle) = Managed::for_test(Attachment {
             meta: AttachmentMeta {
                 attachment_id: Some("my_key".to_owned()),
+                scope: AttachmentScope {
+                    organization_id: 123,
+                    project_id: 456,
+                },
             },
             payload: Bytes::from("hello world"),
         })
@@ -263,7 +300,7 @@ mod tests {
             respond_to: Recipient::<_, NoResponse>::new(tx),
         });
         let uploaded = rx.recv().await.unwrap();
-        assert_eq!(uploaded.meta.attachment_id.as_deref(), Some("my_key"));
+        assert_eq!(uploaded.stored_id, "my_key");
         uploaded.accept(|_| {});
 
         drop(upload_service);

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -1,114 +1,52 @@
 //! Service that uploads attachments.
+use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
 use objectstore_client::{Client, ExpirationPolicy, Session, Usecase};
 use relay_config::UploadServiceConfig;
-use relay_quotas::DataCategory;
-use relay_system::{FromMessage, Interface, NoResponse, Receiver, Recipient, Service};
-use smallvec::smallvec;
+use relay_system::{Addr, FromMessage, Interface, NoResponse, Receiver, Service};
 
 use crate::constants::DEFAULT_ATTACHMENT_RETENTION;
-use crate::managed::{Counted, Managed, OutcomeError, Quantities, Rejected};
+use crate::envelope::{Item, ItemType};
+use crate::managed::{Managed, OutcomeError, TypedEnvelope};
 use crate::services::outcome::DiscardReason;
+use crate::services::processor::Processed;
+use crate::services::store::{Store, StoreEnvelope};
 use crate::statsd::{RelayCounters, RelayGauges};
 
 use super::outcome::Outcome;
 
-/// Message that requests an attachment upload.
-pub struct UploadAttachment {
-    /// The attachment to be uploaded.
-    pub attachment: Managed<Attachment>,
-
-    /// The return address in case of a successful upload.
-    pub respond_to: Recipient<Managed<UploadedAttachment>, NoResponse>,
+/// Message that requests all [`Attachment`]s of the [`Envelope`](crate::envelope::Envelope) to be uploaded.
+pub struct UploadAttachments {
+    /// The envelope containing [`Attachment`]s for upload.
+    pub envelope: TypedEnvelope<Processed>,
 }
 
-pub enum Upload {
-    Attachment(UploadAttachment),
-}
+impl Interface for UploadAttachments {}
 
-impl Interface for Upload {}
-
-impl FromMessage<UploadAttachment> for Upload {
+impl FromMessage<UploadAttachments> for UploadAttachments {
     type Response = NoResponse;
 
-    fn from_message(message: UploadAttachment, _sender: ()) -> Self {
-        Self::Attachment(message)
+    fn from_message(message: UploadAttachments, _sender: ()) -> Self {
+        message
     }
-}
-
-/// The attachment to upload.
-#[derive(Clone, Debug)]
-pub struct Attachment {
-    /// Attachment metadata.
-    pub meta: AttachmentMeta,
-    /// The attachment body.
-    pub payload: Bytes,
-}
-
-impl Counted for Attachment {
-    fn quantities(&self) -> Quantities {
-        smallvec![
-            (DataCategory::Attachment, self.payload.len()),
-            (DataCategory::AttachmentItem, 1),
-        ]
-    }
-}
-
-/// The result of a successful attachment upload.
-///
-/// This is tracked so that the recipient of the success message can emit outcomes for the
-/// attachment.
-#[derive(Clone, Debug)]
-pub struct UploadedAttachment {
-    pub stored_id: String,
-    uploaded_bytes: usize,
-}
-
-impl Counted for UploadedAttachment {
-    fn quantities(&self) -> Quantities {
-        smallvec![
-            (DataCategory::Attachment, self.uploaded_bytes),
-            (DataCategory::AttachmentItem, 1),
-        ]
-    }
-}
-
-/// Metadata of the attachment (stub).
-#[derive(Clone, Debug)]
-pub struct AttachmentMeta {
-    pub attachment_id: Option<String>,
-    // TODO: more fields
-    pub scope: AttachmentScope,
-}
-
-/// The attachment scope.
-#[derive(Clone, Debug)]
-pub struct AttachmentScope {
-    pub organization_id: u64,
-    pub project_id: u64,
 }
 
 /// Errors that can occur when trying to upload an attachment.
 #[derive(Debug)]
 pub enum Error {
-    LoadShed,
     Timeout,
     UploadFailed,
-    KeyMismatch,
 }
 
 impl Error {
     fn as_str(&self) -> &'static str {
         match self {
-            Error::LoadShed => "load_shed",
             Error::Timeout => "timeout",
             Error::UploadFailed => "upload_failed",
-            Error::KeyMismatch => "key_mismatch",
         }
     }
 }
@@ -125,16 +63,17 @@ impl OutcomeError for Error {
 ///
 /// Accepts upload requests and maintains a list of concurrent uploads.
 pub struct UploadService {
-    pending_requests: FuturesUnordered<BoxFuture<'static, Result<(), Rejected<Error>>>>,
+    pending_requests: FuturesUnordered<BoxFuture<'static, ()>>,
     max_concurrent_requests: usize,
-    timeout: Duration,
-
-    objectstore_client: Client,
-    attachments_usecase: Usecase,
+    inner: Arc<UploadServiceInner>,
 }
 
 impl UploadService {
-    pub fn new(config: &UploadServiceConfig) -> anyhow::Result<Option<Self>> {
+    pub fn new(
+        config: &UploadServiceConfig,
+        store: Option<Addr<Store>>,
+    ) -> anyhow::Result<Option<Self>> {
+        let Some(store) = store else { return Ok(None) };
         let UploadServiceConfig {
             objectstore_url,
             max_concurrent_requests,
@@ -146,46 +85,43 @@ impl UploadService {
 
         let objectstore_client = Client::builder(objectstore_url).build()?;
         let attachments_usecase = Usecase::new("attachments")
-            .with_expiration(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
+            .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
+
+        let inner = UploadServiceInner {
+            timeout: Duration::from_secs(*timeout),
+
+            store,
+
+            objectstore_client,
+            attachments_usecase,
+        };
 
         Ok(Some(Self {
             pending_requests: FuturesUnordered::new(),
             max_concurrent_requests: *max_concurrent_requests,
-            timeout: Duration::from_secs(*timeout),
-
-            objectstore_client,
-            attachments_usecase,
+            inner: Arc::new(inner),
         }))
     }
 
-    fn handle_message(&mut self, message: Upload) {
-        let Upload::Attachment(UploadAttachment {
-            attachment,
-            respond_to,
-        }) = message;
+    fn handle_message(&self, message: UploadAttachments) {
+        let UploadAttachments { envelope } = message;
         if self.pending_requests.len() >= self.max_concurrent_requests {
             // Load shed to prevent backlogging in the service queue and affecting other parts of Relay.
             // We might want to have a less aggressive mechanism in the future.
-            count_upload(Err(attachment.reject_err(Error::LoadShed)));
+
+            // for now, this will just forward to the store endpoint without uploading attachments.
+            self.inner.store.send(StoreEnvelope { envelope });
             return;
         }
 
-        let AttachmentScope {
-            organization_id,
-            project_id,
-        } = attachment.meta.scope;
-        let session = self
-            .attachments_usecase
-            .for_project(organization_id, project_id)
-            .session(&self.objectstore_client);
-
-        self.pending_requests
-            .push(handle_upload(self.timeout, session, attachment, respond_to).boxed());
+        let inner = self.inner.clone();
+        let future = async move { inner.handle_envelope(envelope).await };
+        self.pending_requests.push(future.boxed());
     }
 }
 
 impl Service for UploadService {
-    type Interface = Upload;
+    type Interface = UploadAttachments;
 
     async fn run(mut self, mut rx: Receiver<Self::Interface>) {
         relay_log::info!("Upload service started");
@@ -195,10 +131,7 @@ impl Service for UploadService {
                 // Bias towards handling responses so that there's space for new incoming requests.
                 biased;
 
-                Some(result) = self.pending_requests.next() => {
-                    relay_log::trace!("One upload has finished");
-                    count_upload(result);
-                }
+                Some(_) = self.pending_requests.next() => {},
                 Some(message) = rx.recv() => self.handle_message(message),
 
                 else => break,
@@ -212,98 +145,128 @@ impl Service for UploadService {
     }
 }
 
-fn count_upload(result: Result<(), Rejected<Error>>) {
-    let result_msg = match result {
-        Ok(()) => "success",
-        Err(e) => e.into_inner().as_str(),
-    };
-    relay_statsd::metric!(
-        counter(RelayCounters::AttachmentUpload) += 1,
-        result = result_msg
-    );
-}
-
-/// Spend a limited time trying to upload an attachment, and emit outcomes if this fails.
-///
-/// Returns an [`UploadedAttachment`] if the upload was successful.
-async fn handle_upload(
+struct UploadServiceInner {
     timeout: Duration,
-    session: Result<Session, objectstore_client::Error>,
-    attachment: Managed<Attachment>,
-    respond_to: Recipient<Managed<UploadedAttachment>, NoResponse>,
-) -> Result<(), Rejected<Error>> {
-    let session = session.map_err(|_err| attachment.reject_err(Error::UploadFailed))?;
+    store: Addr<Store>,
 
-    relay_log::trace!("Starting upload");
-    let key = attachment.meta.attachment_id.as_deref();
-
-    let mut put_request = session.put(attachment.payload.clone());
-    if let Some(key) = key {
-        put_request = put_request.key(key);
-    }
-    let future = async {
-        let result = put_request.send().await?;
-        Ok(result.key)
-    };
-
-    let new_key = tokio::time::timeout(timeout, future)
-        .await
-        .map_err(|_elapsed| attachment.reject_err(Error::Timeout))?
-        .map_err(|_error: objectstore_client::Error| attachment.reject_err(Error::UploadFailed))?;
-
-    if key.is_some_and(|key| key != new_key) {
-        return Err(attachment.reject_err(Error::KeyMismatch));
-    }
-
-    let uploaded_attachment = attachment.map(|Attachment { payload, .. }, _| UploadedAttachment {
-        stored_id: new_key,
-        uploaded_bytes: payload.len(),
-    });
-
-    respond_to.send(uploaded_attachment);
-    relay_log::trace!("Finished upload");
-    Ok(())
+    objectstore_client: Client,
+    attachments_usecase: Usecase,
 }
 
-#[cfg(test)]
-mod tests {
+impl UploadServiceInner {
+    /// Spend a limited time trying to upload an attachment, and emit outcomes if this fails.
+    ///
+    /// Returns an [`UploadedAttachment`] if the upload was successful.
+    async fn handle_envelope(&self, mut envelope: TypedEnvelope<Processed>) -> () {
+        let scoping = envelope.scoping();
+        let session = self
+            .attachments_usecase
+            .for_project(scoping.organization_id.value(), scoping.project_id.value())
+            .session(&self.objectstore_client);
 
-    use super::*;
+        let attachments = envelope
+            .envelope_mut()
+            .items_mut()
+            .filter(|item| *item.ty() == ItemType::Attachment);
+        let upload_results = if let Ok(session) = session {
+            futures::future::join_all(
+                attachments.map(|attachment| self.handle_attachment(&session, attachment)),
+            )
+            .await
+        } else {
+            // if we have any kind of error constructing the upload session, we mark all attachments as failed
+            attachments.map(|_| Err(Error::UploadFailed)).collect()
+        };
 
-    #[tokio::test]
-    async fn test_basic() {
-        let upload_service = UploadService::new(&UploadServiceConfig {
-            max_concurrent_requests: 2,
-            timeout: 1,
-            objectstore_url: Some("http://127.0.0.1:8888/".into()),
-        })
-        .unwrap()
-        .unwrap()
-        .start_detached();
+        // track the results of attachment upload
+        let managed_attachments = envelope
+            .envelope()
+            .items()
+            .filter(|item| *item.ty() == ItemType::Attachment)
+            .map(|item| Managed::from_envelope(&envelope, item));
+        for (attachment, result) in managed_attachments.zip(upload_results) {
+            let result_msg = match result {
+                Ok(()) => {
+                    attachment.accept(|_| ());
+                    "success"
+                }
+                Err(error) => attachment.reject_err(error).into_inner().as_str(),
+            };
+            relay_statsd::metric!(
+                counter(RelayCounters::AttachmentUpload) += 1,
+                result = result_msg
+            );
+        }
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        // last but not least, forward the envelope to the store endpoint
+        self.store.send(StoreEnvelope { envelope });
+    }
 
-        let (attachment, mut _managed_handle) = Managed::for_test(Attachment {
-            meta: AttachmentMeta {
-                attachment_id: Some("my_key".to_owned()),
-                scope: AttachmentScope {
-                    organization_id: 123,
-                    project_id: 456,
-                },
-            },
-            payload: Bytes::from("hello world"),
-        })
-        .build();
+    async fn handle_attachment(
+        &self,
+        session: &Session,
+        attachment: &mut Item,
+    ) -> Result<(), Error> {
+        // we are not storing zero-size attachments in objectstore
+        if attachment.is_empty() {
+            return Ok(());
+        }
+        relay_log::trace!("Starting attachment upload");
+        let future = async {
+            let result = session.put(attachment.payload()).send().await?;
+            Ok(result.key)
+        };
 
-        upload_service.send(UploadAttachment {
-            attachment,
-            respond_to: Recipient::<_, NoResponse>::new(tx),
-        });
-        let uploaded = rx.recv().await.unwrap();
-        assert_eq!(uploaded.stored_id, "my_key");
-        uploaded.accept(|_| {});
+        let stored_key = tokio::time::timeout(self.timeout, future)
+            .await
+            .map_err(|_elapsed| Error::Timeout)?
+            .map_err(|_error: objectstore_client::Error| Error::UploadFailed)?;
 
-        drop(upload_service);
-        assert!(rx.recv().await.is_none());
+        attachment.set_stored_key(stored_key);
+        relay_log::trace!("Finished attachment upload");
+
+        Ok(())
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[tokio::test]
+//     async fn test_basic() {
+//         let upload_service = UploadService::new(&UploadServiceConfig {
+//             max_concurrent_requests: 2,
+//             timeout: 1,
+//             objectstore_url: Some("http://127.0.0.1:8888/".into()),
+//         })
+//         .unwrap()
+//         .unwrap()
+//         .start_detached();
+
+//         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+//         let (attachment, mut _managed_handle) = Managed::for_test(Attachment {
+//             meta: AttachmentMeta {
+//                 attachment_id: Some("my_key".to_owned()),
+//                 scope: AttachmentScope {
+//                     organization_id: 123,
+//                     project_id: 456,
+//                 },
+//             },
+//             payload: Bytes::from("hello world"),
+//         })
+//         .build();
+
+//         upload_service.send(UploadAttachment {
+//             attachment,
+//             respond_to: Recipient::<_, NoResponse>::new(tx),
+//         });
+//         let uploaded = rx.recv().await.unwrap();
+//         assert_eq!(uploaded.stored_id, "my_key");
+//         uploaded.accept(|_| {});
+
+//         drop(upload_service);
+//         assert!(rx.recv().await.is_none());
+//     }
+// }

--- a/relay-server/src/testutils.rs
+++ b/relay-server/src/testutils.rs
@@ -117,6 +117,8 @@ pub async fn create_test_processor(config: Config) -> EnvelopeProcessorService {
             upstream_relay,
             #[cfg(feature = "processing")]
             store_forwarder: None,
+            #[cfg(feature = "processing")]
+            upload: None,
             aggregator,
             #[cfg(feature = "processing")]
             global_rate_limits,

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -360,15 +360,17 @@ def test_minidump_invalid_nested_formdata(mini_sentry, relay):
 
 
 @pytest.mark.parametrize(
-    "rate_limit,minidump_filename",
+    "rate_limit,minidump_filename,use_objectstore",
     [
-        (None, "minidump.dmp"),
-        ("attachment", "minidump.dmp"),
-        ("transaction", "minidump.dmp"),
-        (None, "minidump.dmp.gz"),
-        (None, "minidump.dmp.xz"),
-        (None, "minidump.dmp.bz2"),
-        (None, "minidump.dmp.zst"),
+        (None, "minidump.dmp", True),
+        (None, "minidump.dmp", False),
+        ("attachment", "minidump.dmp", True),
+        ("attachment", "minidump.dmp", False),
+        ("transaction", "minidump.dmp", False),
+        (None, "minidump.dmp.gz", False),
+        (None, "minidump.dmp.xz", False),
+        (None, "minidump.dmp.bz2", False),
+        (None, "minidump.dmp.zst", False),
     ],
 )
 def test_minidump_with_processing(
@@ -377,6 +379,7 @@ def test_minidump_with_processing(
     attachments_consumer,
     rate_limit,
     minidump_filename,
+    use_objectstore,
 ):
     dmp_path = os.path.join(os.path.dirname(__file__), "fixtures/native/minidump.dmp")
     with open(dmp_path, "rb") as f:
@@ -390,11 +393,20 @@ def test_minidump_with_processing(
         with open(compressed_dmp_path, "rb") as f:
             compressed_content = f.read()
 
-    relay = relay_with_processing()
-
+    if use_objectstore:
+        mini_sentry.global_config["options"][
+            "relay.objectstore-attachments.sample-rate"
+        ] = 1.0
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 50000
+
+    options = (
+        {"processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}}}
+        if use_objectstore
+        else None
+    )
+    relay = relay_with_processing(options)
 
     # Disable scurbbing, the basic and full project configs from the mini_sentry fixture
     # will modify the minidump since it contains user paths in the module list.  This breaks
@@ -431,11 +443,12 @@ def test_minidump_with_processing(
     num_chunks = 0
     attachment_id = None
 
-    while attachment != content:
-        chunk, message = attachments_consumer.get_attachment_chunk()
-        attachment_id = attachment_id or message["id"]
-        attachment += chunk
-        num_chunks += 1
+    if not use_objectstore:
+        while attachment != content:
+            chunk, message = attachments_consumer.get_attachment_chunk()
+            attachment_id = attachment_id or message["id"]
+            attachment += chunk
+            num_chunks += 1
 
     event, message = attachments_consumer.get_event()
 
@@ -451,17 +464,32 @@ def test_minidump_with_processing(
     # Check that the SDK name is correctly detected
     assert event["sdk"]["name"] == "minidump.unknown"
 
-    assert list(message["attachments"]) == [
-        {
-            "id": attachment_id,
+    if not use_objectstore:
+        assert list(message["attachments"]) == [
+            {
+                "id": attachment_id,
+                "name": "minidump.dmp",
+                "rate_limited": rate_limit == "attachment",
+                "attachment_type": "event.minidump",
+                "content_type": "application/x-dmp",
+                "size": len(content),
+                "chunks": num_chunks,
+            }
+        ]
+    else:
+        (attachment,) = message["attachments"]
+
+        # this means the attachment is stored in objectstore
+        assert attachment.pop("stored_id")
+
+        assert attachment.pop("id")
+        assert attachment == {
             "name": "minidump.dmp",
             "rate_limited": rate_limit == "attachment",
             "attachment_type": "event.minidump",
             "content_type": "application/x-dmp",
             "size": len(content),
-            "chunks": num_chunks,
         }
-    ]
 
     assert "errors" not in event
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -3,6 +3,7 @@ import os
 import msgpack
 
 import pytest
+from objectstore_client import Client, Usecase
 from requests import HTTPError
 from uuid import UUID
 
@@ -479,8 +480,11 @@ def test_minidump_with_processing(
     else:
         (attachment,) = message["attachments"]
 
-        # this means the attachment is stored in objectstore
-        assert attachment.pop("stored_id")
+        objectstore_key = attachment.pop("stored_id")
+        objectstore_session = Client("http://127.0.0.1:8888/").session(
+            Usecase("attachments"), org=1, project=project_id
+        )
+        assert objectstore_session.get(objectstore_key).payload.read() == content
 
         assert attachment.pop("id")
         assert attachment == {

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,14 @@ wheels = [
 ]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25" },
+]
+
+[[package]]
 name = "flake8"
 version = "7.0.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -301,6 +309,20 @@ version = "1.9.1"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
     { url = "https://pypi.devinfra.sentry.io/wheels/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9" },
+]
+
+[[package]]
+name = "objectstore-client"
+version = "0.0.11"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+dependencies = [
+    { name = "filetype", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sentry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "zstandard", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/objectstore_client-0.0.11-py3-none-any.whl", hash = "sha256:ed435c7a0297a5b75bfc6a6a90257d1c54e7e2a10ff6b03085faacf604c1eb8b" },
 ]
 
 [[package]]
@@ -491,6 +513,7 @@ dev = [
     { name = "milksnake", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "msgpack", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mypy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "objectstore-client", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "opentelemetry-proto", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pre-commit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -529,6 +552,7 @@ dev = [
     { name = "milksnake", specifier = ">=0.1.6" },
     { name = "msgpack", specifier = ">=1.1.0" },
     { name = "mypy", specifier = ">=1.10.0" },
+    { name = "objectstore-client", specifier = "==0.0.11" },
     { name = "opentelemetry-proto", specifier = ">=1.32.1" },
     { name = "packaging", specifier = "==25.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },


### PR DESCRIPTION
Changes to the `UploadService` to handle whole envelopes, uploading attachments and mutating the envelope items in-place, before forwarding it to the `StoreService` for further forwarding to kafka.