### PR TITLE
fix(store): Flip byte order of UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Bug Fixes**:
+
+- Write item IDs of logs, metrics and trace attachments in correct byte order. ([#5526](https://github.com/getsentry/relay/pull/5526))
+
 **Breaking Changes**:
 
 - Return status code `413` if a request is rejected due to size limits. ([#5474](https://github.com/getsentry/relay/pull/5474))

--- a/relay-server/src/processing/logs/store.rs
+++ b/relay-server/src/processing/logs/store.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::envelope::WithHeader;
 use crate::processing::logs::{Error, Result};
-use crate::processing::utils::store::{extract_meta_attributes, proto_timestamp};
+use crate::processing::utils::store::{extract_meta_attributes, proto_timestamp, uuid_to_item_id};
 use crate::processing::{self, Counted, Retention};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreTraceItem;
@@ -70,7 +70,7 @@ pub fn convert(log: WithHeader<OurLog>, ctx: &Context) -> Result<StoreTraceItem>
         downsampled_retention_days: ctx.retention.downsampled.into(),
         timestamp: Some(proto_timestamp(timestamp.0)),
         trace_id: required!(log.trace_id).to_string(),
-        item_id: Uuid::new_v7(timestamp.into()).as_bytes().to_vec(),
+        item_id: uuid_to_item_id(Uuid::new_v7(timestamp.into())),
         attributes: attributes(meta, attrs, fields),
         client_sample_rate: 1.0,
         server_sample_rate: 1.0,

--- a/relay-server/src/processing/trace_attachments/store.rs
+++ b/relay-server/src/processing/trace_attachments/store.rs
@@ -11,6 +11,7 @@ use crate::processing::Retention;
 use crate::processing::trace_attachments::types::ExpandedAttachment;
 use crate::processing::utils::store::{
     AttributeMeta, extract_client_sample_rate, extract_meta_attributes, proto_timestamp,
+    uuid_to_item_id,
 };
 use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::upload::StoreAttachment;
@@ -89,7 +90,7 @@ fn attachment_to_trace_item(
         organization_id: ctx.scoping.organization_id.value(),
         project_id: ctx.scoping.project_id.value(),
         trace_id: trace_id.into_value()?.to_string(),
-        item_id: attachment_id.into_value()?.into_bytes().to_vec(),
+        item_id: uuid_to_item_id(*attachment_id.into_value()?),
         item_type: TraceItemType::Attachment.into(),
         timestamp: Some(proto_timestamp(timestamp.into_value()?.0)),
         attributes: convert_attributes(annotated_meta, attributes, fields),

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 
 use crate::envelope::WithHeader;
 use crate::processing::trace_metrics::{Error, Result};
-use crate::processing::utils::store::{extract_client_sample_rate, extract_meta_attributes};
+use crate::processing::utils::store::{
+    extract_client_sample_rate, extract_meta_attributes, uuid_to_item_id,
+};
 use crate::processing::{self, Counted, Retention};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreTraceItem;
@@ -69,7 +71,7 @@ pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTr
         downsampled_retention_days: ctx.retention.downsampled.into(),
         timestamp: Some(ts(timestamp.0)),
         trace_id: required!(metric.trace_id).to_string(),
-        item_id: Uuid::new_v7(timestamp.into()).as_bytes().to_vec(),
+        item_id: uuid_to_item_id(Uuid::new_v7(timestamp.into())),
         attributes: attributes(meta, attrs, fields),
         client_sample_rate,
         server_sample_rate: 1.0,

--- a/relay-server/src/processing/utils/store.rs
+++ b/relay-server/src/processing/utils/store.rs
@@ -7,6 +7,7 @@ use relay_protocol::{Annotated, IntoValue, MetaTree, Value};
 
 use sentry_protos::snuba::v1::{AnyValue, ArrayValue, any_value};
 use serde::Serialize;
+use uuid::Uuid;
 
 /// Represents metadata extracted from Relay's annotated model.
 ///
@@ -205,4 +206,10 @@ pub fn extract_client_sample_rate(attributes: &Attributes) -> Option<f64> {
         .and_then(|value| value.as_f64())
         .filter(|v| *v > 0.0)
         .filter(|v| *v <= 1.0)
+}
+
+/// Massages a UUID into the format that EAP expects.
+pub fn uuid_to_item_id(id: Uuid) -> Vec<u8> {
+    // See https://github.com/getsentry/snuba/blob/a319040728d638841612cef117ec414d3e54d70f/rust_snuba/src/processors/eap_items.rs#L257
+    id.as_u128().to_le_bytes().to_vec()
 }

--- a/relay-server/src/processing/utils/store.rs
+++ b/relay-server/src/processing/utils/store.rs
@@ -1,3 +1,4 @@
+use std::array::TryFromSliceError;
 use std::collections::HashMap;
 
 use chrono::Utc;
@@ -212,4 +213,11 @@ pub fn extract_client_sample_rate(attributes: &Attributes) -> Option<f64> {
 pub fn uuid_to_item_id(id: Uuid) -> Vec<u8> {
     // See https://github.com/getsentry/snuba/blob/a319040728d638841612cef117ec414d3e54d70f/rust_snuba/src/processors/eap_items.rs#L257
     id.as_u128().to_le_bytes().to_vec()
+}
+
+/// Reverse operation of [`uuid_to_item_id`].
+pub fn item_id_to_uuid(item_id: &[u8]) -> Result<Uuid, TryFromSliceError> {
+    let item_id: [u8; 16] = item_id.try_into()?;
+    let item_id = u128::from_le_bytes(item_id);
+    Ok(Uuid::from_u128(item_id))
 }

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -407,7 +407,7 @@ def test_attachment_with_matching_span_store(
 
     attachment_item = items_consumer.get_item()
     expected_item_id = base64.b64encode(
-        int(uuid.UUID(hex=attachment_item["attachment_id"]).hex, base=16).to_bytes(
+        int(uuid.UUID(hex=metadata["attachment_id"]).hex, base=16).to_bytes(
             16, "little"
         )
     ).decode("utf-8")

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -141,7 +141,9 @@ def test_standalone_attachment_store(
 
     produced_item = items_consumer.get_item()
     expected_item_id = base64.b64encode(
-        uuid.UUID(hex=attachment_metadata["attachment_id"]).bytes
+        int(uuid.UUID(hex=attachment_metadata["attachment_id"]).hex, base=16).to_bytes(
+            16, "little"
+        )
     ).decode("utf-8")
     assert produced_item == {
         "attributes": {
@@ -405,7 +407,9 @@ def test_attachment_with_matching_span_store(
 
     attachment_item = items_consumer.get_item()
     expected_item_id = base64.b64encode(
-        uuid.UUID(hex=metadata["attachment_id"]).bytes
+        int(uuid.UUID(hex=attachment_item["attachment_id"]).hex, base=16).to_bytes(
+            16, "little"
+        )
     ).decode("utf-8")
     assert attachment_item == {
         "attributes": {


### PR DESCRIPTION
Flip the bytes of a UUID when generating an item ID for EAP. This is what EAP [expects](https://github.com/getsentry/sentry-protos/blob/f95f93a064f7cc5a144dc77d420be2ee162c95fc/proto/sentry_protos/snuba/v1/trace_item.proto#L37-L38), and aligns with writers in sentry, for example

- https://github.com/getsentry/sentry/blob/e23d86283e7e6cc4050fbc826a40787f79b7d6b1/src/sentry/uptime/consumers/eap_converter.py#L172

Fixes INGEST-697