### PR TITLE
feat(spans): Add cache span support with op inference

### DIFF
--- a/relay-spans/src/v2_to_v1.rs
+++ b/relay-spans/src/v2_to_v1.rs
@@ -268,6 +268,14 @@ pub fn derive_op_for_v2_span(attributes: &Annotated<Attributes>) -> String {
         return faas_trigger.to_owned();
     }
 
+    if attributes.contains_key("cache.key") {
+        if attributes.contains_key("cache.hit") {
+            return String::from("cache.get");
+        } else {
+            return String::from("cache.put");
+        }
+    }
+
     op
 }
 


### PR DESCRIPTION
Infers cache.get and cache.put operations based on presence of cache.key and cache.hit attributes. Writes cache.key array values to description for backwards compatibility, ensuring existing descriptions are not overwritten.