### PR TITLE
feat(ourlogs): Add `event.name` to otlp logs transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support comparing release versions without build code. ([#5376](https://github.com/getsentry/relay/pull/5376))
 - Support uploading attachments directly to objectstore. ([#5367](https://github.com/getsentry/relay/pull/5367))
+- Add `event.name` attribute to OTLP logs. ([#5396](https://github.com/getsentry/relay/pull/5396))
 
 **Internal**:
 
@@ -52,7 +53,6 @@
 - Remove sentry.timestamp_nanos for log items. ([#5295](https://github.com/getsentry/relay/pull/5295))
 - Remove the span kind from the Kafka span schema. ([#5368](https://github.com/getsentry/relay/pull/5368))
 - Unconditionally enable span extraction. ([#5308](https://github.com/getsentry/relay/pull/5308))
-
 
 ## 25.10.0
 

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -29,6 +29,7 @@ convention_attributes!(
     DSC_TRACE_ID => "sentry.dsc.trace_id",
     DSC_TRANSACTION => "sentry.dsc.transaction",
     ENVIRONMENT => "sentry.environment",
+    EVENT_NAME => "event.name",
     FAAS_TRIGGER => "faas.trigger",
     GEN_AI_COST_INPUT_TOKENS => "gen_ai.cost.input_tokens",
     GEN_AI_COST_OUTPUT_TOKENS => "gen_ai.cost.output_tokens",

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -60,7 +60,9 @@ pub fn otel_to_sentry_log(
         trace_id,
         span_id,
         event_name,
-        ..
+        observed_time_unix_nano: _,
+        dropped_attributes_count: _,
+        flags: _,
     } = otel_log;
 
     let span_id = match span_id.is_empty() {

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -7,7 +7,7 @@ use chrono::{TimeZone, Utc};
 use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLogRecord;
-use relay_conventions::ORIGIN;
+use relay_conventions::{EVENT_NAME, ORIGIN};
 
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
@@ -59,6 +59,7 @@ pub fn otel_to_sentry_log(
         attributes,
         trace_id,
         span_id,
+        event_name,
         ..
     } = otel_log;
 
@@ -76,6 +77,7 @@ pub fn otel_to_sentry_log(
 
     let mut attribute_data = Attributes::default();
     attribute_data.insert(ORIGIN, "auto.otlp.logs".to_owned());
+    attribute_data.insert(EVENT_NAME, event_name.to_owned());
 
     relay_otel::otel_scope_into_attributes(&mut attribute_data, resource, scope);
 

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -79,7 +79,9 @@ pub fn otel_to_sentry_log(
 
     let mut attribute_data = Attributes::default();
     attribute_data.insert(ORIGIN, "auto.otlp.logs".to_owned());
-    attribute_data.insert(EVENT_NAME, event_name.to_owned());
+    if !event_name.is_empty() {
+        attribute_data.insert(EVENT_NAME, event_name.to_owned());
+    }
 
     relay_otel::otel_scope_into_attributes(&mut attribute_data, resource, scope);
 
@@ -569,6 +571,63 @@ mod tests {
                   ]
                 ]
               }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn parse_otel_log_with_event_name() {
+        // 2024-01-01T10:00:00Z = 1704103200
+        let json = r#"{
+            "eventName": "user.login",
+            "timeUnixNano": "1704103200000000000",
+            "severityText": "INFO",
+            "body": {
+                "stringValue": "User login successful"
+            },
+            "attributes": [
+                {
+                    "key": "user.id",
+                    "value": { "stringValue": "12345" }
+                },
+                {
+                    "key": "login.method",
+                    "value": { "stringValue": "oauth" }
+                }
+            ],
+            "traceId": "abcdef1234567890abcdef1234567890",
+            "spanId": "7890123456789012"
+        }"#;
+
+        let otel_log: OtelLogRecord = serde_json::from_str(json).unwrap();
+        let our_log = otel_to_sentry_log(otel_log, None, None);
+        let annotated_log: Annotated<OurLog> = Annotated::new(our_log);
+
+        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_log), @r#"
+        {
+          "timestamp": 1704103200.0,
+          "trace_id": "abcdef1234567890abcdef1234567890",
+          "span_id": "7890123456789012",
+          "level": "info",
+          "body": "User login successful",
+          "attributes": {
+            "event.name": {
+              "type": "string",
+              "value": "user.login"
+            },
+            "login.method": {
+              "type": "string",
+              "value": "oauth"
+            },
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.otlp.logs"
+            },
+            "user.id": {
+              "type": "string",
+              "value": "12345"
             }
           }
         }


### PR DESCRIPTION
The OTEL spec specifies a `EventName` field on logs: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.46.0/specification/logs/data-model.md#field-eventname

This is specced as `event.name` in our conventions: https://github.com/getsentry/sentry-conventions/blob/main/model/attributes/event/event__name.json.

Right now we don't grab this field from the OTLP schema, which is unexpected behaviour as users would expect this field to show up in the logs. This PR updates the OTLP logs transform to set `event.name`.