### PR TITLE
feat(ai): Normalize model names for a better cost calculation

### DIFF
--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -305,7 +305,7 @@ static VERSION_REGEX: LazyLock<Regex> =
 /// Regex that matches date patterns at the end of a model name
 ///
 /// Pattern breakdown:
-/// 1. Optional separator: [-_@]?
+/// 1. Optional separator: `[-_@]?`
 /// 2. Date patterns (one of):
 ///    - \d{4}[-/\.]\d{2}[-/\.]\d{2} (YYYY-MM-DD with -, /, or .)
 ///    - \d{8} (YYYYMMDD)

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -302,16 +302,14 @@ static VERSION_OR_DATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         (
-            # Date with optional version (e.g., -20250805-v1:0 or -20250522)
-            ([-_@])?                                    # Optional separator before date
-            (\d{4}[-/\.]\d{2}[-/\.]\d{2}|\d{8})        # Date: YYYY-MM-DD or YYYYMMDD
-            ([-_]v\d+[:\.]?\d*([:\-].*)?)?              # Optional version after date
-        |
-            # Version only (e.g., -v1.0)
-            [-_]                                        # Required separator before version
+            ([-_@])?                                    # Optional separator before date (-, _, or @)
+            (\d{4}[-/\.]\d{2}[-/\.]\d{2}|\d{8})        # Date: YYYY-MM-DD/YYYY/MM/DD/YYYY.MM.DD or YYYYMMDD
+        )?                                              # Date is optional
+        (
+            [-_]                                        # Required separator before version (- or _)
             v\d+[:\.]?\d*                               # Version: v1, v1.0, v1:0
-            ([:\-].*)?                                  # Optional trailing content after version
-        )
+            ([:\-].*)?                                  # Optional trailing content
+        )?                                              # Version is optional
         $  # Must be at the end of the string
         ",
     )

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -288,7 +288,7 @@ impl ModelCosts {
     }
 }
 
-/// Regex that matches version and/or date patterns at the end of a model name
+/// Regex that matches version and/or date patterns at the end of a model name.
 ///
 /// Examples matched:
 /// - "-20250805-v1:0" in "claude-opus-4-1-20250805-v1:0" (both)
