### PR TITLE
ref(server): Explicitly handle challenge endpoints in Relay

### DIFF
--- a/relay-server/src/endpoints/forward.rs
+++ b/relay-server/src/endpoints/forward.rs
@@ -41,8 +41,7 @@ async fn handle(
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    let path = uri.to_string().into();
-    ForwardRequest::builder(method, path)
+    ForwardRequest::builder(method, uri.to_string())
         .with_name("forward")
         .with_headers(headers)
         .with_forwarded_for(forwarded_for)

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -19,6 +19,7 @@ mod nel;
 mod playstation;
 mod project_configs;
 mod public_keys;
+mod register;
 mod security_report;
 mod statics;
 mod store;
@@ -67,6 +68,8 @@ fn public_routes_raw(config: &Config) -> Router<ServiceState> {
     let web_routes = Router::new()
         .route("/api/0/relays/projectconfigs/", post(project_configs::handle))
         .route("/api/0/relays/publickeys/", post(public_keys::handle))
+        .route("/api/0/relays/register/challenge/", post(register::challenge))
+        .route("/api/0/relays/register/response/", post(register::response))
         // Network connectivity check for downstream Relays, same as the internal health check.
         .route("/api/0/relays/live/", get(health_check::handle_live))
         .route_layer(DefaultBodyLimit::max(crate::constants::MAX_JSON_SIZE));

--- a/relay-server/src/endpoints/register.rs
+++ b/relay-server/src/endpoints/register.rs
@@ -1,0 +1,29 @@
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use bytes::Bytes;
+
+use crate::service::ServiceState;
+use crate::services::upstream::Method;
+use crate::utils::ForwardRequest;
+
+/// Forwards a challenge request to the upstream.
+pub async fn challenge(state: ServiceState, headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    ForwardRequest::builder(Method::POST, "/api/0/relays/register/challenge/")
+        .with_name("forward-register")
+        .with_headers(headers)
+        .with_body(body)
+        .with_config(state.config())
+        .send_to(state.upstream_relay())
+        .await
+}
+
+/// Forwards a challenge response to the upstream.
+pub async fn response(state: ServiceState, headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    ForwardRequest::builder(Method::POST, "/api/0/relays/register/response/")
+        .with_name("forward-register")
+        .with_headers(headers)
+        .with_body(body)
+        .with_config(state.config())
+        .send_to(state.upstream_relay())
+        .await
+}

--- a/relay-server/src/utils/forward.rs
+++ b/relay-server/src/utils/forward.rs
@@ -128,13 +128,13 @@ pub struct ForwardRequest {
 
 impl ForwardRequest {
     /// Returns a builder for sending a new [`ForwardRequest`].
-    pub fn builder(method: Method, path: Cow<'static, str>) -> ForwardRequestBuilder {
+    pub fn builder(method: Method, path: impl Into<Cow<'static, str>>) -> ForwardRequestBuilder {
         let (sender, receiver) = oneshot::channel();
 
         let request = ForwardRequest {
             name: "forward",
             method,
-            path,
+            path: path.into(),
             headers: Default::default(),
             forwarded_for: None,
             body: Bytes::new(),


### PR DESCRIPTION
Separates those two endpoints out, so they are not lumped in with the `forward` endpoint. This gives better metrics/insights but also allows potentially disabling the forward endpoint.

Refs: INGEST-675