### PR TITLE
ref(ai): Embedd AI operation types into Relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Internal**:
 
+- Embed AI operation type mappings into Relay. ([#5555](https://github.com/getsentry/relay/pull/5555))
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
 
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -267,9 +267,8 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         max_tag_value_length: usize::MAX,
         span_description_rules: None,
         performance_score: None,
-        geoip_lookup: None,          // only supported in relay
-        ai_model_costs: None,        // only supported in relay
-        ai_operation_type_map: None, // only supported in relay
+        geoip_lookup: None,   // only supported in relay
+        ai_model_costs: None, // only supported in relay
         enable_trimming: config.enable_trimming.unwrap_or_default(),
         measurements: None,
         normalize_spans: config.normalize_spans,

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -36,6 +36,8 @@ convention_attributes!(
     GEN_AI_COST_INPUT_TOKENS => "gen_ai.cost.input_tokens",
     GEN_AI_COST_OUTPUT_TOKENS => "gen_ai.cost.output_tokens",
     GEN_AI_COST_TOTAL_TOKENS => "gen_ai.cost.total_tokens",
+    GEN_AI_OPERATION_TYPE => "gen_ai.operation.type",
+    GEN_AI_OPERATION_NAME => "gen_ai.operation.name",
     GEN_AI_REQUEST_MODEL => "gen_ai.request.model",
     GEN_AI_RESPONSE_MODEL => "gen_ai.response.model",
     GEN_AI_RESPONSE_TPS => "gen_ai.response.tokens_per_second",

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -5,9 +5,7 @@ use std::io::BufReader;
 use std::path::Path;
 
 use relay_base_schema::metrics::MetricNamespace;
-use relay_event_normalization::{
-    AiOperationTypeMap, MeasurementsConfig, ModelCosts, SpanOpDefaults,
-};
+use relay_event_normalization::{MeasurementsConfig, ModelCosts, SpanOpDefaults};
 use relay_filter::GenericFiltersConfig;
 use relay_quotas::Quota;
 use serde::{Deserialize, Serialize, de};
@@ -51,10 +49,6 @@ pub struct GlobalConfig {
     /// Configuration for AI span measurements.
     #[serde(skip_serializing_if = "is_model_costs_empty")]
     pub ai_model_costs: ErrorBoundary<ModelCosts>,
-
-    /// Configuration to derive the `gen_ai.operation.type` field from other fields
-    #[serde(skip_serializing_if = "is_ai_operation_type_map_empty")]
-    pub ai_operation_type_map: ErrorBoundary<AiOperationTypeMap>,
 
     /// Configuration to derive the `span.op` from other span fields.
     #[serde(
@@ -349,10 +343,6 @@ fn is_ok_and_empty(value: &ErrorBoundary<MetricExtractionGroups>) -> bool {
 
 fn is_model_costs_empty(value: &ErrorBoundary<ModelCosts>) -> bool {
     matches!(value, ErrorBoundary::Ok(model_costs) if model_costs.is_empty())
-}
-
-fn is_ai_operation_type_map_empty(value: &ErrorBoundary<AiOperationTypeMap>) -> bool {
-    matches!(value, ErrorBoundary::Ok(ai_operation_type_map) if ai_operation_type_map.is_empty())
 }
 
 #[cfg(test)]

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -27,7 +27,6 @@ use relay_protocol::{
 use smallvec::SmallVec;
 use uuid::Uuid;
 
-use crate::normalize::AiOperationTypeMap;
 use crate::normalize::request;
 use crate::span::ai::enrich_ai_event_data;
 use crate::span::tag_extraction::extract_span_tags_from_event;
@@ -141,9 +140,6 @@ pub struct NormalizationConfig<'a> {
     /// Configuration for calculating the cost of AI model runs
     pub ai_model_costs: Option<&'a ModelCosts>,
 
-    /// Configuration for mapping AI operation types from span.op to gen_ai.operation.type
-    pub ai_operation_type_map: Option<&'a AiOperationTypeMap>,
-
     /// An initialized GeoIP lookup.
     pub geoip_lookup: Option<&'a GeoIpLookup>,
 
@@ -198,7 +194,6 @@ impl Default for NormalizationConfig<'_> {
             performance_score: Default::default(),
             geoip_lookup: Default::default(),
             ai_model_costs: Default::default(),
-            ai_operation_type_map: Default::default(),
             enable_trimming: false,
             measurements: None,
             normalize_spans: true,
@@ -328,7 +323,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
             .get_or_default::<PerformanceScoreContext>()
             .score_profile_version = Annotated::new(version);
     }
-    enrich_ai_event_data(event, config.ai_model_costs, config.ai_operation_type_map);
+    enrich_ai_event_data(event, config.ai_model_costs);
     normalize_breakdowns(event, config.breakdowns_config); // Breakdowns are part of the metric extraction too
     normalize_default_attributes(event, meta, config);
     normalize_trace_context_tags(event);
@@ -2334,7 +2329,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 50.0,
           "gen_ai.cost.input_tokens": 10.0,
           "gen_ai.cost.output_tokens": 40.0,
-          "gen_ai.response.tokens_per_second": 62500.0
+          "gen_ai.response.tokens_per_second": 62500.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
         assert_annotated_snapshot!(span2, @r#"
@@ -2346,7 +2342,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 80.0,
           "gen_ai.cost.input_tokens": 20.0,
           "gen_ai.cost.output_tokens": 60.0,
-          "gen_ai.response.tokens_per_second": 62500.0
+          "gen_ai.response.tokens_per_second": 62500.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
     }
@@ -2451,7 +2448,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 75.0,
           "gen_ai.cost.input_tokens": 25.0,
           "gen_ai.cost.output_tokens": 50.0,
-          "gen_ai.response.tokens_per_second": 2000.0
+          "gen_ai.response.tokens_per_second": 2000.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
         assert_annotated_snapshot!(span2, @r#"
@@ -2463,7 +2461,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.cost.input_tokens": 90.0,
           "gen_ai.cost.output_tokens": 100.0,
-          "gen_ai.response.tokens_per_second": 2000.0
+          "gen_ai.response.tokens_per_second": 2000.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
         assert_annotated_snapshot!(span3, @r#"
@@ -2475,7 +2474,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.cost.input_tokens": 90.0,
           "gen_ai.cost.output_tokens": 100.0,
-          "gen_ai.response.tokens_per_second": 2000.0
+          "gen_ai.response.tokens_per_second": 2000.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
     }
@@ -2527,7 +2527,8 @@ mod tests {
 
         assert_annotated_snapshot!(span, @r#"
         {
-          "gen_ai.request.model": "claude-2.1"
+          "gen_ai.request.model": "claude-2.1",
+          "gen_ai.operation.type": "agent"
         }
         "#);
     }
@@ -2618,7 +2619,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 65.0,
           "gen_ai.cost.input_tokens": 25.0,
           "gen_ai.cost.output_tokens": 40.0,
-          "gen_ai.response.tokens_per_second": 62500.0
+          "gen_ai.response.tokens_per_second": 62500.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
         assert_annotated_snapshot!(span2, @r#"
@@ -2630,7 +2632,8 @@ mod tests {
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.cost.input_tokens": 90.0,
           "gen_ai.cost.output_tokens": 100.0,
-          "gen_ai.response.tokens_per_second": 62500.0
+          "gen_ai.response.tokens_per_second": 62500.0,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
     }
@@ -2673,7 +2676,8 @@ mod tests {
         assert_annotated_snapshot!(span, @r#"
         {
           "gen_ai.usage.total_tokens": 500.0,
-          "gen_ai.usage.input_tokens": 500
+          "gen_ai.usage.input_tokens": 500,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
     }
@@ -2716,7 +2720,8 @@ mod tests {
         assert_annotated_snapshot!(span, @r#"
         {
           "gen_ai.usage.total_tokens": 1000.0,
-          "gen_ai.usage.output_tokens": 1000
+          "gen_ai.usage.output_tokens": 1000,
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
     }
@@ -2749,40 +2754,13 @@ mod tests {
 
         let mut event = Annotated::<Event>::from_json(json).unwrap();
 
-        let operation_type_map = AiOperationTypeMap {
-            version: 1,
-            operation_types: HashMap::from([
-                (Pattern::new("gen_ai.chat").unwrap(), "chat".to_owned()),
-                (
-                    Pattern::new("gen_ai.execute_tool").unwrap(),
-                    "execute_tool".to_owned(),
-                ),
-                (
-                    Pattern::new("gen_ai.handoff").unwrap(),
-                    "handoff".to_owned(),
-                ),
-                (
-                    Pattern::new("gen_ai.invoke_agent").unwrap(),
-                    "invoke_agent".to_owned(),
-                ),
-                // fallback to agent
-                (Pattern::new("gen_ai.*").unwrap(), "agent".to_owned()),
-            ]),
-        };
-
-        normalize_event(
-            &mut event,
-            &NormalizationConfig {
-                ai_operation_type_map: Some(&operation_type_map),
-                ..NormalizationConfig::default()
-            },
-        );
+        normalize_event(&mut event, &NormalizationConfig::default());
 
         let [span1, span2, span3] = collect_span_data(event);
 
         assert_annotated_snapshot!(span1, @r#"
         {
-          "gen_ai.operation.type": "chat"
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
         assert_annotated_snapshot!(span2, @r#"
@@ -2792,86 +2770,9 @@ mod tests {
         "#);
         assert_annotated_snapshot!(span3, @r#"
         {
-          "gen_ai.operation.type": "agent"
+          "gen_ai.operation.type": "ai_client"
         }
         "#);
-    }
-
-    #[test]
-    fn test_ai_operation_type_disabled_map() {
-        let json = r#"
-            {
-                "type": "transaction",
-                "transaction": "test-transaction",
-                "spans": [
-                    {
-                        "op": "gen_ai.chat",
-                        "description": "AI chat completion",
-                        "data": {}
-                    }
-                ]
-            }
-        "#;
-
-        let mut event = Annotated::<Event>::from_json(json).unwrap();
-
-        let operation_type_map = AiOperationTypeMap {
-            version: 0, // Disabled version
-            operation_types: HashMap::from([(
-                Pattern::new("gen_ai.chat").unwrap(),
-                "chat".to_owned(),
-            )]),
-        };
-
-        normalize_event(
-            &mut event,
-            &NormalizationConfig {
-                ai_operation_type_map: Some(&operation_type_map),
-                ..NormalizationConfig::default()
-            },
-        );
-
-        let [span] = collect_span_data(event);
-
-        // Should not set operation type when map is disabled
-        assert_annotated_snapshot!(span, @"{}");
-    }
-
-    #[test]
-    fn test_ai_operation_type_empty_map() {
-        let json = r#"
-            {
-                "type": "transaction",
-                "transaction": "test-transaction",
-                "spans": [
-                    {
-                        "op": "gen_ai.chat",
-                        "description": "AI chat completion",
-                        "data": {}
-                    }
-                ]
-            }
-        "#;
-
-        let mut event = Annotated::<Event>::from_json(json).unwrap();
-
-        let operation_type_map = AiOperationTypeMap {
-            version: 1,
-            operation_types: HashMap::new(),
-        };
-
-        normalize_event(
-            &mut event,
-            &NormalizationConfig {
-                ai_operation_type_map: Some(&operation_type_map),
-                ..NormalizationConfig::default()
-            },
-        );
-
-        let [span] = collect_span_data(event);
-
-        // Should not set operation type when map is empty
-        assert_annotated_snapshot!(span, @"{}");
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -371,69 +371,6 @@ pub struct ModelCostV2 {
     pub input_cache_write_per_token: f64,
 }
 
-/// A mapping of AI operation types from span.op to gen_ai.operation.type.
-///
-/// This struct uses a dictionary-based mapping structure with pattern-based span operation keys
-/// and corresponding AI operation type values.
-///
-/// Example JSON:
-/// ```json
-/// {
-///   "version": 1,
-///   "operation_types": {
-///     "gen_ai.execute_tool": "tool",
-///     "gen_ai.handoff": "handoff",
-///     "gen_ai.invoke_agent": "agent",
-///   }
-/// }
-/// ```
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AiOperationTypeMap {
-    /// The version of the operation type mapping struct
-    pub version: u16,
-
-    /// The mappings of span.op => gen_ai.operation.type as a dictionary
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub operation_types: HashMap<Pattern, String>,
-}
-
-impl AiOperationTypeMap {
-    const SUPPORTED_VERSION: u16 = 1;
-
-    /// `true` if the operation type mapping is empty and the version is supported.
-    pub fn is_empty(&self) -> bool {
-        self.operation_types.is_empty() || !self.is_enabled()
-    }
-
-    /// `false` if operation type mapping should be skipped.
-    pub fn is_enabled(&self) -> bool {
-        self.version == Self::SUPPORTED_VERSION
-    }
-
-    /// Gets the AI operation type for the given span operation, if defined.
-    pub fn get_operation_type(&self, span_op: &str) -> Option<&str> {
-        if !self.is_enabled() {
-            return None;
-        }
-
-        // try first direct match with span_op
-        if let Some(value) = self.operation_types.get(span_op) {
-            return Some(value.as_str());
-        }
-
-        // if there is not a direct match, try to find the match using a pattern
-        let operation_type = self.operation_types.iter().find_map(|(key, value)| {
-            if key.is_match(span_op) {
-                Some(value)
-            } else {
-                None
-            }
-        });
-
-        operation_type.map(String::as_str)
-    }
-}
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
@@ -640,61 +577,6 @@ mod tests {
         let deserialized: ModelCosts = serde_json::from_str(version_zero_json).unwrap();
         assert_eq!(deserialized.version, 0);
         assert!(!deserialized.is_enabled());
-    }
-
-    #[test]
-    fn test_ai_operation_type_map_serialization() {
-        // Test serialization and deserialization with patterns
-        let mut operation_types = HashMap::new();
-        operation_types.insert(
-            Pattern::new("gen_ai.chat*").unwrap(),
-            "Inference".to_owned(),
-        );
-        operation_types.insert(
-            Pattern::new("gen_ai.execute_tool").unwrap(),
-            "Tool".to_owned(),
-        );
-
-        let original = AiOperationTypeMap {
-            version: 1,
-            operation_types,
-        };
-
-        let json = serde_json::to_string(&original).unwrap();
-        let deserialized: AiOperationTypeMap = serde_json::from_str(&json).unwrap();
-
-        assert!(deserialized.is_enabled());
-        assert_eq!(
-            deserialized.get_operation_type("gen_ai.chat.completions"),
-            Some("Inference")
-        );
-        assert_eq!(
-            deserialized.get_operation_type("gen_ai.execute_tool"),
-            Some("Tool")
-        );
-        assert_eq!(deserialized.get_operation_type("unknown_op"), None);
-    }
-
-    #[test]
-    fn test_ai_operation_type_map_pattern_matching() {
-        let mut operation_types = HashMap::new();
-        operation_types.insert(Pattern::new("gen_ai.*").unwrap(), "default".to_owned());
-        operation_types.insert(Pattern::new("gen_ai.chat").unwrap(), "chat".to_owned());
-
-        let map = AiOperationTypeMap {
-            version: 1,
-            operation_types,
-        };
-
-        let result = map.get_operation_type("gen_ai.chat");
-        assert!(Some("chat") == result);
-
-        let result = map.get_operation_type("gen_ai.chat.completions");
-        assert!(Some("default") == result);
-
-        assert_eq!(map.get_operation_type("gen_ai.other"), Some("default"));
-
-        assert_eq!(map.get_operation_type("other.operation"), None);
     }
 
     #[test]

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -219,7 +219,6 @@ pub fn normalize(
         .aggregator_config_for(MetricNamespace::Transactions);
 
     let ai_model_costs = ctx.global_config.ai_model_costs.as_ref().ok();
-    let ai_operation_type_map = ctx.global_config.ai_operation_type_map.as_ref().ok();
     let http_span_allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
 
     let project_info = ctx.project_info;
@@ -288,7 +287,6 @@ pub fn normalize(
             span_description_rules: project_info.config.span_description_rules.as_ref(),
             geoip_lookup: Some(geoip_lookup),
             ai_model_costs,
-            ai_operation_type_map,
             enable_trimming: true,
             measurements: Some(CombinedMeasurementsConfig::new(
                 ctx.project_info.config().measurements.as_ref(),

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -30,23 +30,6 @@ def test_ai_spans_example_transaction(
             },
         },
     }
-    mini_sentry.global_config["aiOperationTypeMap"] = {
-        "version": 1,
-        "operationTypes": {
-            "ai.run.generateText": "agent",
-            "ai.run.generateObject": "agent",
-            "invoke_agent": "agent",
-            "gen_ai.invoke_agent": "agent",
-            "ai.pipeline.generate_text": "agent",
-            "ai.pipeline.generate_object": "agent",
-            "ai.pipeline.stream_text": "agent",
-            "ai.pipeline.stream_object": "agent",
-            "gen_ai.create_agent": "agent",
-            "gen_ai.execute_tool": "tool",
-            "gen_ai.handoff": "handoff",
-            "*": "ai_client",
-        },
-    }
 
     relay = relay(relay_with_processing())
 


### PR DESCRIPTION
As discussed a while ago, moves the ai operation type mapping into Relay. It turns out the mapping is somewhat stable and updated not as often as anticipated. This also solves a problem with the current mappings where overlapping matches aren't handled correctly, e.g. `ai.toolCall*` was overlapping with the `*` mapping without ordering guarantees.

Also a preparation to implement the operation type mapping for the span streaming pipeline.

Current mappings in Sentry: https://github.com/getsentry/sentry/blob/master/src/sentry/relay/config/ai_operation_type_map.py