### PR TITLE
test(integration): Retry flaky tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "opentelemetry-proto>=1.32.1",
     "pre-commit>=4.2.0",
     "pytest>=7.4.3",
+    "pytest-rerunfailures>=15.0",
     "pytest-timeout>=2.2.0",
     "pytest-localserver>=0.8.1",
     "pytest-sentry>=0.3.0",

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -116,7 +116,7 @@ def test_batch_size_bytes_asserted(mini_sentry, relay):
     assert relay.wait_for_exit() != 0, "Expected Relay to not start, but it started"
 
 
-@pytest.mark.skip("Flaky test")
+@pytest.mark.flaky(reruns=3)
 def test_forced_shutdown(mini_sentry, relay):
     from time import sleep
 

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -271,6 +271,7 @@ def test_unparsable_project_config(mini_sentry, relay):
     assert mini_sentry.captured_events.empty()
 
 
+@pytest.mark.flaky(reruns=3)
 def test_cached_project_config(mini_sentry, relay):
     mini_sentry.project_config_ignore_revision = True
 

--- a/uv.lock
+++ b/uv.lock
@@ -442,6 +442,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "15.0"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+dependencies = [
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/pytest_rerunfailures-15.0-py3-none-any.whl", hash = "sha256:dd150c4795c229ef44320adc9a0c0532c51b78bb7a6843a8c53556b9a611df1a" },
+]
+
+[[package]]
 name = "pytest-sentry"
 version = "0.3.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -519,6 +531,7 @@ dev = [
     { name = "pre-commit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-localserver", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest-rerunfailures", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-sentry", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-timeout", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-xdist", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -558,6 +571,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-localserver", specifier = ">=0.8.1" },
+    { name = "pytest-rerunfailures", specifier = ">=15.0" },
     { name = "pytest-sentry", specifier = ">=0.3.0" },
     { name = "pytest-timeout", specifier = ">=2.2.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },


### PR DESCRIPTION
Retry some known flaky tests.

To quote the `pytest-retry` docs:

> Flaky tests are not sustainable. This plugin is designed as an easy short-term solution while a permanent fix is implemented. Use the reports generated by this plugin to identify issues with the tests or testing environment and resolve them.
