### PR TITLE
ref(instr): Lower log level of invalid span messages

### DIFF
--- a/relay-server/src/processing/transactions/spans.rs
+++ b/relay-server/src/processing/transactions/spans.rs
@@ -114,7 +114,7 @@ fn make_span_item(
 
     validate(&mut span)
         .inspect_err(|e| {
-            relay_log::error!(
+            relay_log::debug!(
                 error = e as &dyn Error,
                 span = ?span,
                 source = "event",

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -27,7 +27,6 @@ use relay_event_normalization::{
 };
 use relay_event_schema::processor::{ProcessingAction, ProcessingState, process_value};
 use relay_event_schema::protocol::{BrowserContext, Event, EventId, IpAddr, Span, SpanData};
-use relay_log::protocol::{Attachment, AttachmentType};
 use relay_metrics::{MetricNamespace, UnixTimestamp};
 use relay_pii::PiiProcessor;
 use relay_protocol::{Annotated, Empty, Value};
@@ -185,22 +184,10 @@ pub async fn process(
         match processing::transactions::spans::validate(&mut annotated_span) {
             Ok(res) => res,
             Err(err) => {
-                relay_log::with_scope(
-                    |scope| {
-                        scope.add_attachment(Attachment {
-                            buffer: annotated_span.to_json().unwrap_or_default().into(),
-                            filename: "span.json".to_owned(),
-                            content_type: Some("application/json".to_owned()),
-                            ty: Some(AttachmentType::Attachment),
-                        })
-                    },
-                    || {
-                        relay_log::error!(
-                            error = &err as &dyn Error,
-                            source = "standalone",
-                            "invalid span"
-                        )
-                    },
+                relay_log::debug!(
+                    error = &err as &dyn Error,
+                    source = "standalone",
+                    "invalid span"
                 );
                 return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidSpan));
             }


### PR DESCRIPTION
Log messages are triggered by invalid user input -> debug, the messages were used to aid debugging, which is no longer the case.