### PR TITLE
ref(profile-chunks): Finally forbid profile chunk items without platform header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Breaking Changes**:
 
 - Return status code `413` if a request is rejected due to size limits. ([#5474](https://github.com/getsentry/relay/pull/5474))
+- Forbid invalid profile chunks without a platform header. ([#5507](https://github.com/getsentry/relay/pull/5507))
 
 ## 25.12.1
 

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -159,11 +159,12 @@ impl Item {
                 (DataCategory::Span, item_count),
                 (DataCategory::SpanIndexed, item_count),
             ],
-            // NOTE: semantically wrong, but too expensive to parse.
             ItemType::ProfileChunk => match self.profile_type() {
                 Some(ProfileType::Backend) => smallvec![(DataCategory::ProfileChunk, item_count)],
                 Some(ProfileType::Ui) => smallvec![(DataCategory::ProfileChunkUi, item_count)],
-                None => smallvec![],
+                // Profile chunks without platform/profile type are considered invalid,
+                // fallback to `profile chunk` to still get outcomes.
+                None => smallvec![(DataCategory::ProfileChunk, item_count)],
             },
             ItemType::Integration => match self.integration() {
                 Some(Integration::Logs(LogsIntegration::OtelV1 { .. })) => smallvec![

--- a/relay-server/src/processing/profile_chunks/mod.rs
+++ b/relay-server/src/processing/profile_chunks/mod.rs
@@ -168,7 +168,9 @@ impl Counted for SerializedProfileChunks {
             match pc.profile_type() {
                 Some(ProfileType::Ui) => ui += 1,
                 Some(ProfileType::Backend) => backend += 1,
-                None => {}
+                // These are invalid and will be dropped, but we default outcomes to the backend
+                // profile chunk category.
+                None => backend += 1,
             }
         }
 


### PR DESCRIPTION
This has been long in the making, see also #4595 for historic context.

Profile chunks without a platform header in the item header are considered invalid, we simply accepted them at the point of introduction to give some compatibility with beta SDKs. 