### PR TITLE
docs(changelog): Move breaking changes back to the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Breaking Changes**:
+
+- Simplify proxy mode to forward without processing. ([#5165](https://github.com/getsentry/relay/pull/5165))
+
 **Features**:
 
 - Only apply non-destructive PII rules to log bodies by default. ([#5272](https://github.com/getsentry/relay/pull/5272))
@@ -15,10 +19,6 @@
 - Replace `is_remote` with `is_segment` on the Span V2 schema. ([#5306](https://github.com/getsentry/relay/pull/5306))
 - Add `response_timeout` config setting for Redis. ([#5329](https://github.com/getsentry/relay/pull/5329))
 - Remove `projects:discard-transaction` feature flag. ([#5307](https://github.com/getsentry/relay/pull/5307))
-
-**Breaking Changes**:
-
-- Simplify proxy mode to forward without processing. ([#5165](https://github.com/getsentry/relay/pull/5165))
 
 **Bug Fixes**:
 


### PR DESCRIPTION
Self hosted release is coming up, breaking changes should be on the top.