### PR TITLE
ref(buffer): Count loop iterations

### DIFF
--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -633,6 +633,10 @@ impl Service for EnvelopeBufferService {
 
         relay_log::info!("EnvelopeBufferService {}: starting", self.partition_id);
         loop {
+            relay_statsd::metric!(
+                counter(RelayCounters::BufferServiceLoopIteration) += 1,
+                partition_id = &partition_tag
+            );
             let mut sleep = DEFAULT_SLEEP;
 
             tokio::select! {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -735,6 +735,8 @@ pub enum RelayCounters {
     /// Number of times one or more projects of an envelope were pending when trying to pop
     /// their envelope.
     BufferProjectPending,
+    /// Number of iterations of the envelope buffer service loop.
+    BufferServiceLoopIteration,
     /// Number of outcomes and reasons for rejected Envelopes.
     ///
     /// This metric is tagged with:
@@ -973,6 +975,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::BufferUnspooledEnvelopes => "buffer.unspooled_envelopes",
             RelayCounters::BufferProjectChangedEvent => "buffer.project_changed_event",
             RelayCounters::BufferProjectPending => "buffer.project_pending",
+            RelayCounters::BufferServiceLoopIteration => "buffer.service_loop_iteration",
             RelayCounters::Outcomes => "events.outcomes",
             RelayCounters::OutcomeQuantity => "events.outcome_quantity",
             RelayCounters::ProjectStateRequest => "project_state.request",


### PR DESCRIPTION
Looks like we're burning more CPU on the envelope buffer service than we should. Add a counter metric to see how often the main loop executes.

ref: INGEST-659