### PR TITLE
fix(config): Remove unused spooler option

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -924,11 +924,6 @@ fn spool_disk_usage_refresh_frequency_ms() -> u64 {
     100
 }
 
-/// Default bounded buffer size for handling backpressure.
-fn spool_max_backpressure_envelopes() -> usize {
-    500
-}
-
 /// Default max memory usage for unspooling.
 fn spool_max_backpressure_memory_percent() -> f32 {
     0.8
@@ -977,11 +972,6 @@ pub struct EnvelopeSpool {
     /// Defaults to 100ms.
     #[serde(default = "spool_disk_usage_refresh_frequency_ms")]
     pub disk_usage_refresh_frequency_ms: u64,
-    /// The amount of envelopes that the envelope buffer can push to its output queue.
-    ///
-    /// Defaults to 500.
-    #[serde(default = "spool_max_backpressure_envelopes")]
-    pub max_backpressure_envelopes: usize,
     /// The relative memory usage above which the buffer service will stop dequeueing envelopes.
     ///
     /// Only applies when [`Self::path`] is set.
@@ -1031,7 +1021,6 @@ impl Default for EnvelopeSpool {
             batch_size_bytes: spool_envelopes_batch_size_bytes(),
             max_envelope_delay_secs: spool_envelopes_max_envelope_delay_secs(),
             disk_usage_refresh_frequency_ms: spool_disk_usage_refresh_frequency_ms(),
-            max_backpressure_envelopes: spool_max_backpressure_envelopes(),
             max_backpressure_memory_percent: spool_max_backpressure_memory_percent(),
             partitions: spool_envelopes_partitions(),
         }
@@ -2330,11 +2319,6 @@ impl Config {
     /// Returns the refresh frequency for disk usage monitoring as a [`Duration`] object.
     pub fn spool_disk_usage_refresh_frequency_ms(&self) -> Duration {
         Duration::from_millis(self.values.spool.envelopes.disk_usage_refresh_frequency_ms)
-    }
-
-    /// Returns the maximum number of envelopes that can be put in the bounded buffer.
-    pub fn spool_max_backpressure_envelopes(&self) -> usize {
-        self.values.spool.envelopes.max_backpressure_envelopes
     }
 
     /// Returns the relative memory usage up to which the disk buffer will unspool envelopes.


### PR DESCRIPTION


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
