### PR TITLE
test(playstation): Set `eventRetention` to avoid errors rather than ignoring them

### DIFF
--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -16,6 +16,17 @@ def load_dump_file(base_file_name: str):
         return f.read()
 
 
+def playstation_project_config():
+    """Project config extras for PlayStation tests with timestamp validation effectively disabled."""
+    return {
+        "config": {
+            # Set to 100 years to prevent normalization from overwriting the timestamp
+            "eventRetention": 36500,
+            "features": ["organizations:relay-playstation-ingestion"],
+        }
+    }
+
+
 def user_data_event_json(response):
     return {
         "event_id": response.text.replace("-", ""),
@@ -290,16 +301,7 @@ def test_playstation_with_feature_flag(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("playstation.prosperodmp")
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-        extra={
-            "config": {
-                # Set to 100 years to prevent normalization from overwriting the timestamp
-                "eventRetention": 36500,
-                "features": ["organizations:relay-playstation-ingestion"],
-            }
-        },
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
 
@@ -334,16 +336,7 @@ def test_playstation_user_data_extraction(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("user_data.prosperodmp")
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-        extra={
-            "config": {
-                # Set to 100 years to prevent normalization from overwriting the timestamp
-                "eventRetention": 36500,
-                "features": ["organizations:relay-playstation-ingestion"],
-            }
-        },
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
     relay = relay_processing_with_playstation()
@@ -364,10 +357,7 @@ def test_playstation_ignore_large_fields(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("user_data.prosperodmp")
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-        extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
 
     # Make a dummy video that is larger than the dump
     video_content = "1" * (len(playstation_dump) + 100)
@@ -408,16 +398,7 @@ def test_playstation_attachment(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("playstation.prosperodmp")
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-        extra={
-            "config": {
-                # Set to 100 years to prevent normalization from overwriting the timestamp
-                "eventRetention": 36500,
-                "features": ["organizations:relay-playstation-ingestion"],
-            }
-        },
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
     relay = relay_processing_with_playstation()
@@ -535,10 +516,7 @@ def test_playstation_attachment_no_feature_flag(
 
 def test_data_request(mini_sentry, relay_processing_with_playstation):
     PROJECT_ID = 42
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-        extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
     relay = relay_processing_with_playstation()
     response = relay.send_playstation_data_request(PROJECT_ID)
 
@@ -562,16 +540,7 @@ def test_event_merging(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("native_user_data.prosperodmp")
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-        extra={
-            "config": {
-                # Set to 100 years to prevent normalization from overwriting the timestamp
-                "eventRetention": 36500,
-                "features": ["organizations:relay-playstation-ingestion"],
-            }
-        },
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
     relay = relay_processing_with_playstation()

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -450,9 +450,7 @@ def test_playstation_attachment_no_feature_flag(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("playstation.prosperodmp")
-    mini_sentry.add_full_project_config(
-        PROJECT_ID,
-    )
+    mini_sentry.add_full_project_config(PROJECT_ID)
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
     relay = relay_processing_with_playstation()

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -90,8 +90,6 @@ def user_data_event_json(response):
         "project": 42,
         "_metrics": mock.ANY,
         "grouping_config": mock.ANY,
-        "_meta": mock.ANY,
-        "errors": mock.ANY,
     }
 
 
@@ -153,19 +151,10 @@ def playstation_event_json(sdk=mock.ANY):
             ["server_name", "5be3652dd663dbdcd044da0f2144b17f"],
         ],
         "sdk": sdk,
-        "errors": [
-            {
-                "type": "past_timestamp",
-                "name": "timestamp",
-                "sdk_time": "2025-02-20T10:23:01+00:00",
-                "server_time": mock.ANY,
-            }
-        ],
         "key_id": "123",
         "project": 42,
         "grouping_config": mock.ANY,
         "_metrics": mock.ANY,
-        "_meta": mock.ANY,
     }
 
 
@@ -303,7 +292,13 @@ def test_playstation_with_feature_flag(
     playstation_dump = load_dump_file("playstation.prosperodmp")
     mini_sentry.add_full_project_config(
         PROJECT_ID,
-        extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
+        extra={
+            "config": {
+                # Set to 100 years to prevent normalization from overwriting the timestamp
+                "eventRetention": 36500,
+                "features": ["organizations:relay-playstation-ingestion"],
+            }
+        },
     )
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
@@ -341,7 +336,13 @@ def test_playstation_user_data_extraction(
     playstation_dump = load_dump_file("user_data.prosperodmp")
     mini_sentry.add_full_project_config(
         PROJECT_ID,
-        extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
+        extra={
+            "config": {
+                # Set to 100 years to prevent normalization from overwriting the timestamp
+                "eventRetention": 36500,
+                "features": ["organizations:relay-playstation-ingestion"],
+            }
+        },
     )
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
@@ -409,7 +410,13 @@ def test_playstation_attachment(
     playstation_dump = load_dump_file("playstation.prosperodmp")
     mini_sentry.add_full_project_config(
         PROJECT_ID,
-        extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
+        extra={
+            "config": {
+                # Set to 100 years to prevent normalization from overwriting the timestamp
+                "eventRetention": 36500,
+                "features": ["organizations:relay-playstation-ingestion"],
+            }
+        },
     )
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
@@ -557,7 +564,13 @@ def test_event_merging(
     playstation_dump = load_dump_file("native_user_data.prosperodmp")
     mini_sentry.add_full_project_config(
         PROJECT_ID,
-        extra={"config": {"features": ["organizations:relay-playstation-ingestion"]}},
+        extra={
+            "config": {
+                # Set to 100 years to prevent normalization from overwriting the timestamp
+                "eventRetention": 36500,
+                "features": ["organizations:relay-playstation-ingestion"],
+            }
+        },
     )
     outcomes_consumer = outcomes_consumer()
     attachments_consumer = attachments_consumer()
@@ -610,7 +623,7 @@ def test_event_merging(
         "type": "error",
         "logger": "",
         "platform": "native",
-        "timestamp": mock.ANY,
+        "timestamp": 1759841673.0,
         "received": time_within_delta(),
         "release": "test-app@1.0.0",
         "environment": "integration-test",
@@ -685,8 +698,6 @@ def test_event_merging(
             "bytes.ingested.event.minidump": 60446,
             "bytes.ingested.event.attachment": 158008,
         },
-        "_meta": mock.ANY,
-        "errors": mock.ANY,
     }
 
     assert sorted(event["attachments"], key=lambda x: x["name"]) == attachments(


### PR DESCRIPTION
Since the timestamps come from the dump-files (and the files themself are older than 90 days) this causes normalization to override `timestamp` and populate `_meta` and `errors`. The tests previously just asserted against `mock.ANY` which would silently swallow other contents of `_meta`and `errors`. To avoid this, we now set `eventRetention` to 100 years (36500 days) to effectively disable normalization overwriting the timestamps.