### PR TITLE
ref(ai): Always overwrite ai attributes

### DIFF
--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -179,7 +179,9 @@ fn normalize_span(
         if matches!(span.is_segment.value(), Some(true)) {
             eap::normalize_dsc(&mut span.attributes, dsc);
         }
-        eap::normalize_ai(&mut span.attributes, duration, model_costs);
+        if ctx.is_processing() {
+            eap::normalize_ai(&mut span.attributes, duration, model_costs);
+        }
         eap::normalize_attribute_values(&mut span.attributes, allowed_hosts);
         eap::write_legacy_attributes(&mut span.attributes);
     };


### PR DESCRIPTION
Always overwrite AI attributes in the spanv2 pipeline instead of keeping existing attributes to make sure all data is in a consistent state, a state Sentry expects.