@@ -298,17 +298,17 @@ impl ModelCosts {
 /// - "-20250522" in "claude-4-sonnet-20250522" (date only)
 /// - "-2025-06-10" in "o3-pro-2025-06-10" (date only)
 /// - "@20241022" in "claude-3-5-haiku@20241022" (date only)
-static VERSION_OR_DATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+static VERSION_AND_DATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         (
             ([-_@])                                    # Required separator before date (-, _, or @)
-            (\d{4}[-/\.]\d{2}[-/\.]\d{2}|\d{8})        # Date: YYYY-MM-DD/YYYY/MM/DD/YYYY.MM.DD or YYYYMMDD
+            (\d{4}[-/.]\d{2}[-/.]\d{2}|\d{8})          # Date: YYYY-MM-DD/YYYY/MM/DD/YYYY.MM.DD or YYYYMMDD
         )?                                              # Date is optional
         (
             [-_]                                        # Required separator before version (- or _)
-            v\d+[:\.]?\d*                               # Version: v1, v1.0, v1:0
-            ([:\-].*)?                                  # Optional trailing content
+            v\d+[:.]?\d*                                # Version: v1, v1.0, v1:0
+            ([-:].*)?                                   # Optional trailing content
         )?                                              # Version is optional
         $  # Must be at the end of the string
         ",
@@ -347,7 +347,7 @@ static VERSION_OR_DATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 /// Returns:
 ///     The normalized model name without date and version patterns
 fn normalize_ai_model_name(model_id: &str) -> &str {
-    if let Some(captures) = VERSION_OR_DATE_REGEX.captures(model_id) {
+    if let Some(captures) = VERSION_AND_DATE_REGEX.captures(model_id) {
         let match_idx = captures.get(0).map(|m| m.start()).unwrap_or(model_id.len());
         &model_id[..match_idx]
     } else {

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
 use std::hash::Hash;
+use std::{collections::HashMap, sync::LazyLock};
 
+use regex::Regex;
 use relay_base_schema::metrics::MetricUnit;
 use relay_event_schema::protocol::{Event, VALID_PLATFORMS};
 use relay_pattern::Pattern;
@@ -266,19 +267,106 @@ impl ModelCosts {
             return None;
         }
 
+        let normalized_model_id = normalize_ai_model_name(model_id);
+
         // First try exact match by creating a Pattern from the model_id
-        if let Some(value) = self.models.get(model_id) {
+        if let Some(value) = self.models.get(normalized_model_id) {
             return Some(value);
         }
 
         // if there is not a direct match, try to find the match using a pattern
+        // since the name is already normalized, there are still patterns where the
+        // model name can have a prefix e.g. "us.antrophic.claude-sonnet-4" and this
+        // will be matched via glob "*claude-sonnet-4"
         self.models.iter().find_map(|(key, value)| {
-            if key.is_match(model_id) {
+            if key.is_match(normalized_model_id) {
                 Some(value)
             } else {
                 None
             }
         })
+    }
+}
+
+/// Regex that matches version patterns at the end of a model name
+///
+/// Pattern breakdown:
+/// 1. Separator: [-_]
+/// 2. Version pattern: v\d+[:\.]?\d* (must start with 'v': v1, v1.0, v1:0)
+/// 3. Optional trailing content: [:\-].*
+///
+/// Examples matched:
+/// - "-v1:0" in "claude-sonnet-4-20250514-v1:0"
+/// - "_v2" in "model_v2"
+/// - "-v1.0" in "gpt-4-v1.0"
+static VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[-_]v\d+[:\.]?\d*([:\-].*)?$").unwrap());
+
+/// Regex that matches date patterns at the end of a model name
+///
+/// Pattern breakdown:
+/// 1. Optional separator: [-_@]?
+/// 2. Date patterns (one of):
+///    - \d{4}[-/\.]\d{2}[-/\.]\d{2} (YYYY-MM-DD with -, /, or .)
+///    - \d{8} (YYYYMMDD)
+///
+/// Examples matched:
+/// - "-20250522" in "claude-4-sonnet-20250522"
+/// - "-2025-06-10" in "o3-pro-2025-06-10"
+/// - "@20241022" in "claude-3-5-haiku@20241022"
+static DATE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([-_@])?(\d{4}[-/\.]\d{2}[-/\.]\d{2}|\d{8})$").unwrap());
+
+/// Normalizes an AI model name by stripping date and version patterns.
+///
+/// This function converts specific model versions into normalized names suitable for matching
+/// against cost configurations, ensuring that different versions of the same model can share
+/// cost information.
+///
+/// The normalization happens in two steps:
+/// 1. Strip version patterns (if present)
+/// 2. Strip date patterns (if present)
+///
+/// Examples:
+/// - "claude-4-sonnet-20250522" -> "claude-4-sonnet"
+/// - "o3-pro-2025-06-10" -> "o3-pro"
+/// - "claude-3-5-haiku@20241022" -> "claude-3-5-haiku"
+/// - "claude-opus-4-1-20250805-v1:0" -> "claude-opus-4-1"
+/// - "us.anthropic.claude-sonnet-4-20250514-v1:0" -> "us.anthropic.claude-sonnet-4"
+/// - "gpt-4-v1.0" -> "gpt-4"
+/// - "gpt-4-v1:0" -> "gpt-4"
+/// - "model_v2" -> "model"
+///
+/// Version patterns (stripped first):
+/// - Must start with 'v': v1, v1.0, v1:0 (requires -, _ separator)
+///
+/// Date patterns (stripped second):
+/// - YYYYMMDD: 20250522
+/// - YYYY-MM-DD, YYYY/MM/DD, YYYY.MM.DD: 2025-06-10
+///
+/// Args:
+///     model_id: The original model ID
+///
+/// Returns:
+///     The normalized model name without date and version patterns
+fn normalize_ai_model_name(model_id: &str) -> &str {
+    // First, strip version patterns if present
+    let after_version = if let Some(captures) = VERSION_REGEX.captures(model_id) {
+        let match_idx = captures.get(0).map(|m| m.start()).unwrap_or(model_id.len());
+        &model_id[..match_idx]
+    } else {
+        model_id
+    };
+
+    // Then, strip date patterns if present
+    if let Some(captures) = DATE_REGEX.captures(after_version) {
+        let match_idx = captures
+            .get(0)
+            .map(|m| m.start())
+            .unwrap_or(after_version.len());
+        &after_version[..match_idx]
+    } else {
+        after_version
     }
 }
 
@@ -612,6 +700,50 @@ mod tests {
         assert_eq!(map.get_operation_type("gen_ai.other"), Some("default"));
 
         assert_eq!(map.get_operation_type("other.operation"), None);
+    }
+
+    #[test]
+    fn test_normalize_ai_model_name() {
+        // Test date patterns
+        assert_eq!(
+            normalize_ai_model_name("claude-4-sonnet-20250522"),
+            "claude-4-sonnet"
+        );
+        assert_eq!(normalize_ai_model_name("o3-pro-2025-06-10"), "o3-pro");
+        assert_eq!(
+            normalize_ai_model_name("claude-3-5-haiku@20241022"),
+            "claude-3-5-haiku"
+        );
+
+        // Test date with version patterns
+        assert_eq!(
+            normalize_ai_model_name("claude-opus-4-1-20250805-v1:0"),
+            "claude-opus-4-1"
+        );
+        assert_eq!(
+            normalize_ai_model_name("us.anthropic.claude-sonnet-4-20250514-v1:0"),
+            "us.anthropic.claude-sonnet-4"
+        );
+
+        // Test standalone version patterns with 'v' prefix
+        assert_eq!(normalize_ai_model_name("gpt-4-v1.0"), "gpt-4");
+        assert_eq!(normalize_ai_model_name("gpt-4-v1:0"), "gpt-4");
+        assert_eq!(normalize_ai_model_name("gpt-4-v1"), "gpt-4");
+        assert_eq!(normalize_ai_model_name("model_v2"), "model");
+
+        // Test that version patterns WITHOUT 'v' prefix are NOT stripped
+        assert_eq!(normalize_ai_model_name("gpt-4.5"), "gpt-4.5");
+
+        // Test that if version without 'v' comes after date, nothing is stripped
+        // (date regex requires end of string, so date won't match if followed by version)
+        assert_eq!(
+            normalize_ai_model_name("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            "anthropic.claude-3-5-sonnet"
+        );
+
+        // Test no pattern (should return original)
+        assert_eq!(normalize_ai_model_name("gpt-4"), "gpt-4");
+        assert_eq!(normalize_ai_model_name("claude-3-opus"), "claude-3-opus");
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -302,7 +302,7 @@ static VERSION_OR_DATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         (
-            ([-_@])?                                    # Optional separator before date (-, _, or @)
+            ([-_@])                                    # Required separator before date (-, _, or @)
             (\d{4}[-/\.]\d{2}[-/\.]\d{2}|\d{8})        # Date: YYYY-MM-DD/YYYY/MM/DD/YYYY.MM.DD or YYYYMMDD
         )?                                              # Date is optional
         (


### PR DESCRIPTION
Introduces normalization of model names in relay to support use case that weren't possible before. 

Before we would either find the exact match of the cost, or fall back to glob pattern matching, but this couldn't support all the cases (e.g. `us.antrophic.claude-4-v1`) because it would require us to have globs with `*` at the begining and the end of the name (e.g. `*claude-4*`) -- this would lead us to possibly falsy matching `claude-4.5` to `claude-4` pricing.

Now when there is no longer a need to match date and version with glob, we can be more flexible with `*` at the begining of the model name and match custom prefixes like `us.antrophic` before the model name.

Part of TET-1268
