### PR TITLE
ref(server): Explicitly handle challenge endpoints in Relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 **Internal**:
 
 - Revise trace metric and log size limits. ([#5440](https://github.com/getsentry/relay/pull/5440))
+- Implement dedicated endpoints for challenge requests. ([#5488](https://github.com/getsentry/relay/pull/5488))
 - Update `is_ai_span` and `infer_ai_operation_type` to use `gen_ai.operation.name`. ([#5433](https://github.com/getsentry/relay/pull/5433))
 - Add project_id to profile item kafka headers. ([#5458](https://github.com/getsentry/relay/pull/5458))
 - Remove `recycle_check_frequency` from Redis configuration. ([#5476](https://github.com/getsentry/relay/pull/5476))

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -67,6 +67,8 @@ fn public_routes_raw(config: &Config) -> Router<ServiceState> {
     let web_routes = Router::new()
         .route("/api/0/relays/projectconfigs/", post(project_configs::handle))
         .route("/api/0/relays/publickeys/", post(public_keys::handle))
+        .route("/api/0/relays/register/challenge/", post(forward::forward))
+        .route("/api/0/relays/register/response/", post(forward::forward))
         // Network connectivity check for downstream Relays, same as the internal health check.
         .route("/api/0/relays/live/", get(health_check::handle_live))
         .route_layer(DefaultBodyLimit::max(crate::constants::MAX_JSON_SIZE));


### PR DESCRIPTION
Alternative approach to #5487, which just explicitly configures the forward endpoint for these routes.