### PR TITLE
chore(ai): Add metric for tracking ai cost calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
 - Add `gen_ai_response_time_to_first_token` as a `SpanData` attribute. ([#5575](https://github.com/getsentry/relay/pull/5575))
 - Add sampling to expensive envelope buffer statsd metrics. ([#5576](https://github.com/getsentry/relay/pull/5576))
-- Add `gen_ai.cost_calculation.result` metric to track AI cost calculation outcomes by integration and platform.
+- Add `gen_ai.cost_calculation.result` metric to track AI cost calculation outcomes by integration and platform. ([#5560](https://github.com/getsentry/relay/pull/5560))
 
 ## 26.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
 - Add `gen_ai_response_time_to_first_token` as a `SpanData` attribute. ([#5575](https://github.com/getsentry/relay/pull/5575))
 - Add sampling to expensive envelope buffer statsd metrics. ([#5576](https://github.com/getsentry/relay/pull/5576))
+- Add `gen_ai.cost_calculation.result` metric to track AI cost calculation outcomes by integration and platform.
 
 ## 26.1.0
 

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -37,6 +37,8 @@ pub fn normalize_ai(
     normalize_ai_type(attributes);
     let span_origin = attributes
         .get_value(ORIGIN)
+        .and_then(|v| v.as_str())
+        .map(String::from);
     let platform = attributes
         .get_value(PLATFORM)
         .and_then(|v| v.as_str())

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -6,7 +6,7 @@ use relay_protocol::Annotated;
 
 use crate::ModelCosts;
 use crate::span::ai;
-use crate::statsd::{Counters, map_origin_to_integration, platform_tag};
+use crate::statsd::{map_origin_to_integration, platform_tag};
 
 /// Normalizes AI attributes.
 ///
@@ -141,12 +141,6 @@ fn normalize_ai_costs(attributes: &mut Attributes, model_costs: Option<&ModelCos
     let platform = platform_tag(platform);
 
     let Some(costs) = ai::calculate_costs(model_cost, tokens, integration, platform) else {
-        relay_statsd::metric!(
-            counter(Counters::GenAiCostCalculationResult) += 1,
-            result = "calculation_none",
-            integration = integration,
-            platform = platform,
-        );
         return;
     };
 

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -35,22 +35,9 @@ pub fn normalize_ai(
     }
 
     normalize_ai_type(attributes);
-    let span_origin = attributes
-        .get_value(ORIGIN)
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    let platform = attributes
-        .get_value(PLATFORM)
-        .and_then(|v| v.as_str())
-        .map(String::from);
     normalize_total_tokens(attributes);
     normalize_tokens_per_second(attributes, duration);
-    normalize_ai_costs(
-        attributes,
-        costs,
-        span_origin.as_deref(),
-        platform.as_deref(),
-    );
+    normalize_ai_costs(attributes, costs);
 }
 
 /// Returns whether the item is should have AI normalizations applied.
@@ -171,15 +158,9 @@ fn platform_tag(platform: Option<&str>) -> &'static str {
 }
 
 /// Calculates model costs and serializes them into attributes.
-fn normalize_ai_costs(
-    attributes: &mut Attributes,
-    model_costs: Option<&ModelCosts>,
-    origin: Option<&str>,
-    platform: Option<&str>,
-) {
-    if attributes.contains_key(GEN_AI_COST_TOTAL_TOKENS) {
-        return;
-    }
+fn normalize_ai_costs(attributes: &mut Attributes, model_costs: Option<&ModelCosts>) {
+    let origin = extract_string_value(attributes, ORIGIN);
+    let platform = extract_string_value(attributes, PLATFORM);
 
     let model_cost = attributes
         .get_value(GEN_AI_REQUEST_MODEL)
@@ -235,6 +216,10 @@ fn normalize_ai_costs(
     attributes.insert(GEN_AI_COST_INPUT_TOKENS, costs.input);
     attributes.insert(GEN_AI_COST_OUTPUT_TOKENS, costs.output);
     attributes.insert(GEN_AI_COST_TOTAL_TOKENS, costs.total());
+}
+
+fn extract_string_value<'a>(attributes: &'a Attributes, key: &str) -> Option<&'a str> {
+    attributes.get_value(key).and_then(|v| v.as_str())
 }
 
 #[cfg(test)]

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -144,6 +144,7 @@ fn normalize_ai_costs(attributes: &mut Attributes, model_costs: Option<&ModelCos
         return;
     };
 
+    // Overwrite all values, the attributes should reflect the values we used to calculate the total.
     attributes.insert(GEN_AI_COST_INPUT_TOKENS, costs.input);
     attributes.insert(GEN_AI_COST_OUTPUT_TOKENS, costs.output);
     attributes.insert(GEN_AI_COST_TOTAL_TOKENS, costs.total());

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -1,6 +1,6 @@
 //! AI cost calculation.
 
-use crate::statsd::Counters;
+use crate::statsd::{Counters, map_origin_to_integration, platform_tag};
 use crate::{ModelCostV2, ModelCosts};
 use relay_event_schema::protocol::{
     Event, Measurements, OperationType, Span, SpanData, TraceContext,
@@ -177,11 +177,18 @@ pub fn infer_ai_operation_type(op_name: &str) -> Option<&'static str> {
 
 /// Calculates the cost of an AI model based on the model cost and the tokens used.
 /// Calculated cost is in US dollars.
-fn extract_ai_model_cost_data(model_cost: Option<&ModelCostV2>, data: &mut SpanData) {
+fn extract_ai_model_cost_data(
+    model_cost: Option<&ModelCostV2>,
+    data: &mut SpanData,
+    origin: Option<&str>,
+    platform: Option<&str>,
+) {
     let Some(model_cost) = model_cost else { return };
 
     let used_tokens = UsedTokens::from_span_data(&*data);
-    let Some(costs) = calculate_costs(model_cost, used_tokens, "unknown", "unknown") else {
+    let integration = map_origin_to_integration(origin);
+    let platform = platform_tag(platform);
+    let Some(costs) = calculate_costs(model_cost, used_tokens, integration, platform) else {
         return;
     };
 
@@ -239,7 +246,13 @@ fn set_total_tokens(data: &mut SpanData) {
 }
 
 /// Extract the additional data into the span
-fn extract_ai_data(data: &mut SpanData, duration: f64, ai_model_costs: &ModelCosts) {
+fn extract_ai_data(
+    data: &mut SpanData,
+    duration: f64,
+    ai_model_costs: &ModelCosts,
+    origin: Option<&str>,
+    platform: Option<&str>,
+) {
     // Extracts the response tokens per second
     if data.gen_ai_response_tokens_per_second.value().is_none()
         && duration > 0.0
@@ -263,7 +276,12 @@ fn extract_ai_data(data: &mut SpanData, duration: f64, ai_model_costs: &ModelCos
                 .and_then(|val| val.as_str())
         })
     {
-        extract_ai_model_cost_data(ai_model_costs.cost_per_token(model_id), data)
+        extract_ai_model_cost_data(
+            ai_model_costs.cost_per_token(model_id),
+            data,
+            origin,
+            platform,
+        )
     }
 }
 
@@ -274,6 +292,8 @@ fn enrich_ai_span_data(
     measurements: &Annotated<Measurements>,
     duration: f64,
     model_costs: Option<&ModelCosts>,
+    origin: Option<&str>,
+    platform: Option<&str>,
 ) {
     if !is_ai_span(span_data, span_op.value()) {
         return;
@@ -286,7 +306,7 @@ fn enrich_ai_span_data(
     set_total_tokens(data);
 
     if let Some(model_costs) = model_costs {
-        extract_ai_data(data, duration, model_costs);
+        extract_ai_data(data, duration, model_costs, origin, platform);
     }
 
     let ai_op_type = data
@@ -313,6 +333,8 @@ pub fn enrich_ai_span(span: &mut Span, model_costs: Option<&ModelCosts>) {
         &span.measurements,
         duration,
         model_costs,
+        span.origin.as_str(),
+        span.platform.as_str(),
     );
 }
 
@@ -335,6 +357,8 @@ pub fn enrich_ai_event_data(event: &mut Event, model_costs: Option<&ModelCosts>)
             &event.measurements,
             event_duration,
             model_costs,
+            trace_context.origin.as_str(),
+            event.platform.as_str(),
         );
     }
     let spans = event.spans.value_mut().iter_mut().flatten();
@@ -345,6 +369,7 @@ pub fn enrich_ai_event_data(event: &mut Event, model_costs: Option<&ModelCosts>)
             .get_value("span.duration")
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
+        let span_platform = span.platform.as_str().or_else(|| event.platform.as_str());
 
         enrich_ai_span_data(
             &mut span.data,
@@ -352,6 +377,8 @@ pub fn enrich_ai_event_data(event: &mut Event, model_costs: Option<&ModelCosts>)
             &span.measurements,
             span_duration,
             model_costs,
+            span.origin.as_str(),
+            span_platform,
         );
     }
 }

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -92,6 +92,12 @@ pub fn calculate_costs(
     platform: &str,
 ) -> Option<CalculatedCost> {
     if !tokens.has_usage() {
+        relay_statsd::metric!(
+            counter(Counters::GenAiCostCalculationResult) += 1,
+            result = "calculation_none",
+            integration = integration,
+            platform = platform,
+        );
         return None;
     }
 
@@ -110,9 +116,9 @@ pub fn calculate_costs(
         + (tokens.output_reasoning_tokens * reasoning_cost);
 
     let metric_label = match (input, output) {
-        (x, y) if x < 0.0 || y < 0.0 => "negative",
-        (0.0, 0.0) => "zero",
-        _ => "positive",
+        (x, y) if x < 0.0 || y < 0.0 => "calculation_negative",
+        (0.0, 0.0) => "calculation_zero",
+        _ => "calculation_positive",
     };
 
     relay_statsd::metric!(

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -109,10 +109,10 @@ pub fn calculate_costs(
     let output = (tokens.raw_output_tokens() * model_cost.output_per_token)
         + (tokens.output_reasoning_tokens * reasoning_cost);
 
-    let metric_label = match (input.signum(), output.signum()) {
-        (-1.0, _) | (_, -1.0) => "calculation_negative",
-        (0.0, 0.0) => "calculation_zero",
-        _ => "calculation_positive",
+    let metric_label = match (input, output) {
+        (x, y) if x < 0.0 || y < 0.0 => "negative",
+        (0.0, 0.0) => "zero",
+        _ => "positive",
     };
 
     relay_statsd::metric!(

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -2,6 +2,7 @@ use relay_statsd::{CounterMetric, TimerMetric};
 
 pub enum Counters {
     /// Records the status of the AI cost calculation.
+    ///
     /// The metric is tagged with:
     ///  - `result`: The outcome of the cost calculation. Possible values are:
     ///    `calculation_negative`,

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -7,7 +7,7 @@ pub enum Counters {
 impl CounterMetric for Counters {
     fn name(&self) -> &'static str {
         match *self {
-            Self::GenAiCostCalculationResult => "genai.cost_calculation.result",
+            Self::GenAiCostCalculationResult => "gen_ai.cost_calculation.result",
         }
     }
 }
@@ -25,5 +25,53 @@ impl TimerMetric for Timers {
         match *self {
             Self::SpanDescriptionNormalizeSQL => "normalize.span.description.sql",
         }
+    }
+}
+
+/// Maps a span origin to a well-known AI integration name for metrics.
+///
+/// Origins follow the pattern `auto.<integration>.<source>` or `auto.<category>.<protocol>.<source>`.
+/// This function extracts recognized AI integrations for cleaner metric tagging.
+pub fn map_origin_to_integration(origin: Option<&str>) -> &'static str {
+    match origin {
+        Some(o) if o.starts_with("auto.ai.openai_agents") => "openai_agents",
+        Some(o) if o.starts_with("auto.ai.openai") => "openai",
+        Some(o) if o.starts_with("auto.ai.anthropic") => "anthropic",
+        Some(o) if o.starts_with("auto.ai.cohere") => "cohere",
+        Some(o) if o.starts_with("auto.vercelai.") => "vercelai",
+        Some(o) if o.starts_with("auto.ai.langchain") => "langchain",
+        Some(o) if o.starts_with("auto.ai.langgraph") => "langgraph",
+        Some(o) if o.starts_with("auto.ai.google_genai") => "google_genai",
+        Some(o) if o.starts_with("auto.ai.pydantic_ai") => "pydantic_ai",
+        Some(o) if o.starts_with("auto.ai.huggingface_hub") => "huggingface_hub",
+        Some(o) if o.starts_with("auto.ai.litellm") => "litellm",
+        Some(o) if o.starts_with("auto.ai.mcp_server") => "mcp_server",
+        Some(o) if o.starts_with("auto.ai.mcp") => "mcp",
+        Some(o) if o.starts_with("auto.ai.claude_agent_sdk") => "claude_agent_sdk",
+        Some(o) if o.starts_with("auto.ai.") => "other",
+        Some(_) => "other",
+        None => "unknown",
+    }
+}
+
+pub fn platform_tag(platform: Option<&str>) -> &'static str {
+    match platform {
+        Some("cocoa") => "cocoa",
+        Some("csharp") => "csharp",
+        Some("edge") => "edge",
+        Some("go") => "go",
+        Some("java") => "java",
+        Some("javascript") => "javascript",
+        Some("julia") => "julia",
+        Some("native") => "native",
+        Some("node") => "node",
+        Some("objc") => "objc",
+        Some("perl") => "perl",
+        Some("php") => "php",
+        Some("python") => "python",
+        Some("ruby") => "ruby",
+        Some("swift") => "swift",
+        Some(_) => "other",
+        None => "unknown",
     }
 }

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -1,21 +1,21 @@
 use relay_statsd::{CounterMetric, TimerMetric};
 
 pub enum Counters {
+    /// Records the status of the AI cost calculation.
+    /// The metric is tagged with:
+    ///  - `result`: The outcome of the cost calculation. Possible values are:
+    ///    `calculation_negative`,
+    ///    `calculation_zero`,
+    ///    `calculation_positive`,
+    ///    `calculation_none`
+    ///  - `integration`: The integration used for the cost calculation.
+    ///  - `platform`: The platform used for the cost calculation.
     GenAiCostCalculationResult,
 }
 
 impl CounterMetric for Counters {
     fn name(&self) -> &'static str {
         match *self {
-            // Records the status of the AI cost calculation.
-            // The metric is tagged with:
-            //  - `result`: The outcome of the cost calculation. Possible values are:
-            //     `calculation_negative`,
-            //     `calculation_zero`,
-            //     `calculation_positive`,
-            //     `calculation_none`
-            //  - `integration`: The integration used for the cost calculation.
-            //  - `platform`: The platform used for the cost calculation.
             Self::GenAiCostCalculationResult => "gen_ai.cost_calculation.result",
         }
     }

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -1,4 +1,16 @@
-use relay_statsd::TimerMetric;
+use relay_statsd::{CounterMetric, TimerMetric};
+
+pub enum Counters {
+    GenAiCostCalculationResult,
+}
+
+impl CounterMetric for Counters {
+    fn name(&self) -> &'static str {
+        match *self {
+            Self::GenAiCostCalculationResult => "genai.cost_calculation.result",
+        }
+    }
+}
 
 pub enum Timers {
     /// Measures how log normalization of SQL queries in span description take.

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -7,15 +7,15 @@ pub enum Counters {
 impl CounterMetric for Counters {
     fn name(&self) -> &'static str {
         match *self {
-            /// Records the status of the AI cost calculation.
-            /// The metric is tagged with:
-            ///  - `result`: The outcome of the cost calculation. Possible values are:
-            ///     `calculation_negative`,
-            ///     `calculation_zero`,
-            ///     `calculation_positive`,
-            ///     `calculation_none`
-            ///  - `integration`: The integration used for the cost calculation.
-            ///  - `platform`: The platform used for the cost calculation.
+            // Records the status of the AI cost calculation.
+            // The metric is tagged with:
+            //  - `result`: The outcome of the cost calculation. Possible values are:
+            //     `calculation_negative`,
+            //     `calculation_zero`,
+            //     `calculation_positive`,
+            //     `calculation_none`
+            //  - `integration`: The integration used for the cost calculation.
+            //  - `platform`: The platform used for the cost calculation.
             Self::GenAiCostCalculationResult => "gen_ai.cost_calculation.result",
         }
     }

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -7,6 +7,15 @@ pub enum Counters {
 impl CounterMetric for Counters {
     fn name(&self) -> &'static str {
         match *self {
+            /// Records the status of the AI cost calculation.
+            /// The metric is tagged with:
+            ///  - `result`: The outcome of the cost calculation. Possible values are:
+            ///     `calculation_negative`,
+            ///     `calculation_zero`,
+            ///     `calculation_positive`,
+            ///     `calculation_none`
+            ///  - `integration`: The integration used for the cost calculation.
+            ///  - `platform`: The platform used for the cost calculation.
             Self::GenAiCostCalculationResult => "gen_ai.cost_calculation.result",
         }
     }


### PR DESCRIPTION
- Add a new metric in relay-event-normalization `genai.cost_calculation.result` to track positive, negative and zero costs using a metric
- Add finite tag matchers for the origin integration and platform, to prevent our cardinality from becoming too large
- In the cost calculation function `normalize_ai_costs`, emit that metric depending on the outcome

Closes TET-1675
