### PR TITLE
meta(gitattributes): Always show changes to Cargo.lock in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock -linguist-generated


### PR DESCRIPTION
Changes to our `Cargo.lock` are very much intentional, accidentally bumping the wrong dependency can cause big problems (e.g. last time that happened with Tokio).
Any change to the `Cargo.lock` should be intentional and reviewed. Having it collapsed by default makes it much easier to miss (large) changes to it.

This change should make it so Github renders changes to the `Cargo.lock` by default.

Github documentation: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

<img width="1474" height="267" alt="image" src="https://github.com/user-attachments/assets/e7142e3a-1ca7-4e30-bd45-d30fa78b1ef5" />
