### PR TITLE
build: Bump objectstore to 0.0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.0.11"
+version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8042b686597a4697640ac3c5d8541d8510afae1be5fedb12efded9f7e2ca2d"
+checksum = "260ccf94ed55dc83c0a5b470a4d9404d9f15e4b975d6c6e734e89296eef75b59"
 dependencies = [
  "async-compression",
  "bytes",
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-types"
-version = "0.0.11"
+version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e8ef8ad5b9ba35f5f63c2d60bd98d4656ac1d693916667cce6e56409242b9c"
+checksum = "da8b79e6156554da409ff350f06dea1b5ea0b1f863ca753fe9222a74e917592b"
 dependencies = [
  "http",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ minidump = "0.26.0"
 multer = "3.1.0"
 num-traits = "0.2.19"
 num_cpus = "1.17.0"
-objectstore-client = "0.0.11"
+objectstore-client = "0.0.14"
 opentelemetry-semantic-conventions = { version = "0.31.0" }
 opentelemetry-proto = { version = "0.30.0", default-features = false }
 papaya = "0.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
     "flask>=3.0.3",
     "msgpack>=1.1.0",
     "mypy>=1.10.0",
-    "objectstore-client==0.0.11",
+    "objectstore-client==0.0.14",
     "opentelemetry-proto>=1.32.1",
     "pre-commit>=4.2.0",
     "pytest>=7.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "sys_platform == 'darwin' or sys_platform == 'linux'",
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.0.11"
+version = "0.0.14"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "filetype", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -322,7 +322,7 @@ dependencies = [
     { name = "zstandard", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/objectstore_client-0.0.11-py3-none-any.whl", hash = "sha256:ed435c7a0297a5b75bfc6a6a90257d1c54e7e2a10ff6b03085faacf604c1eb8b" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/objectstore_client-0.0.14-py3-none-any.whl", hash = "sha256:ca2edd8733bfcfce5463d5f6078ca70b838cb40a74f628fc37fac431e63515f6" },
 ]
 
 [[package]]
@@ -552,7 +552,7 @@ dev = [
     { name = "milksnake", specifier = ">=0.1.6" },
     { name = "msgpack", specifier = ">=1.1.0" },
     { name = "mypy", specifier = ">=1.10.0" },
-    { name = "objectstore-client", specifier = "==0.0.11" },
+    { name = "objectstore-client", specifier = "==0.0.14" },
     { name = "opentelemetry-proto", specifier = ">=1.32.1" },
     { name = "packaging", specifier = "==25.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },


### PR DESCRIPTION
The new version of the client uses our updated API endpoints.