### PR TITLE
ref(server): Explicitly handle challenge endpoints in Relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 **Internal**:
 
 - Revise trace metric and log size limits. ([#5440](https://github.com/getsentry/relay/pull/5440))
+- Implement dedicated endpoints for challenge requests. ([#5487](https://github.com/getsentry/relay/pull/5487))
 - Update `is_ai_span` and `infer_ai_operation_type` to use `gen_ai.operation.name`. ([#5433](https://github.com/getsentry/relay/pull/5433))
 - Add project_id to profile item kafka headers. ([#5458](https://github.com/getsentry/relay/pull/5458))
 - Remove `recycle_check_frequency` from Redis configuration. ([#5476](https://github.com/getsentry/relay/pull/5476))

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -19,6 +19,7 @@ mod nel;
 mod playstation;
 mod project_configs;
 mod public_keys;
+mod register;
 mod security_report;
 mod statics;
 mod store;
@@ -67,6 +68,8 @@ fn public_routes_raw(config: &Config) -> Router<ServiceState> {
     let web_routes = Router::new()
         .route("/api/0/relays/projectconfigs/", post(project_configs::handle))
         .route("/api/0/relays/publickeys/", post(public_keys::handle))
+        .route("/api/0/relays/register/challenge/", post(register::challenge))
+        .route("/api/0/relays/register/response/", post(register::response))
         // Network connectivity check for downstream Relays, same as the internal health check.
         .route("/api/0/relays/live/", get(health_check::handle_live))
         .route_layer(DefaultBodyLimit::max(crate::constants::MAX_JSON_SIZE));

--- a/relay-server/src/endpoints/register.rs
+++ b/relay-server/src/endpoints/register.rs
@@ -1,0 +1,63 @@
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use relay_auth::{RegisterRequest, RegisterResponse};
+use tokio::time::error::Elapsed;
+
+use crate::service::ServiceState;
+use crate::services::upstream::{SendQuery, UpstreamQuery, UpstreamRequestError};
+
+#[derive(Debug, thiserror::Error)]
+#[error("error while forwarding challenge: {0}")]
+enum RegisterError {
+    Upstream(#[from] UpstreamRequestError),
+    SendError(#[from] relay_system::SendError),
+    Timeout(#[from] Elapsed),
+}
+
+impl IntoResponse for RegisterError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::Upstream(upstream) => {
+                if let Some(status) = upstream.status_code()
+                    && status.is_client_error()
+                {
+                    return status.into_response();
+                }
+
+                StatusCode::BAD_GATEWAY.into_response()
+            }
+            Self::SendError(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            Self::Timeout(_) => StatusCode::REQUEST_TIMEOUT.into_response(),
+        }
+    }
+}
+
+async fn handle<T: UpstreamQuery + 'static>(
+    state: ServiceState,
+    query: T,
+) -> Result<Json<T::Response>, RegisterError> {
+    let response = tokio::time::timeout(
+        state.config().http_timeout(),
+        state.upstream_relay().send(SendQuery(query)),
+    )
+    .await???;
+
+    Ok(Json(response))
+}
+
+/// Forwards a challenge request to the upstream.
+pub async fn challenge(
+    state: ServiceState,
+    Json(body): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    handle(state, body).await
+}
+
+/// Forwards a challenge response to the upstream.
+pub async fn response(
+    state: ServiceState,
+    Json(body): Json<RegisterResponse>,
+) -> impl IntoResponse {
+    handle(state, body).await
+}

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -133,7 +133,7 @@ impl UpstreamRequestError {
     /// If this error is the result of sending a request to the upstream, this method returns `Some`
     /// with the status code. If the request could not be made or the error originates elsewhere,
     /// this returns `None`.
-    fn status_code(&self) -> Option<StatusCode> {
+    pub fn status_code(&self) -> Option<StatusCode> {
         match self {
             UpstreamRequestError::ResponseError(code, _) => Some(*code),
             UpstreamRequestError::Http(HttpError::Reqwest(e)) => e.status(),
@@ -768,10 +768,6 @@ impl UpstreamQuery for RegisterRequest {
         Cow::Borrowed("/api/0/relays/register/challenge/")
     }
 
-    fn priority() -> RequestPriority {
-        unreachable!("sent directly to client")
-    }
-
     fn retry() -> bool {
         false
     }
@@ -790,10 +786,6 @@ impl UpstreamQuery for RegisterResponse {
 
     fn path(&self) -> Cow<'static, str> {
         Cow::Borrowed("/api/0/relays/register/response/")
-    }
-
-    fn priority() -> RequestPriority {
-        unreachable!("sent directly to client")
     }
 
     fn retry() -> bool {


### PR DESCRIPTION
Explicitly handles the register challenge endpoints with a dedicated endpoint, instead of using the forward endpoint.