### PR TITLE
ref(instr): Change task created/terminate metrics into a single task count

### DIFF
--- a/relay-system/src/runtime/spawn.rs
+++ b/relay-system/src/runtime/spawn.rs
@@ -157,17 +157,17 @@ mod tests {
         });
 
         #[cfg(not(windows))]
-        assert_debug_snapshot!(captures, @r###"
+        assert_debug_snapshot!(captures, @r#"
         [
-            "runtime.task.spawn.created:1|c|#id:relay-system/src/runtime/spawn.rs:155,file:relay-system/src/runtime/spawn.rs,line:155",
-            "runtime.task.spawn.terminated:1|c|#id:relay-system/src/runtime/spawn.rs:155,file:relay-system/src/runtime/spawn.rs,line:155",
+            "runtime.task.count:1|c|#id:relay-system/src/runtime/spawn.rs:155,file:relay-system/src/runtime/spawn.rs,line:155",
+            "runtime.task.count:-1|c|#id:relay-system/src/runtime/spawn.rs:155,file:relay-system/src/runtime/spawn.rs,line:155",
         ]
-        "###);
+        "#);
         #[cfg(windows)]
         assert_debug_snapshot!(captures, @r###"
         [
-            "runtime.task.spawn.created:1|c|#id:relay-system\\src\\runtime\\spawn.rs:155,file:relay-system\\src\\runtime\\spawn.rs,line:155",
-            "runtime.task.spawn.terminated:1|c|#id:relay-system\\src\\runtime\\spawn.rs:155,file:relay-system\\src\\runtime\\spawn.rs,line:155",
+            "runtime.task.count:1|c|#id:relay-system\\src\\runtime\\spawn.rs:155,file:relay-system\\src\\runtime\\spawn.rs,line:155",
+            "runtime.task.count:-1|c|#id:relay-system\\src\\runtime\\spawn.rs:155,file:relay-system\\src\\runtime\\spawn.rs,line:155",
         ]
         "###);
     }
@@ -190,11 +190,11 @@ mod tests {
             })
         });
 
-        assert_debug_snapshot!(captures, @r###"
+        assert_debug_snapshot!(captures, @r#"
         [
-            "runtime.task.spawn.created:1|c|#id:relay_system::runtime::spawn::tests::test_spawn_with_custom_id::Foo,file:,line:",
-            "runtime.task.spawn.terminated:1|c|#id:relay_system::runtime::spawn::tests::test_spawn_with_custom_id::Foo,file:,line:",
+            "runtime.task.count:1|c|#id:relay_system::runtime::spawn::tests::test_spawn_with_custom_id::Foo,file:,line:",
+            "runtime.task.count:-1|c|#id:relay_system::runtime::spawn::tests::test_spawn_with_custom_id::Foo,file:,line:",
         ]
-        "###);
+        "#);
     }
 }

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -2,29 +2,22 @@ use relay_statsd::{CounterMetric, GaugeMetric};
 
 /// Counter metrics for Relay system components.
 pub enum SystemCounters {
-    /// Number of runtime tasks created/spawned.
+    /// Number of active runtime tasks.
     ///
-    /// Every call to [`spawn`](`crate::spawn()`) increases this counter by one.
-    ///
-    /// This metric is tagged with:
-    ///  - `id`: A unique identifier for the task, derived from its location in code.
-    ///  - `file`: The source filename where the task is created.
-    ///  - `line`: The source line where the task is created within the file.
-    RuntimeTaskCreated,
-    /// Number of runtime tasks terminated.
+    /// Every call to [`spawn`](`crate::spawn()`) increases this counter by one,
+    /// and decrements the counter by one on termination.
     ///
     /// This metric is tagged with:
     ///  - `id`: A unique identifier for the task, derived from its location in code.
     ///  - `file`: The source filename where the task is created.
     ///  - `line`: The source line where the task is created within the file.
-    RuntimeTaskTerminated,
+    RuntimeTaskCount,
 }
 
 impl CounterMetric for SystemCounters {
     fn name(&self) -> &'static str {
         match self {
-            Self::RuntimeTaskCreated => "runtime.task.spawn.created",
-            Self::RuntimeTaskTerminated => "runtime.task.spawn.terminated",
+            Self::RuntimeTaskCount => "runtime.task.count",
         }
     }
 }


### PR DESCRIPTION
We can combine created/terminated into a single counter instead of tracking two separate rates. This will also give us a more accurate representation of tasks currently active.
