### PR TITLE
feat(eap): Track removed keys in EAP trimming processor

### DIFF
--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -781,7 +781,8 @@ mod tests {
               "value": [
                 "first string",
                 "second string",
-                "another..."
+                "another...",
+                null
               ]
             }
           },
@@ -792,9 +793,6 @@ mod tests {
               },
               "array": {
                 "value": {
-                  "": {
-                    "len": 4
-                  },
                   "2": {
                     "": {
                       "rem": [
@@ -806,6 +804,16 @@ mod tests {
                         ]
                       ],
                       "len": 14
+                    }
+                  },
+                  "3": {
+                    "": {
+                      "rem": [
+                        [
+                          "trimmed",
+                          "x"
+                        ]
+                      ]
                     }
                   }
                 }

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -99,11 +99,11 @@ impl TrimmingProcessor {
         }
     }
 
-    /// Returns a `DeleteAction` for removing the given key.
+    /// Returns a [`DeleteAction`] for removing the given key.
     ///
     /// If there is enough `removed_key_byte_budget` left to accomodate the key,
-    /// this will be `DeleteAction::WithRemark` (which causes a remark to be left).
-    /// Otherwise, it will be `DeleteAction::Hard` (the key is removed without a trace).
+    /// this will be [`DeleteAction::WithRemark`] (which causes a remark to be left).
+    /// Otherwise, it will be [`DeleteAction::Hard`] (the key is removed without a trace).
     fn delete_value(&mut self, key: Option<&str>) -> DeleteAction {
         let len = key.map_or(0, |key| key.len());
         if len <= self.removed_key_byte_budget {

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -263,7 +263,9 @@ impl Processor for TrimmingProcessor {
                 for item in &mut value[split_index..] {
                     match self.delete_value(None) {
                         DeleteAction::Hard => break,
-                        DeleteAction::WithRemark(rule_id) => item.delete_with_remark(rule_id),
+                        DeleteAction::WithRemark(rule_id) => {
+                            processor::delete_with_remark(item, rule_id)
+                        }
                     }
 
                     i += 1;
@@ -326,7 +328,9 @@ impl Processor for TrimmingProcessor {
 
                     match self.delete_value(Some(key.as_ref())) {
                         DeleteAction::Hard => break,
-                        DeleteAction::WithRemark(rule_id) => value.delete_with_remark(rule_id),
+                        DeleteAction::WithRemark(rule_id) => {
+                            processor::delete_with_remark(value, rule_id)
+                        }
                     }
                 }
 
@@ -382,7 +386,9 @@ impl Processor for TrimmingProcessor {
             for (key, value) in &mut sorted[split_idx..] {
                 match self.delete_value(Some(key.as_ref())) {
                     DeleteAction::Hard => break,
-                    DeleteAction::WithRemark(rule_id) => value.delete_with_remark(rule_id),
+                    DeleteAction::WithRemark(rule_id) => {
+                        processor::delete_with_remark(value, rule_id)
+                    }
                 }
 
                 i += 1;

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -240,7 +240,21 @@ impl Processor for TrimmingProcessor {
             }
 
             if let Some(split_index) = split_index {
-                let _ = value.split_off(split_index);
+                let mut i = split_index;
+
+                for item in &mut value[split_index..] {
+                    match self.delete_value(None) {
+                        ProcessingAction::DeleteValueHard => break,
+                        ProcessingAction::DeleteValueWithRemark(rule_id) => {
+                            item.delete_with_remark(rule_id)
+                        }
+                        _ => unreachable!(),
+                    }
+
+                    i += 1;
+                }
+
+                let _ = value.split_off(i);
             }
 
             if value.len() != original_length {

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -90,7 +90,7 @@ impl TrimmingProcessor {
         let len = key.map_or(0, |key| key.len());
         if len <= self.removed_key_byte_budget {
             self.removed_key_byte_budget -= len;
-            ProcessingAction::DeleteValueWithRemark
+            ProcessingAction::DeleteValueWithRemark("trimmed")
         } else {
             ProcessingAction::DeleteValueHard
         }
@@ -295,7 +295,9 @@ impl Processor for TrimmingProcessor {
                 {
                     match self.delete_value(Some(key.as_ref())) {
                         ProcessingAction::DeleteValueHard => break,
-                        ProcessingAction::DeleteValueWithRemark => value.delete_with_remark(),
+                        ProcessingAction::DeleteValueWithRemark(rule_id) => {
+                            value.delete_with_remark(rule_id)
+                        }
                         _ => unreachable!(),
                     }
 
@@ -354,7 +356,9 @@ impl Processor for TrimmingProcessor {
             for (key, value) in &mut sorted[split_idx..] {
                 match self.delete_value(Some(key.as_ref())) {
                     ProcessingAction::DeleteValueHard => break,
-                    ProcessingAction::DeleteValueWithRemark => value.delete_with_remark(),
+                    ProcessingAction::DeleteValueWithRemark(rule_id) => {
+                        value.delete_with_remark(rule_id)
+                    }
                     _ => unreachable!(),
                 }
 

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -293,6 +293,8 @@ impl Processor for TrimmingProcessor {
                 for (key, value) in value
                     .range_mut::<str, _>((Bound::Included(split_key.as_str()), Bound::Unbounded))
                 {
+                    i = key.as_str();
+
                     match self.delete_value(Some(key.as_ref())) {
                         ProcessingAction::DeleteValueHard => break,
                         ProcessingAction::DeleteValueWithRemark(rule_id) => {
@@ -300,8 +302,6 @@ impl Processor for TrimmingProcessor {
                         }
                         _ => unreachable!(),
                     }
-
-                    i = key.as_str();
                 }
 
                 let split_key = i.to_owned();

--- a/relay-event-schema/src/processor/funcs.rs
+++ b/relay-event-schema/src/processor/funcs.rs
@@ -19,10 +19,10 @@ where
 
     match result {
         Ok(()) => (),
-        Err(ProcessingAction::DeleteValueHard) => v.0 = None,
-        Err(ProcessingAction::DeleteValueSoft) => {
-            v.1.set_original_value(v.0.take());
-        }
+        Err(ProcessingAction::DeleteValueHard) => v.delete_hard(),
+        Err(ProcessingAction::DeleteValueFirm) => v.delete_firm(),
+        Err(ProcessingAction::DeleteValueSoft) => v.delete_soft(),
+
         x @ Err(ProcessingAction::InvalidTransaction(_)) => return x,
     }
 

--- a/relay-event-schema/src/processor/funcs.rs
+++ b/relay-event-schema/src/processor/funcs.rs
@@ -20,7 +20,7 @@ where
     match result {
         Ok(()) => (),
         Err(ProcessingAction::DeleteValueHard) => v.delete_hard(),
-        Err(ProcessingAction::DeleteValueFirm) => v.delete_firm(),
+        Err(ProcessingAction::DeleteValueWithRemark) => v.delete_with_remark(),
         Err(ProcessingAction::DeleteValueSoft) => v.delete_soft(),
 
         x @ Err(ProcessingAction::InvalidTransaction(_)) => return x,

--- a/relay-event-schema/src/processor/funcs.rs
+++ b/relay-event-schema/src/processor/funcs.rs
@@ -20,7 +20,7 @@ where
     match result {
         Ok(()) => (),
         Err(ProcessingAction::DeleteValueHard) => v.delete_hard(),
-        Err(ProcessingAction::DeleteValueWithRemark) => v.delete_with_remark(),
+        Err(ProcessingAction::DeleteValueWithRemark(rule_id)) => v.delete_with_remark(rule_id),
         Err(ProcessingAction::DeleteValueSoft) => v.delete_soft(),
 
         x @ Err(ProcessingAction::InvalidTransaction(_)) => return x,

--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -15,6 +15,10 @@ pub enum ProcessingAction {
     #[error("value should be hard-deleted (unreachable, should not surface as error!)")]
     DeleteValueHard,
 
+    /// Discards the value entirely, but leaves a remark.
+    #[error("value should be hard-deleted (unreachable, should not surface as error!)")]
+    DeleteValueFirm,
+
     /// Discards the value and moves it into meta's `original_value`.
     #[error("value should be hard-deleted (unreachable, should not surface as error!)")]
     DeleteValueSoft,

--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -16,8 +16,10 @@ pub enum ProcessingAction {
     DeleteValueHard,
 
     /// Discards the value entirely, but leaves a remark.
+    ///
+    /// The contained string is used as the "rule id" in the remark.
     #[error("value should be hard-deleted (unreachable, should not surface as error!)")]
-    DeleteValueWithRemark,
+    DeleteValueWithRemark(&'static str),
 
     /// Discards the value and moves it into meta's `original_value`.
     #[error("value should be hard-deleted (unreachable, should not surface as error!)")]

--- a/relay-event-schema/src/processor/traits.rs
+++ b/relay-event-schema/src/processor/traits.rs
@@ -17,7 +17,7 @@ pub enum ProcessingAction {
 
     /// Discards the value entirely, but leaves a remark.
     #[error("value should be hard-deleted (unreachable, should not surface as error!)")]
-    DeleteValueFirm,
+    DeleteValueWithRemark,
 
     /// Discards the value and moves it into meta's `original_value`.
     #[error("value should be hard-deleted (unreachable, should not surface as error!)")]

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -202,7 +202,7 @@ impl Processor for PiiProcessor<'_> {
                 Ok(()) => value.push_str(&basename),
                 Err(
                     ProcessingAction::DeleteValueHard
-                    | ProcessingAction::DeleteValueWithRemark
+                    | ProcessingAction::DeleteValueWithRemark(_)
                     | ProcessingAction::DeleteValueSoft,
                 ) => {
                     basename[1..].clone_into(value);

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -202,7 +202,7 @@ impl Processor for PiiProcessor<'_> {
                 Ok(()) => value.push_str(&basename),
                 Err(
                     ProcessingAction::DeleteValueHard
-                    | ProcessingAction::DeleteValueFirm
+                    | ProcessingAction::DeleteValueWithRemark
                     | ProcessingAction::DeleteValueSoft,
                 ) => {
                     basename[1..].clone_into(value);

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -200,7 +200,11 @@ impl Processor for PiiProcessor<'_> {
             let basename = value.split_off(index);
             match self.process_string(value, meta, state) {
                 Ok(()) => value.push_str(&basename),
-                Err(ProcessingAction::DeleteValueHard) | Err(ProcessingAction::DeleteValueSoft) => {
+                Err(
+                    ProcessingAction::DeleteValueHard
+                    | ProcessingAction::DeleteValueFirm
+                    | ProcessingAction::DeleteValueSoft,
+                ) => {
                     basename[1..].clone_into(value);
                 }
                 Err(ProcessingAction::InvalidTransaction(x)) => {

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::meta::{Error, Meta};
 use crate::traits::{Empty, FromValue, IntoValue, SkipSerialization};
 use crate::value::{Map, Value};
-use crate::{Remark, RemarkType};
 
 /// Represents a tree of meta objects.
 #[derive(Default, Debug, Serialize)]
@@ -236,31 +235,6 @@ impl<T> Annotated<T> {
         }
 
         other()
-    }
-
-    /// Deletes this `Annotated`'s value.
-    pub fn delete_hard(&mut self) {
-        self.0 = None;
-    }
-
-    /// Deletes this `Annotated`'s value and adds a remark to the metadata.
-    ///
-    /// The passed `rule_id` is used in the remark.
-    pub fn delete_with_remark(&mut self, rule_id: &str) {
-        self.0 = None;
-        self.1.add_remark(Remark {
-            ty: RemarkType::Removed,
-            rule_id: rule_id.to_owned(),
-            range: None,
-        });
-    }
-}
-
-impl<T: IntoValue> Annotated<T> {
-    /// Deletes this `Annotated`'s value, but retains it as the original
-    /// value in the metadata.
-    pub fn delete_soft(&mut self) {
-        self.1.set_original_value(self.0.take());
     }
 }
 

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -238,10 +238,14 @@ impl<T> Annotated<T> {
         other()
     }
 
+    /// Deletes this `Annotated`'s value.
     pub fn delete_hard(&mut self) {
         self.0 = None;
     }
 
+    /// Deletes this `Annotated`'s value and adds a remark to the metadata.
+    ///
+    /// The passed `rule_id` is used in the remark.
     pub fn delete_with_remark(&mut self, rule_id: &str) {
         self.0 = None;
         self.1.add_remark(Remark {
@@ -253,6 +257,8 @@ impl<T> Annotated<T> {
 }
 
 impl<T: IntoValue> Annotated<T> {
+    /// Deletes this `Annotated`'s value, but retains it as the original
+    /// value in the metadata.
     pub fn delete_soft(&mut self) {
         self.1.set_original_value(self.0.take());
     }

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -242,11 +242,11 @@ impl<T> Annotated<T> {
         self.0 = None;
     }
 
-    pub fn delete_firm(&mut self) {
+    pub fn delete_with_remark(&mut self) {
         self.0 = None;
         self.1.add_remark(Remark {
             ty: RemarkType::Removed,
-            rule_id: "delete_firm".to_owned(),
+            rule_id: "trimmed".to_owned(),
             range: None,
         });
     }

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -242,11 +242,11 @@ impl<T> Annotated<T> {
         self.0 = None;
     }
 
-    pub fn delete_with_remark(&mut self) {
+    pub fn delete_with_remark(&mut self, rule_id: &str) {
         self.0 = None;
         self.1.add_remark(Remark {
             ty: RemarkType::Removed,
-            rule_id: "trimmed".to_owned(),
+            rule_id: rule_id.to_owned(),
             range: None,
         });
     }

--- a/relay-protocol/src/annotated.rs
+++ b/relay-protocol/src/annotated.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::meta::{Error, Meta};
 use crate::traits::{Empty, FromValue, IntoValue, SkipSerialization};
 use crate::value::{Map, Value};
+use crate::{Remark, RemarkType};
 
 /// Represents a tree of meta objects.
 #[derive(Default, Debug, Serialize)]
@@ -235,6 +236,25 @@ impl<T> Annotated<T> {
         }
 
         other()
+    }
+
+    pub fn delete_hard(&mut self) {
+        self.0 = None;
+    }
+
+    pub fn delete_firm(&mut self) {
+        self.0 = None;
+        self.1.add_remark(Remark {
+            ty: RemarkType::Removed,
+            rule_id: "delete_firm".to_owned(),
+            range: None,
+        });
+    }
+}
+
+impl<T: IntoValue> Annotated<T> {
+    pub fn delete_soft(&mut self) {
+        self.1.set_original_value(self.0.take());
     }
 }
 


### PR DESCRIPTION
This introduces a new variant `DeleteFirm` (name provisional) of `ProcessingAction` that is intended to sit between `DeleteHard` and `DeleteSoft`: `Hard` removes the value entirely, `Firm` removes the value and and puts a remark in the metadata, `Soft` moves the value into the `old_value` in the metadata.

This new `ProcessingAction` is used in the EAP trimming processor to remember the keys of deleted attributes, up to a limit.

Open questions:
* Is it reasonable to introduce a new `ProcessingAction` for this, or should the behavior of one of the others be modified?
* Should `DeleteFirm` be able to carry data, like the name of the rule that caused the deletion, or maybe the entire remark?
* Should we extend this to the original trimming processor? It contains some [TODOs](https://github.com/getsentry/relay/blob/0d4b69e0b5a3c2144f652deebc4c528be19ea84b/relay-event-normalization/src/trimming.rs#L77-L85).

ref: #5568. ref: RELAY-196.