### PR TITLE
build(deps): Remove ignored semver addition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ quote = "1.0.41"
 rand = "0.9.2"
 rand_pcg = "0.9.0"
 rdkafka = "0.38.0"
-rdkafka-sys = "4.9.0+2.10.0"
+rdkafka-sys = "4.9.0"
 redis = { version = "0.29.2", default-features = false }
 regex = "1.11.3"
 regex-lite = "0.1.7"


### PR DESCRIPTION
This appendix is ignored and produces a cargo warning when compiling.