### PR TITLE
fix(csp): Add `sample` alias for `script_sample`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
 
+**Bug Fixes**:
+
+- Support `sample` alias in CSP reports. ([#5554](https://github.com/getsentry/relay/pull/5554))
 
 ## 26.1.0
 
@@ -618,7 +621,6 @@
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
 - Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
 - Incorrect pattern matches involving adjacent any and wildcard matchers. ([#4072](https://github.com/getsentry/relay/pull/4072))
-- Support `sample` alias in CSP reports. ([#5554](https://github.com/getsentry/relay/pull/5554))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,7 @@
 - Report invalid spans with appropriate outcome reason. ([#4051](https://github.com/getsentry/relay/pull/4051))
 - Use the duration reported by the profiler instead of the transaction. ([#4058](https://github.com/getsentry/relay/pull/4058))
 - Incorrect pattern matches involving adjacent any and wildcard matchers. ([#4072](https://github.com/getsentry/relay/pull/4072))
+- Support `sample` alias in CSP reports. ([#5554](https://github.com/getsentry/relay/pull/5554))
 
 **Features**:
 

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -248,7 +248,8 @@ struct CspRaw {
     #[serde(
         skip_serializing_if = "Option::is_none",
         alias = "scriptSample",
-        alias = "script-sample"
+        alias = "script-sample",
+        alias = "sample"
     )]
     script_sample: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1454,6 +1455,38 @@ mod tests {
           }
         }
         "###);
+    }
+
+    #[test]
+    fn test_csp_sample_alias() {
+        let json = r#"{
+            "csp-report": {
+                "document-uri": "http://example.com/foo",
+                "violated-directive": "style-src http://cdn.example.com",
+                "effective-directive": "style-src",
+                "sample": "console.log(\"lo\")"
+            }
+    }"#;
+
+        let mut event = Event::default();
+        Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
+        insta::assert_debug_snapshot!(event.csp, @r#"
+        Csp {
+            effective_directive: "style-src",
+            blocked_uri: "self",
+            document_uri: "http://example.com/foo",
+            original_policy: ~,
+            referrer: ~,
+            status_code: ~,
+            violated_directive: "style-src http://cdn.example.com",
+            source_file: ~,
+            line_number: ~,
+            column_number: ~,
+            script_sample: "console.log(\"lo\")",
+            disposition: ~,
+            other: {},
+        }
+        "#);
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/security_report.rs
+++ b/relay-event-schema/src/protocol/security_report.rs
@@ -1470,21 +1470,13 @@ mod tests {
 
         let mut event = Event::default();
         Csp::apply_to_event(json.as_bytes(), &mut event).unwrap();
-        insta::assert_debug_snapshot!(event.csp, @r#"
-        Csp {
-            effective_directive: "style-src",
-            blocked_uri: "self",
-            document_uri: "http://example.com/foo",
-            original_policy: ~,
-            referrer: ~,
-            status_code: ~,
-            violated_directive: "style-src http://cdn.example.com",
-            source_file: ~,
-            line_number: ~,
-            column_number: ~,
-            script_sample: "console.log(\"lo\")",
-            disposition: ~,
-            other: {},
+        assert_annotated_snapshot!(event.csp, @r#"
+        {
+          "effective_directive": "style-src",
+          "blocked_uri": "self",
+          "document_uri": "http://example.com/foo",
+          "violated_directive": "style-src http://cdn.example.com",
+          "script_sample": "console.log(\"lo\")"
         }
         "#);
     }


### PR DESCRIPTION
This fixes https://github.com/getsentry/relay/issues/5547 which points out that the field is also referred to as `sample`.