### PR TITLE
ci(ci): Speed up subsequent integration test runs by always caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,6 +742,7 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}
+          cache-on-failure: "true"
 
       - name: Setup SSH agent
         if: env.SSH_PRIVATE_KEY != ''


### PR DESCRIPTION
This should make tests run faster on the second commit or even a retry as the rust build is already cached.

Only enabled for integration tests for now as this is the biggest and least consequential target.