### PR TITLE
feat(protocol): Add new frame fields for metric kit flamegraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Features**:
 
+- Add new frame fields for MetricKit flamegraphs. ([#5539](https://github.com/getsentry/relay/pull/5539))
 - Apply clock drift correction to logs and trace metrics. ([#5609](https://github.com/getsentry/relay/pull/5609))
 
 **Internal**:

--- a/relay-event-schema/src/protocol/stacktrace.rs
+++ b/relay-event-schema/src/protocol/stacktrace.rs
@@ -104,6 +104,14 @@ pub struct Frame {
     #[metastructure(skip_serialization = "null")]
     pub context_line: Annotated<String>,
 
+    /// The index of the parent frame, used for flamegraphs provided by iOS.
+    #[metastructure(skip_serialization = "null")]
+    pub parent_index: Annotated<i64>,
+
+    /// The number of times this frame was sampled, used for flamegraphs provided by iOS.
+    #[metastructure(skip_serialization = "null")]
+    pub sample_count: Annotated<u64>,
+
     /// Source code of the lines after `lineno`.
     #[metastructure(skip_serialization = "empty")]
     pub post_context: Annotated<Array<String>>,
@@ -600,6 +608,8 @@ mod tests {
                 thread_id: Annotated::new(ThreadId::Int(7)),
                 other: Default::default(),
             }),
+            parent_index: Annotated::empty(),
+            sample_count: Annotated::empty(),
             other: {
                 let mut vars = Object::new();
                 vars.insert(


### PR DESCRIPTION
MetricKit provides app hang data on iOS which the cocoa SDK reports as an event. However, the stacktrace metric kit provides is really a "call stack tree" each node has a sample count and a parent. The best way to visualize it is a flamegraph, so this PR adds the relevant fields to relay allowing us to show the flamegraph on the issue detail page.

It doesn't look that useful yet because the frames are not symbolicated when I run it locally, but once this is merged I'll be able to run it on prod data with the frontend updates to see a symbolicated flamegraph:
<img width="1433" height="482" alt="Screenshot 2026-02-03 at 8 58 09 AM" src="https://github.com/user-attachments/assets/d1d43f0b-c65a-4191-b900-2b082520dd9f" />

Another way of doing this that I considered when chatting with @jan-auer was to include this in the frame `data` but I tried that and it didn't seem like the fields in data were preserved. This seems to work well though, and IMO is a bit cleaner than just throwing it in `data`.

WIP Frontend PR: https://github.com/getsentry/sentry/pull/106412
WIP SDK PR: https://github.com/getsentry/sentry-cocoa/pull/7185