### PR TITLE
ref(spanv2): Drop span kind as a top level field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
-- Remove the span kind from the `Span v2` schema as a top level field. ([#5368](https://github.com/getsentry/relay/pull/5368))
+- Remove the span kind from the Kafka span schema. ([#5368](https://github.com/getsentry/relay/pull/5368))
 - Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5308))
 
 ## 25.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Switch default allocator from jemalloc to mimalloc. ([#5239](https://github.com/getsentry/relay/pull/5239))
 - Add internal attributes to aid searching trace metrics. ([#5260](https://github.com/getsentry/relay/pull/5260))
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
+- Remove the span kind from the `Span v2` schema as a top level field. ([#5368](https://github.com/getsentry/relay/pull/5368))
 - Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5308))
 
 ## 25.10.0

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -78,5 +78,6 @@ mod not_yet_defined {
     pub const STATUS_MESSAGE: &str = "sentry.status.message";
 
     pub const IS_REMOTE: &str = "sentry.is_remote";
+    pub const SPAN_KIND: &str = "sentry.kind";
 }
 pub use self::not_yet_defined::*;

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use serde::Serialize;
 
 use crate::processor::ProcessValue;
-use crate::protocol::{Attributes, OperationType, SpanId, SpanKind, Timestamp, TraceId};
+use crate::protocol::{Attributes, OperationType, SpanId, Timestamp, TraceId};
 
 /// A version 2 (transactionless) span.
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
@@ -31,13 +31,6 @@ pub struct SpanV2 {
 
     /// Whether this span is the root span of a segment.
     pub is_segment: Annotated<bool>,
-
-    /// Used to clarify the relationship between parents and children, or to distinguish between
-    /// spans, e.g. a `server` and `client` span with the same name.
-    ///
-    /// See <https://opentelemetry.io/docs/specs/otel/trace/api/#spankind>
-    #[metastructure(skip_serialization = "empty", trim = false)]
-    pub kind: Annotated<SpanKind>,
 
     /// Timestamp when the span started.
     #[metastructure(required = true)]
@@ -65,7 +58,6 @@ impl Getter for SpanV2 {
         Some(match path.strip_prefix("span.")? {
             "name" => self.name.value()?.as_str().into(),
             "status" => self.status.value()?.as_str().into(),
-            "kind" => self.kind.value()?.as_str().into(),
             path => {
                 if let Some(key) = path.strip_prefix("attributes.") {
                     let key = key.strip_suffix(".value")?;
@@ -208,7 +200,6 @@ mod tests {
   "name": "GET http://app.test/",
   "status": "ok",
   "is_segment": true,
-  "kind": "server",
   "start_timestamp": 1742921669.25,
   "end_timestamp": 1742921669.75,
   "links": [
@@ -309,7 +300,6 @@ mod tests {
             span_id: Annotated::new("438f40bd3b4a41ee".parse().unwrap()),
             parent_span_id: Annotated::empty(),
             status: Annotated::new(SpanV2Status::Ok),
-            kind: Annotated::new(SpanKind::Server),
             is_segment: Annotated::new(true),
             links: Annotated::new(links),
             attributes: Annotated::new(attributes),

--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -701,7 +701,6 @@ mod tests {
             "parent_span_id": "0c7a7dea069bf5a6",
             "start_timestamp": 123,
             "end_timestamp": 123.5,
-            "kind": "client",
             "attributes": {
                 "sentry.kind": {
                     "value": "client",
@@ -1080,7 +1079,6 @@ mod tests {
             "parent_span_id": "0c7a7dea069bf5a6",
             "start_timestamp": 123,
             "end_timestamp": 123.5,
-            "kind": "client",
             "attributes": {
                 "sentry.kind": {
                     "value": "client",
@@ -1210,7 +1208,6 @@ mod tests {
             "start_timestamp": 123,
             "end_timestamp": 123.5,
             "name": "GET /api/users",
-            "kind": "server",
             "attributes": {
                 "sentry.kind": {
                     "value": "server",
@@ -1259,7 +1256,6 @@ mod tests {
             "start_timestamp": 123,
             "end_timestamp": 123.5,
             "name": "SELECT users",
-            "kind": "client",
             "attributes": {
                 "sentry.kind": {
                     "value": "client",
@@ -1308,7 +1304,6 @@ mod tests {
             "start_timestamp": 123,
             "end_timestamp": 123.5,
             "name": "POST /graphql",
-            "kind": "server",
             "attributes": {
                 "sentry.kind": {
                     "value": "server",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -814,7 +814,7 @@ def test_span_ingestion(
                     "value": "my 3rd protobuf OTel span",
                 },
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
-                "sentry.kind": {"type": "double", "value": "consumer"},
+                "sentry.kind": {"type": "string", "value": "consumer"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
                 "sentry.status": {"type": "string", "value": "ok"},

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -746,6 +746,7 @@ def test_span_ingestion(
                 "sentry.browser.name": {"type": "string", "value": "Python Requests"},
                 "sentry.description": {"type": "string", "value": "my 2nd OTel span"},
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
+                "sentry.kind": {"type": "string", "value": "producer"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
                 "sentry.segment.id": {"type": "string", "value": "d342abb1214ca182"},
@@ -757,7 +758,6 @@ def test_span_ingestion(
             },
             "end_timestamp": end.timestamp(),
             "is_segment": True,
-            "kind": "producer",
             "links": [
                 {
                     "trace_id": "89143b0763095bd9c9955e8175d1fb24",
@@ -814,6 +814,7 @@ def test_span_ingestion(
                     "value": "my 3rd protobuf OTel span",
                 },
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
+                "sentry.kind": {"type": "double", "value": "consumer"},
                 "sentry.op": {"type": "string", "value": "default"},
                 "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
                 "sentry.status": {"type": "string", "value": "ok"},
@@ -824,7 +825,6 @@ def test_span_ingestion(
                 },
             },
             "end_timestamp": end.timestamp(),
-            "kind": "consumer",
             "links": [
                 {
                     "trace_id": "89143b0763095bd9c9955e8175d1fb24",

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -98,12 +98,12 @@ def test_span_ingestion(
                 "value": time_within(ts, expect_resolution="ns"),
             },
             "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
+            "sentry.kind": {"type": "string", "value": "server"},
             "ui.component_name": {"type": "string", "value": "MyComponent"},
         },
         "downsampled_retention_days": 90,
         "end_timestamp": time_within(ts.timestamp() - 0.5),
         "key_id": 123,
-        "kind": "server",
         "links": [
             {
                 "attributes": {


### PR DESCRIPTION
Removes the kind as a top level field from a SpanV2 span. Instead merges it into the attribute `sentry.kind` where the buffer previously would extract it to.

The [schema](https://github.com/getsentry/sentry-kafka-schemas/blob/main/schemas/ingest-spans.v1.schema.json#L62-L64) already lists the attribute as optional.

In a follow-up:
- Remove the mapping from Sentry
- Remove the field from the schema
- Add `sentry.kind` to conventions

Refs: INGEST-631