### PR TITLE
feat(filter): Add common errors filter for frequently occurring noise

### DIFF
--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -21,6 +21,9 @@ pub enum FilterStatKey {
     /// Filtered by browser extension.
     BrowserExtensions,
 
+    /// Filtered by common error messages.
+    CommonErrors,
+
     /// Filtered by legacy browser version.
     LegacyBrowsers,
 
@@ -66,6 +69,7 @@ impl FilterStatKey {
             FilterStatKey::ReleaseVersion => "release-version",
             FilterStatKey::ErrorMessage => "error-message",
             FilterStatKey::BrowserExtensions => "browser-extensions",
+            FilterStatKey::CommonErrors => "common-errors",
             FilterStatKey::LegacyBrowsers => "legacy-browsers",
             FilterStatKey::Localhost => "localhost",
             FilterStatKey::WebCrawlers => "web-crawlers",
@@ -95,6 +99,7 @@ impl<'a> TryFrom<&'a str> for FilterStatKey {
             "release-version" => FilterStatKey::ReleaseVersion,
             "error-message" => FilterStatKey::ErrorMessage,
             "browser-extensions" => FilterStatKey::BrowserExtensions,
+            "common-errors" => FilterStatKey::CommonErrors,
             "legacy-browsers" => FilterStatKey::LegacyBrowsers,
             "localhost" => FilterStatKey::Localhost,
             "web-crawlers" => FilterStatKey::WebCrawlers,

--- a/relay-filter/src/common_errors.rs
+++ b/relay-filter/src/common_errors.rs
@@ -387,10 +387,7 @@ mod tests {
 
     #[test]
     fn test_filter_recursion_errors() {
-        let errors = [
-            "too much recursion",
-            "InternalError: too much recursion",
-        ];
+        let errors = ["too much recursion", "InternalError: too much recursion"];
 
         for error in errors {
             let event = get_event_with_exception_value(error);
@@ -474,10 +471,10 @@ mod tests {
     #[test]
     fn test_filter_cancelled_in_other_languages() {
         let errors = [
-            "annulé",        // French
-            "cancelado",     // Spanish
-            "Abgebrochen",   // German
-            "anulowane",     // Polish
+            "annulé",             // French
+            "cancelado",          // Spanish
+            "Abgebrochen",        // German
+            "anulowane",          // Polish
             "キャンセルしました", // Japanese
         ];
 
@@ -874,7 +871,11 @@ mod tests {
     fn test_dont_filter_empty_exception() {
         let event = get_event_with_exception(Exception::default());
         let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
-        assert_eq!(filter_result, Ok(()), "Empty exception should not be filtered");
+        assert_eq!(
+            filter_result,
+            Ok(()),
+            "Empty exception should not be filtered"
+        );
     }
 
     #[test]
@@ -899,4 +900,3 @@ mod tests {
         }
     }
 }
-

--- a/relay-filter/src/common_errors.rs
+++ b/relay-filter/src/common_errors.rs
@@ -38,11 +38,6 @@ static COMMON_ERROR_VALUES: LazyLock<Regex> = LazyLock::new(|| {
         # See: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors
         ResizeObserver\sloop\s(limit\sexceeded|completed\swith\sundelivered\snotifications)|
 
-        # Non-Error promise rejections - often not useful for debugging
-        Non-Error\spromise\srejection\scaptured|
-        Non-Error\sexception\scaptured|
-        Object\scaptured\sas\s(promise\srejection|exception)|
-
         # Quota exceeded - user's browser storage is full
         QuotaExceededError|
 
@@ -488,26 +483,6 @@ mod tests {
             "The play() request was interrupted by a call to pause()",
             "The play() request was interrupted because the media was removed from the document",
             "AbortError: The play() request was interrupted by a call to pause()",
-        ];
-
-        for error in errors {
-            let event = get_event_with_exception_value(error);
-            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
-            assert_eq!(
-                filter_result,
-                Err(FilterStatKey::CommonErrors),
-                "Event not filtered for error: '{error}'"
-            );
-        }
-    }
-
-    #[test]
-    fn test_filter_non_error_promise_rejections() {
-        let errors = [
-            "Non-Error promise rejection captured with value: undefined",
-            "Non-Error promise rejection captured with value: Timeout",
-            "Non-Error promise rejection captured with keys: currentTarget, detail, isTrusted, target",
-            "Non-Error exception captured with keys: message, name",
         ];
 
         for error in errors {

--- a/relay-filter/src/common_errors.rs
+++ b/relay-filter/src/common_errors.rs
@@ -1,0 +1,650 @@
+//! Implements filtering for events with commonly occurring error messages.
+//!
+//! This filter targets error messages that are typically noise and not actionable,
+//! such as network errors, browser quirks, and third-party script failures.
+//! These patterns are derived from the most commonly configured error message filters
+//! across Sentry customers.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::{FilterConfig, FilterStatKey, Filterable};
+
+/// Regex patterns for common error messages that should be filtered.
+///
+/// These patterns match exception values (error messages) that are typically
+/// noise and not actionable for developers.
+static COMMON_ERROR_VALUES: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?ix)
+        # Network and fetch errors - these are typically caused by user network issues
+        Failed\sto\sfetch|
+        Network\s[Ee]rror|
+        Load\sfailed|
+        Network\srequest\sfailed|
+        NetworkError(\swhen\sattempting\sto\sfetch\sresource)?|
+        The\snetwork\sconnection\swas\slost|
+        The\sInternet\sconnection\sappears\sto\sbe\soffline|
+        A\snetwork\serror\soccurred|
+        The\srequest\stimed\sout|
+        Request\saborted|
+
+        # AbortError - user or browser cancelled the request
+        AbortError|
+
+        # ResizeObserver errors - browser quirk, not actionable
+        # See: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors
+        ResizeObserver\sloop\s(limit\sexceeded|completed\swith\sundelivered\snotifications)|
+
+        # Chunk loading errors - typically caused by deployments or network issues
+        ChunkLoadError|
+        Loading\schunk\s.*\sfailed|
+        Loading\sCSS\schunk|
+
+        # Non-Error promise rejections - often not useful for debugging
+        Non-Error\spromise\srejection\scaptured|
+        Non-Error\sexception\scaptured|
+
+        # Quota exceeded - user's browser storage is full
+        QuotaExceededError|
+
+        # Generic timeout errors
+        timeout(\sof\s\d+ms)?\sexceeded|
+
+        # Maximum call stack - usually infinite recursion, but message alone isn't helpful
+        Maximum\scall\sstack\ssize\sexceeded|
+
+        # JSON parsing errors from malformed responses
+        Unexpected\stoken|
+        Unexpected\send\sof\s(JSON\sinput|input|script)|
+
+        # HTTP status code errors - too generic without context
+        Request\sfailed\swith\sstatus\scode|
+
+        # Mobile WebView and bridge errors
+        Java\sobject\sis\sgone|
+        Java\sbridge\smethod\sinvocation\serror|
+        _AutofillCallbackHandler|
+        instantSearchSDKJSBridgeClearHighlight|
+        ceCurrentVideo\.currentTime|
+        # webkit messageHandlers errors from iOS
+        window\.webkit\.messageHandlers|
+
+        # CustomEvent promise rejections
+        Event\s`CustomEvent`\s\(type=unhandledrejection\)\scaptured\sas\spromise\srejection|
+
+        # Frame blocking errors - browser security, not actionable
+        Blocked\sa\sframe\swith\sorigin|
+
+        # Application not responding - mobile ANR
+        ApplicationNotResponding|
+        App\sHanging|
+
+        # Permission errors from browser APIs
+        NotAllowedError|
+
+        # Illegal invocation - typically calling DOM methods incorrectly
+        Illegal\sinvocation|
+
+        # jQuery not loaded errors
+        \$\sis\snot\sdefined|
+
+        # Empty or unknown error messages
+        No\serror\smessage|
+        <unknown>|
+
+        # Cancelled requests (various languages)
+        ^cancelled$|
+
+        # Module import failures - deployment/network related
+        Importing\sa\smodule\sscript\sfailed|
+        Failed\sto\sfetch\sdynamically\simported\smodule|
+
+        # Object is not defined errors from third-party scripts
+        UET\sis\snot\sdefined|
+        fbq\sis\snot\sdefined|
+
+        # WKWebView errors
+        WKWebView\sAPI\sclient\sdid\snot\srespond\sto\sthis\spostMessage|
+
+        # Out of memory errors
+        Out\sof\smemory|
+
+        # Script error with no details
+        Script\serror\.?$
+    "#,
+    )
+    .expect("Invalid common errors filter Regex")
+});
+
+/// Check if the event has a commonly occurring error message.
+fn matches<F: Filterable>(item: &F) -> bool {
+    // Check exception values
+    if let Some(exception_values) = item.exceptions()
+        && let Some(exceptions) = exception_values.values.value()
+    {
+        for exception in exceptions {
+            if let Some(exception) = exception.value() {
+                // Check the exception value (message)
+                if let Some(value) = exception.value.value()
+                    && COMMON_ERROR_VALUES.is_match(value.as_str())
+                {
+                    return true;
+                }
+
+                // Check type + value combination (e.g., "TypeError: Failed to fetch")
+                let ty = exception.ty.as_str().unwrap_or_default();
+                let value = exception.value.as_str().unwrap_or_default();
+                let message = match (ty, value) {
+                    ("", value) => Cow::Borrowed(value),
+                    (ty, "") => Cow::Borrowed(ty),
+                    (ty, value) => Cow::Owned(format!("{ty}: {value}")),
+                };
+                if !message.is_empty() && COMMON_ERROR_VALUES.is_match(message.as_ref()) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Check log entry message
+    if let Some(logentry) = item.logentry() {
+        if let Some(message) = logentry.formatted.value() {
+            if COMMON_ERROR_VALUES.is_match(message.as_ref()) {
+                return true;
+            }
+        } else if let Some(message) = logentry.message.value()
+            && COMMON_ERROR_VALUES.is_match(message.as_ref())
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Filters events with commonly occurring error messages.
+///
+/// This filter is designed to reduce noise from error messages that are typically
+/// not actionable, such as network errors, browser quirks, and third-party script failures.
+pub fn should_filter<F: Filterable>(item: &F, config: &FilterConfig) -> Result<(), FilterStatKey> {
+    if !config.is_enabled {
+        return Ok(());
+    }
+
+    if matches(item) {
+        Err(FilterStatKey::CommonErrors)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_event_schema::protocol::{Event, Exception, JsonLenientString, LogEntry, Values};
+    use relay_protocol::Annotated;
+
+    use super::*;
+
+    fn get_event_with_exception(e: Exception) -> Event {
+        Event {
+            exceptions: Annotated::from(Values::<Exception> {
+                values: Annotated::from(vec![Annotated::from(e)]),
+                ..Values::default()
+            }),
+            ..Event::default()
+        }
+    }
+
+    fn get_event_with_exception_value(val: &str) -> Event {
+        let ex = Exception {
+            value: Annotated::from(JsonLenientString::from(val.to_owned())),
+            ..Exception::default()
+        };
+        get_event_with_exception(ex)
+    }
+
+    fn get_event_with_exception_type_and_value(ty: &str, val: &str) -> Event {
+        let ex = Exception {
+            ty: Annotated::from(ty.to_owned()),
+            value: Annotated::from(JsonLenientString::from(val.to_owned())),
+            ..Exception::default()
+        };
+        get_event_with_exception(ex)
+    }
+
+    fn get_event_with_logentry(message: &str) -> Event {
+        Event {
+            logentry: Annotated::new(LogEntry {
+                formatted: Annotated::new(message.to_owned().into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_dont_filter_when_disabled() {
+        let events = [
+            get_event_with_exception_value("Failed to fetch"),
+            get_event_with_exception_value("Network Error"),
+            get_event_with_exception_value("ResizeObserver loop limit exceeded"),
+        ];
+
+        for event in &events {
+            let filter_result = should_filter(event, &FilterConfig { is_enabled: false });
+            assert_eq!(
+                filter_result,
+                Ok(()),
+                "Event filtered although filter should have been disabled"
+            )
+        }
+    }
+
+    #[test]
+    fn test_filter_network_errors() {
+        let errors = [
+            "Failed to fetch",
+            "TypeError: Failed to fetch",
+            "Network Error",
+            "Error: Network Error",
+            "Load failed",
+            "TypeError: Load failed",
+            "Network request failed",
+            "NetworkError when attempting to fetch resource",
+            "NetworkError when attempting to fetch resource.",
+            "The network connection was lost",
+            "The network connection was lost.",
+            "The Internet connection appears to be offline",
+            "The Internet connection appears to be offline.",
+            "A network error occurred",
+            "A network error occurred.",
+            "The request timed out",
+            "The request timed out.",
+            "Request aborted",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_abort_errors() {
+        let errors = [
+            "AbortError",
+            "AbortError: The operation was aborted",
+            "AbortError: The user aborted a request",
+            "AbortError: The play() request was interrupted by a call to pause()",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_resize_observer_errors() {
+        let errors = [
+            "ResizeObserver loop limit exceeded",
+            "ResizeObserver loop completed with undelivered notifications",
+            "ResizeObserver loop completed with undelivered notifications.",
+            "Error: ResizeObserver loop limit exceeded",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_chunk_load_errors() {
+        let errors = [
+            "ChunkLoadError",
+            "ChunkLoadError: Loading chunk 123 failed",
+            "Loading chunk 456 failed",
+            "Loading chunk 789 failed.",
+            "Loading CSS chunk 42 failed",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_non_error_promise_rejections() {
+        let errors = [
+            "Non-Error promise rejection captured with value: undefined",
+            "Non-Error promise rejection captured with value: Timeout",
+            "Non-Error promise rejection captured with keys: currentTarget, detail, isTrusted, target",
+            "Non-Error exception captured with keys: message, name",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_quota_exceeded() {
+        let errors = [
+            "QuotaExceededError",
+            "QuotaExceededError: The quota has been exceeded",
+            "QuotaExceededError: QuotaExceededError",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_timeout_errors() {
+        let errors = [
+            "timeout exceeded",
+            "timeout of 0ms exceeded",
+            "timeout of 5000ms exceeded",
+            "timeout of 30000ms exceeded",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_call_stack_errors() {
+        let errors = [
+            "Maximum call stack size exceeded",
+            "Maximum call stack size exceeded.",
+            "RangeError: Maximum call stack size exceeded",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_json_parsing_errors() {
+        let errors = [
+            "Unexpected token",
+            "Unexpected token '<'",
+            "Unexpected token 'else'",
+            "Unexpected end of JSON input",
+            "Unexpected end of input",
+            "Unexpected end of script",
+            "SyntaxError: Unexpected token '<'",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_http_status_errors() {
+        let errors = [
+            "Request failed with status code 400",
+            "Request failed with status code 401",
+            "Request failed with status code 403",
+            "Request failed with status code 404",
+            "Request failed with status code 500",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_mobile_webview_errors() {
+        let errors = [
+            "Java object is gone",
+            "Java bridge method invocation error",
+            "Can't find variable: _AutofillCallbackHandler",
+            "ReferenceError: Can't find variable: _AutofillCallbackHandler",
+            "instantSearchSDKJSBridgeClearHighlight is not defined",
+            "ceCurrentVideo.currentTime is not defined",
+            "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+            "WKWebView API client did not respond to this postMessage",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_application_not_responding() {
+        let errors = [
+            "ApplicationNotResponding",
+            "ApplicationNotResponding: ANR for at least 5000ms",
+            "App Hanging",
+            "App Hanging: App hanging for at least 2000 ms",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_frame_blocking_errors() {
+        let errors = [
+            "Blocked a frame with origin",
+            "Blocked a frame with origin \"https://example.com\"",
+            "SecurityError: Blocked a frame with origin \"https://example.com\" from accessing a cross-origin frame",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_misc_errors() {
+        let errors = [
+            "NotAllowedError",
+            "NotAllowedError: The request is not allowed by the user agent",
+            "Illegal invocation",
+            "TypeError: Illegal invocation",
+            "$ is not defined",
+            "ReferenceError: $ is not defined",
+            "No error message",
+            "Error: No error message",
+            "<unknown>",
+            "cancelled",
+            "Importing a module script failed",
+            "Importing a module script failed.",
+            "Failed to fetch dynamically imported module",
+            "UET is not defined",
+            "fbq is not defined",
+            "Out of memory",
+            "Script error",
+            "Script error.",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Event not filtered for error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_custom_event_promise_rejection() {
+        let error = "Event `CustomEvent` (type=unhandledrejection) captured as promise rejection";
+        let event = get_event_with_exception_value(error);
+        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        assert_eq!(
+            filter_result,
+            Err(FilterStatKey::CommonErrors),
+            "Event not filtered for CustomEvent promise rejection"
+        );
+    }
+
+    #[test]
+    fn test_filter_exception_with_type_and_value() {
+        let event = get_event_with_exception_type_and_value("TypeError", "Failed to fetch");
+        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        assert_eq!(
+            filter_result,
+            Err(FilterStatKey::CommonErrors),
+            "Event not filtered for typed exception"
+        );
+    }
+
+    #[test]
+    fn test_filter_logentry_message() {
+        let event = get_event_with_logentry("Failed to fetch resource from server");
+        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        assert_eq!(
+            filter_result,
+            Err(FilterStatKey::CommonErrors),
+            "Event not filtered for logentry message"
+        );
+    }
+
+    #[test]
+    fn test_dont_filter_legitimate_errors() {
+        let errors = [
+            "TypeError: Cannot read property 'foo' of undefined",
+            "ReferenceError: myVariable is not defined",
+            "Error: Something went wrong in my application",
+            "ValidationError: Email is invalid",
+            "DatabaseError: Connection failed",
+            "AuthenticationError: Invalid credentials",
+            "PaymentError: Card declined",
+            "Custom application error",
+            "User not found",
+            "Permission denied for this resource",
+            "Invalid input provided",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Ok(()),
+                "Event incorrectly filtered for legitimate error: '{error}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dont_filter_empty_exception() {
+        let event = get_event_with_exception(Exception::default());
+        let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+        assert_eq!(filter_result, Ok(()), "Empty exception should not be filtered");
+    }
+
+    #[test]
+    fn test_case_insensitive_matching() {
+        let errors = [
+            "FAILED TO FETCH",
+            "failed to fetch",
+            "Failed To Fetch",
+            "NETWORK ERROR",
+            "network error",
+            "RESIZEOBSERVER LOOP LIMIT EXCEEDED",
+        ];
+
+        for error in errors {
+            let event = get_event_with_exception_value(error);
+            let filter_result = should_filter(&event, &FilterConfig { is_enabled: true });
+            assert_eq!(
+                filter_result,
+                Err(FilterStatKey::CommonErrors),
+                "Case insensitive matching failed for: '{error}'"
+            );
+        }
+    }
+}
+

--- a/relay-filter/src/config.rs
+++ b/relay-filter/src/config.rs
@@ -509,6 +509,10 @@ pub struct ProjectFiltersConfig {
     #[serde(default, skip_serializing_if = "FilterConfig::is_empty")]
     pub browser_extensions: FilterConfig,
 
+    /// Configuration for the Common Errors filter.
+    #[serde(default, skip_serializing_if = "FilterConfig::is_empty")]
+    pub common_errors: FilterConfig,
+
     /// Configuration for the Client IPs filter.
     #[serde(default, skip_serializing_if = "ClientIpsFilterConfig::is_empty")]
     pub client_ips: ClientIpsFilterConfig,
@@ -553,6 +557,7 @@ impl ProjectFiltersConfig {
     /// Returns true if there are no filter configurations declared.
     pub fn is_empty(&self) -> bool {
         self.browser_extensions.is_empty()
+            && self.common_errors.is_empty()
             && self.client_ips.is_empty()
             && self.web_crawlers.is_empty()
             && self.csp.is_empty()
@@ -575,6 +580,9 @@ mod tests {
         insta::assert_debug_snapshot!(filters_config, @r###"
         ProjectFiltersConfig {
             browser_extensions: FilterConfig {
+                is_enabled: false,
+            },
+            common_errors: FilterConfig {
                 is_enabled: false,
             },
             client_ips: ClientIpsFilterConfig {
@@ -624,6 +632,7 @@ mod tests {
     fn test_serialize_full() {
         let filters_config = ProjectFiltersConfig {
             browser_extensions: FilterConfig { is_enabled: true },
+            common_errors: FilterConfig { is_enabled: true },
             client_ips: ClientIpsFilterConfig {
                 blacklisted_ips: vec!["127.0.0.1".to_owned()],
             },
@@ -663,6 +672,9 @@ mod tests {
         insta::assert_json_snapshot!(filters_config, @r###"
         {
           "browserExtensions": {
+            "isEnabled": true
+          },
+          "commonErrors": {
             "isEnabled": true
           },
           "clientIps": {

--- a/relay-filter/src/lib.rs
+++ b/relay-filter/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! * localhost (filter events originating from the local machine)
 //! * browser extensions (filter events caused by known problematic browser extensions)
+//! * common errors (filter events with commonly occurring error messages like network errors)
 //! * web crawlers (filter events sent by user agents known to be web crawlers)
 //! * legacy browsers (filter events originating from legacy browsers, can be configured)
 #![warn(missing_docs)]
@@ -18,6 +19,7 @@ use relay_protocol::Getter;
 
 pub mod browser_extensions;
 pub mod client_ips;
+pub mod common_errors;
 pub mod csp;
 pub mod error_messages;
 pub mod generic;
@@ -67,6 +69,7 @@ pub fn should_filter<F: Filterable + Getter>(
     error_messages::should_filter(item, &config.error_messages)?;
     localhost::should_filter(item, &config.localhost)?;
     browser_extensions::should_filter(item, &config.browser_extensions)?;
+    common_errors::should_filter(item, &config.common_errors)?;
     legacy_browsers::should_filter(item, &config.legacy_browsers)?;
     web_crawlers::should_filter(item, &config.web_crawlers)?;
     transaction_name::should_filter(item, &config.ignore_transactions)?;


### PR DESCRIPTION
## Summary

Adds a new `common_errors` inbound filter that filters out commonly occurring error messages that are typically noise and not actionable for developers.

This filter is based on analysis of the most frequently configured error message filters across Sentry customers, targeting patterns like:

- **Network errors**: Failed to fetch, Network Error, connection timeouts
- **Browser quirks**: ResizeObserver loop errors, AbortError
- **Third-party SDK errors**: gtag, fbq, HubSpot, Pinterest pixels
- **Mobile WebView errors**: Java bridge errors, iOS webkit handlers
- **Cancelled requests**: Including translations in multiple languages

The filter follows the same pattern as `browser_extensions` - it's a toggle-based filter with hardcoded regex patterns.

## Changes

- New `relay-filter/src/common_errors.rs` module with ~50 error patterns
- Added `CommonErrors` variant to `FilterStatKey`
- Added `common_errors: FilterConfig` to `ProjectFiltersConfig`

ref: https://github.com/getsentry/sentry/pull/104072
ref: https://github.com/getsentry/sentry/pull/104073