### PR TITLE
fix(spanv2): Indexed rate limits should not drop metric payloads

### DIFF
--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -14,6 +14,7 @@ use crate::integrations::Integration;
 use crate::managed::{
     Counted, Managed, ManagedEnvelope, ManagedResult, OutcomeError, Quantities, Rejected,
 };
+use crate::metrics_extraction::transactions::ExtractedMetrics;
 use crate::processing::trace_attachments::forward::attachment_to_item;
 use crate::processing::trace_attachments::process::ScrubAttachmentError;
 use crate::processing::trace_attachments::types::ExpandedAttachment;
@@ -181,17 +182,21 @@ impl processing::Processor for SpansProcessor {
         process::normalize(&mut spans, &self.geo_lookup, ctx);
         filter::filter(&mut spans, ctx);
 
-        let mut spans = self.limiter.enforce_quotas(spans, ctx).await?;
+        let spans = self.limiter.enforce_quotas(spans, ctx).await?;
+        let mut spans = match spans.transpose() {
+            Either::Left(spans) => spans,
+            Either::Right(metrics) => return Ok(Output::metrics(metrics)),
+        };
 
         process::scrub(&mut spans, ctx);
 
-        Ok(match dynamic_sampling::create_indexed_metrics(spans, ctx) {
-            Either::Left(spans) => Output::just(SpanOutput::TotalAndIndexed(spans)),
-            Either::Right((spans, metrics)) => Output {
+        match dynamic_sampling::try_split_indexed_and_total(spans, ctx) {
+            Either::Left(spans) => Ok(Output::just(SpanOutput::TotalAndIndexed(spans))),
+            Either::Right((spans, metrics)) => Ok(Output {
                 main: Some(SpanOutput::Indexed(spans)),
                 metrics: Some(metrics),
-            },
-        })
+            }),
+        }
     }
 }
 
@@ -535,14 +540,14 @@ impl Counted for ExpandedSpans<Indexed> {
 }
 
 impl RateLimited for Managed<ExpandedSpans<TotalAndIndexed>> {
-    type Output = Self;
+    type Output = Managed<Either<ExpandedSpans<TotalAndIndexed>, ExtractedMetrics>>;
     type Error = Error;
 
     async fn enforce<R>(
         mut self,
         mut rate_limiter: R,
         _: Context<'_>,
-    ) -> Result<Self, Rejected<Self::Error>>
+    ) -> Result<Self::Output, Rejected<Self::Error>>
     where
         R: processing::RateLimiter,
     {
@@ -567,8 +572,10 @@ impl RateLimited for Managed<ExpandedSpans<TotalAndIndexed>> {
                 .try_consume(scoping.item(DataCategory::SpanIndexed), span)
                 .await;
             if !limits.is_empty() {
-                // If there is a span quota reject all the spans and the associated attachments.
-                return Err(self.reject_err(Error::from(limits)));
+                // If there is an indexed span quota reject all the spans and the associated attachments,
+                // but keep the total counts.
+                let total = dynamic_sampling::reject_indexed_spans(self, limits.into());
+                return Ok(total.map(|total, _| Either::Right(total)));
             }
         }
 
@@ -592,7 +599,7 @@ impl RateLimited for Managed<ExpandedSpans<TotalAndIndexed>> {
             .await;
         }
 
-        Ok(self)
+        Ok(self.map(|s, _| Either::Left(s)))
     }
 }
 

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -1019,6 +1019,27 @@ def test_attachment_dropped_with_invalid_spans(mini_sentry, relay):
 @pytest.mark.parametrize(
     "quota_config,expected_outcomes",
     [
+        # TODO: https://github.com/getsentry/relay/issues/5469
+        # pytest.param(
+        #     [
+        #         {
+        #             "categories": ["span"],
+        #             "limit": 0,
+        #             "window": 3600,
+        #             "id": "span_limit",
+        #             "reasonCode": "span_quota_exceeded",
+        #         }
+        #     ],
+        #     {
+        #         # Rate limit spans
+        #         (DataCategory.SPAN.value, 2): 1,
+        #         (DataCategory.SPAN_INDEXED.value, 2): 1,
+        #         # Rate limit associated span attachments
+        #         (DataCategory.ATTACHMENT.value, 2): 64,
+        #         (DataCategory.ATTACHMENT_ITEM.value, 2): 2,
+        #     },
+        #     id="span_quota_exceeded",
+        # ),
         pytest.param(
             [
                 {
@@ -1030,14 +1051,11 @@ def test_attachment_dropped_with_invalid_spans(mini_sentry, relay):
                 }
             ],
             {
-                # Rate limit spans
-                (DataCategory.SPAN.value, 2): 1,
                 (DataCategory.SPAN_INDEXED.value, 2): 1,
-                # Rate limit associated span attachments
                 (DataCategory.ATTACHMENT.value, 2): 64,
                 (DataCategory.ATTACHMENT_ITEM.value, 2): 2,
             },
-            id="span_quota_exceeded",
+            id="span_indexed_quota_exceeded",
         ),
         pytest.param(
             [
@@ -1059,7 +1077,7 @@ def test_attachment_dropped_with_invalid_spans(mini_sentry, relay):
         pytest.param(
             [
                 {
-                    "categories": ["span_indexed"],
+                    "categories": ["span"],
                     "limit": 0,
                     "window": 3600,
                     "id": "span_limit",
@@ -1194,7 +1212,6 @@ def test_span_attachment_independent_rate_limiting(
         outcome_counter[key] += outcome["quantity"]
 
     assert outcome_counter == expected_outcomes
-
     assert mini_sentry.captured_outcomes.empty()
 
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -365,7 +365,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
             },
         ]
 
-    assert mini_sentry.captured_events.empty()
+    assert mini_sentry.captured_envelopes.empty()
     assert mini_sentry.captured_outcomes.empty()
 
 


### PR DESCRIPTION
In the case of indexed rate limits, we still need to keep the total counts (metrics) alive. This fixes a bug in the SpanV2 rate limiting which would drop the entire payload when there was an indexed rate limit active.

Closes: INGEST-651