### PR TITLE
test(quota): Fix flaky global quota test

### DIFF
--- a/relay-quotas/src/global.rs
+++ b/relay-quotas/src/global.rs
@@ -466,10 +466,14 @@ mod tests {
         let mut total = 0;
         let mut total_counter_1 = 0;
         let mut total_counter_2 = 0;
+
+        let scoping = scoping.item(DataCategory::MetricBucket);
+        let ts = UnixTimestamp::now();
+
         for i in 0.. {
             let quantity = i % 17;
 
-            let quota = [build_redis_quota(&quota, &scoping, quantity)];
+            let quota = [RedisQuota::new(&quota, quantity, scoping, ts).unwrap()];
             if counter1
                 .filter_rate_limited(&client, &quota)
                 .await


### PR DESCRIPTION
Since `build_redis_quota` would use a new timestamp on every iteration it is possible to have an inconsistent test. This modifies the test to only take time once and essentially freeze it.

I broke this recently with a refactor, when I put `quantity` into the `RedisQuota`.