### PR TITLE
feat(event-schema): Add `gen_ai_response_time_to_first_token` as a `SpanData` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Embed AI operation type mappings into Relay. ([#5555](https://github.com/getsentry/relay/pull/5555))
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
+- Add `gen_ai_response_time_to_first_token` as a `SpanData` attribute. ([#5575](https://github.com/getsentry/relay/pull/5575))
 
 ## 26.1.0
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -611,6 +611,10 @@ pub struct SpanData {
     #[metastructure(field = "gen_ai.response.tokens_per_second", pii = "maybe")]
     pub gen_ai_response_tokens_per_second: Annotated<Value>,
 
+    /// Time to first token from the LLM response
+    #[metastructure(field = "gen_ai.response.time_to_first_token", pii = "maybe")]
+    pub gen_ai_response_time_to_first_token: Annotated<Value>,
+
     /// The available tools for a request to an LLM
     #[metastructure(
         field = "gen_ai.request.available_tools",
@@ -1492,6 +1496,7 @@ mod tests {
             gen_ai_response_object: ~,
             gen_ai_response_streaming: ~,
             gen_ai_response_tokens_per_second: ~,
+            gen_ai_response_time_to_first_token: ~,
             gen_ai_request_available_tools: ~,
             gen_ai_request_frequency_penalty: ~,
             gen_ai_request_presence_penalty: ~,

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -180,6 +180,7 @@ mod tests {
                 gen_ai_response_object: ~,
                 gen_ai_response_streaming: ~,
                 gen_ai_response_tokens_per_second: ~,
+                gen_ai_response_time_to_first_token: ~,
                 gen_ai_request_available_tools: ~,
                 gen_ai_request_frequency_penalty: ~,
                 gen_ai_request_presence_penalty: ~,


### PR DESCRIPTION
Adds new field `gen_ai_response_time_to_first_token` for attribute `gen_ai.response.time_to_first_token` with PII `maybe`

Closes https://linear.app/getsentry/issue/TET-1760/ttft-relay-treats-it-as-pii