### PR TITLE
feat(spanv2): Add http attribute normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Apply existing cookie rules to `http.request.header.cookie.<key>` fields. ([#5456](https://github.com/getsentry/relay/pull/5456))
 - Add functionality to process and store trace attachments. ([#5457](https://github.com/getsentry/relay/pull/5457))
 - Lower default memory utilization threshold for disk spooling from 90% to 80%. When Relay hits 80% memory utilization, it will start spooling envelopes to disk instead of processing them. ([#5472](https://github.com/getsentry/relay/pull/5472))
+- Add http attribute normalization to SpanV2 pipeline. ([#5479](https://github.com/getsentry/relay/pull/5479))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Apply existing cookie rules to `http.request.header.cookie.<key>` fields. ([#5456](https://github.com/getsentry/relay/pull/5456))
 - Add functionality to process and store trace attachments. ([#5457](https://github.com/getsentry/relay/pull/5457))
 - Lower default memory utilization threshold for disk spooling from 90% to 80%. When Relay hits 80% memory utilization, it will start spooling envelopes to disk instead of processing them. ([#5472](https://github.com/getsentry/relay/pull/5472))
-- Add http attribute normalization to SpanV2 pipeline. ([#5479](https://github.com/getsentry/relay/pull/5479))
+- Add http attribute normalization. ([#5479](https://github.com/getsentry/relay/pull/5479))
 
 **Bug Fixes**:
 

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -70,6 +70,8 @@ convention_attributes!(
     STATUS_MESSAGE => "sentry.status.message",
     URL_FULL => "url.full",
     URL_PATH => "url.path",
+    URL_SCHEME => "url.scheme",
+    URL_DOMAIN => "url.domain",
     USER_AGENT_ORIGINAL => "user_agent.original",
     USER_GEO_CITY => "user.geo.city",
     USER_GEO_COUNTRY_CODE => "user.geo.country_code",

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -1313,14 +1313,17 @@ mod tests {
           },
           "url.full": {
             "type": "string",
-            "value": "http://192.168.1.1:3000"
+            "value": "https://application.www.xn--85x722f.xn--55qx5d.cn"
           }
         }
       "#,
         )
         .unwrap();
 
-        normalize_http_attributes(&mut attributes, &["192.168.1.1".to_owned()]);
+        normalize_http_attributes(
+            &mut attributes,
+            &["application.www.xn--85x722f.xn--55qx5d.cn".to_owned()],
+        );
 
         insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
         {
@@ -1334,11 +1337,11 @@ mod tests {
           },
           "server.address": {
             "type": "string",
-            "value": "192.168.1.1:3000"
+            "value": "application.www.xn--85x722f.xn--55qx5d.cn"
           },
           "url.full": {
             "type": "string",
-            "value": "http://192.168.1.1:3000"
+            "value": "https://application.www.xn--85x722f.xn--55qx5d.cn"
           }
         }
         "#);

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -410,7 +410,8 @@ fn normalize_db_attributes(annotated_attributes: &mut Annotated<Attributes>) {
 
 /// Normalizes the following http attributes: `http.request.method` and `server.address`.
 ///
-/// The normalization process first scrubs the http method and url and extracts the server address from the url.
+/// The normalization process first scrubs the url and extracts the server address from the url.
+/// It also sets 'url.full' to the raw url if it is not already set and can be retrieved from the server address.
 fn normalize_http_attributes(annotated_attributes: &mut Annotated<Attributes>) {
     let Some(attributes) = annotated_attributes.value() else {
         return;
@@ -465,7 +466,7 @@ fn normalize_http_attributes(annotated_attributes: &mut Annotated<Attributes>) {
         }
 
         if let Some(raw_url) = raw_url {
-            attributes.insert(URL_FULL, raw_url);
+            attributes.insert_if_missing(URL_FULL, || raw_url);
         }
     }
 }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -151,6 +151,7 @@ fn normalize_span(
         let dsc = headers.dsc();
         let duration = span_duration(span);
         let model_costs = ctx.global_config.ai_model_costs.as_ref().ok();
+        let allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
 
         validate_timestamps(span)?;
 
@@ -167,8 +168,7 @@ fn normalize_span(
             eap::normalize_dsc(&mut span.attributes, dsc);
         }
         eap::normalize_ai(&mut span.attributes, duration, model_costs);
-
-        eap::normalize_attribute_values(&mut span.attributes);
+        eap::normalize_attribute_values(&mut span.attributes, allowed_hosts);
     };
 
     process_value(span, &mut TrimmingProcessor::new(), ProcessingState::root())?;

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1009,25 +1009,49 @@ def test_spansv2_attribute_normalization(
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
 
     ts = datetime.now(timezone.utc)
-    envelope = envelope_with_spans(
-        {
-            "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.5,
-            "trace_id": "5b8efff798038103d269b633813fc60c",
-            "span_id": "eee19b7ec3c1b175",
-            "is_segment": True,
-            "name": "some op",
-            "status": "ok",
-            "attributes": {
-                "db.system.name": {"value": "mysql", "type": "string"},
-                "db.operation.name": {"value": "SELECT", "type": "string"},
-                "db.query.text": {
-                    "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
-                    "type": "string",
-                },
-                "db.collection.name": {"value": "users", "type": "string"},
+
+    db_span_id = "eee19b7ec3c1b174"
+    db_span = {
+        "start_timestamp": ts.timestamp(),
+        "end_timestamp": ts.timestamp() + 0.5,
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "span_id": db_span_id,
+        "is_segment": True,
+        "name": "some op",
+        "status": "ok",
+        "attributes": {
+            "db.system.name": {"value": "mysql", "type": "string"},
+            "db.operation.name": {"value": "SELECT", "type": "string"},
+            "db.query.text": {
+                "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
+                "type": "string",
+            },
+            "db.collection.name": {"value": "users", "type": "string"},
+        },
+    }
+
+    http_span_id = "eee19b7ec3c1b175"
+    http_span = {
+        "start_timestamp": ts.timestamp(),
+        "end_timestamp": ts.timestamp() + 0.5,
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "span_id": http_span_id,
+        "is_segment": False,
+        "name": "GET https://api.example.com/users",
+        "status": "ok",
+        "attributes": {
+            "sentry.op": {"value": "http.client", "type": "string"},
+            "http.request.method": {"value": "get", "type": "string"},
+            "url.full": {
+                "value": "https://www.service.io/users/01234-qwerty/settings/98765-adfghj",
+                "type": "string",
             },
         },
+    }
+
+    envelope = envelope_with_spans(
+        db_span,
+        http_span,
         trace_info={
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "public_key": project_config["publicKeys"][0]["publicKey"],
@@ -1039,55 +1063,32 @@ def test_spansv2_attribute_normalization(
 
     relay.send_envelope(project_id, envelope)
 
-    assert spans_consumer.get_span() == {
-        "trace_id": "5b8efff798038103d269b633813fc60c",
-        "span_id": "eee19b7ec3c1b175",
-        "attributes": {
-            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
-            "sentry.browser.version": {"type": "string", "value": "2.32"},
-            "sentry.dsc.environment": {"type": "string", "value": "prod"},
-            "sentry.dsc.public_key": {
-                "type": "string",
-                "value": project_config["publicKeys"][0]["publicKey"],
-            },
-            "sentry.dsc.release": {"type": "string", "value": "foo@1.0"},
-            "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
-            "sentry.dsc.trace_id": {
-                "type": "string",
-                "value": "5b8efff798038103d269b633813fc60c",
-            },
-            "sentry.op": {"type": "string", "value": "db"},
-            "db.system.name": {"type": "string", "value": "mysql"},
-            "db.operation.name": {"type": "string", "value": "SELECT"},
-            "db.query.text": {
-                "type": "string",
-                "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
-            },
-            "db.collection.name": {"type": "string", "value": "users"},
-            "sentry.normalized_db_query": {
-                "type": "string",
-                "value": "SELECT id FROM users WHERE id = %s AND name = %s",
-            },
-            "sentry.normalized_db_query.hash": {
-                "type": "string",
-                "value": "f79af0ba3d26284c",
-            },
-            "sentry.observed_timestamp_nanos": {
-                "type": "string",
-                "value": time_within(ts, expect_resolution="ns"),
-            },
-        },
-        "name": "some op",
-        "received": time_within(ts),
-        "start_timestamp": time_is(ts),
-        "end_timestamp": time_is(ts.timestamp() + 0.5),
-        "is_segment": True,
-        "status": "ok",
-        "retention_days": 42,
-        "downsampled_retention_days": 1337,
-        "key_id": 123,
-        "organization_id": 1,
-        "project_id": 42,
+    spans = [spans_consumer.get_span(), spans_consumer.get_span()]
+    spans_by_id = {s["span_id"]: s for s in spans}
+
+    # Verify DB attribute normalization
+    db_result = spans_by_id[db_span_id]
+    assert db_result["attributes"]["sentry.op"] == {"type": "string", "value": "db"}
+    assert db_result["attributes"]["sentry.normalized_db_query"] == {
+        "type": "string",
+        "value": "SELECT id FROM users WHERE id = %s AND name = %s",
+    }
+    assert db_result["attributes"]["sentry.normalized_db_query.hash"] == {
+        "type": "string",
+        "value": "f79af0ba3d26284c",
+    }
+
+    # Verify HTTP attribute normalization
+    http_result = spans_by_id[http_span_id]
+
+    assert http_result["attributes"]["http.request.method"] == {
+        "type": "string",
+        "value": "GET",
+    }
+
+    assert http_result["attributes"]["server.address"] == {
+        "type": "string",
+        "value": "*.service.io",
     }
 
 


### PR DESCRIPTION
Ports over http attribute normalization logic from the transactions span pipeline. The actual logic for normalization is extracted from the SpanV1 [tag extraction function](https://github.com/getsentry/relay/blob/7cb7f0096bdc50b7e1b7ad22f8100a779b1279a3/relay-event-normalization/src/normalize/span/tag_extraction.rs#L758) and the [description scrubbing function](https://github.com/getsentry/relay/blob/master/relay-event-normalization/src/normalize/span/description/mod.rs#L44).