### PR TITLE
fix(project-config): Only report error if processing enabled

### DIFF
--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -100,8 +100,8 @@ pub struct ProjectConfig {
 
 impl ProjectConfig {
     /// Validates fields in this project config and removes values that are partially invalid.
-    pub fn sanitize(&mut self, is_processing: bool) {
-        self.remove_invalid_quotas(is_processing);
+    pub fn sanitize(&mut self, report_errors: bool) {
+        self.remove_invalid_quotas(report_errors);
 
         metrics::convert_conditional_tagging(self);
         defaults::add_span_metrics(self);
@@ -113,33 +113,34 @@ impl ProjectConfig {
         for flag in GRADUATED_FEATURE_FLAGS {
             self.features.0.insert(*flag);
         }
-
-        // Check if indexed and non-indexed are double-counting towards the same ID.
-        // This is probably not intended behavior.
-        for quota in &self.quotas {
-            if let Some(id) = quota.id.as_deref() {
-                for category in &*quota.categories {
-                    if let Some(indexed) = category.index_category()
-                        && quota.categories.contains(&indexed)
-                    {
-                        relay_log::error!(
-                            tags.id = id,
-                            "Categories {category} and {indexed} share the same quota ID. This will double-count items.",
-                        );
-                    }
-                }
-            }
-        }
     }
 
-    fn remove_invalid_quotas(&mut self, report: bool) {
+    fn remove_invalid_quotas(&mut self, report_errors: bool) {
         let invalid_quotas: Vec<_> = self.quotas.extract_if(.., |q| !q.is_valid()).collect();
-        if !invalid_quotas.is_empty() && report {
-            {
-                relay_log::warn!(
-                    invalid_quotas = ?invalid_quotas,
-                    "Found an invalid quota definition",
-                );
+        if report_errors {
+            if !invalid_quotas.is_empty() {
+                {
+                    relay_log::warn!(
+                        invalid_quotas = ?invalid_quotas,
+                        "Found an invalid quota definition",
+                    );
+                }
+            }
+            // Check if indexed and non-indexed are double-counting towards the same ID.
+            // This is probably not intended behavior.
+            for quota in &self.quotas {
+                if let Some(id) = quota.id.as_deref() {
+                    for category in &*quota.categories {
+                        if let Some(indexed) = category.index_category()
+                            && quota.categories.contains(&indexed)
+                        {
+                            relay_log::error!(
+                                tags.id = id,
+                                "Categories {category} and {indexed} share the same quota ID. This will double-count items.",
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -196,7 +196,7 @@ mod tests {
             metric_extraction: metric_extraction.map(ErrorBoundary::Ok).unwrap_or_default(),
             ..ProjectConfig::default()
         };
-        project.sanitize(); // enables metrics extraction rules
+        project.sanitize(false); // enables metrics extraction rules
         let project = project.metric_extraction.ok().unwrap();
 
         OwnedConfig { global, project }

--- a/relay-server/src/services/projects/project/info.rs
+++ b/relay-server/src/services/projects/project/info.rs
@@ -284,11 +284,11 @@ impl ProjectInfo {
     }
 
     /// Validates data in this project state and removes values that are partially invalid.
-    pub fn sanitized(mut self, is_processing: bool) -> Self {
+    pub fn sanitized(mut self, report_errors: bool) -> Self {
         relay_log::with_scope(
             |scope| scope.set_tag("project_id", self.project_id.map_or(0, ProjectId::value)),
             || {
-                self.config.sanitize(is_processing);
+                self.config.sanitize(report_errors);
             },
         );
         self

--- a/relay-server/src/services/projects/project/info.rs
+++ b/relay-server/src/services/projects/project/info.rs
@@ -284,11 +284,11 @@ impl ProjectInfo {
     }
 
     /// Validates data in this project state and removes values that are partially invalid.
-    pub fn sanitized(mut self) -> Self {
+    pub fn sanitized(mut self, is_processing: bool) -> Self {
         relay_log::with_scope(
             |scope| scope.set_tag("project_id", self.project_id.map_or(0, ProjectId::value)),
             || {
-                self.config.sanitize();
+                self.config.sanitize(is_processing);
             },
         );
         self

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -44,9 +44,11 @@ impl ProjectState {
     }
 
     /// Runs a post-deserialization step to normalize the project config (e.g. legacy fields).
-    pub fn sanitized(self) -> Self {
+    pub fn sanitized(self, is_processing: bool) -> Self {
         match self {
-            Self::Enabled(state) => Self::Enabled(Arc::new(state.as_ref().clone().sanitized())),
+            Self::Enabled(state) => {
+                Self::Enabled(Arc::new(state.as_ref().clone().sanitized(is_processing)))
+            }
             Self::Disabled => Self::Disabled,
             Self::Pending => Self::Pending,
         }

--- a/relay-server/src/services/projects/source/mod.rs
+++ b/relay-server/src/services/projects/source/mod.rs
@@ -78,7 +78,7 @@ impl ProjectSource {
                 //
                 // If it is pending, we must fallback to fetching from the upstream.
                 Ok(SourceProjectState::New(state)) => {
-                    let state = state.sanitized();
+                    let state = state.sanitized(self.config.processing_enabled());
                     if !state.is_pending() {
                         return Ok(state.into());
                     }
@@ -105,7 +105,9 @@ impl ProjectSource {
             .await?;
 
         Ok(match state {
-            SourceProjectState::New(state) => SourceProjectState::New(state.sanitized()),
+            SourceProjectState::New(state) => {
+                SourceProjectState::New(state.sanitized(self.config.processing_enabled()))
+            }
             SourceProjectState::NotModified => SourceProjectState::NotModified,
         })
     }


### PR DESCRIPTION
External relays should not report an error if they receive an unknown quota.