### PR TITLE
feat(logs): Count log envelopes with dynamic sampling context

### DIFF
--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -138,6 +138,7 @@ impl processing::Processor for LogsProcessor {
         ctx: Context<'_>,
     ) -> Result<Output<Self::Output>, Rejected<Error>> {
         validate::container(&logs).reject(&logs)?;
+        validate::dsc(&logs);
 
         // Fast filters, which do not need expanded logs.
         filter::feature_flag(ctx).reject(&logs)?;

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -935,6 +935,11 @@ pub enum RelayCounters {
     /// - `result`: `success` or the failure reason.
     #[cfg(feature = "processing")]
     AttachmentUpload,
+    /// Whether a logs envelope has a trace context header or not
+    ///
+    /// This metric is tagged with:
+    /// - `dsc`: yes or no
+    EnvelopeWithLogs,
 }
 
 impl CounterMetric for RelayCounters {
@@ -991,6 +996,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::SamplingDecision => "sampling.decision",
             #[cfg(feature = "processing")]
             RelayCounters::AttachmentUpload => "attachment.upload",
+            RelayCounters::EnvelopeWithLogs => "logs.envelope",
         }
     }
 }


### PR DESCRIPTION
Logs are never dynamically sampled, so they should not come with a dynamic sampling context.

This PR adds a metric to verify that assumption. Once it's validated, we can make the absence of a DSC a hard-requirement, so that if we add other items to the envelope (e.g. attachments), they are also not sampled.

ref: INGEST-654