### PR TITLE
feat(otlp): Populate `sentry.platform` during ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Remove feature flag for Vercel Log Drain endpoint. ([#5406](https://github.com/getsentry/relay/pull/5406))
 - Add `http.request.header.cookie` to fields scrubbed by cookie rules. ([#5408](https://github.com/getsentry/relay/pull/5408))
 - Map `request_id` to `trace_id` in vercel log drain transform. ([#5333](https://github.com/getsentry/relay/pull/5333))
+- Populate `sentry.platform` during OTLP ingestion. ([#5411](https://github.com/getsentry/relay/pull/5411))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,6 +3108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,6 +4510,7 @@ dependencies = [
  "hex",
  "insta",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
  "relay-conventions",
  "relay-event-schema",
  "relay-otel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4194,6 +4194,7 @@ version = "25.11.0"
 dependencies = [
  "insta",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
  "relay-event-schema",
  "relay-protocol",
  "serde_json",
@@ -4510,7 +4511,6 @@ dependencies = [
  "hex",
  "insta",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "relay-conventions",
  "relay-event-schema",
  "relay-otel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ multer = "3.1.0"
 num-traits = "0.2.19"
 num_cpus = "1.17.0"
 objectstore-client = "0.0.11"
+opentelemetry-semantic-conventions = { version = "0.31.0" }
 opentelemetry-proto = { version = "0.30.0", default-features = false }
 papaya = "0.2.3"
 parking_lot = "0.12.5"

--- a/relay-otel/Cargo.toml
+++ b/relay-otel/Cargo.toml
@@ -19,6 +19,7 @@ opentelemetry-proto = { workspace = true, features = [
     "trace",
     "logs",
 ] }
+opentelemetry-semantic-conventions = { workspace = true }
 relay-event-schema = { workspace = true }
 relay-protocol = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn test_otel_resource_to_attribute_with_unmapped_langauge() {
+    fn test_otel_resource_to_attribute_with_unmapped_language() {
         let resource = serde_json::from_value(serde_json::json!({
             "attributes": [{
                 "key": "telemetry.sdk.language",
@@ -336,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn test_otel_resource_to_attribute_with_mapped_langauge() {
+    fn test_otel_resource_to_attribute_with_mapped_language() {
         let resource = serde_json::from_value(serde_json::json!({
             "attributes": [{
                 "key": "telemetry.sdk.language",

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -133,7 +133,7 @@ pub fn otel_scope_into_attributes(
 
 /// Returns the telemetry language SDK from the resource, mapped into a `sentry.platform` value.
 pub fn otel_resource_to_platform(resource: &Resource) -> Option<&str> {
-    if let any_value::Value::StringValue(language) = resource
+    let any_value::Value::StringValue(language) = resource
         .attributes
         .iter()
         .find(|attr| attr.key == otel_semconv::TELEMETRY_SDK_LANGUAGE)?
@@ -141,20 +141,20 @@ pub fn otel_resource_to_platform(resource: &Resource) -> Option<&str> {
         .as_ref()?
         .value
         .as_ref()?
-    {
-        // Smooth out some naming differences between OTel
-        // (https://opentelemetry.io/docs/specs/semconv/resource/#telemetry-sdk)
-        // and Sentry
-        // (https://github.com/getsentry/relay/blob/8e6c963cdd79dc9ba2bebc21518a3553f70feeb3/relay-event-schema/src/protocol/event.rs#L251-L253).
-        Some(match language.as_str() {
-            "dotnet" => "csharp",
-            "nodejs" => "node",
-            "webjs" => "javascript",
-            _ => language,
-        })
-    } else {
-        None
-    }
+    else {
+        return None;
+    };
+
+    // Smooth out some naming differences between OTel
+    // (https://opentelemetry.io/docs/specs/semconv/resource/#telemetry-sdk)
+    // and Sentry
+    // (https://github.com/getsentry/relay/blob/8e6c963cdd79dc9ba2bebc21518a3553f70feeb3/relay-event-schema/src/protocol/event.rs#L251-L253).
+    Some(match language.as_str() {
+        "dotnet" => "csharp",
+        "nodejs" => "node",
+        "webjs" => "javascript",
+        _ => language,
+    })
 }
 
 #[cfg(test)]

--- a/relay-spans/Cargo.toml
+++ b/relay-spans/Cargo.toml
@@ -20,6 +20,7 @@ opentelemetry-proto = { workspace = true, features = [
     "with-serde",
     "trace",
 ] }
+opentelemetry-semantic-conventions = { workspace = true }
 relay-conventions = { workspace = true }
 relay-event-schema = { workspace = true }
 relay-otel = { workspace = true }

--- a/relay-spans/Cargo.toml
+++ b/relay-spans/Cargo.toml
@@ -20,7 +20,6 @@ opentelemetry-proto = { workspace = true, features = [
     "with-serde",
     "trace",
 ] }
-opentelemetry-semantic-conventions = { workspace = true }
 relay-conventions = { workspace = true }
 relay-event-schema = { workspace = true }
 relay-otel = { workspace = true }


### PR DESCRIPTION
Having `sentry.platform` populated will allow us to track per-language adoption of the OTLP endpoint. Since the platform is also used in the product for display purposes, I also added a mapping for the few language name values that differed between OTel and Sentry.

Fixes https://github.com/getsentry/relay/issues/5409.