### PR TITLE
test(integration): Bump default timeouts 5 -> 10

### DIFF
--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -50,7 +50,7 @@ class Sentry(SentryLike):
         self.project_config_simulate_pending = False
         self.project_config_ignore_revision = False
 
-        self.timeout = 5
+        self.timeout = 10
 
     @property
     def internal_error_dsn(self):

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -195,11 +195,11 @@ class ConsumerBase:
         self.consumer = consumer
         self.test_producer = kafka_producer(options)
         self.topic_name = topic_name
-        self.timeout = timeout or 5
+        self.timeout = timeout or 10
 
         # Connect to the topic and poll a first test message.
         # First poll takes forever, the next ones are fast.
-        self.assert_empty(timeout=5)
+        self.assert_empty()
 
     def poll(self, timeout=None):
         if timeout is None:


### PR DESCRIPTION
Slow github CI -> longer timeouts. When tests are fast longer timeouts should not have any negative effects, as they are used to await a message.

Ideally helps with CI errors like:

```
  File "/home/runner/work/relay/relay/tests/integration/test_feedback.py", line 133, in test_feedback_events_without_processing
    envelope = mini_sentry.get_captured_event()
  File "/home/runner/work/relay/relay/tests/integration/fixtures/mini_sentry.py", line 207, in get_captured_event
    return self.captured_events.get(timeout=timeout or self.timeout)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.5/x64/lib/python3.13/queue.py", line 212, in get
    raise Empty
_queue.Empty
```

This is crazy:

```
2025-12-05T11:47:12.507121Z TRACE relay_server::services::processor::event: processing user_report_v2
2025-12-05T11:47:17.213923Z TRACE relay_server::services::processor: sending envelope to sentry endpoint
```