### PR TITLE
fix(relay): Fix parsing of data categories via serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Fix parsing of data categories/quotas when using an aliased data category name. ([#5435](https://github.com/getsentry/relay/pull/5435))
+
 ## 25.11.1
 
 **Breaking Changes**:

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -135,12 +135,10 @@ impl ProjectConfig {
     fn remove_invalid_quotas(&mut self) {
         let invalid_quotas: Vec<_> = self.quotas.extract_if(.., |q| !q.is_valid()).collect();
         if !invalid_quotas.is_empty() {
-            {
-                relay_log::error!(
-                    invalid_quotas = ?invalid_quotas,
-                    "Found an invalid quota definition",
-                );
-            }
+            relay_log::warn!(
+                invalid_quotas = ?invalid_quotas,
+                "Found an invalid quota definition",
+            );
         }
     }
 }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -585,18 +585,18 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: None,
           categories: [
-            transaction,
+            "transaction",
           ],
           scope: organization,
           limit: Some(0),
           namespace: None,
           reasonCode: Some(ReasonCode("not_yet")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -718,11 +718,11 @@ mod tests {
 
         let quota = serde_json::from_str::<Quota>(json).expect("parse quota");
 
-        insta::assert_ron_snapshot!(quota, @r###"
+        insta::assert_ron_snapshot!(quota, @r#"
         Quota(
           id: Some("f"),
           categories: [
-            unknown,
+            "unknown",
           ],
           scope: unknown,
           scopeId: Some("1"),
@@ -731,7 +731,7 @@ mod tests {
           namespace: None,
           reasonCode: Some(ReasonCode("not_so_fast")),
         )
-        "###);
+        "#);
     }
 
     #[test]

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -835,13 +835,13 @@ mod tests {
             namespaces: smallvec![],
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                default,
-                error,
+                "default",
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: Some(ReasonCode("second")),
@@ -850,7 +850,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -874,13 +874,13 @@ mod tests {
             namespaces: smallvec![],
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                default,
-                error,
+                "default",
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: Some(ReasonCode("first")),
@@ -889,7 +889,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -922,12 +922,12 @@ mod tests {
             namespaces: smallvec![],
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -936,7 +936,7 @@ mod tests {
             ),
             RateLimit(
               categories: [
-                transaction,
+                "transaction",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -945,7 +945,7 @@ mod tests {
             ),
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Project(ProjectId(21)),
               reason_code: None,
@@ -954,7 +954,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     /// Regression test that ensures namespaces are correctly added to rate limits.
@@ -979,12 +979,12 @@ mod tests {
             namespaces: smallvec![MetricNamespace::Spans],
         });
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                metric_bucket,
+                "metric_bucket",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -995,7 +995,7 @@ mod tests {
             ),
             RateLimit(
               categories: [
-                metric_bucket,
+                "metric_bucket",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -1006,7 +1006,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1031,17 +1031,17 @@ mod tests {
         });
 
         let rate_limit = rate_limits.longest().unwrap();
-        insta::assert_ron_snapshot!(rate_limit, @r###"
+        insta::assert_ron_snapshot!(rate_limit, @r#"
         RateLimit(
           categories: [
-            transaction,
+            "transaction",
           ],
           scope: Organization(OrganizationId(42)),
           reason_code: Some(ReasonCode("second")),
           retry_after: RetryAfter(10),
           namespaces: [],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1072,12 +1072,12 @@ mod tests {
         rate_limits.clean_expired(Instant::now());
 
         // Check that the expired limit has been removed
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -1086,7 +1086,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1183,12 +1183,12 @@ mod tests {
         });
 
         // Check that the error limit is applied
-        insta::assert_ron_snapshot!(applied_limits, @r###"
+        insta::assert_ron_snapshot!(applied_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -1197,7 +1197,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1246,12 +1246,12 @@ mod tests {
 
         let applied_limits = rate_limits.check_with_quotas(quotas, item_scoping);
 
-        insta::assert_ron_snapshot!(applied_limits, @r###"
+        insta::assert_ron_snapshot!(applied_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: Some(ReasonCode("zero")),
@@ -1260,7 +1260,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1294,12 +1294,12 @@ mod tests {
 
         rate_limits1.merge(rate_limits2);
 
-        insta::assert_ron_snapshot!(rate_limits1, @r###"
+        insta::assert_ron_snapshot!(rate_limits1, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: Some(ReasonCode("second")),
@@ -1308,7 +1308,7 @@ mod tests {
             ),
             RateLimit(
               categories: [
-                transaction_indexed,
+                "transaction_indexed",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -1317,7 +1317,7 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -1344,12 +1344,12 @@ mod tests {
 
         let rate_limits = cached.current_limits();
 
-        insta::assert_ron_snapshot!(rate_limits, @r###"
+        insta::assert_ron_snapshot!(rate_limits, @r#"
         RateLimits(
           limits: [
             RateLimit(
               categories: [
-                error,
+                "error",
               ],
               scope: Organization(OrganizationId(42)),
               reason_code: None,
@@ -1358,6 +1358,6 @@ mod tests {
             ),
           ],
         )
-        "###);
+        "#);
     }
 }

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -180,12 +180,12 @@ ITEM_TYPE_RATE_LIMIT_BEHAVIORS = [
     RateLimitBehavior(
         "user_report",
         PayloadType.BINARY,
-        [{"category": "user_report_v2", "quantity": 1, "reason": "generic"}],
+        [{"category": "feedback", "quantity": 1, "reason": "generic"}],
     ),
     RateLimitBehavior(
         "feedback",
         PayloadType.BINARY,
-        [{"category": "user_report_v2", "quantity": 1, "reason": "generic"}],
+        [{"category": "feedback", "quantity": 1, "reason": "generic"}],
     ),
     RateLimitBehavior(
         "profile",


### PR DESCRIPTION
Serde did not consider the alias programmed into `from_name` and `name` causing a mismatch of behaviour when deserializing data categories.

Also lowered the severity for the quota parsing issue from error to warn.