### PR TITLE
ref(limits): Revise size limits for logs and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fix parsing of data categories/quotas when using an aliased data category name. ([#5435](https://github.com/getsentry/relay/pull/5435))
 
+**Internal**:
+
+- Revise trace metric and log size limits. ([#5440](https://github.com/getsentry/relay/pull/5440))
+
 ## 25.11.1
 
 **Breaking Changes**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,6 +4210,7 @@ dependencies = [
  "opentelemetry-proto",
  "relay-common",
  "relay-conventions",
+ "relay-event-normalization",
  "relay-event-schema",
  "relay-otel",
  "relay-protocol",

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -621,12 +621,6 @@ pub struct Limits {
     pub max_envelope_size: ByteSize,
     /// The maximum number of session items per envelope.
     pub max_session_count: usize,
-    /// The maximum number of standalone span items per envelope.
-    pub max_span_count: usize,
-    /// The maximum number of log items per envelope.
-    pub max_log_count: usize,
-    /// The maximum number of trace metrics per envelope.
-    pub max_trace_metric_count: usize,
     /// The maximum payload size for general API requests.
     pub max_api_payload_size: ByteSize,
     /// The maximum payload size for file uploads and chunks.
@@ -711,9 +705,6 @@ impl Default for Limits {
             max_check_in_size: ByteSize::kibibytes(100),
             max_envelope_size: ByteSize::mebibytes(200),
             max_session_count: 100,
-            max_span_count: 1000,
-            max_log_count: 1000,
-            max_trace_metric_count: 1000,
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
@@ -2387,6 +2378,18 @@ impl Config {
         self.values.limits.max_container_size.as_bytes()
     }
 
+    /// Returns the maximum payload size for logs integration items in bytes.
+    pub fn max_logs_integration_size(&self) -> usize {
+        // Not explicitly configured, inherited from the maximum size of a log container.
+        self.max_container_size()
+    }
+
+    /// Returns the maximum payload size for spans integration items in bytes.
+    pub fn max_spans_integration_size(&self) -> usize {
+        // Not explicitly configured, inherited from the maximum size of a span container.
+        self.max_container_size()
+    }
+
     /// Returns the maximum size of an envelope payload in bytes.
     ///
     /// Individual item size limits still apply.
@@ -2397,21 +2400,6 @@ impl Config {
     /// Returns the maximum number of sessions per envelope.
     pub fn max_session_count(&self) -> usize {
         self.values.limits.max_session_count
-    }
-
-    /// Returns the maximum number of standalone spans per envelope.
-    pub fn max_span_count(&self) -> usize {
-        self.values.limits.max_span_count
-    }
-
-    /// Returns the maximum number of logs per envelope.
-    pub fn max_log_count(&self) -> usize {
-        self.values.limits.max_log_count
-    }
-
-    /// Returns the maximum number of trace metrics per envelope.
-    pub fn max_trace_metric_count(&self) -> usize {
-        self.values.limits.max_trace_metric_count
     }
 
     /// Returns the maximum payload size of a statsd metric in bytes.

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -20,8 +20,10 @@ use crate::span::tag_extraction::{sql_action_from_query, sql_tables_from_query};
 use crate::{ClientHints, FromUserAgentInfo as _, RawUserAgentInfo};
 
 mod ai;
+mod size;
 
 pub use self::ai::normalize_ai;
+pub use self::size::*;
 
 /// Infers the sentry.op attribute and inserts it into [`Attributes`] if not already set.
 pub fn normalize_sentry_op(attributes: &mut Annotated<Attributes>) {

--- a/relay-event-normalization/src/eap/size.rs
+++ b/relay-event-normalization/src/eap/size.rs
@@ -1,0 +1,166 @@
+use relay_event_schema::protocol::{Attribute, Attributes};
+use relay_protocol::{Annotated, Value};
+
+/// Calculates the canonical size of [`Attributes`].
+///
+/// Simple data types have a fixed size assigned to them:
+///  - Boolean: 1 byte
+///  - Integer: 8 byte
+///  - Double: 8 Byte
+///  - Strings are counted by their byte (UTF-8 encoded) representation.
+///
+/// Complex types like objects and arrays are counted as the sum of all contained simple data types.
+///
+/// The size of all attributes is the sum of all attribute values and their keys.
+pub fn attributes_size(attributes: &Attributes) -> usize {
+    attributes
+        .0
+        .iter()
+        .map(|(k, v)| k.len() + attribute_size(v))
+        .sum()
+}
+
+/// Calculates the size of a single attribute.
+///
+/// As described in [`attributes_size`], only the value of the attribute is considered for the size
+/// of an attribute.
+pub fn attribute_size(v: &Annotated<Attribute>) -> usize {
+    v.value().map(|v| &v.value.value).map_or(0, value_size)
+}
+
+/// Recursively calculates the size of a [`Value`], using the rules described in [`attributes_size`].
+pub fn value_size(v: &Annotated<Value>) -> usize {
+    let Some(v) = v.value() else {
+        return 0;
+    };
+
+    match v {
+        Value::Bool(_) => 1,
+        Value::I64(_) => 8,
+        Value::U64(_) => 8,
+        Value::F64(_) => 8,
+        Value::String(v) => v.len(),
+        Value::Array(v) => v.iter().map(value_size).sum(),
+        Value::Object(v) => v.iter().map(|(k, v)| k.len() + value_size(v)).sum(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_protocol::{Error, Object};
+
+    use super::*;
+
+    #[test]
+    fn test_value_size_basic() {
+        assert_eq!(value_size(&Value::Bool(true).into()), 1);
+        assert_eq!(value_size(&Value::Bool(false).into()), 1);
+        assert_eq!(value_size(&Value::I64(0).into()), 8);
+        assert_eq!(value_size(&Value::I64(i64::MIN).into()), 8);
+        assert_eq!(value_size(&Value::I64(i64::MAX).into()), 8);
+        assert_eq!(value_size(&Value::U64(0).into()), 8);
+        assert_eq!(value_size(&Value::U64(u64::MIN).into()), 8);
+        assert_eq!(value_size(&Value::U64(u64::MAX).into()), 8);
+        assert_eq!(value_size(&Value::F64(123.42).into()), 8);
+        assert_eq!(value_size(&Value::F64(f64::MAX).into()), 8);
+        assert_eq!(value_size(&Value::F64(f64::MIN).into()), 8);
+        assert_eq!(value_size(&Value::F64(f64::NAN).into()), 8);
+        assert_eq!(value_size(&Value::F64(f64::NEG_INFINITY).into()), 8);
+        assert_eq!(value_size(&Value::String("foobar".to_owned()).into()), 6);
+        assert_eq!(value_size(&Value::String("ඞ".to_owned()).into()), 3);
+        assert_eq!(value_size(&Value::String("".to_owned()).into()), 0);
+    }
+
+    #[test]
+    fn test_value_size_array() {
+        let array = Value::Array(vec![
+            Annotated::empty(),
+            Annotated::new(Value::Bool(true)),
+            Annotated::new(Value::Bool(false)),
+            Annotated::from_error(Error::invalid("oops"), Some(Value::U64(0))),
+            Annotated::new(Value::String("42".to_owned())),
+            Annotated::new(Value::Array(vec![])),
+            Annotated::new(Value::Array(vec![
+                Annotated::new(Value::Array(vec![Annotated::new(Value::Bool(false))])),
+                Annotated::new(Value::Object(Object::from([
+                    ("ඞ".to_owned(), Annotated::new(Value::I64(3))),
+                    ("empty_key".to_owned(), Annotated::empty()),
+                ]))),
+                Annotated::empty(),
+            ])),
+        ]);
+
+        assert_eq!(value_size(&array.into()), 25);
+    }
+
+    #[test]
+    fn test_value_size_object() {
+        let obj = Value::Object(Object::from([
+            ("".to_owned(), Annotated::new(Value::Bool(false))),
+            ("1".to_owned(), Annotated::new(Value::Bool(false))),
+            ("ඞ".to_owned(), Annotated::empty()),
+            (
+                "key".to_owned(),
+                Annotated::new(Value::Object(Object::from([
+                    (
+                        "foo".to_owned(),
+                        Annotated::new(Value::Array(vec![
+                            Annotated::new(Value::I64(21)),
+                            Annotated::new(Value::F64(42.0)),
+                        ])),
+                    ),
+                    ("bar".to_owned(), Annotated::empty()),
+                ]))),
+            ),
+        ]));
+
+        assert_eq!(value_size(&obj.into()), 31);
+    }
+
+    macro_rules! assert_calculated_size_of {
+        ($expected:expr, $json:expr) => {{
+            let json = $json;
+
+            let attrs = Annotated::<Attributes>::from_json(json)
+                .unwrap()
+                .into_value()
+                .unwrap();
+
+            let size = attributes_size(&attrs);
+            assert_eq!(size, $expected, "attrs: {json}");
+        }};
+    }
+
+    #[test]
+    fn test_attributes_size_full() {
+        assert_calculated_size_of!(
+            82,
+            r#"{
+            "k1": {
+                "value": "string value",
+                "type": "string"
+            },
+            "k2": {
+                "value": 18446744073709551615,
+                "type": "integer"
+            },
+            "k3": {
+                "value": 42.01234567891234567899,
+                "type": "double"
+            },
+            "k4": {
+                "value": false,
+                "type": "boolean"
+            },
+            "k5": {
+                "value": {
+                    "nested": {
+                        "array": [1.0, 2, -12, "7 bytes", false]
+                    }
+                },
+                "type": "not yet supported"
+            }
+        }"#
+        );
+    }
+}

--- a/relay-ourlogs/Cargo.toml
+++ b/relay-ourlogs/Cargo.toml
@@ -20,11 +20,12 @@ opentelemetry-proto = { workspace = true, features = [
     "with-serde",
     "logs",
 ] }
+relay-common = { workspace = true }
 relay-conventions = { workspace = true }
 relay-event-schema = { workspace = true }
+relay-event-normalization = { workspace = true }
 relay-otel = { workspace = true }
 relay-protocol = { workspace = true }
-relay-common = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/relay-server/src/processing/trace_metrics/validate.rs
+++ b/relay-server/src/processing/trace_metrics/validate.rs
@@ -1,12 +1,80 @@
 use relay_event_schema::protocol::{MetricType, TraceMetric};
 use relay_protocol::Annotated;
 
+use crate::envelope::WithHeader;
 use crate::managed::{Managed, Rejected};
+use crate::processing::Context;
 use crate::processing::trace_metrics::{
     Error, ExpandedTraceMetrics, Result, SerializedTraceMetrics,
 };
 use crate::services::outcome::DiscardReason;
 
+/// Validates that there is only a single trace metric container processed at a time.
+///
+/// Similar to logs, the `TraceMetric` item must always be sent as an `ItemContainer`, currently it is not allowed to
+/// send multiple containers for trace metrics.
+///
+/// This restriction may be lifted in the future.
+///
+/// This limit mostly exists to incentivise SDKs to batch multiple trace metrics into a single container,
+/// technically it can be removed without issues.
+pub fn container(metrics: &Managed<SerializedTraceMetrics>) -> Result<(), Rejected<Error>> {
+    // It's fine if there was no trace metric container, as we may accept OTel trace metrics in the future.
+    if metrics.metrics.len() > 1 {
+        return Err(metrics.reject_err(Error::DuplicateContainer));
+    }
+
+    Ok(())
+}
+
+/// Validates contained logs do not exceed the maximum size limit.
+///
+/// Currently this only considers the maximum log size configured in the configuration.
+///
+/// In the future we may want to increase the limit or start trimming excessive
+/// attributes/payloads. For now we drop logs which exceed our size limit.
+///
+/// This matches the logic defined in [`check_envelope_size_limits`](crate::utils::check_envelope_size_limits),
+/// when validating envelope sizes, the actual size of individual logs is not known and therefore
+/// must be enforced consistently after parsing again.
+pub fn size(metrics: &mut Managed<ExpandedTraceMetrics>, ctx: Context<'_>) {
+    let max_size_bytes = ctx.config.max_trace_metric_size();
+
+    metrics.retain(
+        |metrics| &mut metrics.metrics,
+        |metric, _| {
+            let size = calculate_size(metric);
+
+            match size > max_size_bytes {
+                true => Err(Error::TooLarge),
+                false => Ok(()),
+            }
+        },
+    );
+}
+
+/// Calculates the byte size for a trace metric.
+///
+/// Similar to [`relay_ourlogs::calculate_size`].
+fn calculate_size(metric: &WithHeader<TraceMetric>) -> usize {
+    let Some(metric) = metric.value() else {
+        // Same logic we use for logs.
+        return 1;
+    };
+
+    let mut size = 0;
+
+    size += metric.name.value().map_or(0, |s| s.len());
+    size += relay_event_normalization::eap::value_size(&metric.value);
+
+    if let Some(attributes) = metric.attributes.value() {
+        size += relay_event_normalization::eap::attributes_size(attributes);
+    }
+
+    size
+}
+
+/// Validates the semantic validity of a trace metric.
 pub fn validate(metrics: &mut Managed<ExpandedTraceMetrics>) {
     metrics.retain(
         |metrics| &mut metrics.metrics,
@@ -25,23 +93,5 @@ fn validate_trace_metric(metric: &Annotated<TraceMetric>) -> Result<()> {
             return Err(Error::Invalid(DiscardReason::InvalidTraceMetric));
         }
     }
-    Ok(())
-}
-
-/// Validates that there is only a single trace metric container processed at a time.
-///
-/// Similar to logs, the `TraceMetric` item must always be sent as an `ItemContainer`, currently it is not allowed to
-/// send multiple containers for trace metrics.
-///
-/// This restriction may be lifted in the future.
-///
-/// This limit mostly exists to incentivise SDKs to batch multiple trace metrics into a single container,
-/// technically it can be removed without issues.
-pub fn container(metrics: &Managed<SerializedTraceMetrics>) -> Result<(), Rejected<Error>> {
-    // It's fine if there was no trace metric container, as we may accept OTel trace metrics in the future.
-    if metrics.metrics.len() > 1 {
-        return Err(metrics.reject_err(Error::DuplicateContainer));
-    }
-
     Ok(())
 }

--- a/relay-server/src/processing/trace_metrics/validate.rs
+++ b/relay-server/src/processing/trace_metrics/validate.rs
@@ -27,15 +27,15 @@ pub fn container(metrics: &Managed<SerializedTraceMetrics>) -> Result<(), Reject
     Ok(())
 }
 
-/// Validates contained logs do not exceed the maximum size limit.
+/// Validates contained metrics do not exceed the maximum size limit.
 ///
-/// Currently this only considers the maximum log size configured in the configuration.
+/// Currently this only considers the maximum metric size configured in the configuration.
 ///
 /// In the future we may want to increase the limit or start trimming excessive
-/// attributes/payloads. For now we drop logs which exceed our size limit.
+/// attributes/payloads. For now we drop metrics which exceed our size limit.
 ///
 /// This matches the logic defined in [`check_envelope_size_limits`](crate::utils::check_envelope_size_limits),
-/// when validating envelope sizes, the actual size of individual logs is not known and therefore
+/// when validating envelope sizes, the actual size of individual metrics is not known and therefore
 /// must be enforced consistently after parsing again.
 pub fn size(metrics: &mut Managed<ExpandedTraceMetrics>, ctx: Context<'_>) {
     let max_size_bytes = ctx.config.max_trace_metric_size();
@@ -71,7 +71,7 @@ fn calculate_size(metric: &WithHeader<TraceMetric>) -> usize {
         size += relay_event_normalization::eap::attributes_size(attributes);
     }
 
-    size
+    size.max(1)
 }
 
 /// Validates the semantic validity of a trace metric.

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -24,6 +24,7 @@ use crate::services::outcome::{DiscardAttachmentType, DiscardItemType};
 ///  - `max_session_count`
 ///  - `max_span_size`
 ///  - `max_statsd_size`
+///  - `max_trace_metric_size`
 ///  - `max_container_size`
 pub fn check_envelope_size_limits(
     config: &Config,

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -251,6 +251,7 @@ class Sentry(SentryLike):
                 ).get("outcomes")
                 timeout = 0.1  # only wait the first time
                 for outcome in outcomes:
+                    del outcome["timestamp"]
                     quantity = outcome.pop("quantity")
                     aggregated[tuple(sorted(outcome.items()))] += quantity
         except Empty:

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1071,7 +1071,6 @@ def test_invalid_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 3,
             "reason": "invalid_span",
-            "timestamp": time_within_delta(),
         },
         {
             "category": DataCategory.SPAN.value,
@@ -1080,7 +1079,6 @@ def test_invalid_spans(mini_sentry, relay):
             "outcome": 3,
             "project_id": 42,
             "reason": "no_data",
-            "timestamp": time_within_delta(),
             "quantity": 4,
         },
         {
@@ -1090,7 +1088,6 @@ def test_invalid_spans(mini_sentry, relay):
             "outcome": 3,
             "project_id": 42,
             "reason": "timestamp",
-            "timestamp": time_within_delta(),
             "quantity": 6,
         },
         {
@@ -1101,7 +1098,6 @@ def test_invalid_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 3,
             "reason": "invalid_span",
-            "timestamp": time_within_delta(),
         },
         {
             "category": DataCategory.SPAN_INDEXED.value,
@@ -1110,7 +1106,6 @@ def test_invalid_spans(mini_sentry, relay):
             "outcome": 3,
             "project_id": 42,
             "reason": "no_data",
-            "timestamp": time_within_delta(),
             "quantity": 4,
         },
         {
@@ -1120,7 +1115,6 @@ def test_invalid_spans(mini_sentry, relay):
             "outcome": 3,
             "project_id": 42,
             "reason": "timestamp",
-            "timestamp": time_within_delta(),
             "quantity": 6,
         },
     ]


### PR DESCRIPTION
- Removes count checks, we're only checking size now for general infra/stability limits. For counts and more granular limits our quota system is well equipped to deal with.
- Clarify how integration sizes are configured and they depend on the container limits (as integrations get converted into these containers eventually)
- Re-Use the size calculation of logs for trace metrics
- Validates sizes now consistently in the processors (span processor will also need this implemented separately), this makes sure there are still infra relevant limits enforced, independent of the source (integration/non-integration)
- Adds additional tests for the size limits

Refs: INGEST-655