### PR TITLE
build(dev): Enable basic optimizations for dev builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,11 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Cargo Tests
-        run: cargo test --workspace
+        env:
+          # Faster compilation on slower CI runners.
+          CARGO_PROFILE_DEV_OPT_LEVEL: 0
+        run: |
+          cargo test --workspace
 
   test_all:
     needs: build-setup
@@ -233,6 +237,9 @@ jobs:
           key: ${{ github.job }}
 
       - name: Run Cargo Tests
+        env:
+          # Faster compilation on slower CI runners.
+          CARGO_PROFILE_DEV_OPT_LEVEL: 0
         run: cargo test --workspace --all-features
 
   test_py:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 # Debug information slows down the build and increases caches in the
 # target folder, but we don't require stack traces in most cases.
 debug = false
+opt-level = 1
 
 [profile.dev-debug]
 # A version of the dev profile with debug information enabled, for e.g. local

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ opt-level = 1
 # debugging.
 inherits = "dev"
 debug = true
+opt-level = 0
 
 [profile.release]
 # In release, however, we do want full debug information to report

--- a/relay-event-normalization/src/normalize/span/description/sql/parser.rs
+++ b/relay-event-normalization/src/normalize/span/description/sql/parser.rs
@@ -884,6 +884,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))] // Causes a `STATUS_STACK_OVERFLOW` when compiled with opt-level=1 on windows
     fn visit_deep_expression() {
         struct TestVisitor;
         impl Visitor for TestVisitor {

--- a/tests/integration/asserts/__init__.py
+++ b/tests/integration/asserts/__init__.py
@@ -1,11 +1,12 @@
 from typing import Any, Callable
-from .time import time_after, time_within, time_within_delta
+from .time import time_after, time_within, time_within_delta, time_is
 from .protocol import only_items
 
 __all__ = [
     "matches",
     "only_items",
     "time_after",
+    "time_is",
     "time_within",
     "time_within_delta",
 ]

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -2,6 +2,7 @@ import pytest
 import uuid
 import json
 
+from unittest import mock
 from requests.exceptions import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from objectstore_client import Client, Usecase
@@ -153,10 +154,10 @@ def test_attachments_with_objectstore(
     )
     assert objectstore_session.get(objectstore_key).payload.read() == chunked_contents
 
-    assert attachment["attachment"].pop("id")
     assert attachment == {
         "type": "attachment",
         "attachment": {
+            "id": mock.ANY,
             "name": "foo.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -170,11 +171,10 @@ def test_attachments_with_objectstore(
 
     # An empty attachment
     attachment = attachments_consumer.get_individual_attachment()
-    assert attachment["attachment"].pop("id")
-
     assert attachment == {
         "type": "attachment",
         "attachment": {
+            "id": mock.ANY,
             "name": "foobar.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -3,7 +3,7 @@ from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 from unittest import mock
 
-from .asserts import time_within_delta, time_within
+from .asserts import time_within_delta, time_is
 from .test_spansv2 import envelope_with_spans
 
 from .test_dynamic_sampling import _add_sampling_config
@@ -215,8 +215,8 @@ def test_attachment_with_matching_span(mini_sentry, relay):
             "name": "test span",
             "status": "ok",
             "is_segment": True,
-            "start_timestamp": time_within(ts),
-            "end_timestamp": time_within(ts.timestamp() + 0.5),
+            "start_timestamp": time_is(ts),
+            "end_timestamp": time_is(ts.timestamp() + 0.5),
             "attributes": mock.ANY,
         }
     ]
@@ -304,8 +304,8 @@ def test_two_attachments_mapping_to_same_span(mini_sentry, relay):
             "name": "test span",
             "status": "ok",
             "is_segment": True,
-            "start_timestamp": time_within(ts),
-            "end_timestamp": time_within(ts.timestamp() + 0.5),
+            "start_timestamp": time_is(ts),
+            "end_timestamp": time_is(ts.timestamp() + 0.5),
             "attributes": mock.ANY,
         }
     ]

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -187,7 +187,7 @@ def test_lcp_span(
                 "transaction": "/insights/projects/",
             },
             "retention_days": 90,
-            "received_at": time_within(ts),
+            "received_at": time_within(ts, precision="s"),
         },
         {
             "org_id": 1,
@@ -198,7 +198,7 @@ def test_lcp_span(
             "timestamp": time_within_delta(ts),
             "tags": {},
             "retention_days": 90,
-            "received_at": time_within(ts),
+            "received_at": time_within(ts, precision="s"),
         },
         # No metric extraction in the SpanV2 pipeline.
         *(
@@ -218,7 +218,7 @@ def test_lcp_span(
                         "transaction": "/insights/projects/",
                     },
                     "retention_days": 90,
-                    "received_at": time_within(ts),
+                    "received_at": time_within(ts, precision="s"),
                 }
             ]
             if mode == "legacy"
@@ -362,7 +362,7 @@ def test_cls_span(
                 "transaction": "/insights/projects/",
             },
             "retention_days": 90,
-            "received_at": time_within(ts),
+            "received_at": time_within(ts, precision="s"),
         },
         {
             "org_id": 1,
@@ -373,7 +373,7 @@ def test_cls_span(
             "timestamp": time_within_delta(ts),
             "tags": {},
             "retention_days": 90,
-            "received_at": time_within(ts),
+            "received_at": time_within(ts, precision="s"),
         },
         # No metric extraction in the SpanV2 pipeline.
         *(
@@ -393,7 +393,7 @@ def test_cls_span(
                         "transaction": "/insights/projects/",
                     },
                     "retention_days": 90,
-                    "received_at": time_within(ts),
+                    "received_at": time_within(ts, precision="s"),
                 }
             ]
             if mode == "legacy"
