### PR TITLE
build: Bump sentry-release-parser to 1.4.0 and add semver-1 feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,12 +4933,13 @@ dependencies = [
 
 [[package]]
 name = "sentry-release-parser"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663a866435288420b8af1ecd0fe5774c4d5f0f584eadb2456303d8ab0f5c8313"
+checksum = "c98f1c38deb5d037aacfcbf6790951da8acba07b7e3a3c8b90df531f2d4ebae2"
 dependencies = [
  "lazy_static",
  "regex",
+ "semver",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ sentry = { version = "0.41.0", default-features = false, features = [
 ] }
 sentry-core = "0.41.0"
 sentry-kafka-schemas = { version = "2.1.14", default-features = false }
-sentry-release-parser = { version = "1.3.2", default-features = false }
+sentry-release-parser = { version = "1.4.0", default-features = false, features = ["semver-1"] }
 sentry-types = "0.41.0"
 sentry_protos = "0.4.2"
 serde = { version = "=1.0.228", features = ["derive", "rc"] }

--- a/relay-cabi/Cargo.toml
+++ b/relay-cabi/Cargo.toml
@@ -33,7 +33,7 @@ relay-ffi = { workspace = true }
 relay-pii = { workspace = true }
 relay-protocol = { workspace = true }
 relay-sampling = { workspace = true }
-sentry-release-parser = { workspace = true, features = ["serde"] }
+sentry-release-parser = { workspace = true, features = ["serde", "semver-1"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
relates to REPLAY-803

Bump sentry-release-parser to version 1.4.0. 

This release includes the addition of a [new feature flag `semver-1`](https://github.com/getsentry/sentry-release-parser/pull/49), which exposes the `semver` 1.0 API (we are currently exposing `semver` 0.9 API under feature flag `semver`). By using `semver-1` feature flag we can access the `cmp_precedence` function, which will allow us to support comparing release versions while ignoring build code.

followup: https://github.com/getsentry/relay/pull/5376