### PR TITLE
ref(gocd): Bump gocd lib version to v2.18.0

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.17.0"
+      "version": "v2.18.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "d0490a3079bfb0490016ce2cc14627f5fb90e522",
-      "sum": "eZZ8rwc3QIKR4Q6IIq/504XKoCB/rcx6WL4KkklWAz0="
+      "version": "3b7e3b151fb20d21d66c2f04d17a740ba0b09ac0",
+      "sum": "cgfkKWTz+bBKHa8WVji1v4Ke5JM3bTeMnqPtYZuy9VM="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/pops.jsonnet
+++ b/gocd/templates/pops.jsonnet
@@ -11,6 +11,7 @@ local pipedream_config = {
     'customer-1',
     'customer-2',
     'customer-4',
+    's4s2',
   ],
   materials: {
     relay_repo: {


### PR DESCRIPTION
Bump gocd lib version to v2.18.0.
Remove s4s2 from pops deployment pipeline - there are no relay-pop in primary cluster and no pop regions for it.