### PR TITLE
fix(buffer): Maintain `Managed` for proper bookkeeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "relay-config",
  "relay-log",
  "relay-server",
+ "relay-system",
  "serde_json",
  "tempfile",
  "tokio",

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -71,13 +71,12 @@ impl Counted for Box<Envelope> {
         let mut quantities = Quantities::new();
 
         // This matches the implementation of `ManagedEnvelope::reject`.
-        // Note: index_category is pushed first, then event_category (same order as ManagedEnvelope::reject).
         let summary = EnvelopeSummary::compute(self);
         if let Some(category) = summary.event_category {
-            if let Some(index_category) = category.index_category() {
-                quantities.push((index_category, 1));
-            }
             quantities.push((category, 1));
+            if let Some(category) = category.index_category() {
+                quantities.push((category, 1));
+            }
         }
 
         let data = [

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -71,12 +71,13 @@ impl Counted for Box<Envelope> {
         let mut quantities = Quantities::new();
 
         // This matches the implementation of `ManagedEnvelope::reject`.
+        // Note: index_category is pushed first, then event_category (same order as ManagedEnvelope::reject).
         let summary = EnvelopeSummary::compute(self);
         if let Some(category) = summary.event_category {
-            quantities.push((category, 1));
-            if let Some(category) = category.index_category() {
-                quantities.push((category, 1));
+            if let Some(index_category) = category.index_category() {
+                quantities.push((index_category, 1));
             }
+            quantities.push((category, 1));
         }
 
         let data = [

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -190,6 +190,11 @@ impl<T: Counted> Managed<T> {
         self.meta.received_at
     }
 
+    /// Returns a reference to the outcome aggregator.
+    pub fn outcome_aggregator(&self) -> &Addr<TrackOutcome> {
+        &self.meta.outcome_aggregator
+    }
+
     /// Scoping information stored in this context.
     pub fn scoping(&self) -> Scoping {
         self.meta.scoping

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -116,7 +116,10 @@ impl PolymorphicEnvelopeBuffer {
     }
 
     /// Pops the next-in-line envelope.
-    pub async fn pop(&mut self) -> Result<Option<Box<Envelope>>, EnvelopeBufferError> {
+    ///
+    /// Returns a [`Managed`] envelope that will automatically emit outcomes when dropped
+    /// if not explicitly accepted.
+    pub async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, EnvelopeBufferError> {
         let envelope = relay_statsd::metric!(
             timer(RelayTimers::BufferPop),
             partition_id = self.partition_tag(),
@@ -388,7 +391,10 @@ where
     ///
     /// The priority of the envelope's stack is updated with the next envelope's received_at
     /// time. If the stack is empty after popping, it is removed from the priority queue.
-    pub async fn pop(&mut self) -> Result<Option<Box<Envelope>>, EnvelopeBufferError> {
+    ///
+    /// Returns a [`Managed`] envelope that will automatically emit outcomes when dropped
+    /// if not explicitly accepted.
+    pub async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, EnvelopeBufferError> {
         let Some((QueueItem { key, value: stack }, _)) = self.priority_queue.peek_mut() else {
             return Ok(None);
         };

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -316,7 +316,7 @@ where
         );
     }
 
-    /// Pushes a managed envelope to the appropriate envelope stack and re-prioritizes the stack.
+    /// Pushes an envelope to the appropriate envelope stack and re-prioritizes the stack.
     ///
     /// If the envelope stack does not exist, a new stack is pushed to the priority queue.
     /// The priority of the stack is updated with the envelope's received_at time.
@@ -488,7 +488,7 @@ where
             .await;
     }
 
-    /// Pushes a new [`EnvelopeStack`] with the given managed [`Envelope`] inserted.
+    /// Pushes a new [`EnvelopeStack`] with the given [`Envelope`] inserted.
     async fn push_stack(
         &mut self,
         stack_creation_type: StackCreationType,

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -78,9 +78,6 @@ impl PolymorphicEnvelopeBuffer {
     }
 
     /// Adds a managed envelope to the buffer.
-    ///
-    /// The envelope remains managed throughout the operation, ensuring automatic rejection
-    /// with outcomes if any error occurs.
     pub async fn push(
         &mut self,
         envelope: Managed<Box<Envelope>>,
@@ -320,9 +317,6 @@ where
     ///
     /// If the envelope stack does not exist, a new stack is pushed to the priority queue.
     /// The priority of the stack is updated with the envelope's received_at time.
-    ///
-    /// The envelope remains managed throughout the push operation, ensuring that any failures
-    /// will automatically reject the envelope with outcomes when the Managed wrapper is dropped.
     pub async fn push(
         &mut self,
         envelope: Managed<Box<Envelope>>,

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -116,9 +116,6 @@ impl PolymorphicEnvelopeBuffer {
     }
 
     /// Pops the next-in-line envelope.
-    ///
-    /// Returns a [`Managed`] envelope that will automatically emit outcomes when dropped
-    /// if not explicitly accepted.
     pub async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, EnvelopeBufferError> {
         let envelope = relay_statsd::metric!(
             timer(RelayTimers::BufferPop),
@@ -391,9 +388,6 @@ where
     ///
     /// The priority of the envelope's stack is updated with the next envelope's received_at
     /// time. If the stack is empty after popping, it is removed from the priority queue.
-    ///
-    /// Returns a [`Managed`] envelope that will automatically emit outcomes when dropped
-    /// if not explicitly accepted.
     pub async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, EnvelopeBufferError> {
         let Some((QueueItem { key, value: stack }, _)) = self.priority_queue.peek_mut() else {
             return Ok(None);

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -52,7 +52,6 @@ where
 
     async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, Self::Error> {
         if let Some(envelope) = self.cached.take() {
-            // Return the managed envelope - caller is responsible for accepting or dropping
             Ok(Some(envelope))
         } else {
             self.inner.pop().await

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -34,11 +34,9 @@ where
     type Error = S::Error;
 
     async fn push(&mut self, envelope: Managed<Box<Envelope>>) -> Result<(), Self::Error> {
-        // If there's a cached envelope, push it to the inner stack first
         if let Some(cached) = self.cached.take() {
             self.inner.push(cached).await?;
         }
-        // Cache the new managed envelope (not yet accepted)
         self.cached = Some(envelope);
 
         Ok(())
@@ -68,7 +66,6 @@ where
             relay_log::error!(
                 "error while pushing the cached envelope in the inner stack during flushing",
             );
-            // The managed envelope will be dropped here, automatically rejecting it
         }
         self.inner.flush().await;
     }

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -50,10 +50,10 @@ where
         }
     }
 
-    async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
+    async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, Self::Error> {
         if let Some(envelope) = self.cached.take() {
-            // Accept the envelope when popping it - it's been successfully stored in cache
-            Ok(Some(envelope.accept(|e| e)))
+            // Return the managed envelope - caller is responsible for accepting or dropping
+            Ok(Some(envelope))
         } else {
             self.inner.pop().await
         }

--- a/relay-server/src/services/buffer/envelope_stack/caching.rs
+++ b/relay-server/src/services/buffer/envelope_stack/caching.rs
@@ -10,7 +10,7 @@ use crate::managed::Managed;
 pub struct CachingEnvelopeStack<S> {
     /// The underlying envelope stack
     inner: S,
-    /// The cached managed envelope (if any)
+    /// The cached envelope (if any)
     cached: Option<Managed<Box<Envelope>>>,
 }
 

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -20,7 +20,6 @@ impl EnvelopeStack for MemoryEnvelopeStack {
     type Error = Infallible;
 
     async fn push(&mut self, envelope: Managed<Box<Envelope>>) -> Result<(), Self::Error> {
-        // Store the managed envelope without accepting - it will be accepted on pop
         self.0.push(envelope);
         Ok(())
     }
@@ -30,7 +29,6 @@ impl EnvelopeStack for MemoryEnvelopeStack {
     }
 
     async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, Self::Error> {
-        // Return the managed envelope - caller is responsible for accepting or dropping
         Ok(self.0.pop())
     }
 

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -3,6 +3,7 @@ use std::convert::Infallible;
 use chrono::{DateTime, Utc};
 
 use crate::Envelope;
+use crate::managed::Managed;
 
 use super::EnvelopeStack;
 
@@ -18,7 +19,9 @@ impl MemoryEnvelopeStack {
 impl EnvelopeStack for MemoryEnvelopeStack {
     type Error = Infallible;
 
-    async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), Self::Error> {
+    async fn push(&mut self, envelope: Managed<Box<Envelope>>) -> Result<(), Self::Error> {
+        // Accept the envelope immediately since in-memory storage cannot fail
+        let envelope = envelope.accept(|e| e);
         self.0.push(envelope);
         Ok(())
     }

--- a/relay-server/src/services/buffer/envelope_stack/memory.rs
+++ b/relay-server/src/services/buffer/envelope_stack/memory.rs
@@ -29,9 +29,9 @@ impl EnvelopeStack for MemoryEnvelopeStack {
         Ok(self.0.last().map(|e| e.received_at()))
     }
 
-    async fn pop(&mut self) -> Result<Option<Box<Envelope>>, Self::Error> {
-        // Accept the envelope only when popping it
-        Ok(self.0.pop().map(|envelope| envelope.accept(|e| e)))
+    async fn pop(&mut self) -> Result<Option<Managed<Box<Envelope>>>, Self::Error> {
+        // Return the managed envelope - caller is responsible for accepting or dropping
+        Ok(self.0.pop())
     }
 
     async fn flush(self) {}

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -29,7 +29,10 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     fn peek(&mut self) -> impl Future<Output = Result<Option<DateTime<Utc>>, Self::Error>>;
 
     /// Pops the [`Envelope`] on top of the stack.
-    fn pop(&mut self) -> impl Future<Output = Result<Option<Box<Envelope>>, Self::Error>>;
+    ///
+    /// Returns a [`Managed`] envelope that will automatically emit outcomes when dropped
+    /// if not explicitly accepted.
+    fn pop(&mut self) -> impl Future<Output = Result<Option<Managed<Box<Envelope>>>, Self::Error>>;
 
     /// Persists all envelopes in the [`EnvelopeStack`]s to external storage, if possible,
     /// and consumes the stack provider.

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use chrono::{DateTime, Utc};
 
 use crate::envelope::Envelope;
+use crate::managed::Managed;
 
 pub mod caching;
 pub mod memory;
@@ -14,8 +15,15 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     /// [`EnvelopeStack`].
     type Error: std::fmt::Debug + std::error::Error;
 
-    /// Pushes an [`Envelope`] on top of the stack.
-    fn push(&mut self, envelope: Box<Envelope>) -> impl Future<Output = Result<(), Self::Error>>;
+    /// Pushes a [`Managed`] envelope on top of the stack.
+    ///
+    /// The envelope is accepted (extracted from the Managed wrapper) only when it has been
+    /// successfully stored. If any error occurs, the Managed wrapper is dropped, which
+    /// automatically rejects the envelope with outcomes.
+    fn push(
+        &mut self,
+        envelope: Managed<Box<Envelope>>,
+    ) -> impl Future<Output = Result<(), Self::Error>>;
 
     /// Peeks the [`Envelope`] on top of the stack.
     fn peek(&mut self) -> impl Future<Output = Result<Option<DateTime<Utc>>, Self::Error>>;

--- a/relay-server/src/services/buffer/envelope_stack/mod.rs
+++ b/relay-server/src/services/buffer/envelope_stack/mod.rs
@@ -16,10 +16,6 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     type Error: std::fmt::Debug + std::error::Error;
 
     /// Pushes a [`Managed`] envelope on top of the stack.
-    ///
-    /// The envelope is accepted (extracted from the Managed wrapper) only when it has been
-    /// successfully stored. If any error occurs, the Managed wrapper is dropped, which
-    /// automatically rejects the envelope with outcomes.
     fn push(
         &mut self,
         envelope: Managed<Box<Envelope>>,
@@ -29,9 +25,6 @@ pub trait EnvelopeStack: Send + std::fmt::Debug {
     fn peek(&mut self) -> impl Future<Output = Result<Option<DateTime<Utc>>, Self::Error>>;
 
     /// Pops the [`Envelope`] on top of the stack.
-    ///
-    /// Returns a [`Managed`] envelope that will automatically emit outcomes when dropped
-    /// if not explicitly accepted.
     fn pop(&mut self) -> impl Future<Output = Result<Option<Managed<Box<Envelope>>>, Self::Error>>;
 
     /// Persists all envelopes in the [`EnvelopeStack`]s to external storage, if possible,

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -178,7 +178,7 @@ impl EnvelopeStack for SqliteEnvelopeStack {
             { DatabaseEnvelope::try_from(&**envelope)? }
         );
 
-        // Only accept the envelope after successful encoding
+        // Need to formally `accept` the envelope to convert it to an untracked envelope.
         envelope.accept(|_| ());
 
         self.batch.push(encoded_envelope);
@@ -211,7 +211,7 @@ impl EnvelopeStack for SqliteEnvelopeStack {
         // Create a Managed instance for the envelope using the captured outcome aggregator.
         // If no outcome_aggregator is available (shouldn't happen in normal flow), we use a
         // dummy address which will discard any outcomes.
-        let outcome_aggregator = self.outcome_aggregator.clone().unwrap_or_else(Addr::dummy);
+        let outcome_aggregator = self.outcome_aggregator.clone().expect("Addr should have been added on push");
         let managed = Managed::from_envelope(envelope, outcome_aggregator);
 
         Ok(Some(managed))

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(peeked.timestamp_millis(), timestamps[4].timestamp_millis());
 
         // We pop 5 envelopes (in reverse order - LIFO).
-        for (i, expected_event_id) in event_ids.iter().enumerate().rev() {
+        for (_i, expected_event_id) in event_ids.iter().enumerate().rev() {
             let popped_envelope = stack.pop().await.unwrap().unwrap();
             assert_eq!(popped_envelope.event_id().unwrap(), *expected_event_id);
         }

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -211,7 +211,10 @@ impl EnvelopeStack for SqliteEnvelopeStack {
         // Create a Managed instance for the envelope using the captured outcome aggregator.
         // If no outcome_aggregator is available (shouldn't happen in normal flow), we use a
         // dummy address which will discard any outcomes.
-        let outcome_aggregator = self.outcome_aggregator.clone().expect("Addr should have been added on push");
+        let outcome_aggregator = self
+            .outcome_aggregator
+            .clone()
+            .expect("Addr should have been added on push");
         let managed = Managed::from_envelope(envelope, outcome_aggregator);
 
         Ok(Some(managed))

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -476,7 +476,6 @@ impl EnvelopeBufferService {
                 error = &e as &dyn std::error::Error,
                 "failed to push envelope"
             );
-            // The managed envelope was dropped, automatically rejecting it with an internal outcome
         }
     }
 
@@ -528,7 +527,6 @@ impl EnvelopeBufferService {
         relay_log::trace!("EnvelopeBufferService: popping envelope");
 
         // If we arrived here, know that both projects are available, so we pop the envelope.
-        // The envelope is already managed, so it will auto-reject if dropped.
         let mut managed_envelope = buffer
             .pop()
             .await?

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -936,6 +936,10 @@ mod tests {
         assert_eq!(envelope_processor_rx.len(), 0);
 
         let outcome = outcome_aggregator_rx.try_recv().unwrap();
+        assert_eq!(outcome.category, DataCategory::Transaction);
+        assert_eq!(outcome.quantity, 1);
+
+        let outcome = outcome_aggregator_rx.try_recv().unwrap();
         assert_eq!(outcome.category, DataCategory::TransactionIndexed);
         assert_eq!(outcome.quantity, 1);
     }

--- a/relay-server/src/services/buffer/stack_provider/sqlite.rs
+++ b/relay-server/src/services/buffer/stack_provider/sqlite.rs
@@ -132,7 +132,7 @@ mod tests {
     use crate::services::buffer::common::ProjectKeyPair;
     use crate::services::buffer::stack_provider::sqlite::SqliteStackProvider;
     use crate::services::buffer::stack_provider::{StackCreationType, StackProvider};
-    use crate::services::buffer::testutils::utils::mock_envelopes;
+    use crate::services::buffer::testutils::utils::managed_envelopes;
 
     fn mock_config() -> Arc<Config> {
         let path = std::env::temp_dir()
@@ -167,7 +167,7 @@ mod tests {
             ProjectKeyPair::new(own_key, sampling_key),
         );
 
-        let envelopes = mock_envelopes(10);
+        let envelopes = managed_envelopes(10);
         for envelope in envelopes {
             envelope_stack.push(envelope).await.unwrap();
         }

--- a/relay-server/src/services/buffer/testutils.rs
+++ b/relay-server/src/services/buffer/testutils.rs
@@ -13,6 +13,8 @@ pub mod utils {
     use crate::Envelope;
     use crate::envelope::{Item, ItemType};
     use crate::extractors::RequestMeta;
+    use crate::managed::Managed;
+    use relay_system::Addr;
 
     /// Sets up a temporary SQLite database for testing purposes.
     pub async fn setup_db(run_migrations: bool) -> Pool<Sqlite> {
@@ -85,6 +87,17 @@ pub mod utils {
         let now = Utc::now();
         (0..count)
             .map(|i| mock_envelope(now - chrono::Duration::seconds((count - i) as i64)))
+            .collect()
+    }
+
+    pub fn managed_envelope(received_at: DateTime<Utc>) -> Managed<Box<Envelope>> {
+        Managed::from_envelope(mock_envelope(received_at), Addr::dummy())
+    }
+
+    pub fn managed_envelopes(count: usize) -> Vec<Managed<Box<Envelope>>> {
+        let now = Utc::now();
+        (0..count)
+            .map(|i| managed_envelope(now - chrono::Duration::seconds((count - i) as i64)))
             .collect()
     }
 }

--- a/tools/bench-buffer/Cargo.toml
+++ b/tools/bench-buffer/Cargo.toml
@@ -15,6 +15,7 @@ rand = { workspace = true }
 relay-config = { path = "../../relay-config" }
 relay-log = { path = "../../relay-log" }
 relay-server = { path = "../../relay-server" }
+relay-system = { path = "../../relay-system" }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/tools/bench-buffer/src/main.rs
+++ b/tools/bench-buffer/src/main.rs
@@ -3,7 +3,9 @@ use chrono::Utc;
 use clap::{Parser, ValueEnum};
 use rand::RngCore;
 use relay_config::Config;
+use relay_server::managed::Managed;
 use relay_server::{Envelope, MemoryChecker, MemoryStat, PolymorphicEnvelopeBuffer};
+use relay_system::Addr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -133,7 +135,10 @@ async fn run_sequential(
         let envelope = mock_envelope(envelope_size, project_count, compression_ratio);
 
         let before = Instant::now();
-        buffer.push(envelope).await.unwrap();
+        buffer
+            .push(Managed::from_envelope(envelope, Addr::dummy()))
+            .await
+            .unwrap();
         let after = Instant::now();
 
         write_duration += after - before;
@@ -194,7 +199,10 @@ async fn run_interleaved(
         let envelope = mock_envelope(envelope_size, project_count, compression_ratio);
 
         let before = Instant::now();
-        buffer.push(envelope).await.unwrap();
+        buffer
+            .push(Managed::from_envelope(envelope, Addr::dummy()))
+            .await
+            .unwrap();
         let after_write = Instant::now();
         buffer.pop().await.unwrap();
         let after_read = Instant::now();


### PR DESCRIPTION
Pass `Managed` envelopes into the envelope buffer so that outcomes are reported when they are dropped. When reading envelopes from the buffer, convert them back into managed as well.

Fixes RELAY-44.