### PR TITLE
ref(server): Improvements to the forward handling

### DIFF
--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -3,182 +3,24 @@
 //! This endpoint will issue a client request to the upstream and append relay's own headers
 //! (`X-Forwarded-For` and `Sentry-Relay-Id`). The response is then streamed back to the origin.
 
-use std::borrow::Cow;
-use std::error::Error;
-use std::fmt;
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::LazyLock;
 
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::handler::Handler;
-use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use relay_common::glob2::GlobMatcher;
 use relay_config::Config;
-use tokio::sync::oneshot;
-use tokio::sync::oneshot::error::RecvError;
 
 use crate::extractors::ForwardedFor;
-use crate::http::{HttpError, RequestBuilder, Response as UpstreamResponse};
 use crate::service::ServiceState;
-use crate::services::upstream::{Method, SendRequest, UpstreamRequest, UpstreamRequestError};
-
-/// Headers that this endpoint must handle and cannot forward.
-static HOP_BY_HOP_HEADERS: &[HeaderName] = &[
-    header::CONNECTION,
-    header::PROXY_AUTHENTICATE,
-    header::PROXY_AUTHORIZATION,
-    header::TE,
-    header::TRAILER,
-    header::TRANSFER_ENCODING,
-    header::UPGRADE,
-];
-
-/// Headers ignored in addition to the headers defined in `HOP_BY_HOP_HEADERS`.
-static IGNORED_REQUEST_HEADERS: &[HeaderName] = &[
-    header::HOST,
-    header::CONTENT_ENCODING,
-    header::CONTENT_LENGTH,
-];
+use crate::services::upstream::Method;
+use crate::utils::ForwardRequest;
 
 /// Root path of all API endpoints.
 const API_PATH: &str = "/api/";
