### PR TITLE
build(conventions): Bump sentry conventions

### DIFF
--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -16,10 +16,19 @@ convention_attributes!(
     BROWSER_NAME => "sentry.browser.name",
     BROWSER_VERSION => "sentry.browser.version",
     CLIENT_ADDRESS => "client.address",
+    CLIENT_SAMPLE_RATE => "sentry.client_sample_rate",
     DB_QUERY_TEXT => "db.query.text",
     DB_STATEMENT => "db.statement",
     DB_SYSTEM_NAME => "db.system.name",
     DESCRIPTION => "sentry.description",
+    DSC_ENVIRONMENT => "sentry.dsc.environment",
+    DSC_PUBLIC_KEY => "sentry.dsc.public_key",
+    DSC_RELEASE => "sentry.dsc.release",
+    DSC_SAMPLED => "sentry.dsc.sampled",
+    DSC_SAMPLE_RATE => "sentry.dsc.sample_rate",
+    DSC_TRACE_ID => "sentry.dsc.trace_id",
+    DSC_TRANSACTION => "sentry.dsc.transaction",
+    ENVIRONMENT => "sentry.environment",
     FAAS_TRIGGER => "faas.trigger",
     GEN_AI_COST_INPUT_TOKENS => "gen_ai.cost.input_tokens",
     GEN_AI_COST_OUTPUT_TOKENS => "gen_ai.cost.output_tokens",
@@ -33,51 +42,40 @@ convention_attributes!(
     GEN_AI_USAGE_OUTPUT_REASONING_TOKENS => "gen_ai.usage.output_tokens.reasoning",
     GEN_AI_USAGE_OUTPUT_TOKENS => "gen_ai.usage.output_tokens",
     GEN_AI_USAGE_TOTAL_TOKENS => "gen_ai.usage.total_tokens",
+    GRAPHQL_OPERATION => "sentry.graphql.operation",
     HTTP_PREFETCH => "sentry.http.prefetch",
     HTTP_REQUEST_METHOD => "http.request.method",
     HTTP_RESPONSE_STATUS_CODE => "http.response.status_code",
     HTTP_ROUTE => "http.route",
     HTTP_TARGET => "http.target",
+    IS_REMOTE => "sentry.is_remote",
     MESSAGING_SYSTEM => "messaging.system",
-    ENVIRONMENT => "sentry.environment",
     OBSERVED_TIMESTAMP_NANOS => "sentry.observed_timestamp_nanos",
     OP => "sentry.op",
     ORIGIN => "sentry.origin",
     PLATFORM => "sentry.platform",
     PROFILE_ID => "sentry.profile_id",
     RELEASE => "sentry.release",
-    SERVER_ADDRESS => "server.address",
     RPC_GRPC_STATUS_CODE => "rpc.grpc.status_code",
     RPC_SERVICE => "rpc.service",
     SEGMENT_ID => "sentry.segment.id",
     SEGMENT_NAME => "sentry.segment.name",
+    SERVER_ADDRESS => "server.address",
+    SPAN_KIND => "sentry.kind",
+    STATUS_MESSAGE => "sentry.status.message",
     URL_FULL => "url.full",
     URL_PATH => "url.path",
+    USER_AGENT_ORIGINAL => "user_agent.original",
     USER_GEO_CITY => "user.geo.city",
     USER_GEO_COUNTRY_CODE => "user.geo.country_code",
     USER_GEO_REGION => "user.geo.region",
     USER_GEO_SUBDIVISION => "user.geo.subdivision",
-    USER_AGENT_ORIGINAL => "user_agent.original",
-    CLIENT_SAMPLE_RATE => "sentry.client_sample_rate",
-    DSC_TRACE_ID => "sentry.dsc.trace_id",
-    DSC_PUBLIC_KEY => "sentry.dsc.public_key",
-    DSC_RELEASE => "sentry.dsc.release",
-    DSC_ENVIRONMENT => "sentry.dsc.environment",
-    DSC_TRANSACTION => "sentry.dsc.transaction",
-    DSC_SAMPLE_RATE => "sentry.dsc.sample_rate",
-    DSC_SAMPLED => "sentry.dsc.sampled",
 );
 
 /// Attributes which are in use by Relay but are not yet defined in the Sentry conventions.
-mod not_yet_defined {
-    // For now, it can be found in the JavaScript SDK:
-    // https://github.com/getsentry/sentry-javascript/blob/4756112a9d233ca6f1b0be64d64d892279797a39/packages/opentelemetry/src/semanticAttributes.ts#L4-L5
-    pub const GRAPHQL_OPERATION: &str = "sentry.graphql.operation";
-    // It was introduced in `a1f1e89` (https://github.com/getsentry/relay/pull/4876)
-    // to absorb the `status.message` field from OTEL.
-    pub const STATUS_MESSAGE: &str = "sentry.status.message";
-
-    pub const IS_REMOTE: &str = "sentry.is_remote";
-    pub const SPAN_KIND: &str = "sentry.kind";
-}
+///
+/// Really do not add to this list, at all, ever. The only reason this opt-out even exists to make a
+/// transition easier for attributes which Relay already uses but aren't yet in conventions.
+mod not_yet_defined {}
+#[expect(unused, reason = "no special attributes at the moment")]
 pub use self::not_yet_defined::*;


### PR DESCRIPTION
Updates Sentry conventions, no longer any extra attributes required.

Also sorts the existing list alphabetically again.