### PR TITLE
ref(spanv2): Unify counting spans for outcomes

### DIFF
--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -286,6 +286,21 @@ pub struct SerializedSpans {
 }
 
 impl SerializedSpans {
+    /// Returns a best effort count of spans contained in [`Self`].
+    ///
+    /// Best effort as it relies on unvalidated counts specified in the envelope.
+    pub fn span_count(&self) -> u32 {
+        let Self {
+            headers: _,
+            spans,
+            legacy,
+            integrations,
+            attachments: _,
+        } = self;
+
+        outcome_count(spans) + outcome_count(legacy) + outcome_count(integrations)
+    }
+
     fn sampled(self, server_sample_rate: Option<f64>) -> SampledSpans {
         SampledSpans {
             inner: self,
@@ -296,10 +311,7 @@ impl SerializedSpans {
 
 impl Counted for SerializedSpans {
     fn quantities(&self) -> Quantities {
-        let span_quantity = (outcome_count(&self.spans)
-            + outcome_count(&self.legacy)
-            + outcome_count(&self.integrations)) as usize;
-
+        let span_quantity = self.span_count() as usize;
         let attachment_quantity = self
             .attachments
             .iter()


### PR DESCRIPTION
Somewhat of a follow-up to #5421, counts spans in a single place now and destructures the structure to make it less likely to forget to update the counting logic. 