### PR TITLE
ci(gocd): Add 's4s2' to exclude_regions in pops.jsonnet

### DIFF
--- a/gocd/templates/pops.jsonnet
+++ b/gocd/templates/pops.jsonnet
@@ -8,6 +8,7 @@ local pipedream_config = {
   name: 'relay-pop',
   auto_deploy: false,
   exclude_regions: [
+    's4s2',
     'customer-1',
     'customer-2',
     'customer-4',


### PR DESCRIPTION
`s4s2` pops are managed in the `edge` project, not within `s4s2` - exclude them from gocd pipelines.