### PR TITLE
ref(instr): Lower logging level for invalid security reports

### DIFF
--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -104,7 +104,7 @@ pub fn extract<Group: EventProcessing>(
         relay_log::trace!("processing security report");
         event_from_security_report(item, envelope.meta()).map_err(|error| {
             if !matches!(error, ProcessingError::UnsupportedSecurityType) {
-                relay_log::error!(
+                relay_log::debug!(
                     error = &error as &dyn Error,
                     "failed to extract security report"
                 );
@@ -145,7 +145,7 @@ pub fn serialize<Group: EventProcessing>(
     spans_extracted: SpansExtracted,
 ) -> Result<(), ProcessingError> {
     if event.is_empty() {
-        relay_log::error!("Cannot serialize empty event");
+        relay_log::debug!("Cannot serialize empty event");
         return Ok(());
     }
 


### PR DESCRIPTION
These errors are triggered by user input and currently not useful.