### PR TITLE
ref(quotas): Tune quota cache hashmap

### DIFF
--- a/relay-quotas/src/cache.rs
+++ b/relay-quotas/src/cache.rs
@@ -71,7 +71,14 @@ where
             NonZeroU64::new(max_over_spend_divisor as u64).unwrap_or(NonZeroU64::MIN);
 
         Self {
-            cache: Default::default(),
+            cache: papaya::HashMap::builder()
+                // `ahash` for a faster hasher
+                .hasher(ahash::RandomState::new())
+                // Blocking resizes help with iteration, which we need for cleanups,
+                // as well as our workload seems to match the description of `Blocking`
+                // very well.
+                .resize_mode(papaya::ResizeMode::Blocking)
+                .build(),
             max_over_spend_divisor,
             limit_max_divisor: None,
             vacuum_interval: Duration::from_secs(30),


### PR DESCRIPTION
Separate PR to have separate revisions for additional performance tests. `ahash` should just be an upgrade, for `blocking` our actual workload seems to favor the blocking mode over the default incremental.

> Blocking resizes tend to be better in terms of throughput, especially in setups with multiple writers that can perform the resize in parallel. However, they can lead to latency spikes for insert operations that have to resize large tables.

Latency spikes on inserts are acceptable and we do have a lot of writers.