### PR TITLE
fix(gocd): Update monitor IDs

### DIFF
--- a/gocd/templates/pipelines/pops.libsonnet
+++ b/gocd/templates/pipelines/pops.libsonnet
@@ -45,7 +45,7 @@ local region_pops = {
 // List of datadog monitors to check during the soak time in the different regions
 local soak_monitors = {
   // (Service Queues are Backlogging), (CrashLoopBackoff Count is High)
-  s4s: '165839949, 237862998',
+  s4s: '165839949 237862998',
   // (Retry Count for a Single Event is High), (Service Queues are Backlogging), (CrashLoopBackoff Count is High)
   us: '165839953 165839955 237862996',
   default: '',
@@ -54,7 +54,7 @@ local soak_monitors = {
 // List of datadog monitors to check during the canary deployment in the different regions
 local canary_monitors = {
   // (S4S Service Queues are Backlogging), (CrashLoopBackoff Count is High)
-  s4s: '165839949, 237862998',
+  s4s: '165839949 237862998',
   // (Retry Count for a Single Event is High), (Service Queues are Backlogging), (CrashLoopBackoff Count is High)
   us: '165839953 165839955 237862996',
   // (CrashLoopBackoff Count is High)

--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -6,8 +6,11 @@ local single_tenants = ['disney', 'geico', 'goldmansachs', 'ly', 's4s'];
 
 // List of datadog monitors to check during the soak time in the different regions
 local soak_monitors = {
+  // (The Number of Pending Projects is High), (Service Queues are Backlogging), (CrashLoopBackoff Count is High)
   s4s: '14146876 154096678 237863001',
+  // (The Number of Pending Projects is High), (Service Queues are Backlogging), (CrashLoopBackoff Count is High)
   us: '14146876 154096671 237862997',
+  // (The Number of Pending Projects is High)
   default: '14146876',
 };
 


### PR DESCRIPTION
As spotted by Joris the recent Monitor changes (https://github.com/getsentry/relay/pull/5391) broke one more Monitor than anticipated. This updates the Monitor and also adds some comments so that it is easier in the future to know to which Monitor an ID pointed to.