### PR TITLE
ref(server): Return status code 413 if envelope is rejected due to size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Breaking Changes**:
+
+- Return status code `413` if a request is rejected due to size limits. ([#5474](https://github.com/getsentry/relay/pull/5474))
+
 ## 25.12.1
 
 **Features**:

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -133,6 +133,7 @@ impl IntoResponse for BadStoreRequest {
                 // now executed asynchronously in `EnvelopeProcessor`.
                 (StatusCode::FORBIDDEN, body).into_response()
             }
+            BadStoreRequest::Overflow(_) => (StatusCode::PAYLOAD_TOO_LARGE, body).into_response(),
             _ => {
                 // In all other cases, we indicate a generic bad request to the client and render
                 // the cause. This was likely the client's fault.


### PR DESCRIPTION
From a discussion with the SDK team(s). SDKs are currently emitting client reports when Relay rejects an item if it is too large, but Relay also emits an outcome in that case. If SDKs can differentiate the item size limit, we can stop emitting these outcomes (for stats) twice.

Discussion point: Is this a breaking change, ideally SDKs only special case 429. DACI: https://www.notion.so/sentry/DACI-Relay-Returns-413-for-too-large-envelopes-2c68b10e4b5d8034be83e524c855e73d

After some investigation all our SDKs handle a new status code just fine.