### PR TITLE
fix(spanv2): Fix accounting in indexed and total categories after metric extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -4327,6 +4327,7 @@ dependencies = [
  "chrono",
  "criterion",
  "data-encoding",
+ "either",
  "flate2",
  "futures",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ dialoguer = "0.11.0"
 dynfmt = "0.1.5"
 ed25519-dalek = { version = "2.2.0", features = ["digest"] }
 enumset = "1.1.10"
+either = "1.15.0"
 flate2 = "1.1.4"
 flume = { version = "0.11.1", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -44,6 +44,7 @@ bytes = { workspace = true, features = ["serde"] }
 bzip2 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 data-encoding = { workspace = true }
+either = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true, features = ["async-await"] }
 hashbrown = { workspace = true }

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -106,12 +106,6 @@ impl Counted for WithHeader<SpanV2> {
     }
 }
 
-impl Counted for SpanV2 {
-    fn quantities(&self) -> Quantities {
-        smallvec::smallvec![(DataCategory::Span, 1), (DataCategory::SpanIndexed, 1)]
-    }
-}
-
 impl Counted for Annotated<Span> {
     fn quantities(&self) -> Quantities {
         smallvec::smallvec![(DataCategory::Span, 1), (DataCategory::SpanIndexed, 1)]

--- a/relay-server/src/metrics/minimal.rs
+++ b/relay-server/src/metrics/minimal.rs
@@ -1,6 +1,4 @@
-use relay_metrics::{
-    BucketMetadata, CounterType, MetricName, MetricNamespace, MetricResourceIdentifier,
-};
+use relay_metrics::{CounterType, MetricName, MetricNamespace, MetricResourceIdentifier};
 use serde::Deserialize;
 use serde::de::IgnoredAny;
 
@@ -15,8 +13,6 @@ pub struct MinimalTrackableBucket {
     name: MetricName,
     #[serde(flatten)]
     value: MinimalValue,
-    #[serde(default)]
-    metadata: BucketMetadata,
 }
 
 impl TrackableBucket for MinimalTrackableBucket {
@@ -44,10 +40,6 @@ impl TrackableBucket for MinimalTrackableBucket {
             }),
             _ => BucketSummary::default(),
         }
-    }
-
-    fn metadata(&self) -> BucketMetadata {
-        self.metadata
     }
 }
 
