### PR TITLE
ref(logs): Emit client name with metric

### DIFF
--- a/relay-server/src/processing/logs/validate.rs
+++ b/relay-server/src/processing/logs/validate.rs
@@ -32,7 +32,8 @@ pub fn dsc(logs: &Managed<SerializedLogs>) {
         dsc = match logs.headers.dsc() {
             Some(_) => "yes",
             None => "no",
-        }
+        },
+        sdk = crate::utils::client_name_tag(logs.headers.meta().client_name())
     )
 }
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -940,6 +940,7 @@ pub enum RelayCounters {
     ///
     /// This metric is tagged with:
     /// - `dsc`: yes or no
+    /// - `sdk`: low-cardinality client name
     EnvelopeWithLogs,
 }
 


### PR DESCRIPTION
Some clients seem to be sending a DSC with logs. Add the client name to identify them.