### PR TITLE
ref(instr): Instrument rate limit timings for new processing pipeline

### DIFF
--- a/relay-server/src/processing/limits.rs
+++ b/relay-server/src/processing/limits.rs
@@ -72,7 +72,12 @@ impl QuotaRateLimiter {
             redis::CombinedRateLimiter(limiter, redis)
         };
 
-        relay_statsd::metric!(timer(RelayTimers::EventProcessingRateLimiting), type = "consistent", unit = std::any::type_name::<T>(), {
+        let ty = match self.redis.is_some() {
+            true => "consistent",
+            false => "cached",
+        };
+
+        relay_statsd::metric!(timer(RelayTimers::EventProcessingRateLimiting), type = ty, unit = std::any::type_name::<T>(), {
             data.enforce(limiter, ctx).await
         })
     }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -389,6 +389,8 @@ pub enum RelayTimers {
     ///
     /// This metric is tagged with:
     ///  - `type`: The type of limiter executed, `cached` or `consistent`.
+    ///  - `unit`: The item/unit of work which is being rate limited, only available for new
+    ///    processing pipelines.
     EventProcessingRateLimiting,
     /// Time in milliseconds spent in data scrubbing for the current event. Data scrubbing happens
     /// last before serializing the event back to JSON.


### PR DESCRIPTION
Selects the type based on what is enforced, for consistent this will include the cached limits, but that's okay.