### PR TITLE
ref(trimming): Remove limit from EAP processor

### DIFF
--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -26,7 +26,6 @@ struct SizeState {
 /// This means that large attributes will be trimmed or discarded before small ones.
 #[derive(Default)]
 pub struct TrimmingProcessor {
-    max_item_size: Option<usize>,
     size_state: Vec<SizeState>,
     /// Whether we are currently trimming a collection of attributes.
     /// This case needs to be distinguished for the purpose of accounting
@@ -36,22 +35,9 @@ pub struct TrimmingProcessor {
 
 impl TrimmingProcessor {
     /// Creates a new trimming processor.
-    ///
-    /// The `max_item_size` parameter is a global byte size
-    /// limit for the item being processed.
-    pub fn new(max_item_size: Option<usize>) -> Self {
-        let mut size_state = Vec::new();
-        if max_item_size.is_some() {
-            size_state.push(SizeState {
-                size_remaining: max_item_size,
-                encountered_at_depth: 0,
-                max_depth: None,
-            });
-        }
-
+    pub fn new() -> Self {
         Self {
-            max_item_size,
-            size_state,
+            size_state: Default::default(),
             in_attributes: false,
         }
     }
@@ -361,7 +347,12 @@ impl Processor for TrimmingProcessor {
 
 #[cfg(test)]
 mod tests {
-    use relay_event_schema::protocol::{AttributeType, AttributeValue};
+    use std::borrow::Cow;
+
+    use relay_event_schema::{
+        processor::FieldAttrs,
+        protocol::{AttributeType, AttributeValue},
+    };
     use relay_protocol::{Annotated, FromValue, IntoValue, SerializableAnnotated, Value};
 
     use super::*;
@@ -393,7 +384,7 @@ mod tests {
             footer: Annotated::empty(),
         });
 
-        let mut processor = TrimmingProcessor::new(None);
+        let mut processor = TrimmingProcessor::new();
 
         let state = ProcessingState::new_root(Default::default(), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
@@ -467,7 +458,7 @@ mod tests {
             footer: Annotated::empty(),
         });
 
-        let mut processor = TrimmingProcessor::new(None);
+        let mut processor = TrimmingProcessor::new();
 
         let state = ProcessingState::new_root(Default::default(), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
@@ -542,7 +533,7 @@ mod tests {
             footer: Annotated::empty(),
         });
 
-        let mut processor = TrimmingProcessor::new(None);
+        let mut processor = TrimmingProcessor::new();
 
         let state = ProcessingState::new_root(Default::default(), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
@@ -600,13 +591,14 @@ mod tests {
             footer: Annotated::new("Hello World".to_owned()),
         });
 
+        let mut processor = TrimmingProcessor::new();
+
         // The `body` takes up 5B, the `"small"` attribute 13B, and the key "medium string" another 13B.
         // That leaves 9B for the string's value.
         // Note that the `number` field doesn't take up any size.
         // The `"footer"` is removed because it comes after the attributes and there's no space left.
-        let mut processor = TrimmingProcessor::new(Some(40));
-
-        let state = ProcessingState::new_root(Default::default(), []);
+        let state =
+            ProcessingState::new_root(Some(Cow::Owned(FieldAttrs::default().max_bytes(40))), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
 
         insta::assert_json_snapshot!(SerializableAnnotated(&value), @r###"
@@ -675,7 +667,7 @@ mod tests {
             footer: Annotated::empty(),
         });
 
-        let mut processor = TrimmingProcessor::new(None);
+        let mut processor = TrimmingProcessor::new();
         let state = ProcessingState::new_root(Default::default(), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
 
@@ -739,8 +731,9 @@ mod tests {
             footer: Annotated::new("Hello World".to_owned()), // 11B
         });
 
-        let mut processor = TrimmingProcessor::new(Some(30));
-        let state = ProcessingState::new_root(Default::default(), []);
+        let mut processor = TrimmingProcessor::new();
+        let state =
+            ProcessingState::new_root(Some(Cow::Owned(FieldAttrs::default().max_bytes(30))), []);
         processor::process_value(&mut value, &mut processor, &state).unwrap();
 
         insta::assert_json_snapshot!(SerializableAnnotated(&value), @r###"

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -244,6 +244,21 @@ impl FieldAttrs {
         self
     }
 
+    /// Sets the maximum number of bytes allowed in the field.
+    pub const fn max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = SizeMode::Static(Some(max_bytes));
+        self
+    }
+
+    /// Sets the maximum number of bytes allowed in the field dynamically based on the current state.
+    pub const fn max_bytes_dynamic(
+        mut self,
+        max_bytes: fn(&ProcessingState) -> Option<usize>,
+    ) -> Self {
+        self.max_bytes = SizeMode::Dynamic(max_bytes);
+        self
+    }
+
     /// Sets whether additional properties should be retained during normalization.
     pub const fn retain(mut self, retain: bool) -> Self {
         self.retain = retain;


### PR DESCRIPTION
This parameter field is unnecessary—you can just pass in a root state with a size limit, cf. the test changes. That didn't occur to me when I made the processor.