### PR TITLE
fix(spans): Prevent duplicate `end_timestamp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Tag spans' count per root metric with the trace root's transaction instead of the local transaction. ([#5281](https://github.com/getsentry/relay/pull/5281))
 - Use `vercel.path` instead of `url.path` for Vercel Log Drain Transform. ([#5274](https://github.com/getsentry/relay/pull/5274))
 - Add Google Storebot to the crawler filter list. ([#5300](https://github.com/getsentry/relay/pull/5300))
+- Prevent duplicate fields in kafka spans. ([#5373](https://github.com/getsentry/relay/pull/5373))
 
 **Internal**:
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -134,9 +134,8 @@ pub struct Span {
     )]
     pub performance_issues_spans: Annotated<bool>,
 
-    // TODO remove retain when the api stabilizes
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(additional_properties, retain = true, pii = "maybe")]
+    #[metastructure(additional_properties, pii = "maybe")]
     pub other: Object<Value>,
 }
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -134,8 +134,9 @@ pub struct Span {
     )]
     pub performance_issues_spans: Annotated<bool>,
 
+    // TODO remove retain when the api stabilizes
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(additional_properties, pii = "maybe")]
+    #[metastructure(additional_properties, retain = true, pii = "maybe")]
     pub other: Object<Value>,
 }
 

--- a/relay-protocol-derive/src/lib.rs
+++ b/relay-protocol-derive/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 #![recursion_limit = "256"]
 
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use proc_macro2::{Span, TokenStream};
@@ -333,6 +334,14 @@ fn derive_metastructure(mut s: synstructure::Structure<'_>, t: Trait) -> syn::Re
 
     let mut is_tuple_struct = false;
 
+    let mut field_names = BTreeSet::new();
+    for (index, bi) in variant.bindings().iter().enumerate() {
+        let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct)?;
+        if !field_attrs.additional_properties {
+            field_names.insert(field_attrs.field_name.clone());
+        }
+    }
+
     for (index, bi) in variant.bindings().iter().enumerate() {
         let field_attrs = parse_field_attributes(index, bi.ast(), &mut is_tuple_struct)?;
         let field_name = field_attrs.field_name.clone();
@@ -349,16 +358,24 @@ fn derive_metastructure(mut s: synstructure::Structure<'_>, t: Trait) -> syn::Re
             }).to_tokens(&mut from_value_body);
 
             (quote! {
-                __map.extend(#bi.into_iter().map(|(__key, __value)| (
-                    __key,
-                    Annotated::map_value(__value, ::relay_protocol::IntoValue::into_value)
-                )));
+                for (__key, __value) in #bi {
+                    // Additional properties may not overwrite existing fields:
+                    __map.entry(__key).or_insert(
+                        Annotated::map_value(__value, ::relay_protocol::IntoValue::into_value)
+                    );
+                }
             })
             .to_tokens(&mut to_value_body);
 
+            let field_names = field_names.iter().map(String::as_str).collect::<Vec<_>>();
+            assert!(field_names.is_sorted());
             (quote! {
+                let __field_names = &[ #( #field_names ),* ];
                 for (__key, __value) in #bi.iter() {
                     if !__value.skip_serialization(#skip_serialization_attr) {
+                        if __field_names.binary_search(&__key.as_str()).is_ok() {
+                            continue;
+                        }
                         ::serde::ser::SerializeMap::serialize_key(&mut __map_serializer, __key)?;
                         ::serde::ser::SerializeMap::serialize_value(&mut __map_serializer, &::relay_protocol::SerializePayload(__value, #skip_serialization_attr))?;
                     }

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -39,7 +39,7 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
         was_transaction,
         kind,
         performance_issues_spans,
-        other,
+        other: _,
     } = span_v1;
 
     let mut annotated_attributes = attributes_from_data(data);
@@ -130,7 +130,7 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
         end_timestamp: timestamp,
         links: links.map_value(span_v1_links_to_span_v2_links),
         attributes: annotated_attributes,
-        other,
+        other: Default::default(), // cannot carry over because of schema mismatch
     }
 }
 
@@ -432,7 +432,6 @@ mod tests {
               "value": true
             }
           },
-          "additional_field": "additional field value",
           "_meta": {
             "attributes": {
               "my.array": {

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn conflicting_other() {
+    fn start_timestamp() {
         let json = r#"{"timestamp": 123, "end_timestamp": "invalid data"}"#;
         let span_v1 = Annotated::<SpanV1>::from_json(json).unwrap();
         let span_v2 = span_v1_to_span_v2(span_v1.into_value().unwrap());
@@ -501,7 +501,7 @@ mod tests {
             &Timestamp(DateTime::from_timestamp_secs(123).unwrap())
         );
 
-        let serialized = Annotated::from(span_v2).to_json().unwrap();
+        let serialized = Annotated::from(span_v2).payload_to_json().unwrap();
         assert_eq!(
             &serialized,
             r#"{"status":"ok","end_timestamp":123.0,"attributes":{}}"#

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn start_timestamp() {
+    fn conflicting_other() {
         let json = r#"{"timestamp": 123, "end_timestamp": "invalid data"}"#;
         let span_v1 = Annotated::<SpanV1>::from_json(json).unwrap();
         let span_v2 = span_v1_to_span_v2(span_v1.into_value().unwrap());
@@ -501,7 +501,7 @@ mod tests {
             &Timestamp(DateTime::from_timestamp_secs(123).unwrap())
         );
 
-        let serialized = Annotated::from(span_v2).payload_to_json().unwrap();
+        let serialized = Annotated::from(span_v2).to_json().unwrap();
         assert_eq!(
             &serialized,
             r#"{"status":"ok","end_timestamp":123.0,"attributes":{}}"#


### PR DESCRIPTION
1. The span V1 schema had `retain=true` on `additional_properties`.
2. On conversion from V1 to V2, additional properties were moved over 1:1.
3. An SDK accidentally sent `end_timestamp` instead of `timestamp` for a V1 span, which shadowed the `end_timestamp` of the span V2.
4. This timestamp was formatted as a string and got picked up by the consumer, which could not parse it.

ref: INC-1497, INGEST-633