### PR TITLE
feat(config): Allow loading config values from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-**Bug Fixes**:
-
-- Write item IDs of logs, metrics and trace attachments in correct byte order. ([#5526](https://github.com/getsentry/relay/pull/5526))
-
 **Breaking Changes**:
 
 - Return status code `413` if a request is rejected due to size limits. ([#5474](https://github.com/getsentry/relay/pull/5474))
@@ -16,12 +12,14 @@
 
 **Bug Fixes**:
 
+- Write item IDs of logs, metrics and trace attachments in correct byte order. ([#5526](https://github.com/getsentry/relay/pull/5526))
 - Reworked AI span extraction to also take trace context into account. ([#5515](https://github.com/getsentry/relay/pull/5515))
 
 **Internal**:
 
 - Release Docker image to GHCR and DockerHub via Craft. ([#5509](https://github.com/getsentry/relay/pull/5509))
 - Tag span `usage` and `count_per_root_project` metrics with segment information. ([#5511](https://github.com/getsentry/relay/pull/5511))
+- Experimental support for loading configuration values from files. ([#5531](https://github.com/getsentry/relay/pull/5531))
 
 ## 25.12.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5137,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "serde-vars"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd17b13c31689268178a0fdc71bca328adcd4384f55a537e01ee8b6ab0857e34"
+checksum = "c31ed6ad0418012bd1f7493bb01d9b107e81aec23042be9292d7d154909a5c45"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ sentry-types = "0.41.0"
 sentry_protos = "0.4.8"
 serde = { version = "=1.0.228", features = ["derive", "rc"] }
 serde-transcode = "1.1.1"
-serde-vars = "0.2.0"
+serde-vars = "0.3.1"
 serde_bytes = "0.11.17"
 serde_json = "1.0.140"
 serde_path_to_error = "0.1.20"

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -171,7 +171,13 @@ trait ConfigObject: DeserializeOwned + Serialize {
             .with_context(|| ConfigError::file(ConfigErrorKind::CouldNotOpenFile, &path))?;
         let f = io::BufReader::new(f);
 
-        let mut source = serde_vars::EnvSource::default();
+        let mut source = {
+            let file = serde_vars::FileSource::default()
+                .with_variable_prefix("${file:")
+                .with_base_path(base);
+            let env = serde_vars::EnvSource::default();
+            (file, env)
+        };
         match Self::format() {
             ConfigFormat::Yaml => {
                 serde_vars::deserialize(serde_yaml::Deserializer::from_reader(f), &mut source)

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -174,8 +174,11 @@ trait ConfigObject: DeserializeOwned + Serialize {
         let mut source = {
             let file = serde_vars::FileSource::default()
                 .with_variable_prefix("${file:")
+                .with_variable_suffix("}")
                 .with_base_path(base);
-            let env = serde_vars::EnvSource::default();
+            let env = serde_vars::EnvSource::default()
+                .with_variable_prefix("${")
+                .with_variable_suffix("}");
             (file, env)
         };
         match Self::format() {

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,3 +1,9 @@
+import tempfile
+import pytest
+
+from requests import HTTPError
+
+
 def test_invalid_kafka_config_should_fail(mini_sentry, relay_with_processing):
     options = {
         "processing": {
@@ -44,3 +50,19 @@ def test_missing_env_var_in_config(mini_sentry, relay, relay_credentials):
     )
 
     assert relay.wait_for_exit() != 0
+
+
+def test_variable_loaded_from_file(mini_sentry, relay):
+    tmp = tempfile.NamedTemporaryFile(delete_on_close=False)
+    tmp.write(b"1B")
+    tmp.close()
+
+    relay = relay(
+        mini_sentry,
+        options={
+            "limits": {"max_event_size": f"${{file:{tmp.name}}}"},
+        },
+    )
+
+    with pytest.raises(HTTPError, match="413 Client Error"):
+        relay.send_event(42)


### PR DESCRIPTION
Allows loading config values referenced from a file.

We discussed in our TSC to introduce the `file:` prefix and keep the env var as it is due to compatibility reasons. We considered options such as `@{...}` or `${@...}`.