### PR TITLE
feat(spanv2): Compute hashed sentry.normalized_db_query and store it in attributes

### DIFF
--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -54,6 +54,7 @@ convention_attributes!(
     IS_REMOTE => "sentry.is_remote",
     MESSAGING_SYSTEM => "messaging.system",
     NORMALIZED_DB_QUERY => "sentry.normalized_db_query",
+    NORMALIZED_DB_QUERY_HASH => "sentry.normalized_db_query.hash",
     OBSERVED_TIMESTAMP_NANOS => "sentry.observed_timestamp_nanos",
     OP => "sentry.op",
     ORIGIN => "sentry.origin",

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -389,7 +389,11 @@ pub fn normalize_db_attributes(annotated_attributes: &mut Annotated<Attributes>)
 
     if let Some(attributes) = annotated_attributes.value_mut() {
         if let Some(normalized_db_query) = normalized_db_query {
+            let mut normalized_db_query_hash = format!("{:?}", md5::compute(&normalized_db_query));
+            normalized_db_query_hash.truncate(16);
+
             attributes.insert(NORMALIZED_DB_QUERY, normalized_db_query);
+            attributes.insert("sentry.normalized_db_query.hash", normalized_db_query_hash);
         }
         if let Some(db_operation_name) = db_operation {
             attributes.insert(DB_OPERATION_NAME, db_operation_name)
@@ -929,6 +933,10 @@ mod tests {
             "type": "string",
             "value": "SELECT %s"
           },
+          "sentry.normalized_db_query.hash": {
+            "type": "string",
+            "value": "3a377dcc490b1690"
+          },
           "sentry.op": {
             "type": "string",
             "value": "db.query"
@@ -994,6 +1002,10 @@ mod tests {
           "sentry.normalized_db_query": {
             "type": "string",
             "value": "{\"find\":\"documents\",\"foo\":\"?\"}"
+          },
+          "sentry.normalized_db_query.hash": {
+            "type": "string",
+            "value": "aedc5c7e8cec726b"
           },
           "sentry.op": {
             "type": "string",

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -389,7 +389,7 @@ pub fn normalize_db_attributes(annotated_attributes: &mut Annotated<Attributes>)
 
     if let Some(attributes) = annotated_attributes.value_mut() {
         if let Some(normalized_db_query) = normalized_db_query {
-            let mut normalized_db_query_hash = format!("{:?}", md5::compute(&normalized_db_query));
+            let mut normalized_db_query_hash = format!("{:x}", md5::compute(&normalized_db_query));
             normalized_db_query_hash.truncate(16);
 
             attributes.insert(NORMALIZED_DB_QUERY, normalized_db_query);

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -393,7 +393,7 @@ pub fn normalize_db_attributes(annotated_attributes: &mut Annotated<Attributes>)
             normalized_db_query_hash.truncate(16);
 
             attributes.insert(NORMALIZED_DB_QUERY, normalized_db_query);
-            attributes.insert("sentry.normalized_db_query.hash", normalized_db_query_hash);
+            attributes.insert(NORMALIZED_DB_QUERY_HASH, normalized_db_query_hash);
         }
         if let Some(db_operation_name) = db_operation {
             attributes.insert(DB_OPERATION_NAME, db_operation_name)

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -967,6 +967,10 @@ def test_spansv2_attribute_normalization(
                 "type": "string",
                 "value": "SELECT id FROM users WHERE id = %s AND name = %s",
             },
+            "sentry.normalized_db_query.hash": {
+                "type": "string",
+                "value": "f79af0ba3d26284c",
+            },
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),


### PR DESCRIPTION
Previously, relay wrote the hashed normalized description to span.group. We are now trying to move away from this vague attribute and instead use a more specific attribute to store hashes. In this case, the hash is used for span grouping for the insights query summary page (db queries get normalized into more general/non-specific queries and grouped by their hashes).

Note: bumping sentry conventions on a separate branch (and rebasing after it is merged)