### PR TITLE
ci(gocd): Point s4s2 to sentry-st

### DIFF
--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -11,6 +11,24 @@ local soak_monitors = {
   default: '14146876',
 };
 
+local sentry_deploy_vars(region) = {
+  SENTRY_REGION: region,
+  SENTRY_SINGLE_TENANT: 'false',
+  SENTRY_BASE: 'https://sentry.io/api/0',
+  SENTRY_AUTH_TOKEN: if region == 's4s2' then '{{SECRET:[devinfra-sentryst][token]}}' else '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
+  // Sentry projects to check for errors <project_id>:<project_slug>:<service>
+  SENTRY_PROJECTS: if region == 's4s2' then '4510747659468800:relay:relay' else '4510703820210272:relay:relay',
+};
+
+local sentry_create_env_vars(region) = {
+  SENTRY_ORG: if region == 's4s2' then 'sentry-st' else 'sentry-s4s2',
+  SENTRY_PROJECT: 'relay',
+  SENTRY_URL: 'https://sentry.io',
+  // Temporary; self-service encrypted secrets aren't implemented yet.
+  // This should really be rotated to an internal integration token.
+  SENTRY_AUTH_TOKEN: if region == 's4s2' then '{{SECRET:[devinfra-sentryst][token]}}' else '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
+};
+
 // The purpose of this stage is to let the deployment soak for a while and
 // detect any issues that might have been introduced.
 local soak_time(region) =
@@ -21,23 +39,17 @@ local soak_time(region) =
           jobs: {
             soak: {
               environment_variables: {
-                SENTRY_REGION: region,
                 GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the soak time
                 DATADOG_MONITOR_IDS: if std.objectHas(soak_monitors, region) then soak_monitors[region] else soak_monitors.default,
-                // Sentry projects to check for errors <project_id>:<project_slug>:<service>
-                SENTRY_PROJECTS: '4510703820210272:relay:relay',
-                SENTRY_SINGLE_TENANT: 'false',
-                SENTRY_BASE: 'https://sentry.io/api/0',
                 // TODO: Set a proper error limit
                 ERROR_LIMIT: 500,
                 PAUSE_MESSAGE: 'Detecting issues in the deployment. Pausing pipeline.',
                 // TODO: Switch dry run to false once we're confident in the soak time
                 DRY_RUN: 'true',
-              },
+              } + sentry_deploy_vars(region),
               elastic_profile_id: 'relay',
               tasks: [
                 gocdtasks.script(importstr '../bash/wait-soak.sh'),
@@ -64,14 +76,7 @@ local deploy_canary(region) =
           fetch_materials: true,
           jobs: {
             create_sentry_release: {
-              environment_variables: {
-                SENTRY_ORG: 'sentry-s4s2',
-                SENTRY_PROJECT: 'relay',
-                SENTRY_URL: 'https://sentry-s4s2.sentry.io/',
-                // Temporary; self-service encrypted secrets aren't implemented yet.
-                // This should really be rotated to an internal integration token.
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
-              },
+              environment_variables: sentry_create_env_vars(region),
               timeout: 1200,
               elastic_profile_id: 'relay',
               tasks: [
@@ -82,23 +87,17 @@ local deploy_canary(region) =
               timeout: 1200,
               elastic_profile_id: 'relay',
               environment_variables: {
-                SENTRY_REGION: region,
                 GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 // Datadog monitor IDs for the canary deployment
                 DATADOG_MONITOR_IDS: '14146876 154096671 237862997',
-                // Sentry projects to check for errors <project_id>:<project_slug>:<service>
-                SENTRY_PROJECTS: '4510703820210272:relay:relay',
-                SENTRY_SINGLE_TENANT: 'false',
-                SENTRY_BASE: 'https://sentry.io/api/0',
                 // TODO: Set a proper error limit
                 ERROR_LIMIT: 500,
                 PAUSE_MESSAGE: 'Pausing pipeline due to canary failure.',
                 // TODO: Switch dry run to false once we're confident in the canary
                 DRY_RUN: 'true',
-              },
+              } + sentry_deploy_vars(region),
               tasks: [
                 gocdtasks.script(importstr '../bash/deploy-processing-canary.sh'),
                 gocdtasks.script(importstr '../bash/wait-canary.sh'),
@@ -122,14 +121,7 @@ local deploy_primary(region) = [
       fetch_materials: true,
       jobs: {
         create_sentry_release: {
-          environment_variables: {
-            SENTRY_ORG: 'sentry-s4s2',
-            SENTRY_PROJECT: 'relay',
-            SENTRY_URL: 'https://sentry-s4s2.sentry.io/',
-            // Temporary; self-service encrypted secrets aren't implemented yet.
-            // This should really be rotated to an internal integration token.
-            SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
-          },
+          environment_variables: sentry_create_env_vars(region),
           timeout: 1200,
           elastic_profile_id: 'relay',
           tasks: [


### PR DESCRIPTION
Creates environments and uploads debug files to sentry-st for s4s2.

This does not modify the pops pipeline, as s4s2 is excluded from that pipeline.