### PR TITLE
fix: Correct flat size estimation for i64

### DIFF
--- a/relay-protocol/src/size.rs
+++ b/relay-protocol/src/size.rs
@@ -107,7 +107,7 @@ impl ser::Serializer for &mut SizeEstimatingSerializer {
 
     #[inline]
     fn serialize_i64(self, v: i64) -> Result<(), Error> {
-        self.size += &v.to_string().len();
+        self.count_size(v.to_string().len());
         Ok(())
     }
 
@@ -422,7 +422,7 @@ impl ser::SerializeStructVariant for &mut SizeEstimatingSerializer {
         T: ?Sized + Serialize,
     {
         self.count_comma_sep();
-        self.size += 2;
+        self.count_size(2);
         key.serialize(&mut **self)?;
         value.serialize(&mut **self)
     }

--- a/relay-protocol/src/size.rs
+++ b/relay-protocol/src/size.rs
@@ -439,12 +439,19 @@ mod tests {
     use super::*;
 
     use crate::annotated::Annotated;
-    use crate::value::{Object, Value};
+    use crate::value::{Array, Object, Value};
 
     #[test]
     fn test_estimate_size() {
         let json = r#"{"a":["Hello","World","aha","hmm",false,{"blub":42,"x":true},null]}"#;
         let value = Annotated::<Object<Value>>::from_json(json).unwrap();
         assert_eq!(estimate_size(value.value()), json.len());
+    }
+
+    #[test]
+    fn test_estimate_size_flat_scalars() {
+        let json = r#"[-17,"foobar",true]"#;
+        let value = Annotated::<Array<Value>>::from_json(json).unwrap();
+        assert_eq!(estimate_size_flat(value.value()), 2);
     }
 }


### PR DESCRIPTION
The function `estimate_size_flat` would count signed integer values even in nested structures. This is because `serialize_i64` doesn't go through the `count_size` method, which correctly handles this. The same is true for `serialize_field` in the `SerializeStructVariant` impl.

The new test `test_estimate_size_flat_scalars` validates the fix.