@@ -521,7 +521,7 @@ def test_inp_span(
                 "transaction": "/insights/projects/",
             },
             "retention_days": 90,
-            "received_at": time_within(ts),
+            "received_at": time_within(ts, precision="s"),
         },
         {
             "org_id": 1,
@@ -532,7 +532,7 @@ def test_inp_span(
             "timestamp": time_within_delta(ts),
             "tags": {},
             "retention_days": 90,
-            "received_at": time_within(ts),
+            "received_at": time_within(ts, precision="s"),
         },
         # No metric extraction in the SpanV2 pipeline.
         *(
@@ -552,7 +552,7 @@ def test_inp_span(
                         "transaction": "/insights/projects/",
                     },
                     "retention_days": 90,
-                    "received_at": time_within(ts),
+                    "received_at": time_within(ts, precision="s"),
                 }
             ]
             if mode == "legacy"

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -4,7 +4,7 @@ from unittest import mock
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within
+from .asserts import time_within_delta, time_within, time_is
 
 from .test_dynamic_sampling import _add_sampling_config
 
@@ -125,8 +125,8 @@ def test_spansv2_basic(
         },
         "name": "some op",
         "received": time_within(ts),
-        "start_timestamp": time_within(ts),
-        "end_timestamp": time_within(ts.timestamp() + 0.5),
+        "start_timestamp": time_is(ts),
+        "end_timestamp": time_is(ts.timestamp() + 0.5),
         "is_segment": True,
         "status": "ok",
         "retention_days": 42,
@@ -141,7 +141,7 @@ def test_spansv2_basic(
             "name": "c:spans/count_per_root_project@none",
             "org_id": 1,
             "project_id": 42,
-            "received_at": time_within_delta(),
+            "received_at": time_within(ts, precision="s"),
             "retention_days": 90,
             "tags": {
                 "decision": "keep",
@@ -156,7 +156,7 @@ def test_spansv2_basic(
             "name": "c:spans/usage@none",
             "org_id": 1,
             "project_id": 42,
-            "received_at": time_within_delta(),
+            "received_at": time_within(ts, precision="s"),
             "retention_days": 90,
             "tags": {},
             "timestamp": time_within_delta(),
@@ -329,7 +329,7 @@ def test_spansv2_ds_sampled(
             "name": "c:spans/count_per_root_project@none",
             "org_id": 1,
             "project_id": 43,
-            "received_at": time_within_delta(),
+            "received_at": time_within(ts, precision="s"),
             "retention_days": 90,
             "tags": {
                 "decision": "keep",
@@ -344,7 +344,7 @@ def test_spansv2_ds_sampled(
             "name": "c:spans/usage@none",
             "org_id": 1,
             "project_id": 42,
-            "received_at": time_within_delta(),
+            "received_at": time_within(ts, precision="s"),
             "retention_days": 90,
             "tags": {},
             "timestamp": time_within_delta(),
@@ -425,7 +425,7 @@ def test_spansv2_ds_root_in_different_org(
             "name": "c:spans/count_per_root_project@none",
             "org_id": 1,
             "project_id": 42,
-            "received_at": time_within_delta(),
+            "received_at": time_within(ts, precision="s"),
             "retention_days": 90,
             "tags": {"decision": "drop", "target_project_id": "42"},
             "timestamp": time_within_delta(),
@@ -436,7 +436,7 @@ def test_spansv2_ds_root_in_different_org(
             "name": "c:spans/usage@none",
             "org_id": 1,
             "project_id": 42,
-            "received_at": time_within_delta(),
+            "received_at": time_within(ts, precision="s"),
             "retention_days": 90,
             "tags": {},
             "timestamp": time_within_delta(),
@@ -815,8 +815,8 @@ def test_spanv2_with_string_pii_scrubbing(
             },
         },
         "name": "Test span",
-        "start_timestamp": time_within(ts),
-        "end_timestamp": time_within(ts.timestamp() + 0.5),
+        "start_timestamp": time_is(ts),
+        "end_timestamp": time_is(ts.timestamp() + 0.5),
         "is_segment": False,
         "status": "ok",
     }
@@ -974,8 +974,8 @@ def test_spansv2_attribute_normalization(
         },
         "name": "some op",
         "received": time_within(ts),
-        "start_timestamp": time_within(ts),
-        "end_timestamp": time_within(ts.timestamp() + 0.5),
+        "start_timestamp": time_is(ts),
+        "end_timestamp": time_is(ts.timestamp() + 0.5),
         "is_segment": True,
         "status": "ok",
         "retention_days": 42,


### PR DESCRIPTION
Enables basic optimizations for dev builds, hopefully not slowing down the build process that much, while speeding up integration and unit tests. Especially with how bad Github Actions Runners have been performance wise, this maybe helps alleviate some issues.

Locally on an integration test I tried it with, I get an almost 2x speedup.