### PR TITLE
feat(integrations): Raise logs integration size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Increases log size limits to better support log drains. ([#5441](https://github.com/getsentry/relay/pull/5441))
+
 **Bug Fixes**:
 
 - Fix parsing of data categories/quotas when using an aliased data category name. ([#5435](https://github.com/getsentry/relay/pull/5435))

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -712,7 +712,7 @@ impl Default for Limits {
             max_trace_metric_size: ByteSize::kibibytes(2),
             max_log_size: ByteSize::mebibytes(1),
             max_span_size: ByteSize::mebibytes(1),
-            max_container_size: ByteSize::mebibytes(3),
+            max_container_size: ByteSize::mebibytes(12),
             max_statsd_size: ByteSize::mebibytes(1),
             max_metric_buckets_size: ByteSize::mebibytes(1),
             max_replay_compressed_size: ByteSize::mebibytes(10),

--- a/relay-server/src/endpoints/integrations/otlp.rs
+++ b/relay-server/src/endpoints/integrations/otlp.rs
@@ -49,7 +49,7 @@ mod traces {
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-        post(handle).route_layer(DefaultBodyLimit::max(config.max_envelope_size()))
+        post(handle).route_layer(DefaultBodyLimit::max(config.max_spans_integration_size()))
     }
 }
 
@@ -78,6 +78,6 @@ mod logs {
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-        post(handle).route_layer(DefaultBodyLimit::max(config.max_envelope_size()))
+        post(handle).route_layer(DefaultBodyLimit::max(config.max_logs_integration_size()))
     }
 }

--- a/relay-server/src/endpoints/integrations/vercel.rs
+++ b/relay-server/src/endpoints/integrations/vercel.rs
@@ -44,6 +44,6 @@ mod logs {
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-        post(handle).route_layer(DefaultBodyLimit::max(config.max_envelope_size()))
+        post(handle).route_layer(DefaultBodyLimit::max(config.max_logs_integration_size()))
     }
 }


### PR DESCRIPTION
Raises the logs integration limits to 12 MiB to enable support for Cloudflare log drains sending up to 10MiB. 2MiB extra as headroom for eventual size mismatches and transport overheads.

Closes: INGEST-655
