### PR TITLE
ref(upload): Lower default concurrency

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1284,7 +1284,7 @@ impl Default for UploadServiceConfig {
     fn default() -> Self {
         Self {
             objectstore_url: None,
-            max_concurrent_requests: 100,
+            max_concurrent_requests: 10,
             timeout: 60,
         }
     }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -76,7 +76,7 @@ use {
     crate::services::global_rate_limits::{GlobalRateLimits, GlobalRateLimitsServiceHandle},
     crate::services::processor::nnswitch::SwitchProcessingError,
     crate::services::store::{Store, StoreEnvelope},
-    crate::services::upload::UploadAttachments,
+    crate::services::upload::Upload,
     crate::utils::Enforcement,
     itertools::Itertools,
     relay_cardinality::{
@@ -1105,7 +1105,7 @@ pub struct Addrs {
     pub outcome_aggregator: Addr<TrackOutcome>,
     pub upstream_relay: Addr<UpstreamRelay>,
     #[cfg(feature = "processing")]
-    pub upload: Option<Addr<UploadAttachments>>,
+    pub upload: Option<Addr<Upload>>,
     #[cfg(feature = "processing")]
     pub store_forwarder: Option<Addr<Store>>,
     pub aggregator: Addr<Aggregator>,
@@ -2318,7 +2318,7 @@ impl EnvelopeProcessorService {
                         && use_objectstore()
                     {
                         // the `UploadService` will upload all attachments, and then forward the envelope to the `StoreService`.
-                        upload.send(UploadAttachments { envelope })
+                        upload.send(StoreEnvelope { envelope })
                     } else {
                         store_forwarder.send(StoreEnvelope { envelope })
                     }

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -108,9 +108,14 @@ impl UploadService {
             // Load shed to prevent backlogging in the service queue and affecting other parts of Relay.
             // We might want to have a less aggressive mechanism in the future.
 
+            let attachment_count = envelope
+                .envelope()
+                .items()
+                .filter(|item| *item.ty() == ItemType::Attachment)
+                .count();
             relay_statsd::metric!(
-                counter(RelayCounters::AttachmentUpload) += 1,
-                result = "load-shed",
+                counter(RelayCounters::AttachmentUpload) += attachment_count as u64,
+                result = "load_shed",
                 type = "envelope",
             );
 

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -180,6 +180,7 @@ impl UploadServiceInner {
                 relay_statsd::metric!(
                     counter(RelayCounters::AttachmentUpload) += attachments.count() as u64,
                     result = error.to_string().as_str(),
+                    type = "envelope",
                 );
             }
             Ok(session) => {
@@ -190,7 +191,8 @@ impl UploadServiceInner {
                         result = match result {
                             Ok(()) => "success",
                             Err(error) => error.as_str(),
-                        }
+                        },
+                        type = "envelope",
                     );
                 }
             }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -933,6 +933,7 @@ pub enum RelayCounters {
     ///
     /// This metric is tagged with:
     /// - `result`: `success` or the failure reason.
+    /// - `type`: `envelope` or `attachment_v2`
     #[cfg(feature = "processing")]
     AttachmentUpload,
 }


### PR DESCRIPTION
This PR

- lowers the default concurrency for objectstore uploads from 100 to 10 to match current capacity,
- removes the `join_all` from the envelope attachment upload to prevent having a higher actual concurrency,
- refactors the service interface to directly take a `StoreEnvelope`.

ref: INGEST-614