### PR TITLE
ref(managed): `split_once` with record keeping

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -278,7 +278,7 @@ fn queue_envelope(
         let is_metric = |i: &Item| matches!(i.ty(), ItemType::Statsd | ItemType::MetricBuckets);
 
         let metrics;
-        (envelope, metrics) = envelope.split_once(|mut envelope| {
+        (envelope, metrics) = envelope.split_once(|mut envelope, _| {
             let metrics = envelope.take_items_by(is_metric).into_vec();
             (envelope, metrics)
         });

--- a/relay-server/src/managed/managed/debug.rs
+++ b/relay-server/src/managed/managed/debug.rs
@@ -7,37 +7,6 @@ use crate::managed;
 #[derive(Debug)]
 pub struct Quantities(pub BTreeMap<DataCategory, usize>);
 
-impl Quantities {
-    /// Asserts that all categories contained in this instance are also contained in `other` with the same quantities.
-    ///
-    /// Additional entries in `other` are ignored.
-    #[track_caller]
-    pub fn assert_only_extra<T>(&self, other: T)
-    where
-        T: Into<Self>,
-    {
-        let mut other = other.into();
-
-        for (category, quantity) in &self.0 {
-            match other.0.remove(category) {
-                None => {
-                    panic!("Expected {quantity} outcomes in category '{category}', but got none")
-                }
-                Some(other) => {
-                    assert_eq!(
-                        *quantity, other,
-                        "Expected {quantity} outcomes in category '{category}', but got '{other}'"
-                    );
-                }
-            }
-        }
-
-        if !other.0.is_empty() {
-            relay_log::debug!("Additional outcomes created: {:?}", other.0);
-        }
-    }
-}
-
 impl std::ops::Add for Quantities {
     type Output = Self;
 

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -180,7 +180,7 @@ fn split_indexed_and_total(
 ) -> SpansAndMetrics {
     let scoping = spans.scoping();
 
-    spans.split_once(|spans| {
+    spans.split_once(|spans, _| {
         let metrics = create_metrics(scoping, &spans.spans, spans.headers.dsc(), decision);
 
         (spans.into_indexed(), metrics)

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -6,7 +6,7 @@ use either::Either;
 use relay_dynamic_config::ErrorBoundary;
 use relay_metrics::{Bucket, BucketMetadata, BucketValue, UnixTimestamp};
 use relay_protocol::{FiniteF64, get_value};
-use relay_quotas::Scoping;
+use relay_quotas::{DataCategory, Scoping};
 use relay_sampling::config::RuleType;
 use relay_sampling::evaluation::{SamplingDecision, SamplingEvaluator};
 use relay_sampling::{DynamicSamplingContext, SamplingConfig};
@@ -180,7 +180,8 @@ fn split_indexed_and_total(
 ) -> SpansAndMetrics {
     let scoping = spans.scoping();
 
-    spans.split_once(|spans, _| {
+    spans.split_once(|spans, r| {
+        r.lenient(DataCategory::MetricBucket);
         let metrics = create_metrics(scoping, &spans.spans, spans.headers.dsc(), decision);
 
         (spans.into_indexed(), metrics)


### PR DESCRIPTION
Needed for https://github.com/getsentry/relay/pull/5379: Add a record keeper to `Managed::split_once` and add explicit leniency for metrics buckets.
