### PR TITLE
fix(spans): Mark root spans as segments in OTel conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Write item IDs of logs, metrics and trace attachments in correct byte order. ([#5526](https://github.com/getsentry/relay/pull/5526))
 - Reworked AI span extraction to also take trace context into account. ([#5515](https://github.com/getsentry/relay/pull/5515))
+- Mark root spans (spans without a parent) as segments in OTEL conversion. ([#5532](https://github.com/getsentry/relay/pull/5532))
 
 **Internal**:
 

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -232,6 +232,7 @@ mod tests {
             "span_key": "span_value"
           },
           "exclusive_time": 0.0,
+          "is_segment": true,
           "links": [],
           "op": "default",
           "span_id": "e342abb1214ca181",

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -807,6 +807,7 @@ mod tests {
           "op": "default",
           "span_id": "e342abb1214ca181",
           "trace_id": "3c79f60c11214eb38604f4ae0781bfb2",
+          "is_segment": true,
           "status": "ok",
           "data": {
             "sentry.origin": "auto.otlp.spans"
@@ -849,6 +850,7 @@ mod tests {
           "op": "default",
           "span_id": "e342abb1214ca181",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": true,
           "status": "internal_error",
           "data": {
             "sentry.origin": "auto.otlp.spans",

--- a/relay-spans/src/otel_to_sentry.rs
+++ b/relay-spans/src/otel_to_sentry.rs
@@ -140,6 +140,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "description": "GET /home",
           "data": {
@@ -195,6 +196,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "description": "middleware - fastify -> @fastify/multipart",
           "data": {
@@ -230,6 +232,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "description": "middleware - fastify -> @fastify/multipart",
           "data": {
@@ -291,6 +294,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "description": "SELECT \"table\".\"col\" FROM \"table\" WHERE \"table\".\"col\" = %s",
           "data": {
@@ -356,6 +360,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "description": "index view query",
           "data": {
@@ -408,6 +413,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "description": "GET /api/search?q=foobar",
           "data": {
@@ -477,6 +483,7 @@ mod tests {
           "span_id": "fa90fdead5f74052",
           "parent_span_id": "fa90fdead5f74051",
           "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+          "is_segment": false,
           "status": "ok",
           "description": "cmd.run",
           "data": {
@@ -639,6 +646,7 @@ mod tests {
           "parent_span_id": "fa90fdead5f74051",
           "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
           "segment_id": "fa90fdead5f74052",
+          "is_segment": false,
           "status": "ok",
           "description": "mydescription",
           "profile_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
@@ -714,6 +722,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "data": {
             "sentry.is_remote": false,
@@ -746,6 +755,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "parent_span_id": "0c7a7dea069bf5a6",
           "trace_id": "89143b0763095bd9c9955e8175d1fb23",
+          "is_segment": false,
           "status": "ok",
           "data": {
             "sentry.origin": "auto.otlp.spans"

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -120,7 +120,7 @@ pub fn otel_to_sentry_span(
         otel_to_sentry_kind(kind).map_value(|v| v.to_string()),
     );
 
-    // A remote span is a segment span, but not every segment span is remote:
+    // A remote span is a segment span, but not every segment span is remote.
     // A span is also a segment if it has no parent span (i.e., it's a root span).
     let is_root_span = parent_span_id.value().is_none();
     let is_segment = match is_remote {

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -123,19 +123,14 @@ pub fn otel_to_sentry_span(
     // A remote span is a segment span, but not every segment span is remote.
     // A span is also a segment if it has no parent span (i.e., it's a root span).
     let is_root_span = parent_span_id.value().is_none();
-    let is_segment = match is_remote {
-        Some(true) => Some(true),
-        _ if is_root_span => Some(true),
-        _ => None,
-    }
-    .into();
+    let is_segment = is_root_span || is_remote.unwrap_or(false);
 
     SentrySpanV2 {
         name: name.into(),
         trace_id,
         span_id,
         parent_span_id,
-        is_segment,
+        is_segment: is_segment.into(),
         start_timestamp: Timestamp(start_timestamp).into(),
         end_timestamp: Timestamp(end_timestamp).into(),
         status: status
@@ -298,6 +293,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "name": "middleware - fastify -> @fastify/multipart",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 1697620454.98,
           "end_timestamp": 1697620454.980079,
           "links": [],
@@ -396,6 +392,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "name": "middleware - fastify -> @fastify/multipart",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 1697620454.98,
           "end_timestamp": 1697620454.980079,
           "links": [],
@@ -458,6 +455,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "name": "database query",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 1697620454.98,
           "end_timestamp": 1697620454.980079,
           "links": [],
@@ -534,6 +532,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "name": "database query",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 1697620454.98,
           "end_timestamp": 1697620454.980079,
           "links": [],
@@ -602,6 +601,7 @@ mod tests {
           "span_id": "e342abb1214ca181",
           "name": "http client request",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 1697620454.98,
           "end_timestamp": 1697620454.980079,
           "links": [],
@@ -770,6 +770,7 @@ mod tests {
           "span_id": "fa90fdead5f74052",
           "name": "myname",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 123.0,
           "end_timestamp": 123.5,
           "links": [],
@@ -887,6 +888,7 @@ mod tests {
           "parent_span_id": "0c7a7dea069bf5a6",
           "span_id": "e342abb1214ca181",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 123.0,
           "end_timestamp": 123.5,
           "links": [],
@@ -953,6 +955,7 @@ mod tests {
           "parent_span_id": "0c7a7dea069bf5a6",
           "span_id": "e342abb1214ca181",
           "status": "ok",
+          "is_segment": false,
           "start_timestamp": 123.0,
           "end_timestamp": 123.5,
           "links": [],

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -905,7 +905,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_span_is_root() {
+    fn span_is_segment_if_it_has_no_parent() {
         let json = r#"{
           "traceId": "89143b0763095bd9c9955e8175d1fb23",
           "spanId": "e342abb1214ca181",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -820,6 +820,7 @@ def test_span_ingestion(
                     },
                 }
             ],
+            "is_segment": False,
             "name": "my 3rd protobuf OTel span",
             "parent_span_id": "f0f0f0abcdef1234",
             "span_id": "f0b809703e783d00",


### PR DESCRIPTION
Previously, the is_segment flag was only set when is_remote was true.  However, root spans should also be marked as segments. This fix adds a check for empty parent_span_id to correctly identify root spans as segments.
