### PR TITLE
feat(profiling): Add project id to profile item kafka headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Revise trace metric and log size limits. ([#5440](https://github.com/getsentry/relay/pull/5440))
 - Update `is_ai_span` and `infer_ai_operation_type` to use `gen_ai.operation.name`. ([#5433](https://github.com/getsentry/relay/pull/5433))
+- Add project_id to profile item kafka headers. ([#5458](https://github.com/getsentry/relay/pull/5458))
 
 ## 25.11.1
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1596,14 +1596,14 @@ impl Message for KafkaMessage<'_> {
             | KafkaMessage::SpanRaw { headers, .. }
             | KafkaMessage::SpanV2 { headers, .. }
             | KafkaMessage::Item { headers, .. }
-            | KafkaMessage::Profile(ProfileKafkaMessage { headers, .. }) => Some(headers),
+            | KafkaMessage::Profile(ProfileKafkaMessage { headers, .. })
+            | KafkaMessage::ProfileChunk(ProfileChunkKafkaMessage { headers, .. })=> Some(headers),
 
             KafkaMessage::Event(_)
             | KafkaMessage::UserReport(_)
             | KafkaMessage::CheckIn(_)
             | KafkaMessage::Attachment(_)
             | KafkaMessage::AttachmentChunk(_)
-            | KafkaMessage::ProfileChunk(_)
             | KafkaMessage::ReplayEvent(_)
             | KafkaMessage::ReplayRecordingNotChunked(_) => None,
         }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -908,10 +908,13 @@ impl StoreService {
             key_id,
             received: safe_timestamp(received_at),
             retention_days,
-            headers: BTreeMap::from([(
-                "sampled".to_owned(),
-                if item.sampled() { "true" } else { "false" }.to_owned(),
-            )]),
+            headers: BTreeMap::from([
+                (
+                    "sampled".to_owned(),
+                    if item.sampled() { "true" } else { "false" }.to_owned(),
+                ),
+                ("project_id".to_owned(), project_id.to_string()),
+            ]),
             payload: item.payload(),
         };
         self.produce(KafkaTopic::Profiles, KafkaMessage::Profile(message))?;
@@ -1159,6 +1162,7 @@ impl StoreService {
             project_id,
             received: safe_timestamp(received_at),
             retention_days,
+            headers: BTreeMap::from([("project_id".to_owned(), project_id.to_string())]),
             payload: item.payload(),
         };
         self.produce(KafkaTopic::Profiles, KafkaMessage::ProfileChunk(message))?;

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1483,6 +1483,8 @@ struct ProfileChunkKafkaMessage {
     project_id: ProjectId,
     received: u64,
     retention_days: u16,
+    #[serde(skip)]
+    headers: BTreeMap<String, String>,
     payload: Bytes,
 }
 
@@ -1597,7 +1599,7 @@ impl Message for KafkaMessage<'_> {
             | KafkaMessage::SpanV2 { headers, .. }
             | KafkaMessage::Item { headers, .. }
             | KafkaMessage::Profile(ProfileKafkaMessage { headers, .. })
-            | KafkaMessage::ProfileChunk(ProfileChunkKafkaMessage { headers, .. })=> Some(headers),
+            | KafkaMessage::ProfileChunk(ProfileChunkKafkaMessage { headers, .. }) => Some(headers),
 
             KafkaMessage::Event(_)
             | KafkaMessage::UserReport(_)

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -744,7 +744,7 @@ def test_relay_chain_keep_unsampled_profile(
 
     profile, headers = profiles_consumer.get_profile()
 
-    assert headers == [("sampled", b"false")]
+    assert headers == [("project_id", b"42"), ("sampled", b"false")]
     profile_payload = json.loads(profile["payload"])
     assert (
         profile_payload["transaction_metadata"]["transaction"] == "my_first_transaction"

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -124,7 +124,9 @@ def test_profile_chunk_outcomes(
     # No outcome is emitted in Relay since it's a successful ingestion.
     # However, we will emit the outcome for PROFILE_DURATION in sentry.
     outcomes_consumer.assert_empty()
-    assert profiles_consumer.get_profile()
+    profile, headers = profiles_consumer.get_profile()
+    assert headers == [("project_id", b"42")]
+    assert profile
 
 
 def test_profile_chunk_outcomes_invalid(


### PR DESCRIPTION
Complementary PR to getsentry/sentry#104587. This adds the project id to the kafka headers so it can be used in the killswitch.