### PR TITLE
ref(quotas): Consider consumed and total use for limit max

### DIFF
--- a/relay-quotas/src/cache.rs
+++ b/relay-quotas/src/cache.rs
@@ -480,7 +480,8 @@ mod tests {
         assert_eq!(cache.check_quota(q1, 5), Action::Accept);
         assert_eq!(cache.check_quota(q1, 1), Action::Check(6));
 
-        // 31 remaining -> 3 (10%), consumption still under limit threshold (70)
+        // 31 remaining -> 3 (10%), consumption still under limit threshold (70),
+        // but a request of `2` (71) exceeds the limit.
         cache.set_quota(q1, 69);
         assert_eq!(cache.check_quota(q1, 2), Action::Check(2));
 


### PR DESCRIPTION
Since the remaining is calculated (still) from the total limit not the truncated limit (max), it is possible that there is an over accounting above the "truncated limit" (max). Changes the logic to consider total use against that limit to correct some potential errors.

If this shows an error, there is an option to consider the "truncated limit" (max) for the calculation of the over use quota instead.