### PR TITLE
ref: Remove profile from SourceQuantities

### DIFF
--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -1053,8 +1053,6 @@ pub struct SourceQuantities {
     pub transactions: usize,
     /// Spans quantity.
     pub spans: usize,
-    /// Profile quantity.
-    pub profiles: usize,
     /// Total number of buckets.
     pub buckets: usize,
 }
@@ -1064,12 +1062,10 @@ impl AddAssign for SourceQuantities {
         let Self {
             transactions,
             spans,
-            profiles,
             buckets,
         } = self;
         *transactions += other.transactions;
         *spans += other.spans;
-        *profiles += other.profiles;
         *buckets += other.buckets;
     }
 }

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -158,14 +158,12 @@ impl Counted for ExtractedMetrics {
         let SourceQuantities {
             transactions,
             spans,
-            profiles,
             buckets,
         } = metrics::extract_quantities(&self.project_metrics);
 
         [
             (DataCategory::Transaction, transactions),
             (DataCategory::Span, spans),
-            (DataCategory::Profile, profiles),
             (DataCategory::MetricBucket, buckets),
         ]
         .into_iter()

--- a/relay-server/src/metrics/outcomes.rs
+++ b/relay-server/src/metrics/outcomes.rs
@@ -36,14 +36,12 @@ impl MetricOutcomes {
             let SourceQuantities {
                 transactions,
                 spans,
-                profiles,
                 buckets,
             } = extract_quantities(buckets);
 
             let categories = [
                 (DataCategory::Transaction, transactions as u32),
                 (DataCategory::Span, spans as u32),
-                (DataCategory::Profile, profiles as u32),
                 (DataCategory::MetricBucket, buckets as u32),
             ];
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -280,7 +280,6 @@ impl EnvelopeSummary {
             if let Some(source_quantities) = item.source_quantities() {
                 summary.secondary_transaction_quantity += source_quantities.transactions;
                 summary.secondary_span_quantity += source_quantities.spans;
-                summary.profile_quantity += source_quantities.profiles;
             }
 
             summary.payload_size += item.len();
@@ -2065,7 +2064,6 @@ mod tests {
         item.set_source_quantities(SourceQuantities {
             transactions: 5,
             spans: 0,
-            profiles: 2,
             buckets: 5,
         });
         envelope.add_item(item);
@@ -2074,14 +2072,12 @@ mod tests {
         item.set_source_quantities(SourceQuantities {
             transactions: 2,
             spans: 0,
-            profiles: 0,
             buckets: 3,
         });
         envelope.add_item(item);
 
         let summary = EnvelopeSummary::compute(&envelope);
 
-        assert_eq!(summary.profile_quantity, 2);
         assert_eq!(summary.secondary_transaction_quantity, 7);
     }
 


### PR DESCRIPTION
We do not track source quantities for profiles anymore, see https://github.com/getsentry/relay/pull/4365/.