### PR TITLE
ref(quotas): Arc-ify quotas

### DIFF
--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -117,8 +117,8 @@ impl ProjectConfig {
         // Check if indexed and non-indexed are double-counting towards the same ID.
         // This is probably not intended behavior.
         for quota in &self.quotas {
-            if let Some(id) = &quota.id {
-                for category in &quota.categories {
+            if let Some(id) = quota.id.as_deref() {
+                for category in &*quota.categories {
                     if let Some(indexed) = category.index_category()
                         && quota.categories.contains(&indexed)
                     {

--- a/relay-quotas/src/global.rs
+++ b/relay-quotas/src/global.rs
@@ -302,7 +302,7 @@ mod tests {
 
     fn build_quota(window: u64, limit: impl Into<Option<u64>>) -> Quota {
         Quota {
-            id: Some(uuid::Uuid::new_v4().to_string()),
+            id: Some(uuid::Uuid::new_v4().to_string().into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Global,
             scope_id: None,

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -486,7 +486,7 @@ mod tests {
                 namespace: None,
             },
             Quota {
-                id: Some("42".to_owned()),
+                id: Some("42".into()),
                 categories: DataCategories::new(),
                 scope: QuotaScope::Organization,
                 scope_id: None,
@@ -533,7 +533,7 @@ mod tests {
         let quota_limit = 5;
         let get_quota = |namespace: Option<MetricNamespace>| -> Quota {
             Quota {
-                id: Some(format!("test_simple_quota_{}", uuid::Uuid::new_v4())),
+                id: Some(format!("test_simple_quota_{}", uuid::Uuid::new_v4()).into()),
                 categories: DataCategories::new(),
                 scope: QuotaScope::Organization,
                 scope_id: None,
@@ -602,7 +602,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_quota() {
         let quotas = &[Quota {
-            id: Some(format!("test_simple_quota_{}", uuid::Uuid::new_v4())),
+            id: Some(format!("test_simple_quota_{}", uuid::Uuid::new_v4()).into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
@@ -653,7 +653,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_global_quota() {
         let quotas = &[Quota {
-            id: Some(format!("test_simple_global_quota_{}", uuid::Uuid::new_v4())),
+            id: Some(format!("test_simple_global_quota_{}", uuid::Uuid::new_v4()).into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Global,
             scope_id: None,
@@ -704,7 +704,7 @@ mod tests {
     #[tokio::test]
     async fn test_quantity_0() {
         let quotas = &[Quota {
-            id: Some(format!("test_quantity_0_{}", uuid::Uuid::new_v4())),
+            id: Some(format!("test_quantity_0_{}", uuid::Uuid::new_v4()).into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
@@ -767,7 +767,7 @@ mod tests {
     #[tokio::test]
     async fn test_quota_go_over() {
         let quotas = &[Quota {
-            id: Some(format!("test_quota_go_over{}", uuid::Uuid::new_v4())),
+            id: Some(format!("test_quota_go_over{}", uuid::Uuid::new_v4()).into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
@@ -850,7 +850,7 @@ mod tests {
     async fn test_limited_with_unlimited_quota() {
         let quotas = &[
             Quota {
-                id: Some("q0".to_owned()),
+                id: Some("q0".into()),
                 categories: DataCategories::new(),
                 scope: QuotaScope::Organization,
                 scope_id: None,
@@ -860,7 +860,7 @@ mod tests {
                 namespace: None,
             },
             Quota {
-                id: Some("q1".to_owned()),
+                id: Some("q1".into()),
                 categories: DataCategories::new(),
                 scope: QuotaScope::Organization,
                 scope_id: None,
@@ -912,7 +912,7 @@ mod tests {
     #[tokio::test]
     async fn test_quota_with_quantity() {
         let quotas = &[Quota {
-            id: Some(format!("test_quantity_quota_{}", uuid::Uuid::new_v4())),
+            id: Some(format!("test_quantity_quota_{}", uuid::Uuid::new_v4()).into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
@@ -963,10 +963,10 @@ mod tests {
     #[tokio::test]
     async fn test_get_redis_key_scoped() {
         let quota = Quota {
-            id: Some("foo".to_owned()),
+            id: Some("foo".into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Project,
-            scope_id: Some("42".to_owned()),
+            scope_id: Some("42".into()),
             window: Some(2),
             limit: Some(0),
             reason_code: None,
@@ -992,7 +992,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_redis_key_unscoped() {
         let quota = Quota {
-            id: Some("foo".to_owned()),
+            id: Some("foo".into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
@@ -1021,7 +1021,7 @@ mod tests {
     #[tokio::test]
     async fn test_large_redis_limit_large() {
         let quota = Quota {
-            id: Some("foo".to_owned()),
+            id: Some("foo".into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,

--- a/relay-server/src/metrics/rate_limits.rs
+++ b/relay-server/src/metrics/rate_limits.rs
@@ -218,14 +218,13 @@ mod tests {
     use relay_metrics::{BucketMetadata, BucketValue, UnixTimestamp};
     use relay_quotas::QuotaScope;
     use relay_system::Addr;
-    use smallvec::smallvec;
 
     use super::*;
 
     fn deny(category: DataCategory) -> Vec<Quota> {
         vec![Quota {
             id: None,
-            categories: smallvec![category],
+            categories: [category].into(),
             scope: QuotaScope::Organization,
             scope_id: None,
             limit: Some(0),

--- a/relay-server/src/services/global_rate_limits.rs
+++ b/relay-server/src/services/global_rate_limits.rs
@@ -195,7 +195,7 @@ mod tests {
 
     fn build_quota(window: u64, limit: impl Into<Option<u64>>) -> Quota {
         Quota {
-            id: Some(uuid::Uuid::new_v4().to_string()),
+            id: Some(uuid::Uuid::new_v4().to_string().into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Global,
             scope_id: None,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -3462,7 +3462,7 @@ mod tests {
     fn mock_quota(id: &str) -> Quota {
         Quota {
             id: Some(id.into()),
-            categories: smallvec::smallvec![DataCategory::MetricBucket],
+            categories: [DataCategory::MetricBucket].into(),
             scope: QuotaScope::Organization,
             scope_id: None,
             limit: Some(0),
@@ -3517,9 +3517,9 @@ mod tests {
             let project_info = {
                 let quota = Quota {
                     id: Some("testing".into()),
-                    categories: vec![DataCategory::MetricBucket].into(),
+                    categories: [DataCategory::MetricBucket].into(),
                     scope: relay_quotas::QuotaScope::Organization,
-                    scope_id: Some(rate_limited_org.organization_id.to_string()),
+                    scope_id: Some(rate_limited_org.organization_id.to_string().into()),
                     limit: Some(0),
                     window: None,
                     reason_code: Some(ReasonCode::new("test")),

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -4,8 +4,8 @@ use std::marker::PhantomData;
 
 use relay_profiling::ProfileType;
 use relay_quotas::{
-    DataCategories, DataCategory, ItemScoping, QuotaScope, RateLimit, RateLimitScope, RateLimits,
-    ReasonCode, Scoping,
+    DataCategory, ItemScoping, QuotaScope, RateLimit, RateLimitScope, RateLimits, ReasonCode,
+    Scoping,
 };
 
 use crate::envelope::{Envelope, Item, ItemType};
@@ -68,12 +68,13 @@ pub fn parse_rate_limits(scoping: &Scoping, string: &str) -> RateLimits {
             None => continue,
         };
 
-        let mut categories = DataCategories::new();
-        for category in components.next().unwrap_or("").split(';') {
-            if !category.is_empty() {
-                categories.push(DataCategory::from_name(category));
-            }
-        }
+        let categories = components
+            .next()
+            .unwrap_or("")
+            .split(';')
+            .filter(|category| !category.is_empty())
+            .map(DataCategory::from_name)
+            .collect();
 
         let quota_scope = QuotaScope::from_name(components.next().unwrap_or(""));
         let scope = RateLimitScope::for_quota(*scoping, quota_scope);
@@ -1024,7 +1025,7 @@ mod tests {
 
         // Add a generic rate limit for all categories.
         rate_limits.add(RateLimit {
-            categories: DataCategories::new(),
+            categories: Default::default(),
             scope: RateLimitScope::Organization(OrganizationId::new(42)),
             reason_code: Some(ReasonCode::new("my_limit")),
             retry_after: RetryAfter::from_secs(42),
@@ -1033,7 +1034,7 @@ mod tests {
 
         // Add a more specific rate limit for just one category.
         rate_limits.add(RateLimit {
-            categories: smallvec![DataCategory::Transaction, DataCategory::Security],
+            categories: [DataCategory::Transaction, DataCategory::Security].into(),
             scope: RateLimitScope::Project(ProjectId::new(21)),
             reason_code: None,
             retry_after: RetryAfter::from_secs(4711),
@@ -1051,7 +1052,7 @@ mod tests {
 
         // Rate limit with reason code and namespace.
         rate_limits.add(RateLimit {
-            categories: smallvec![DataCategory::MetricBucket],
+            categories: [DataCategory::MetricBucket].into(),
             scope: RateLimitScope::Organization(OrganizationId::new(42)),
             reason_code: Some(ReasonCode::new("my_limit")),
             retry_after: RetryAfter::from_secs(42),
@@ -1060,7 +1061,7 @@ mod tests {
 
         // Rate limit without reason code.
         rate_limits.add(RateLimit {
-            categories: smallvec![DataCategory::MetricBucket],
+            categories: [DataCategory::MetricBucket].into(),
             scope: RateLimitScope::Organization(OrganizationId::new(42)),
             reason_code: None,
             retry_after: RetryAfter::from_secs(42),
@@ -1105,18 +1106,19 @@ mod tests {
             rate_limits,
             vec![
                 RateLimit {
-                    categories: DataCategories::new(),
+                    categories: Default::default(),
                     scope: RateLimitScope::Organization(OrganizationId::new(42)),
                     reason_code: Some(ReasonCode::new("my_limit")),
                     retry_after: rate_limits[0].retry_after,
                     namespaces: smallvec![],
                 },
                 RateLimit {
-                    categories: smallvec![
+                    categories: [
                         DataCategory::Unknown,
                         DataCategory::Transaction,
                         DataCategory::Security,
-                    ],
+                    ]
+                    .into(),
                     scope: RateLimitScope::Project(ProjectId::new(21)),
                     reason_code: None,
                     retry_after: rate_limits[1].retry_after,
@@ -1145,7 +1147,7 @@ mod tests {
         assert_eq!(
             rate_limits,
             vec![RateLimit {
-                categories: smallvec![DataCategory::MetricBucket],
+                categories: [DataCategory::MetricBucket].into(),
                 scope: RateLimitScope::Organization(OrganizationId::new(42)),
                 reason_code: None,
                 retry_after: rate_limits[0].retry_after,
@@ -1171,7 +1173,7 @@ mod tests {
         assert_eq!(
             rate_limits,
             vec![RateLimit {
-                categories: smallvec![DataCategory::MetricBucket],
+                categories: [DataCategory::MetricBucket].into(),
                 scope: RateLimitScope::Organization(OrganizationId::new(42)),
                 reason_code: Some(ReasonCode::new("some_reason")),
                 retry_after: rate_limits[0].retry_after,
@@ -1196,7 +1198,7 @@ mod tests {
         assert_eq!(
             rate_limits,
             vec![RateLimit {
-                categories: smallvec![DataCategory::Unknown, DataCategory::Unknown],
+                categories: [DataCategory::Unknown, DataCategory::Unknown].into(),
                 scope: RateLimitScope::Organization(OrganizationId::new(42)),
                 reason_code: None,
                 retry_after: rate_limits[0].retry_after,
@@ -1235,7 +1237,7 @@ mod tests {
 
     fn rate_limit(category: DataCategory) -> RateLimit {
         RateLimit {
-            categories: vec![category].into(),
+            categories: [category].into(),
             scope: RateLimitScope::Organization(OrganizationId::new(42)),
             reason_code: None,
             retry_after: RetryAfter::from_secs(60),


### PR DESCRIPTION
While working on the planned quota cache, I noticed that the quotas are getting cloned quite a bit and I also will need another clone for the cache. Almost all (with the exception of one place in the code) of the quota fields are immutable.

This PR changes `String` to `Arc<str>` as well as `DataCategories` to a `Arc<[DataCategory]>` which is internally deduplicated and sorted allowing for equality comparisons required for `RateLimits`.

This also revealed a bug in the existing rate limiting code where we added a data category to the end of the data categories, but never re-sorted the list, violating an internal invariant. This is no longer possible.

Of course, there is the possibility of using a string type like `SmolStr` which is superior to `Arc<str>`, but we should consider this separately and then clean-up all the uses of `Arc<str>`.

Refs: INGEST-638