### PR TITLE
feat(trimming): Allow overriding size in bytes

### DIFF
--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -482,8 +482,6 @@ impl FieldAttrs {
 
         let bytes_size = if let Some(ref bytes_size) = self.bytes_size {
             bytes_size.as_tokens()
-        } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
-            quote!(#parent_attrs.bytes_size)
         } else {
             quote!(::relay_event_schema::processor::SizeMode::Static(None))
         };

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -387,6 +387,7 @@ struct FieldAttrs {
     max_chars_allowance: Option<TokenStream>,
     max_depth: Option<TokenStream>,
     max_bytes: Option<Size>,
+    bytes_size: Option<Size>,
     trim: Option<bool>,
 }
 
@@ -479,6 +480,14 @@ impl FieldAttrs {
             quote!(::relay_event_schema::processor::SizeMode::Static(None))
         };
 
+        let bytes_size = if let Some(ref bytes_size) = self.bytes_size {
+            bytes_size.as_tokens()
+        } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
+            quote!(#parent_attrs.bytes_size)
+        } else {
+            quote!(::relay_event_schema::processor::SizeMode::Static(None))
+        };
+
         let characters = if let Some(ref characters) = self.characters {
             quote!(Some(#characters))
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
@@ -498,6 +507,7 @@ impl FieldAttrs {
                 characters: #characters,
                 max_depth: #max_depth,
                 max_bytes: #max_bytes,
+                bytes_size: #bytes_size,
                 pii: #pii,
                 retain: #retain,
                 trim: #trim,
@@ -568,6 +578,8 @@ fn parse_field_attributes(
                 rv.max_depth = Some(quote!(#s));
             } else if ident == "max_bytes" {
                 rv.max_bytes = Some(meta.value()?.parse()?);
+            } else if ident == "bytes_size" {
+                rv.bytes_size = Some(meta.value()?.parse()?);
             } else if ident == "pii" {
                 rv.pii = Some(meta.value()?.parse()?);
             } else if ident == "retain" {

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -28,10 +28,6 @@ struct SizeState {
 pub struct TrimmingProcessor {
     max_item_size: Option<usize>,
     size_state: Vec<SizeState>,
-    /// Whether we are currently trimming a collection of attributes.
-    /// This case needs to be distinguished for the purpose of accounting
-    /// for bool/number lengths, which we only want to count in attributes.
-    in_attributes: bool,
 }
 
 impl TrimmingProcessor {
@@ -52,7 +48,6 @@ impl TrimmingProcessor {
         Self {
             max_item_size,
             size_state,
-            in_attributes: false,
         }
     }
 
@@ -85,7 +80,8 @@ impl TrimmingProcessor {
             .min()
     }
 
-    fn consume_size(&mut self, size: usize) {
+    fn consume_size(&mut self, state: Option<&ProcessingState>, default: usize) {
+        let size = state.and_then(|s| s.bytes_size()).unwrap_or(default);
         for remaining in self
             .size_state
             .iter_mut()
@@ -145,11 +141,9 @@ impl Processor for TrimmingProcessor {
         &mut self,
         _value: &mut u64,
         _meta: &mut Meta,
-        _state: &ProcessingState<'_>,
+        state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        if self.in_attributes {
-            self.consume_size(8);
-        }
+        self.consume_size(Some(state), 8);
         Ok(())
     }
 
@@ -157,11 +151,9 @@ impl Processor for TrimmingProcessor {
         &mut self,
         _value: &mut i64,
         _meta: &mut Meta,
-        _state: &ProcessingState<'_>,
+        state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        if self.in_attributes {
-            self.consume_size(8);
-        }
+        self.consume_size(Some(state), 8);
         Ok(())
     }
 
@@ -169,11 +161,9 @@ impl Processor for TrimmingProcessor {
         &mut self,
         _value: &mut f64,
         _meta: &mut Meta,
-        _state: &ProcessingState<'_>,
+        state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        if self.in_attributes {
-            self.consume_size(8);
-        }
+        self.consume_size(Some(state), 8);
         Ok(())
     }
 
@@ -181,11 +171,9 @@ impl Processor for TrimmingProcessor {
         &mut self,
         _value: &mut bool,
         _meta: &mut Meta,
-        _state: &ProcessingState<'_>,
+        state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        if self.in_attributes {
-            self.consume_size(1);
-        }
+        self.consume_size(Some(state), 1);
         Ok(())
     }
 
@@ -200,7 +188,7 @@ impl Processor for TrimmingProcessor {
         }
 
         if !state.attrs().trim {
-            self.consume_size(value.len());
+            self.consume_size(Some(state), value.len());
             return Ok(());
         }
 
@@ -208,7 +196,7 @@ impl Processor for TrimmingProcessor {
             crate::trimming::trim_string(value, meta, size_remaining, 0);
         }
 
-        self.consume_size(value.len());
+        self.consume_size(Some(state), value.len());
 
         Ok(())
     }
@@ -315,9 +303,6 @@ impl Processor for TrimmingProcessor {
             return Ok(());
         }
 
-        // Mark `self.in_attributes` so we don't double-count string sizes
-        self.in_attributes = true;
-
         let original_length = size::attributes_size(attributes);
 
         // Sort attributes by key + value size so small attributes are more likely to be preserved
@@ -334,12 +319,10 @@ impl Processor for TrimmingProcessor {
                 break;
             }
 
-            self.consume_size(key.len());
+            self.consume_size(None, key.len());
 
             let value_state = state.enter_borrowed(key, None, ValueType::for_field(value));
-            processor::process_value(value, self, &value_state).inspect_err(|_| {
-                self.in_attributes = false;
-            })?;
+            processor::process_value(value, self, &value_state)?;
         }
 
         if let Some(split_idx) = split_idx {
@@ -352,8 +335,6 @@ impl Processor for TrimmingProcessor {
         if new_size != original_length {
             meta.set_original_length(Some(original_length));
         }
-
-        self.in_attributes = false;
 
         Ok(())
     }
@@ -371,7 +352,11 @@ mod tests {
         #[metastructure(max_chars = 10, trim = true)]
         body: Annotated<String>,
         // This should neither be trimmed nor factor into size calculations.
+        #[metastructure(trim = false, bytes_size = 0)]
         number: Annotated<u64>,
+        // This should count as 10B.
+        #[metastructure(trim = false, bytes_size = 10)]
+        other_number: Annotated<u64>,
         #[metastructure(max_bytes = 40, trim = true)]
         attributes: Annotated<Attributes>,
         #[metastructure(trim = true)]
@@ -388,7 +373,8 @@ mod tests {
 
         let mut value = Annotated::new(TestObject {
             attributes: Annotated::new(attributes),
-            number: Annotated::new(0),
+            number: Annotated::empty(),
+            other_number: Annotated::empty(),
             body: Annotated::new("This is longer than allowed".to_owned()),
             footer: Annotated::empty(),
         });
@@ -401,7 +387,6 @@ mod tests {
         insta::assert_json_snapshot!(SerializableAnnotated(&value), @r###"
         {
           "body": "This is...",
-          "number": 0,
           "attributes": {
             "medium string": {
               "type": "string",
@@ -462,7 +447,8 @@ mod tests {
 
         let mut value = Annotated::new(TestObject {
             attributes: Annotated::new(attributes),
-            number: Annotated::new(0),
+            number: Annotated::empty(),
+            other_number: Annotated::empty(),
             body: Annotated::new("This is longer than allowed".to_owned()),
             footer: Annotated::empty(),
         });
@@ -475,7 +461,6 @@ mod tests {
         insta::assert_json_snapshot!(SerializableAnnotated(&value), @r###"
         {
           "body": "This is...",
-          "number": 0,
           "attributes": {
             "medium attribute": {
               "type": "string",
@@ -537,7 +522,8 @@ mod tests {
 
         let mut value = Annotated::new(TestObject {
             attributes: Annotated::new(attributes),
-            number: Annotated::new(0),
+            number: Annotated::empty(),
+            other_number: Annotated::empty(),
             body: Annotated::new("This is longer than allowed".to_owned()),
             footer: Annotated::empty(),
         });
@@ -550,7 +536,6 @@ mod tests {
         insta::assert_json_snapshot!(SerializableAnnotated(&value), @r###"
         {
           "body": "This is...",
-          "number": 0,
           "attributes": {
             "attribute with long name": {
               "type": "integer",
@@ -596,15 +581,16 @@ mod tests {
         let mut value = Annotated::new(TestObject {
             attributes: Annotated::new(attributes),
             number: Annotated::new(0),
+            other_number: Annotated::new(0),
             body: Annotated::new("Short".to_owned()),
             footer: Annotated::new("Hello World".to_owned()),
         });
 
-        // The `body` takes up 5B, the `"small"` attribute 13B, and the key "medium string" another 13B.
+        // The `body` takes up 5B, `other_number` 10B, the `"small"` attribute 13B, and the key "medium string" another 13B.
         // That leaves 9B for the string's value.
         // Note that the `number` field doesn't take up any size.
         // The `"footer"` is removed because it comes after the attributes and there's no space left.
-        let mut processor = TrimmingProcessor::new(Some(40));
+        let mut processor = TrimmingProcessor::new(Some(50));
 
         let state = ProcessingState::new_root(Default::default(), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
@@ -613,6 +599,7 @@ mod tests {
         {
           "body": "Short",
           "number": 0,
+          "other_number": 0,
           "attributes": {
             "medium string": {
               "type": "string",
@@ -670,7 +657,8 @@ mod tests {
 
         let mut value = Annotated::new(TestObject {
             attributes: Annotated::new(attributes),
-            number: Annotated::new(0),
+            number: Annotated::empty(),
+            other_number: Annotated::empty(),
             body: Annotated::new("Short".to_owned()),
             footer: Annotated::empty(),
         });
@@ -684,7 +672,6 @@ mod tests {
         insta::assert_json_snapshot!(SerializableAnnotated(&value), @r###"
         {
           "body": "Short",
-          "number": 0,
           "attributes": {
             "array": {
               "type": "array",
@@ -735,6 +722,7 @@ mod tests {
         let mut value = Annotated::new(TestObject {
             body: Annotated::new("Hi".to_owned()), // 2B
             number: Annotated::new(0),
+            other_number: Annotated::empty(),
             attributes: Annotated::new(attributes),
             footer: Annotated::new("Hello World".to_owned()), // 11B
         });

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -1267,13 +1267,17 @@ mod tests {
             #[metastructure(max_chars = 10, trim = true)]
             body: Annotated<String>,
             // This should neither be trimmed nor factor into size calculations.
-            #[metastructure(trim = false, bytes_size = 0)]
+            #[metastructure(trim = false, bytes_size = "always_zero")]
             number: Annotated<u64>,
             // This should count as 10B.
             #[metastructure(trim = false, bytes_size = 10)]
             other_number: Annotated<u64>,
             #[metastructure(trim = true)]
             footer: Annotated<String>,
+        }
+
+        fn always_zero(_state: &ProcessingState) -> Option<usize> {
+            Some(0)
         }
 
         let mut object = Annotated::new(TestObject {

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -151,7 +151,7 @@ pub struct FieldAttrs {
     ///
     /// There are two axes to this:
     /// * `Static`/`Dynamic` denotes whether the value is fixed or computed based
-    /// on the `ProcessingState`;
+    ///   on the `ProcessingState`;
     /// * `None` means a processor should use its default method to compute/estimate the size,
     ///   `Some(size)` means the item should count as `size` bytes.
     pub bytes_size: SizeMode,

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -147,6 +147,14 @@ pub struct FieldAttrs {
     pub max_depth: Option<usize>,
     /// The maximum number of bytes of this field.
     pub max_bytes: SizeMode,
+    /// How this item's size is computed.
+    ///
+    /// There are two axes to this:
+    /// * `Static`/`Dynamic` denotes whether the value is fixed or computed based
+    /// on the `ProcessingState`;
+    /// * `None` means a processor should use its default method to compute/estimate the size,
+    ///   `Some(size)` means the item should count as `size` bytes.
+    pub bytes_size: SizeMode,
     /// The type of PII on the field.
     pub pii: PiiMode,
     /// Whether additional properties should be retained during normalization.
@@ -193,6 +201,7 @@ impl FieldAttrs {
             pii: PiiMode::Static(Pii::False),
             retain: false,
             trim: true,
+            bytes_size: SizeMode::Static(None),
         }
     }
 
@@ -489,6 +498,18 @@ impl<'a> ProcessingState<'a> {
         match self.attrs().max_bytes {
             SizeMode::Static(n) => n,
             SizeMode::Dynamic(max_bytes_fn) => max_bytes_fn(self),
+        }
+    }
+
+    /// Returns the bytes size for this state.
+    ///
+    /// If the state's `FieldAttrs` contain a fixed `bytes_size` value,
+    /// it is returned. If they contain a dynamic `bytes_size` value (a function),
+    /// it is applied to this state and the output returned.
+    pub fn bytes_size(&self) -> Option<usize> {
+        match self.attrs().bytes_size {
+            SizeMode::Static(n) => n,
+            SizeMode::Dynamic(bytes_size_fn) => bytes_size_fn(self),
         }
     }
 


### PR DESCRIPTION
This adds a key `"bytes_size"` to `metastructure` that let you override the size in bytes of an item for trimming purposes. The override can either be a constant value or a function that takes a `ProcessingState`. In particular, this can be used to exclude an item from size calculations by overriding its size to 0. This lets us get rid of the `in_attributes` kludge in the EAP trimming processor.

If the attribute is not supplied, each processor has to decide how to measure size, which is the current behavior.

Fixes #5538. Fixes RELAY-194.