### PR TITLE
ref(spanv2): Change db query hash to fnv1a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,6 +4017,7 @@ dependencies = [
  "bytecount",
  "chrono",
  "dynfmt",
+ "fnv",
  "insta",
  "itertools 0.14.0",
  "maxminddb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ enumset = "1.1.10"
 either = "1.15.0"
 flate2 = "1.1.4"
 flume = { version = "0.11.1", default-features = false }
+fnv = "1.0.7"
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
 globset = "0.4.16"
 hash32 = "1.0.0"

--- a/relay-event-normalization/Cargo.toml
+++ b/relay-event-normalization/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 bytecount = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 dynfmt = { workspace = true, features = ["python", "curly"] }
+fnv = { workspace = true }
 itertools = { workspace = true }
 maxminddb = { workspace = true }
 md5 = { workspace = true }
@@ -25,6 +26,7 @@ relay-base-schema = { workspace = true }
 relay-common = { workspace = true }
 relay-conventions = { workspace = true }
 relay-event-schema = { workspace = true }
+relay-filter = { workspace = true }
 relay-log = { workspace = true }
 relay-pattern = { workspace = true, features = ["serde"] }
 relay-protocol = { workspace = true }
@@ -32,7 +34,6 @@ relay-sampling = { workspace = true }
 relay-spans = { workspace = true }
 relay-statsd = { workspace = true }
 relay-ua = { workspace = true }
-relay-filter = { workspace = true }
 sentry-release-parser = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -406,7 +406,7 @@ pub fn normalize_db_attributes(annotated_attributes: &mut Annotated<Attributes>)
 ///
 /// Used to fill the [`NORMALIZED_DB_QUERY_HASH`] attribute.
 ///
-/// It uses a `fnv1a` as the underlying hash.
+/// It uses `fnv1a` as the underlying hash algorithm.
 fn compute_normalized_db_query_hash(query: &str) -> String {
     use std::hash::Hasher;
     let mut hasher = fnv::FnvHasher::default();

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -969,7 +969,7 @@ def test_spansv2_attribute_normalization(
             },
             "sentry.normalized_db_query.hash": {
                 "type": "string",
-                "value": "f79af0ba3d26284c",
+                "value": "b3d0365a1a7a3826",
             },
             "sentry.observed_timestamp_nanos": {
                 "type": "string",


### PR DESCRIPTION
There is no need to use a cryptographic hash, we now have the opportunity with a new field to switch away from the old `md5` usage.

`md5` alerts on security scanners and is 'cryptographic' which is definitely not required for this use-case, ideally also gaining a little bit of performance.

Fnv is already widely used in Sentry (Relay uses it for metric sets, Snuba uses it internally to distribute to columns).
Uses the 64 bit variant to keep the generated amount of bytes the same, also eventually allows us to drop the `hash32` dependency, `fnv` is used much wider in the ecosystem.