### PR TITLE
feat(quotas): Normalize ratio/percentage with quota window

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1193,13 +1193,17 @@ pub struct Processing {
     /// Maximum rate limit to report to clients.
     #[serde(default = "default_max_rate_limit")]
     pub max_rate_limit: Option<u32>,
-    /// Configures the quota cache.
+    /// Configures the quota cache ratio between `0.0` and `1.0`.
     ///
     /// The quota cache, caches the specified percentage of remaining quota in memory to reduce the
     /// amount of synchronizations required with Redis.
     ///
+    /// The ratio is applied to the (per second) rate of the quota, not the total limit.
+    /// For example a quota with limit 100 with a 10 second window is treated equally to a quota of
+    /// 10 with a 1 second window.
+    ///
     /// By default quota caching is disabled.
-    pub quota_cache_percentage: Option<f32>,
+    pub quota_cache_ratio: Option<f32>,
     /// Configuration for attachment uploads.
     #[serde(default)]
     pub upload: UploadServiceConfig,
@@ -1221,7 +1225,7 @@ impl Default for Processing {
             attachment_chunk_size: default_chunk_size(),
             projectconfig_cache_prefix: default_projectconfig_cache_prefix(),
             max_rate_limit: default_max_rate_limit(),
-            quota_cache_percentage: None,
+            quota_cache_ratio: None,
             upload: UploadServiceConfig::default(),
         }
     }
@@ -2610,8 +2614,8 @@ impl Config {
     }
 
     /// Amount of remaining quota which is cached in memory.
