### PR TITLE
test(playstation): Fix failing test due to hard coded ts and clock drift correction

### DIFF
--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -610,7 +610,7 @@ def test_event_merging(
         "type": "error",
         "logger": "",
         "platform": "native",
-        "timestamp": 1759841673.0,
+        "timestamp": mock.ANY,
         "received": time_within_delta(),
         "release": "test-app@1.0.0",
         "environment": "integration-test",
@@ -685,6 +685,8 @@ def test_event_merging(
             "bytes.ingested.event.minidump": 60446,
             "bytes.ingested.event.attachment": 158008,
         },
+        "_meta": mock.ANY,
+        "errors": mock.ANY,
     }
 
     assert sorted(event["attachments"], key=lambda x: x["name"]) == attachments(


### PR DESCRIPTION
The timestamp is now 90s days in the past hence we now fail some validation and get an error. Update the assertion for now to deal with that, something similar already has been done in the file: https://github.com/getsentry/relay/pull/5079.

A better solution might be doing something like this: https://github.com/getsentry/relay/blob/8e6612d8c3c47f0c1c60b165627ca10c031da8fd/tests/integration/test_minidump.py#L578-L583
