### PR TITLE
feat(spans): Add span_count item header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Support uploading attachments directly to objectstore. ([#5367](https://github.com/getsentry/relay/pull/5367))
+- Add `span_count` item header to the envelope protocol. ([#5392](https://github.com/getsentry/relay/pull/5392))
 
 ## 25.11.0
 
@@ -26,7 +27,6 @@
 - Add `response_timeout` config setting for Redis. ([#5329](https://github.com/getsentry/relay/pull/5329))
 - Remove `projects:discard-transaction` feature flag. ([#5307](https://github.com/getsentry/relay/pull/5307))
 - Add SEER_USER data category. ([#5383](https://github.com/getsentry/relay/pull/5383))
-- Add `span_count` item header to the envelope protocol. ([#5392](https://github.com/getsentry/relay/pull/5392))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add `response_timeout` config setting for Redis. ([#5329](https://github.com/getsentry/relay/pull/5329))
 - Remove `projects:discard-transaction` feature flag. ([#5307](https://github.com/getsentry/relay/pull/5307))
 - Add SEER_USER data category. ([#5383](https://github.com/getsentry/relay/pull/5383))
+- Add `span_count` item header to the envelope protocol. ([#5392](https://github.com/getsentry/relay/pull/5392))
 
 **Bug Fixes**:
 

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -232,11 +232,7 @@ impl Item {
     pub fn ensure_span_count(&mut self) -> usize {
         match self.headers.span_count {
             Some(count) => count,
-            None => {
-                relay_statsd::metric!(timer(RelayTimers::CheckNestedSpans), {
-                    self.refresh_span_count()
-                })
-            }
+            None => self.refresh_span_count(),
         }
     }
 
@@ -582,7 +578,9 @@ impl Item {
             return None;
         }
 
-        let event = serde_json::from_slice::<PartialEvent>(&self.payload()).ok()?;
+        let event = relay_statsd::metric!(timer(RelayTimers::CheckNestedSpans), {
+            serde_json::from_slice::<PartialEvent>(&self.payload()).ok()?
+        });
 
         Some(event.spans.0)
     }

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -197,6 +197,11 @@ impl Item {
         self.headers.span_count.unwrap_or(0)
     }
 
+    #[cfg(test)]
+    pub fn set_span_count(&mut self, value: usize) {
+        self.headers.span_count = Some(value);
+    }
+
     /// Sets the `span_count` item header by shallow parsing the event.
     ///
     /// Returns the recomputed count.

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -110,10 +110,19 @@ impl Item {
 
         match self.ty() {
             ItemType::Event => smallvec![(DataCategory::Error, item_count)],
-            ItemType::Transaction => smallvec![
-                (DataCategory::Transaction, item_count),
-                (DataCategory::TransactionIndexed, item_count),
-            ],
+            ItemType::Transaction => {
+                let mut quantities = smallvec![
+                    (DataCategory::Transaction, item_count),
+                    (DataCategory::TransactionIndexed, item_count),
+                ];
+                if !self.spans_extracted() {
+                    quantities.extend([
+                        (DataCategory::Span, item_count + self.span_count()),
+                        (DataCategory::SpanIndexed, item_count + self.span_count()),
+                    ]);
+                }
+                quantities
+            }
             ItemType::Security | ItemType::RawSecurity => {
                 smallvec![(DataCategory::Security, item_count)]
             }

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -193,18 +193,17 @@ impl Item {
     }
 
     /// Returns the number of spans in `event.spans`.
+    pub fn span_count(&self) -> Option<usize> {
+        self.headers.span_count
+    }
+
+    /// Sets the `span_count` item header by shallow parsing the event.
     ///
-    /// This function lazily sets & returns the span count if it is `None`.
-    pub fn span_count(&mut self) -> usize {
-        match &mut self.headers.span_count {
-            Some(count) => *count,
-            None => {
-                let count = self.parse_span_count();
-                self.headers.span_count = Some(count);
-                count
-            }
-        }
-        // TODO(follow-up): Refresh span count after re-serializing the transaction
+    /// Returns the recomputed count.
+    pub fn refresh_span_count(&mut self) -> usize {
+        let count = self.parse_span_count();
+        self.headers.span_count = Some(count);
+        count
     }
 
     /// Returns the content type of this item's payload.
@@ -959,10 +958,6 @@ fn default_true() -> bool {
 
 fn is_true(value: &bool) -> bool {
     *value
-}
-
-fn is_zero(val: &u32) -> bool {
-    *val == 0
 }
 
 #[cfg(test)]

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -14,6 +14,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::envelope::{AttachmentType, ContentType, EnvelopeError};
 use crate::integrations::{Integration, LogsIntegration, SpansIntegration};
+use crate::statsd::RelayTimers;
 
 #[derive(Clone, Debug)]
 pub struct Item {
@@ -192,32 +193,41 @@ impl Item {
         }
     }
 
-    /// Returns the number of spans in `event.spans`.
+    /// Returns the number of spans in the `event.spans` array.
+    ///
+    /// Should always be 0 except for transaction items.
+    ///
+    /// When a transaction is dropped before spans were extracted from a transaction,
+    /// this number is used to emit correct outcomes for the spans category.
+    ///
+    /// This number does *not* count the transaction itself.
     pub fn span_count(&self) -> usize {
         self.headers.span_count.unwrap_or(0)
     }
 
-    #[cfg(test)]
-    pub fn set_span_count(&mut self, value: usize) {
-        self.headers.span_count = Some(value);
+    /// Sets the number of spans in the transaction payload.
+    pub fn set_span_count(&mut self, value: Option<usize>) {
+        self.headers.span_count = value;
     }
 
     /// Sets the `span_count` item header by shallow parsing the event.
     ///
     /// Returns the recomputed count.
-    pub fn refresh_span_count(&mut self) -> usize {
+    fn refresh_span_count(&mut self) -> usize {
         let count = self.parse_span_count();
         self.headers.span_count = count;
         count.unwrap_or(0)
     }
 
-    /// Returns the span_count header, and computes it if it is not yet set.
-    ///
-    /// Returns the recomputed count.
+    /// Returns the `span_count`` header, and computes it if it has not yet been set.
     pub fn ensure_span_count(&mut self) -> usize {
         match self.headers.span_count {
             Some(count) => count,
-            None => self.refresh_span_count(),
+            None => {
+                relay_statsd::metric!(timer(RelayTimers::CheckNestedSpans), {
+                    self.refresh_span_count()
+                })
+            }
         }
     }
 

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -162,6 +162,7 @@ pub fn serialize<Group: EventProcessing>(
     event_item.set_metrics_extracted(event_metrics_extracted.0);
     event_item.set_spans_extracted(spans_extracted.0);
     event_item.set_fully_normalized(event_fully_normalized.0);
+    event_item.refresh_span_count();
 
     managed_envelope.envelope_mut().add_item(event_item);
 

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -162,7 +162,7 @@ pub fn serialize<Group: EventProcessing>(
     event_item.set_metrics_extracted(event_metrics_extracted.0);
     event_item.set_spans_extracted(spans_extracted.0);
     event_item.set_fully_normalized(event_fully_normalized.0);
-    event_item.refresh_span_count();
+    event_item.set_span_count(event.value().and_then(|e| e.spans.value()).map(Vec::len));
 
     managed_envelope.envelope_mut().add_item(event_item);
 

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -144,7 +144,9 @@ fn sync_spans_to_enforcement(envelope: &mut ManagedEnvelope, enforcement: &mut E
         .envelope_mut()
         .items_mut()
         .find(|item| *item.ty() == ItemType::Transaction && !item.spans_extracted())
-        .map_or(0, |item| item.span_count());
+        .map_or(0, |item| item.refresh_span_count());
+
+    // TODO(follow-up): Refresh span count after re-serializing the transaction
 
     if spans_count == 0 {
         return;

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -144,7 +144,7 @@ fn sync_spans_to_enforcement(envelope: &mut ManagedEnvelope, enforcement: &mut E
         .envelope_mut()
         .items_mut()
         .find(|item| *item.ty() == ItemType::Transaction && !item.spans_extracted())
-        .map_or(0, |item| item.ensure_span_count());
+        .map_or(0, |item| 1 + item.ensure_span_count());
 
     if spans_count == 0 {
         return;
@@ -200,6 +200,15 @@ mod tests {
             .unwrap();
 
         RequestMeta::new(dsn)
+    }
+
+    fn get_span_count(managed_envelope: &ManagedEnvelope) -> usize {
+        managed_envelope
+            .envelope()
+            .items()
+            .next()
+            .unwrap()
+            .span_count()
     }
 
     #[tokio::test]
@@ -258,7 +267,9 @@ mod tests {
 
         let managed_envelope = ManagedEnvelope::new(envelope, outcome_aggregator.clone());
 
+        assert_eq!(get_span_count(&managed_envelope), 0); // not written yet
         project.check_envelope(managed_envelope).await.unwrap();
+
         drop(outcome_aggregator);
 
         let expected = [
@@ -266,6 +277,69 @@ mod tests {
             (DataCategory::TransactionIndexed, 1),
             (DataCategory::Span, 3),
             (DataCategory::SpanIndexed, 3),
+        ];
+
+        for (expected_category, expected_quantity) in expected {
+            let outcome = outcome_aggregator_rx.recv().await.unwrap();
+            assert_eq!(outcome.category, expected_category);
+            assert_eq!(outcome.quantity, expected_quantity);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_track_nested_spans_outcomes_predefined() {
+        let config = Default::default();
+        let project = create_project(
+            &config,
+            Some(json!({
+                "quotas": [{
+                   "id": "foo",
+                   "categories": ["transaction"],
+                   "window": 3600,
+                   "limit": 0,
+                   "reasonCode": "foo",
+               }]
+            })),
+        );
+
+        let mut envelope = Envelope::from_request(Some(EventId::new()), request_meta());
+
+        let mut transaction = Item::new(ItemType::Transaction);
+        transaction.set_span_count(666);
+        transaction.set_payload(
+            ContentType::Json,
+            r#"{
+  "event_id": "52df9022835246eeb317dbd739ccd059",
+  "type": "transaction",
+  "transaction": "I have a stale timestamp, but I'm recent!",
+  "start_timestamp": 1,
+  "timestamp": 2,
+  "contexts": {
+    "trace": {
+      "trace_id": "ff62a8b040f340bda5d830223def1d81",
+      "span_id": "bd429c44b67a3eb4"
+    }
+  },
+  "spans": []
+}"#,
+        );
+
+        envelope.add_item(transaction);
+
+        let (outcome_aggregator, mut outcome_aggregator_rx) = relay_system::Addr::custom();
+
+        let managed_envelope = ManagedEnvelope::new(envelope, outcome_aggregator.clone());
+
+        assert_eq!(get_span_count(&managed_envelope), 666);
+        project.check_envelope(managed_envelope).await.unwrap();
+
+        drop(outcome_aggregator);
+
+        let expected = [
+            (DataCategory::Transaction, 1),
+            (DataCategory::TransactionIndexed, 1),
+            (DataCategory::Span, 667),
+            (DataCategory::SpanIndexed, 667),
         ];
 
         for (expected_category, expected_quantity) in expected {

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -173,6 +173,7 @@ fn count_nested_spans(envelope: &mut ManagedEnvelope) -> Option<usize> {
 
     let count = event.spans.0;
     item.set_span_count(count as u32);
+    // TODO(follow-up): Update span count when serializing the event back into the envelope.
 
     Some(count)
 }

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -144,9 +144,7 @@ fn sync_spans_to_enforcement(envelope: &mut ManagedEnvelope, enforcement: &mut E
         .envelope_mut()
         .items_mut()
         .find(|item| *item.ty() == ItemType::Transaction && !item.spans_extracted())
-        .map_or(0, |item| item.refresh_span_count());
-
-    // TODO(follow-up): Refresh span count after re-serializing the transaction
+        .map_or(0, |item| item.ensure_span_count());
 
     if spans_count == 0 {
         return;

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -9,7 +9,6 @@ use crate::managed::ManagedEnvelope;
 use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::projects::cache::state::SharedProject;
 use crate::services::projects::project::ProjectState;
-use crate::statsd::RelayTimers;
 use crate::utils::{CheckLimits, Enforcement, EnvelopeLimiter};
 
 /// A loaded project.
@@ -88,9 +87,7 @@ impl<'a> Project<'a> {
 
         // If we can extract spans from the event, we want to try and count the number of nested
         // spans to correctly emit negative outcomes in case the transaction itself is dropped.
-        relay_statsd::metric!(timer(RelayTimers::CheckNestedSpans), {
-            sync_spans_to_enforcement(&mut envelope, &mut enforcement);
-        });
+        sync_spans_to_enforcement(&mut envelope, &mut enforcement);
 
         enforcement.apply_with_outcomes(&mut envelope);
 
@@ -305,7 +302,7 @@ mod tests {
         let mut envelope = Envelope::from_request(Some(EventId::new()), request_meta());
 
         let mut transaction = Item::new(ItemType::Transaction);
-        transaction.set_span_count(666);
+        transaction.set_span_count(Some(666));
         transaction.set_payload(
             ContentType::Json,
             r#"{

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1635,6 +1635,8 @@ mod tests {
             vec![
                 (DataCategory::Transaction, 1),
                 (DataCategory::TransactionIndexed, 1),
+                (DataCategory::Span, 1),
+                (DataCategory::SpanIndexed, 1),
             ]
         );
     }
@@ -1665,8 +1667,11 @@ mod tests {
         assert!(!enforcement.event.is_active());
         assert!(!enforcement.profiles_indexed.is_active());
         assert!(!enforcement.profiles.is_active());
+        assert!(!enforcement.spans.is_active());
+        assert!(!enforcement.spans_indexed.is_active());
         mock.lock().await.assert_call(DataCategory::Transaction, 1);
         mock.lock().await.assert_call(DataCategory::Profile, 1);
+        mock.lock().await.assert_call(DataCategory::Span, 1);
     }
 
     #[tokio::test]
@@ -1722,6 +1727,8 @@ mod tests {
                 (DataCategory::TransactionIndexed, 1),
                 (DataCategory::Profile, 1),
                 (DataCategory::ProfileIndexed, 1),
+                (DataCategory::Span, 1),
+                (DataCategory::SpanIndexed, 1),
             ]
         );
     }
@@ -1769,7 +1776,8 @@ mod tests {
             vec![
                 (DataCategory::TransactionIndexed, 1),
                 (DataCategory::Attachment, 10),
-                (DataCategory::AttachmentItem, 1)
+                (DataCategory::AttachmentItem, 1),
+                (DataCategory::SpanIndexed, 1),
             ]
         );
     }

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1157,13 +1157,16 @@ def test_no_transaction_metrics_when_filtered(mini_sentry, relay):
     relay.send_transaction(project_id, tx)
 
     # The only envelopes received should be outcomes for Transaction{,Indexed}:
-    reports = [mini_sentry.get_client_report() for _ in range(2)]
+    reports = [mini_sentry.get_client_report() for _ in range(4)]
     filtered_events = [
         outcome for report in reports for outcome in report["filtered_events"]
     ]
     filtered_events.sort(key=lambda x: x["category"])
 
+    # NOTE: span categories should be 2.
     assert filtered_events == [
+        {"reason": "release-version", "category": "span", "quantity": 1},
+        {"reason": "release-version", "category": "span_indexed", "quantity": 1},
         {"reason": "release-version", "category": "transaction", "quantity": 1},
         {"reason": "release-version", "category": "transaction_indexed", "quantity": 1},
     ]

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1164,6 +1164,7 @@ def test_no_transaction_metrics_when_filtered(mini_sentry, relay):
     filtered_events.sort(key=lambda x: x["category"])
 
     # NOTE: span categories should be 2.
+    # Will be fixed in https://github.com/getsentry/relay/pull/5379.
     assert filtered_events == [
         {"reason": "release-version", "category": "span", "quantity": 1},
         {"reason": "release-version", "category": "span_indexed", "quantity": 1},

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -2029,7 +2029,7 @@ def test_span_outcomes_invalid(
     envelope = make_envelope()
     upstream.send_envelope(project_id, envelope)
 
-    outcomes = outcomes_consumer.get_outcomes(timeout=10.0, n=4)
+    outcomes = outcomes_consumer.get_outcomes(timeout=10.0, n=5)
     outcomes.sort(key=lambda o: sorted(o.items()))
 
     assert outcomes == [

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -2029,7 +2029,7 @@ def test_span_outcomes_invalid(
     envelope = make_envelope()
     upstream.send_envelope(project_id, envelope)
 
-    outcomes = outcomes_consumer.get_outcomes(timeout=10.0, n=5)
+    outcomes = outcomes_consumer.get_outcomes(timeout=10.0, n=6)
     outcomes.sort(key=lambda o: sorted(o.items()))
 
     assert outcomes == [
@@ -2048,7 +2048,9 @@ def test_span_outcomes_invalid(
             (DataCategory.TRANSACTION, "invalid_transaction"),
             (DataCategory.TRANSACTION_INDEXED, "invalid_transaction"),
             (DataCategory.SPAN, "invalid_span"),
+            (DataCategory.SPAN, "invalid_transaction"),
             (DataCategory.SPAN_INDEXED, "invalid_span"),
+            (DataCategory.SPAN_INDEXED, "invalid_transaction"),
         ]
     ]
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -243,7 +243,7 @@ def _send_event(relay, project_id=42, event_type="error", event_id=None, trace_i
                     "type": "trace",
                 }
             },
-            "spans": [{}],
+            "spans": [],
             "extra": {"id": event_id},
             "environment": "production",
             "release": "foo@1.2.3",
@@ -481,8 +481,6 @@ def test_outcome_forwarding(
 
     _send_event(downstream_relay, event_type=event_type)
 
-    # NOTE: This should emit a span count of 2, will be fixed in
-    # https://github.com/getsentry/relay/pull/5379.
     expected_categories = [1] if event_type == "error" else [2, 9, 12, 16]
 
     outcomes = outcomes_consumer.get_outcomes(n=len(expected_categories))

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -243,7 +243,7 @@ def _send_event(relay, project_id=42, event_type="error", event_id=None, trace_i
                     "type": "trace",
                 }
             },
-            "spans": [],
+            "spans": [{}],
             "extra": {"id": event_id},
             "environment": "production",
             "release": "foo@1.2.3",
@@ -481,7 +481,10 @@ def test_outcome_forwarding(
 
     _send_event(downstream_relay, event_type=event_type)
 
-    expected_categories = [1] if event_type == "error" else [2, 9]
+    # NOTE: This should emit a span count of 2, will be fixed in
+    # https://github.com/getsentry/relay/pull/5379.
+    expected_categories = [1] if event_type == "error" else [2, 9, 12, 16]
+
     outcomes = outcomes_consumer.get_outcomes(n=len(expected_categories))
     outcomes.sort(key=lambda x: x["category"])
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -274,6 +274,8 @@ def test_outcomes_non_processing(relay, mini_sentry, event_type):
         [
             DataCategory.TRANSACTION,
             DataCategory.TRANSACTION_INDEXED,
+            DataCategory.SPAN,
+            DataCategory.SPAN_INDEXED,
         ]
         if event_type == "transaction"
         else [DataCategory.ERROR]

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -148,6 +148,8 @@ ITEM_TYPE_RATE_LIMIT_BEHAVIORS = [
         "transaction",
         PayloadType.JSON,
         [
+            {"category": "span", "quantity": 1, "reason": "generic"},
+            {"category": "span_indexed", "quantity": 1, "reason": "generic"},
             {"category": "transaction", "quantity": 1, "reason": "generic"},
             {"category": "transaction_indexed", "quantity": 1, "reason": "generic"},
         ],

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1425,7 +1425,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     elif category == "transaction_indexed":
         assert summarize_outcomes() == {
             (9, 2): 1,  # TransactionIndexed, Rate Limited
-            (16, 2): 2,  # SpanIndexed, Rate Limited
+            (16, 2): expected_span_count,  # SpanIndexed, Rate Limited
         }
         # Metrics are always correct:
         assert usage_metrics() == (1, 2)

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1368,6 +1368,8 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     end = start + timedelta(seconds=1)
 
     envelope = envelope_with_transaction_and_spans(start, end)
+    if span_count_header is not None:
+        envelope.items[0].headers["span_count"] = span_count_header
 
     # First batch passes
     relay.send_envelope(project_id, envelope)
@@ -1423,7 +1425,7 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
     elif category == "transaction_indexed":
         assert summarize_outcomes() == {
             (9, 2): 1,  # TransactionIndexed, Rate Limited
-            (16, 2): expected_span_count,  # SpanIndexed, Rate Limited
+            (16, 2): 2,  # SpanIndexed, Rate Limited
         }
         # Metrics are always correct:
         assert usage_metrics() == (1, 2)

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1423,9 +1423,11 @@ def test_rate_limit_is_consistent_between_transaction_and_spans(
         }
         assert usage_metrics() == (0, 0)
     elif category == "transaction_indexed":
+        # We do not check indexed limits on the fast path,
+        # so we count the correct number of spans (ignoring the span_count header):
         assert summarize_outcomes() == {
             (9, 2): 1,  # TransactionIndexed, Rate Limited
-            (16, 2): expected_span_count,  # SpanIndexed, Rate Limited
+            (16, 2): 2,  # SpanIndexed, Rate Limited
         }
         # Metrics are always correct:
         assert usage_metrics() == (1, 2)


### PR DESCRIPTION
We already count the number of nested spans in a transaction on the fast path, so we might as well persist this value on the item such that it can later be used for emitting outcomes.

This opens up the possibilty of sending `span_count` directly from the SDK to skip costly parsing on the fast path.

ref: INGEST-610