-    pub fn quota_cache_percentage(&self) -> Option<f32> {
-        self.values.processing.quota_cache_percentage
+    pub fn quota_cache_ratio(&self) -> Option<f32> {
+        self.values.processing.quota_cache_ratio
     }
 
     /// Cache vacuum interval for the cardinality limiter in memory cache.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1195,7 +1195,7 @@ pub struct Processing {
     pub max_rate_limit: Option<u32>,
     /// Configures the quota cache ratio between `0.0` and `1.0`.
     ///
-    /// The quota cache, caches the specified percentage of remaining quota in memory to reduce the
+    /// The quota cache, caches the specified ratio of remaining quota in memory to reduce the
     /// amount of synchronizations required with Redis.
     ///
     /// The ratio is applied to the (per second) rate of the quota, not the total limit.

--- a/relay-quotas/src/cache.rs
+++ b/relay-quotas/src/cache.rs
@@ -126,7 +126,7 @@ where
                 //
                 // This means we get a consistent behaviour for short (10s) quotas (e.g. abuse) as well
                 // as long (1h) quotas (e.g. spike protection) with a more predictable error.
-                / usize::try_from(quota.window).unwrap_or(1).max(1)
+                / usize::try_from(quota.window).unwrap_or(usize::MAX).max(1)
                 // Apply ratio precision, which is already pre-multiplied into `max_over_spend_divisor`.
                 * RATIO_PRECISION
                 // Apply the actual ratio with the pre-computed divisor.

--- a/relay-quotas/src/cache.rs
+++ b/relay-quotas/src/cache.rs
@@ -37,7 +37,7 @@ where
     /// The amount the cache is allowed to opportunistically over-accept based on the remaining
     /// quota.
     ///
-    /// For example: Setting this to `10 * PERCENT_PRECISION` means, if there is 100 quota remaining,
+    /// For example: Setting this to `10 * RATIO_PRECISION` means, if there is 100 quota remaining,
     /// the cache will opportunistically accept the next 10 items, if there is a quota of 90 remaining,
     /// the cache will accept the next 9 items.
     max_over_spend_divisor: NonZeroUsize,

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -317,10 +317,10 @@ impl<T: GlobalLimiter> RedisRateLimiter<T> {
     /// The opportunistic cache, opportunistically serves quotas from a local cache, reducing the
     /// load on Redis heavily.
     ///
-    /// Caching considers a percentage of the remaining quota to be available and periodically
+    /// Caching considers a ratio of the remaining quota to be available and periodically
     /// synchronizes with Redis.
-    pub fn cache(mut self, max_over_spend_percentage: Option<f32>) -> Self {
-        self.cache = max_over_spend_percentage
+    pub fn cache(mut self, max_over_spend_ratio: Option<f32>) -> Self {
+        self.cache = max_over_spend_ratio
             .map(OpportunisticQuotaCache::new)
             .map(Arc::new);
 

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -69,7 +69,7 @@ pub struct OwnedRedisQuota {
     scoping: ItemScoping,
     /// The Redis key prefix mapped from the quota id.
     prefix: Arc<str>,
-    /// The redis window in seconds mapped from the quota.
+    /// The Redis window in seconds mapped from the quota.
     window: u64,
     /// The quantity being checked.
     quantity: usize,
@@ -224,6 +224,16 @@ impl<'a> RedisQuota<'a> {
             slot: self.slot(),
         }
     }
+
+    /// Returns a [`cache::Quota`] built from this [`RedisQuota`].
+    fn for_cache(&self) -> cache::Quota<QuotaCacheKey> {
+        cache::Quota {
+            limit: self.limit(),
+            window: self.window,
+            key: self.key(),
+            expiry: UnixTimestamp::from_secs(self.key_expiry()),
+        }
+    }
 }
 
 impl std::ops::Deref for RedisQuota<'_> {
@@ -362,22 +372,15 @@ impl<T: GlobalLimiter> RedisRateLimiter<T> {
                 if quota.scope == QuotaScope::Global {
                     global_quotas.push(quota);
                 } else {
-                    let key = quota.key();
-                    let redis_key = key.to_string();
-
                     if let Some(cache) = &self.cache {
-                        let k = cache::Quota {
-                            limit: quota.limit(),
-                            key,
-                            expiry: UnixTimestamp::from_secs(quota.key_expiry()),
-                        };
-                        quota.quantity = match cache.check_quota(k, quantity) {
+                        quota.quantity = match cache.check_quota(quota.for_cache(), quantity) {
                             cache::Action::Accept => continue,
                             cache::Action::Check(quantity) => quantity,
                         };
                     }
 
-                    // Remaining quotas are expected to be trackable in Redis.
+                    let redis_key = quota.key().to_string();
+                    // Remaining quotas are expected to be track-able in Redis.
                     let refund_key = get_refunded_quota_key(&redis_key);
 
                     invocation.key(redis_key);
@@ -451,14 +454,7 @@ impl<T: GlobalLimiter> RedisRateLimiter<T> {
             } else if let Some(cache) = &self.cache {
                 // Only update the cache if it's really necessary. Quotas which are being rejected,
                 // will not be able to be handled from the cache anyways.
-                cache.update_quota(
-                    cache::Quota {
-                        limit: quota.limit(),
-                        key: quota.key(),
-                        expiry: UnixTimestamp::from_secs(quota.key_expiry()),
-                    },
-                    state.consumed,
-                );
+                cache.update_quota(quota.for_cache(), state.consumed);
             }
         }
 
@@ -1409,7 +1405,7 @@ mod tests {
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
-            limit: Some(50),
+            limit: Some(50 * 60),
             window: Some(60),
             reason_code: Some(ReasonCode::new("get_lost")),
             namespace: None,
@@ -1458,13 +1454,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_quota_with_cache_slightly_over_account() {
+        let window = 60;
+        let limit = 50 * window;
+
         let quotas = &[Quota {
             id: Some(format!("test_simple_quota_{}", uuid::Uuid::new_v4()).into()),
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
-            limit: Some(50),
-            window: Some(60),
+            limit: Some(limit),
+            window: Some(window),
             reason_code: Some(ReasonCode::new("get_lost")),
             namespace: None,
         }];
@@ -1499,7 +1498,7 @@ mod tests {
 
         // Consume right up to the limit on the other limiter
         let rate_limits = rate_limiter2
-            .is_rate_limited(quotas, scoping, 49, false)
+            .is_rate_limited(quotas, scoping, limit as usize - 1, false)
             .await
             .unwrap();
         assert!(rate_limits.is_empty());

--- a/relay-quotas/src/redis.rs
+++ b/relay-quotas/src/redis.rs
@@ -1405,7 +1405,7 @@ mod tests {
             categories: DataCategories::new(),
             scope: QuotaScope::Organization,
             scope_id: None,
-            limit: Some(50 * 60),
+            limit: Some(50),
             window: Some(60),
             reason_code: Some(ReasonCode::new("get_lost")),
             namespace: None,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1201,7 +1201,7 @@ impl EnvelopeProcessorService {
             (Some(redis), Some(global)) => Some(
                 RedisRateLimiter::new(redis, global)
                     .max_limit(config.max_rate_limit())
-                    .cache(config.quota_cache_percentage()),
+                    .cache(config.quota_cache_ratio()),
             ),
             _ => None,
         };


### PR DESCRIPTION
Normalizes the applied ratio with the window size of the quota to have a consistent error independent of the size of the quota window. Closes: INGEST-657.

Also renames the config option to `ratio`. Closes: INGEST-658.