@@ -141,7 +133,6 @@ mod tests {
         for (b, mb) in buckets.iter().zip(min_buckets.iter()) {
             assert_eq!(b.name(), mb.name());
             assert_eq!(b.summary(), mb.summary());
-            assert_eq!(b.metadata, mb.metadata);
         }
 
         let summary = min_buckets.iter().map(|b| b.summary()).collect::<Vec<_>>();

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -144,7 +144,7 @@ pub async fn run(
 /// Type returned by [`create_indexed_metrics`].
 ///
 /// Contains the indexed spans and the metrics extracted from the spans.
-type ExtractedSpans = (Managed<ExpandedSpans<Indexed>>, Managed<ExtractedMetrics>);
+type SpansAndMetrics = (Managed<ExpandedSpans<Indexed>>, Managed<ExtractedMetrics>);
 
 /// Creates/extracts metrics for spans which have been determined to be kept by dynamic sampling.
 ///
@@ -153,7 +153,7 @@ type ExtractedSpans = (Managed<ExpandedSpans<Indexed>>, Managed<ExtractedMetrics
 pub fn create_indexed_metrics(
     spans: Managed<ExpandedSpans>,
     ctx: Context<'_>,
-) -> Either<Managed<ExpandedSpans>, ExtractedSpans> {
+) -> Either<Managed<ExpandedSpans>, SpansAndMetrics> {
     if !ctx.is_processing() {
         return Either::Left(spans);
     }

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 
 use chrono::Utc;
+use either::Either;
 use relay_dynamic_config::ErrorBoundary;
 use relay_metrics::{Bucket, BucketMetadata, BucketValue, UnixTimestamp};
 use relay_protocol::get_value;
@@ -15,7 +16,7 @@ use crate::managed::{Counted, Managed, Quantities};
 use crate::metrics_extraction::transactions::ExtractedMetrics;
 use crate::processing::Context;
 use crate::processing::spans::{
-    Error, ExpandedSpans, Result, SampledSpans, SerializedSpans, outcome_count,
+    Error, ExpandedSpans, Indexed, Result, SampledSpans, SerializedSpans, outcome_count,
 };
 use crate::services::outcome::Outcome;
 use crate::services::projects::project::ProjectInfo;
@@ -140,34 +141,36 @@ pub async fn run(
     Err(metrics)
 }
 
+/// Type returned by [`create_indexed_metrics`].
+///
+/// Contains the indexed spans and the metrics extracted from the spans.
+type ExtractedSpans = (Managed<ExpandedSpans<Indexed>>, Managed<ExtractedMetrics>);
+
 /// Creates/extracts metrics for spans which have been determined to be kept by dynamic sampling.
 ///
 /// Indexed metrics can only be extracted from the Relay making the final sampling decision,
-/// if the current Relay is not the final Relay, the function returns `None`.
+/// if the current Relay is not the final Relay, the function returns the original spans unchanged.
 pub fn create_indexed_metrics(
-    spans: &Managed<ExpandedSpans>,
+    spans: Managed<ExpandedSpans>,
     ctx: Context<'_>,
-) -> Option<Managed<ExtractedMetrics>> {
+) -> Either<Managed<ExpandedSpans>, ExtractedSpans> {
     if !ctx.is_processing() {
-        return None;
+        return Either::Left(spans);
     }
 
-    let metrics = create_metrics(
-        spans.scoping(),
-        spans.spans.len() as u32,
-        spans.headers.dsc(),
-        SamplingDecision::Keep,
-    );
+    let scoping = spans.scoping();
+    let (indexed, metrics) = spans.split_once(|spans| {
+        let metrics = create_metrics(
+            scoping,
+            spans.spans.len() as u32,
+            spans.headers.dsc(),
+            SamplingDecision::Keep,
+        );
 
-    // Metrics are extracted from indexed spans, they should not emit any span outcomes.
-    debug_assert!(
-        metrics
-            .quantities()
-            .into_iter()
-            .all(|(c, _)| c == DataCategory::MetricBucket)
-    );
+        (spans.into_indexed(), metrics)
+    });
 
-    Some(spans.wrap(metrics))
+    Either::Right((indexed, metrics))
 }
 
 async fn compute(spans: &Managed<SerializedSpans>, ctx: Context<'_>) -> SamplingResult {

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -39,6 +39,7 @@ pub fn expand(spans: Managed<SampledSpans>) -> Managed<ExpandedSpans> {
             headers: spans.inner.headers,
             server_sample_rate: spans.server_sample_rate,
             spans: all_spans,
+            category: spans::TotalAndIndexed,
         }
     })
 }

--- a/relay-server/src/processing/spans/store.rs
+++ b/relay-server/src/processing/spans/store.rs
@@ -3,9 +3,8 @@ use std::ops::Deref;
 use relay_event_schema::protocol::SpanV2;
 use relay_protocol::{Annotated, FiniteF64};
 
-use crate::envelope::WithHeader;
 use crate::processing::Retention;
-use crate::processing::spans::{Error, Result};
+use crate::processing::spans::{Error, IndexedSpan, Result};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreSpanV2;
 
@@ -33,8 +32,8 @@ pub struct Context {
 }
 
 /// Converts a processed [`SpanV2`] into a [Kafka](crate::services::store::Store) compatible format.
-pub fn convert(span: WithHeader<SpanV2>, ctx: &Context) -> Result<Box<StoreSpanV2>> {
-    let mut span = required!(span.value);
+pub fn convert(span: IndexedSpan, ctx: &Context) -> Result<Box<StoreSpanV2>> {
+    let mut span = required!(span.0.value);
 
     let routing_key = span.trace_id.value().map(|v| *v.deref());
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -137,7 +137,7 @@ pub struct StoreSpanV2 {
 
 impl Counted for StoreSpanV2 {
     fn quantities(&self) -> Quantities {
-        self.item.quantities()
+        smallvec::smallvec![(DataCategory::SpanIndexed, 1)]
     }
 }
 


### PR DESCRIPTION
When initially implementing it, I made the mistake to keep the total category with the span itself, but after metric extraction the ownership of the total category should transfer over to the metrics.

Adds the `either` crate as a dependency, it's not a new dependency it was already in the dependency tree. I think this models the use well, alternatively I can also make our own `Either` enum.