### PR TITLE
ref(instr): Lower level on invalid user report logs

### DIFF
--- a/relay-server/src/services/processor/report.rs
+++ b/relay-server/src/services/processor/report.rs
@@ -210,7 +210,10 @@ pub fn process_user_reports<Group>(managed_envelope: &mut TypedEnvelope<Group>) 
         let report = match serde_json::from_slice::<UserReport>(payload) {
             Ok(report) => report,
             Err(error) => {
-                relay_log::error!(error = &error as &dyn Error, "failed to store user report");
+                relay_log::debug!(
+                    error = &error as &dyn Error,
+                    "failed to deserialize user report"
+                );
                 return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidJson));
             }
         };


### PR DESCRIPTION
Error driven by user input -> debug. I kept the error below as that is something which actually should never happen.