### PR TITLE
fix(lint): Unused variable in object store service

### DIFF
--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -343,13 +343,13 @@ impl UploadServiceInner {
             #[cfg(debug_assertions)]
             let original_key = key.clone();
 
-            let stored_key = self
+            let _stored_key = self
                 .upload("attachment_v2", &session, body, Some(key))
                 .await
                 .reject(&trace_item)?;
 
             #[cfg(debug_assertions)]
-            debug_assert_eq!(stored_key, original_key);
+            debug_assert_eq!(_stored_key, original_key);
             relay_log::trace!("Finished attachment upload");
         }
 


### PR DESCRIPTION
```
warning: unused variable: `stored_key`
   --> relay-server/src/services/upload.rs:346:17
    |
346 |             let stored_key = self
    |                 ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_stored_key`
    |
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
```