### PR TITLE
feat(otlp): Conditionally enable Span V2 pipeline processing for OTLP

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -117,6 +117,9 @@ pub enum Feature {
     /// Enables the experimental Span V2 processing pipeline in Relay.
     #[serde(rename = "projects:span-v2-experimental-processing")]
     SpanV2ExperimentalProcessing,
+    /// Enables OTLP spans to use the Span V2 processing pipeline in Relay.
+    #[serde(rename = "organizations:span-v2-otlp-processing")]
+    SpanV2OtlpProcessing,
     /// This feature has deprecated and is kept for external Relays.
     #[doc(hidden)]
     #[serde(rename = "projects:span-metrics-extraction")]

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -287,6 +287,7 @@ impl ProcessingGroup {
 
         let span_v2_items = envelope.take_items_by(|item| {
             let exp_feature = project_info.has_feature(Feature::SpanV2ExperimentalProcessing);
+            let otlp_feature = project_info.has_feature(Feature::SpanV2OtlpProcessing);
             let is_supported_integration = {
                 matches!(
                     item.integration(),
@@ -298,7 +299,7 @@ impl ProcessingGroup {
 
             ItemContainer::<SpanV2>::is_container(item)
                 || (exp_feature && is_span)
-                || (exp_feature && is_supported_integration)
+                || ((exp_feature || otlp_feature) && is_supported_integration)
                 || (exp_feature && is_span_attachment)
         });
 

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import pytest
 from opentelemetry.proto.common.v1.common_pb2 import (
     AnyValue,
     InstrumentationScope,
@@ -16,12 +17,20 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 from .asserts import time_within_delta, time_within
 
 
+@pytest.mark.parametrize(
+    "span_v2_feature",
+    [
+        "projects:span-v2-experimental-processing",
+        "organizations:span-v2-otlp-processing",
+    ],
+)
 def test_span_ingestion(
     mini_sentry,
     relay,
     relay_with_processing,
     spans_consumer,
     metrics_consumer,
+    span_v2_feature,
 ):
     spans_consumer = spans_consumer()
     metrics_consumer = metrics_consumer()
@@ -33,7 +42,7 @@ def test_span_ingestion(
     project_config["config"]["features"] = [
         "organizations:standalone-span-ingestion",
         "organizations:relay-otlp-traces-endpoint",
-        "projects:span-v2-experimental-processing",
+        span_v2_feature,
     ]
 
     ts = datetime.now(timezone.utc)


### PR DESCRIPTION
Uses the flag added in https://github.com/getsentry/sentry/pull/105840 to control switching OTLP spans to use the V2 pipeline. This is intended to be temporary; once everything looks good we can remove the flag + conditional.