### PR TITLE
ref(quotas): Return consumed quota from Redis script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Derive the rate limiting decision in Relay from consumed quota. ([#5390](https://github.com/getsentry/relay/pull/5390))
+
 ## 25.11.0
 
 **Breaking Changes**:

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -361,7 +361,7 @@ impl<T: GlobalLimiter> RedisRateLimiter<T> {
             let is_rejected = limit >= 0
                 && match quantity == 0 || over_accept_once {
                     true => consumed >= limit,
-                    false => consumed + quantity > limit,
+                    false => consumed.saturating_add(quantity) > limit,
                 };
 
             if is_rejected {

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug};
 
 use relay_common::time::UnixTimestamp;
 use relay_log::protocol::value;
-use relay_redis::redis::{FromRedisValue, Script};
+use relay_redis::redis::{self, FromRedisValue, Script};
 use relay_redis::{AsyncRedisClient, RedisError, RedisScripts};
 use thiserror::Error;
 
@@ -378,10 +378,10 @@ impl<T: GlobalLimiter> RedisRateLimiter<T> {
 struct ScriptResult(Vec<QuotaState>);
 
 impl FromRedisValue for ScriptResult {
-    fn from_redis_value(v: &relay_redis::redis::Value) -> relay_redis::redis::RedisResult<Self> {
+    fn from_redis_value(v: &redis::Value) -> redis::RedisResult<Self> {
         let Some(seq) = v.as_sequence() else {
-            return Err(relay_redis::redis::RedisError::from((
-                relay_redis::redis::ErrorKind::TypeError,
+            return Err(redis::RedisError::from((
+                redis::ErrorKind::TypeError,
                 "Expected a sequence from the rate limiting script",
                 format!("{v:?}"),
             )));
@@ -389,8 +389,8 @@ impl FromRedisValue for ScriptResult {
 
         let (chunks, rem) = seq.as_chunks();
         if !rem.is_empty() {
-            return Err(relay_redis::redis::RedisError::from((
-                relay_redis::redis::ErrorKind::TypeError,
+            return Err(redis::RedisError::from((
+                redis::ErrorKind::TypeError,
                 "Expected an even number of values from the rate limiting script",
                 format!("{v:?}"),
             )));


### PR DESCRIPTION
~~Instead of returning the rate limiting decision from the Redis script, the script now returns the currently consumed quota, we then derive the rate limiting decision from that in Relay again.~~

~~This seems like a complication at first, but to improve the rate limiter we need the currently consumed quota and the alternative to just returning the consumed quota is to return the consumed quota and the decision, which means we need to transfer double the amount of information from Redis to Relay with a more complicated encoding scheme. Hence the decision to derive the rejected status from the consumed amount a second time in Relay.~~

The Redis script now also returns the currently consumed quota, before making a decision, to support future use-cases where we need to know the currently consumed quota.

Returning the value before applying the decision may need to be changed in the future, depending on requirements, it is fine for now and the value is currently unused.

While the rejected decision can be derived from the consumed value and the quota, we want to make a consistent decision in the script to avoid possible bugs.

Refs: INGEST-639