### PR TITLE
test(attachments): Remove small/redundant timeouts from int tests

### DIFF
--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -73,7 +73,7 @@ def test_standalone_attachment_forwarding(mini_sentry, relay):
     envelope.add_item(attachment_item)
     relay.send_envelope(project_id, envelope)
 
-    forwarded_envelope = mini_sentry.captured_events.get(timeout=1)
+    forwarded_envelope = mini_sentry.get_captured_event()
     attachment_item = forwarded_envelope.items[0]
     assert attachment_item.type == "attachment"
 
@@ -129,7 +129,7 @@ def test_invalid_item_headers(mini_sentry, relay, invalid_headers, quantity):
     envelope.add_item(Item(payload=PayloadRef(bytes=combined_payload), headers=headers))
     relay.send_envelope(project_id, envelope)
 
-    assert mini_sentry.get_outcomes(n=2, timeout=1) == [
+    assert mini_sentry.get_outcomes(n=2) == [
         {
             "category": DataCategory.ATTACHMENT.value,
             "org_id": 1,
@@ -204,7 +204,7 @@ def test_attachment_with_matching_span(mini_sentry, relay):
     )
 
     relay.send_envelope(project_id, envelope)
-    forwarded = mini_sentry.captured_events.get(timeout=5)
+    forwarded = mini_sentry.get_captured_event()
 
     span_item = next(i for i in forwarded.items if i.type == "span")
     spans = json.loads(span_item.payload.bytes.decode())["items"]
@@ -293,7 +293,7 @@ def test_two_attachments_mapping_to_same_span(mini_sentry, relay):
     )
 
     relay.send_envelope(project_id, envelope)
-    forwarded = mini_sentry.captured_events.get(timeout=5)
+    forwarded = mini_sentry.get_captured_event()
 
     span_item = next(i for i in forwarded.items if i.type == "span")
     spans = json.loads(span_item.payload.bytes.decode())["items"]
@@ -383,7 +383,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
 
     relay.send_envelope(project_id, envelope)
 
-    assert mini_sentry.get_outcomes(n=3, timeout=3) == [
+    assert mini_sentry.get_outcomes(n=3) == [
         {
             "timestamp": time_within_delta(),
             "org_id": 1,
@@ -502,7 +502,7 @@ def test_attachments_dropped_with_span_inbound_filters(mini_sentry, relay):
     )
 
     relay.send_envelope(project_id, envelope, headers=headers)
-    assert mini_sentry.get_outcomes(n=4, timeout=3) == [
+    assert mini_sentry.get_outcomes(n=4) == [
         {
             "timestamp": time_within_delta(ts),
             "org_id": 1,
@@ -595,7 +595,7 @@ def test_attachment_dropped_with_invalid_spans(mini_sentry, relay):
     )
 
     relay.send_envelope(project_id, envelope)
-    assert mini_sentry.get_outcomes(n=4, timeout=3) == [
+    assert mini_sentry.get_outcomes(n=4) == [
         {
             "timestamp": time_within_delta(ts),
             "org_id": 1,
@@ -791,7 +791,7 @@ def test_span_attachment_independent_rate_limiting(
 
     relay.send_envelope(project_id, envelope)
 
-    outcomes = mini_sentry.get_outcomes(n=len(expected_outcomes), timeout=3)
+    outcomes = mini_sentry.get_outcomes(n=len(expected_outcomes))
     outcome_counter = {}
     for outcome in outcomes:
         key = (outcome["category"], outcome["outcome"])


### PR DESCRIPTION
`get_captured_event()` has a builtin timeout, so do all the outcome functions, this should prevent some CI failures due to slow runners, also allows us to have a single configurable timeout in case it needs tuning.

