### PR TITLE
ci(ci): Upgrade Kafka to 7.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,16 +754,19 @@ jobs:
         ports:
           - 6379:6379
 
-      zookeeper:
-        image: ghcr.io/getsentry/image-mirror-confluentinc-cp-zookeeper:6.2.0
-        env:
-          ZOOKEEPER_CLIENT_PORT: 2181
-
       kafka:
-        image: ghcr.io/getsentry/image-mirror-confluentinc-cp-kafka:6.2.0
+        image: ghcr.io/getsentry/image-mirror-confluentinc-cp-kafka:7.5.0
         env:
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+          # KRaft mode configuration (no Zookeeper)
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1001@127.0.0.1:29093
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_NODE_ID: 1001
+          CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:29092,EXTERNAL://127.0.0.1:9092
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+          KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
         ports:


### PR DESCRIPTION
Upgrade Kafka container from 6.2.0 to 7.5.0 to match devservices. This removes the Zookeeper dependency as Kafka 7.5.0 uses KRaft mode for built-in consensus.
