### PR TITLE
ref(processing): Pass store handle to forward_store

### DIFF
--- a/relay-server/src/processing/check_ins/mod.rs
+++ b/relay-server/src/processing/check_ins/mod.rs
@@ -112,13 +112,13 @@ impl Forward for CheckInsOutput {
     #[cfg(feature = "processing")]
     fn forward_store(
         self,
-        s: &relay_system::Addr<crate::services::store::Store>,
+        s: processing::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let envelope = self.serialize_envelope(ctx)?;
         let envelope = ManagedEnvelope::from(envelope).into_processed();
 
-        s.send(crate::services::store::StoreEnvelope { envelope });
+        s.store(crate::services::store::StoreEnvelope { envelope });
 
         Ok(())
     }

--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -1,6 +1,8 @@
 use crate::Envelope;
 use crate::managed::{Managed, Rejected};
 use crate::processing::ForwardContext;
+#[cfg(feature = "processing")]
+use crate::processing::StoreHandle;
 use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::logs::LogsProcessor;
 use crate::processing::sessions::SessionsProcessor;
@@ -30,7 +32,7 @@ macro_rules! outputs {
             #[cfg(feature = "processing")]
             fn forward_store(
                 self,
-                s: &relay_system::Addr<crate::services::store::Store>,
+                s: StoreHandle<'_>,
                 ctx: ForwardContext<'_>,
             ) -> Result<(), Rejected<()>> {
                 match self {

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -175,7 +175,7 @@ impl Forward for LogOutput {
     #[cfg(feature = "processing")]
     fn forward_store(
         self,
-        s: &relay_system::Addr<crate::services::store::Store>,
+        s: processing::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let Self(logs) = self;
@@ -188,7 +188,7 @@ impl Forward for LogOutput {
 
         for log in logs.split(|logs| logs.logs) {
             if let Ok(log) = log.try_map(|log, _| store::convert(log, &ctx)) {
-                s.send(log)
+                s.store(log)
             };
         }
 

--- a/relay-server/src/processing/sessions/mod.rs
+++ b/relay-server/src/processing/sessions/mod.rs
@@ -123,7 +123,7 @@ impl Forward for SessionsOutput {
     #[cfg(feature = "processing")]
     fn forward_store(
         self,
-        _: &relay_system::Addr<crate::services::store::Store>,
+        _: processing::forward::StoreHandle<'_>,
         _: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let SessionsOutput(sessions) = self;

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -216,7 +216,7 @@ impl Forward for SpanOutput {
     #[cfg(feature = "processing")]
     fn forward_store(
         self,
-        s: &relay_system::Addr<crate::services::store::Store>,
+        s: processing::forward::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let spans = match self {
@@ -234,7 +234,7 @@ impl Forward for SpanOutput {
 
         for span in spans.split(|spans| spans.into_indexed_spans()) {
             if let Ok(span) = span.try_map(|span, _| store::convert(span, &ctx)) {
-                s.send(span)
+                s.store(span)
             };
         }
 

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -161,7 +161,7 @@ impl Forward for TraceMetricOutput {
     #[cfg(feature = "processing")]
     fn forward_store(
         self,
-        s: &relay_system::Addr<crate::services::store::Store>,
+        s: processing::forward::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
         let Self(metrics) = self;
@@ -174,7 +174,7 @@ impl Forward for TraceMetricOutput {
 
         for metric in metrics.split(|metrics| metrics.metrics) {
             if let Ok(metric) = metric.try_map(|metric, _| store::convert(metric, &ctx)) {
-                s.send(metric);
+                s.store(metric);
             }
         }
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2301,6 +2301,9 @@ impl EnvelopeProcessorService {
         if self.inner.config.processing_enabled()
             && let Some(store_forwarder) = &self.inner.addrs.store_forwarder
         {
+            use crate::processing::StoreHandle;
+
+            let upload = self.inner.addrs.upload.as_ref();
             match submit {
                 Submit::Envelope(envelope) => {
                     let envelope_has_attachments = envelope
@@ -2324,7 +2327,7 @@ impl EnvelopeProcessorService {
                     }
                 }
                 Submit::Output { output, ctx } => output
-                    .forward_store(store_forwarder, ctx)
+                    .forward_store(StoreHandle::new(store_forwarder, upload), ctx)
                     .unwrap_or_else(|err| err.into_inner()),
             }
             return;


### PR DESCRIPTION
Starting with https://github.com/getsentry/relay/pull/5423, the `SpansProcessor` will send messages directly to the upload service. Replace the `Addr<Store>` in the `Forward` trait with a handle that dispatches messages to either Store or Upload.

ref: INGEST-614