-
-/// A wrapper struct that allows conversion of UpstreamRequestError into a `dyn ResponseError`. The
-/// conversion logic is really only acceptable for blindly forwarded requests.
-#[derive(Debug, thiserror::Error)]
-#[error("error while forwarding request: {0}")]
-struct ForwardError(#[from] UpstreamRequestError);
-
-impl From<RecvError> for ForwardError {
-    fn from(_: RecvError) -> Self {
-        Self(UpstreamRequestError::ChannelClosed)
-    }
-}
-
-impl IntoResponse for ForwardError {
-    fn into_response(self) -> Response {
-        match &self.0 {
-            UpstreamRequestError::Http(e) => match e {
-                HttpError::Overflow => StatusCode::PAYLOAD_TOO_LARGE.into_response(),
-                HttpError::Reqwest(error) => {
-                    relay_log::error!(error = error as &dyn Error);
-                    error
-                        .status()
-                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
-                        .into_response()
-                }
-                HttpError::Io(_) => StatusCode::BAD_GATEWAY.into_response(),
-                HttpError::Json(_) => StatusCode::BAD_REQUEST.into_response(),
-            },
-            UpstreamRequestError::SendFailed(e) => {
-                if e.is_timeout() {
-                    StatusCode::GATEWAY_TIMEOUT.into_response()
-                } else {
-                    StatusCode::BAD_GATEWAY.into_response()
-                }
-            }
-            error => {
-                // should all be unreachable
-                relay_log::error!(error = error as &dyn Error, "unreachable code");
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-        }
-    }
-}
-
-type ForwardResponse = (StatusCode, HeaderMap<HeaderValue>, Vec<u8>);
-
-struct ForwardRequest {
-    method: Method,
-    path: String,
-    headers: HeaderMap<HeaderValue>,
-    forwarded_for: ForwardedFor,
-    data: Bytes,
-    max_response_size: usize,
-    sender: oneshot::Sender<Result<ForwardResponse, UpstreamRequestError>>,
-}
-
-impl fmt::Debug for ForwardRequest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ForwardRequest")
-            .field("method", &self.method)
-            .field("path", &self.path)
-            .finish()
-    }
-}
-
-impl UpstreamRequest for ForwardRequest {
-    fn method(&self) -> Method {
-        self.method.clone()
-    }
-
-    fn path(&self) -> Cow<'_, str> {
-        self.path.as_str().into()
-    }
-
-    fn retry(&self) -> bool {
-        false
-    }
-
-    fn intercept_status_errors(&self) -> bool {
-        false
-    }
-
-    fn set_relay_id(&self) -> bool {
-        false
-    }
-
-    fn route(&self) -> &'static str {
-        "forward"
-    }
-
-    fn build(&mut self, builder: &mut RequestBuilder) -> Result<(), HttpError> {
-        for (key, value) in &self.headers {
-            // Since the body is always decompressed by the server, we must not forward the
-            // content-encoding header, as the upstream client will do its own content encoding.
-            // Also, remove content-length because it's likely wrong.
-            if !HOP_BY_HOP_HEADERS.contains(key) && !IGNORED_REQUEST_HEADERS.contains(key) {
-                builder.header(key, value);
-            }
-        }
-
-        builder
-            .header("X-Forwarded-For", self.forwarded_for.as_ref())
-            .body(self.data.clone());
-
-        Ok(())
-    }
-
-    fn respond(
-        self: Box<Self>,
-        result: Result<UpstreamResponse, UpstreamRequestError>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> {
-        Box::pin(async move {
-            let result = match result {
-                Ok(response) => {
-                    let status = response.status();
-                    let headers = response
-                        .headers()
-                        .iter()
-                        .filter(|(name, _)| !HOP_BY_HOP_HEADERS.contains(name))
-                        .map(|(name, value)| (name.clone(), value.clone()))
-                        .collect();
-
-                    match response.bytes(self.max_response_size).await {
-                        Ok(body) => Ok((status, headers, body)),
-                        Err(error) => Err(UpstreamRequestError::Http(error)),
-                    }
-                }
-                Err(error) => Err(error),
-            };
-
-            self.sender.send(result).ok();
-        })
-    }
-}
 
 /// Internal implementation of the forward endpoint.
 async fn handle(
@@ -188,37 +30,27 @@ async fn handle(
     uri: Uri,
     headers: HeaderMap<HeaderValue>,
     data: Bytes,
-) -> Result<impl IntoResponse, ForwardError> {
+) -> impl IntoResponse {
     if !state.config().http_forward() {
-        return Ok(StatusCode::NOT_FOUND.into_response());
+        return StatusCode::NOT_FOUND.into_response();
     }
 
     // The `/api/` path is special as it is actually a web UI endpoint. Therefore, reject requests
     // that either go to the API root or point outside the API.
     if uri.path() == API_PATH || !uri.path().starts_with(API_PATH) {
-        return Ok(StatusCode::NOT_FOUND.into_response());
+        return StatusCode::NOT_FOUND.into_response();
     }
 
-    let (tx, rx) = oneshot::channel();
-
-    let request = ForwardRequest {
-        method,
-        path: uri.to_string(),
-        headers,
-        forwarded_for,
-        data,
-        max_response_size: state.config().max_api_payload_size(),
-        sender: tx,
-    };
-
-    state.upstream_relay().send(SendRequest(request));
-    let (status, headers, body) = rx.await??;
-
-    Ok(if headers.contains_key(header::CONTENT_TYPE) {
-        (status, headers, body).into_response()
-    } else {
-        (status, headers).into_response()
-    })
+    let path = uri.to_string().into();
+    ForwardRequest::builder(method, path)
+        .with_name("forward")
+        .with_headers(headers)
+        .with_forwarded_for(forwarded_for)
+        .with_body(data)
+        .with_config(state.config())
+        .send_to(state.upstream_relay())
+        .await
+        .into_response()
 }
 
 /// Route classes with request body limit overrides.

--- a/relay-server/src/utils/forward.rs
+++ b/relay-server/src/utils/forward.rs
@@ -1,0 +1,278 @@
+use std::borrow::Cow;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use bytes::Bytes;
+use relay_config::Config;
+use relay_system::Addr;
+use tokio::sync::oneshot;
+
+use crate::extractors::ForwardedFor;
+use crate::http::{HttpError, RequestBuilder, Response as UpstreamResponse};
+use crate::services::upstream::{
+    Method, SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
+};
+
+/// Headers that this endpoint must handle and cannot forward.
+static HOP_BY_HOP_HEADERS: &[HeaderName] = &[
+    header::CONNECTION,
+    header::PROXY_AUTHENTICATE,
+    header::PROXY_AUTHORIZATION,
+    header::TE,
+    header::TRAILER,
+    header::TRANSFER_ENCODING,
+    header::UPGRADE,
+];
+
+/// Headers ignored in addition to the headers defined in `HOP_BY_HOP_HEADERS`.
+static IGNORED_REQUEST_HEADERS: &[HeaderName] = &[
+    header::HOST,
+    header::CONTENT_ENCODING,
+    header::CONTENT_LENGTH,
+];
+
+/// Default timeout for the forward request.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Errors which may occur when forwarding a request.
+///
+/// This error implements an [`IntoResponse`] conversion which is only acceptable for blindly
+/// forwarded requests.
+#[derive(Debug, thiserror::Error)]
+#[error("error while forwarding request: {0}")]
+pub enum ForwardError {
+    Upstream(#[from] UpstreamRequestError),
+    SendError(#[from] oneshot::error::RecvError),
+    Timeout(#[from] tokio::time::error::Elapsed),
+}
+
+impl IntoResponse for ForwardError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Upstream(UpstreamRequestError::Http(e)) => match e {
+                HttpError::Overflow => StatusCode::PAYLOAD_TOO_LARGE.into_response(),
+                HttpError::Reqwest(error) => error
+                    .status()
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+                    .into_response(),
+                HttpError::Io(_) => StatusCode::BAD_GATEWAY.into_response(),
+                HttpError::Json(_) => StatusCode::BAD_REQUEST.into_response(),
+            },
+            Self::Upstream(UpstreamRequestError::SendFailed(e)) => {
+                if e.is_timeout() {
+                    StatusCode::GATEWAY_TIMEOUT.into_response()
+                } else {
+                    StatusCode::BAD_GATEWAY.into_response()
+                }
+            }
+            Self::SendError(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            Self::Upstream(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            Self::Timeout(_) => StatusCode::GATEWAY_TIMEOUT.into_response(),
+        }
+    }
+}
+
+/// A http response of a successfully forwarded request.
+pub struct ForwardResponse {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: axum::body::Body,
+}
+
+impl ForwardResponse {
+    fn from_upstream(response: UpstreamResponse) -> Self {
+        let response = axum::http::Response::from(response.0);
+
+        let (parts, body) = response.into_parts();
+        let body = axum::body::Body::new(body);
+
+        let status = parts.status;
+        let headers = {
+            let mut headers = parts.headers;
+            // Make sure we clean out any headers which should not be forwarded from the upstream
+            // response.
+            for header in HOP_BY_HOP_HEADERS {
+                headers.remove(header);
+            }
+            headers
+        };
+
+        Self {
+            status,
+            headers,
+            body,
+        }
+    }
+}
+
+impl IntoResponse for ForwardResponse {
+    fn into_response(self) -> Response {
+        (self.status, self.headers, self.body).into_response()
+    }
+}
+
+/// A request which can be forwarded to the next upstream Relay.
+pub struct ForwardRequest {
+    name: &'static str,
+    method: Method,
+    path: Cow<'static, str>,
+    headers: HeaderMap<HeaderValue>,
+    forwarded_for: Option<ForwardedFor>,
+    body: Bytes,
+    sender: oneshot::Sender<Result<ForwardResponse, UpstreamRequestError>>,
+}
+
+impl ForwardRequest {
+    /// Returns a builder for sending a new [`ForwardRequest`].
+    pub fn builder(method: Method, path: Cow<'static, str>) -> ForwardRequestBuilder {
+        let (sender, receiver) = oneshot::channel();
+
+        let request = ForwardRequest {
+            name: "forward",
+            method,
+            path,
+            headers: Default::default(),
+            forwarded_for: None,
+            body: Bytes::new(),
+            sender,
+        };
+
+        ForwardRequestBuilder {
+            request,
+            receiver,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl fmt::Debug for ForwardRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForwardRequest")
+            .field("name", &self.name)
+            .field("method", &self.method)
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl UpstreamRequest for ForwardRequest {
+    fn method(&self) -> Method {
+        self.method.clone()
+    }
+
+    fn path(&self) -> Cow<'_, str> {
+        self.path.as_ref().into()
+    }
+
+    fn retry(&self) -> bool {
+        false
+    }
+
+    fn intercept_status_errors(&self) -> bool {
+        false
+    }
+
+    fn set_relay_id(&self) -> bool {
+        false
+    }
+
+    fn route(&self) -> &'static str {
+        self.name
+    }
+
+    fn build(&mut self, builder: &mut RequestBuilder) -> Result<(), HttpError> {
+        for (key, value) in &self.headers {
+            // Since the body is always decompressed by the server, we must not forward the
+            // content-encoding header, as the upstream client will do its own content encoding.
+            // Also, remove content-length because it's likely wrong.
+            if !HOP_BY_HOP_HEADERS.contains(key) && !IGNORED_REQUEST_HEADERS.contains(key) {
+                builder.header(key, value);
+            }
+        }
+
+        if let Some(forwarded_for) = &self.forwarded_for {
+            builder.header("X-Forwarded-For", forwarded_for.as_ref());
+        }
+
+        builder.body(self.body.clone());
+
+        Ok(())
+    }
+
+    fn respond(
+        self: Box<Self>,
+        result: Result<UpstreamResponse, UpstreamRequestError>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> {
+        Box::pin(async move {
+            let result = result.map(ForwardResponse::from_upstream);
+            let _ = self.sender.send(result);
+        })
+    }
+}
+
+/// A builder for creating and sending a [`ForwardRequest`].
+pub struct ForwardRequestBuilder {
+    request: ForwardRequest,
+    timeout: Duration,
+    receiver: oneshot::Receiver<Result<ForwardResponse, UpstreamRequestError>>,
+}
+
+impl ForwardRequestBuilder {
+    /// Changes the request name used for internal reporting of metrics.
+    ///
+    /// If not set the name defaults to `forward`.
+    pub fn with_name(mut self, name: &'static str) -> Self {
+        self.request.name = name;
+        self
+    }
+
+    /// Adds additional headers to the request.
+    ///
+    /// The builder takes care of removing headers which can or should not be forwarded to a
+    /// different http server.
+    pub fn with_headers(mut self, mut headers: HeaderMap) -> Self {
+        let headers_to_remove = HOP_BY_HOP_HEADERS.iter().chain(IGNORED_REQUEST_HEADERS);
+        for header in headers_to_remove {
+            headers.remove(header);
+        }
+
+        self.request.headers = headers;
+        self
+    }
+
+    /// Adds an optional forwarded for header.
+    pub fn with_forwarded_for(mut self, ff: impl Into<Option<ForwardedFor>>) -> Self {
+        self.request.forwarded_for = ff.into();
+        self
+    }
+
+    /// Adds the request body.
+    ///
+    /// The body may be empty for `GET` requests.
+    pub fn with_body(mut self, body: Bytes) -> Self {
+        self.request.body = body;
+        self
+    }
+
+    /// Applies the specified Relay [`Config`] to the forwarded request.
+    pub fn with_config(mut self, config: &Config) -> Self {
+        self.timeout = config.http_timeout();
+        self
+    }
+
+    /// Sends the final request to the next upstream Relay and awaits its response.
+    ///
+    /// The return result can be turned into a [`axum::response::Response`].
+    pub async fn send_to(
+        self,
+        upstream: &Addr<UpstreamRelay>,
+    ) -> Result<ForwardResponse, ForwardError> {
+        upstream.send(SendRequest(self.request));
+
+        Ok(tokio::time::timeout(self.timeout, self.receiver).await???)
+    }
+}

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -13,6 +13,7 @@ mod statsd;
 mod thread_pool;
 
 mod feature;
+mod forward;
 mod memory;
 #[cfg(feature = "processing")]
 mod native;
@@ -22,6 +23,8 @@ mod unreal;
 
 pub use self::api::*;
 pub use self::dynamic_sampling::*;
+pub use self::feature::*;
+pub use self::forward::*;
 pub use self::memory::*;
 pub use self::multipart::*;
 #[cfg(feature = "processing")]
@@ -39,4 +42,3 @@ pub use self::statsd::*;
 pub use self::thread_pool::*;
 #[cfg(feature = "processing")]
 pub use self::unreal::*;
-pub use feature::*;


### PR DESCRIPTION
Makes general improvements to the forward endpoint.

- Separates the endpoint logic (limits etc.) from the implementation of the forwarding.
- Implements response body streaming (no more in memory buffering for the response, request may also be possible, not implemented for now)
- Implements timeouts. No longer infinite timeouts on these requests. One more improvement can be still made here, where we cancel the upstream request if the http/axum handler already quit.

This is also a basis to for separating the challenge/register endpoints from forward/fallback endpoint.

Refs: INGEST-675