### PR TITLE
feat: Cleanup Vercel Log Drain feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Support uploading attachments directly to objectstore. ([#5367](https://github.com/getsentry/relay/pull/5367))
 - Add `span_count` item header to the envelope protocol. ([#5392](https://github.com/getsentry/relay/pull/5392))
 - Add `event.name` attribute to OTLP logs. ([#5396](https://github.com/getsentry/relay/pull/5396))
+- Remove feature flag for Vercel Log Drain endpoint. ([#5406](https://github.com/getsentry/relay/pull/5406))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -9,6 +9,7 @@ pub const GRADUATED_FEATURE_FLAGS: &[Feature] = &[
     Feature::IngestUnsampledProfiles,
     Feature::ScrubMongoDbDescriptions,
     Feature::DeprecatedExtractSpansFromEvent,
+    Feature::VercelLogDrainEndpoint,
 ];
 
 /// Features exposed by project config.
@@ -61,6 +62,11 @@ pub enum Feature {
     /// Serialized as `organizations:relay-otel-logs-endpoint`.
     #[serde(rename = "organizations:relay-otel-logs-endpoint")]
     OtelLogsEndpoint,
+    /// Enable logs ingestion via the Vercel Log Drain endpoint.
+    ///
+    /// Serialized as `organizations:relay-vercel-log-drain-endpoint`.
+    #[serde(rename = "organizations:relay-vercel-log-drain-endpoint")]
+    VercelLogDrainEndpoint,
     /// Enable playstation crash dump ingestion via the `/playstation/` endpoint.
     ///
     /// Serialized as `organizations:relay-playstation-ingestion`.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -9,7 +9,6 @@ pub const GRADUATED_FEATURE_FLAGS: &[Feature] = &[
     Feature::IngestUnsampledProfiles,
     Feature::ScrubMongoDbDescriptions,
     Feature::DeprecatedExtractSpansFromEvent,
-    Feature::VercelLogDrainEndpoint,
 ];
 
 /// Features exposed by project config.
@@ -62,11 +61,6 @@ pub enum Feature {
     /// Serialized as `organizations:relay-otel-logs-endpoint`.
     #[serde(rename = "organizations:relay-otel-logs-endpoint")]
     OtelLogsEndpoint,
-    /// Enable logs ingestion via the Vercel Log Drain endpoint.
-    ///
-    /// Serialized as `organizations:relay-vercel-log-drain-endpoint`.
-    #[serde(rename = "organizations:relay-vercel-log-drain-endpoint")]
-    VercelLogDrainEndpoint,
     /// Enable playstation crash dump ingestion via the `/playstation/` endpoint.
     ///
     /// Serialized as `organizations:relay-playstation-ingestion`.

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -61,11 +61,6 @@ pub enum Feature {
     /// Serialized as `organizations:relay-otel-logs-endpoint`.
     #[serde(rename = "organizations:relay-otel-logs-endpoint")]
     OtelLogsEndpoint,
-    /// Enable logs ingestion via the Vercel Log Drain endpoint.
-    ///
-    /// Serialized as `organizations:relay-vercel-log-drain-endpoint`.
-    #[serde(rename = "organizations:relay-vercel-log-drain-endpoint")]
-    VercelLogDrainEndpoint,
     /// Enable playstation crash dump ingestion via the `/playstation/` endpoint.
     ///
     /// Serialized as `organizations:relay-playstation-ingestion`.

--- a/relay-server/src/endpoints/integrations/vercel.rs
+++ b/relay-server/src/endpoints/integrations/vercel.rs
@@ -3,7 +3,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use relay_config::Config;
-use relay_dynamic_config::Feature;
 
 use crate::endpoints::common;
 use crate::envelope::ContentType;

--- a/relay-server/src/endpoints/integrations/vercel.rs
+++ b/relay-server/src/endpoints/integrations/vercel.rs
@@ -37,7 +37,6 @@ mod logs {
 
         let envelope = builder
             .with_type(LogsIntegration::VercelDrainLog { format })
-            .with_required_feature(Feature::VercelLogDrainEndpoint)
             .build();
 
         common::handle_envelope(&state, envelope).await?;


### PR DESCRIPTION
The Vercel Log Drain is now GA (https://github.com/getsentry/sentry-options-automator/pull/5786, https://docs.sentry.io/product/drains/integration/vercel/#log-drains).

We need to start cleaning up the feature flags. This PR starts with removing it from relay features.

ref https://linear.app/getsentry/issue/LOGS-395/clean-up-feature-flags-for-vercel-log-drains