### PR TITLE
feat(statsd): Add sampling parameter to distribution metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Embed AI operation type mappings into Relay. ([#5555](https://github.com/getsentry/relay/pull/5555))
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
+- Add sampling to expensive envelope buffer statsd metrics. ([#5576](https://github.com/getsentry/relay/pull/5576))
 
 ## 26.1.0
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -569,7 +569,7 @@ pub struct Metrics {
     ///
     /// For example, a value of `0.3` means that only 30% of the emitted metrics will be sent.
     /// Defaults to `1.0` (100%).
-    pub sample_rate: f32,
+    pub sample_rate: f64,
     /// Interval for periodic metrics emitted from Relay.
     ///
     /// Setting it to `0` seconds disables the periodic metrics.
@@ -2179,7 +2179,7 @@ impl Config {
     }
 
     /// Returns the global sample rate for all metrics.
-    pub fn metrics_sample_rate(&self) -> f32 {
+    pub fn metrics_sample_rate(&self) -> f64 {
         self.values.metrics.sample_rate
     }
 

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -79,13 +79,13 @@ impl PolymorphicEnvelopeBuffer {
     /// Adds an envelope to the buffer.
     pub async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), EnvelopeBufferError> {
         relay_statsd::metric!(
-            distribution(RelayDistributions::BufferEnvelopeBodySize) =
+            distribution(RelayDistributions::BufferEnvelopeBodySize, sample = 0.01) =
                 envelope.items().map(Item::len).sum::<usize>() as u64,
             partition_id = self.partition_tag()
         );
 
         relay_statsd::metric!(
-            timer(RelayTimers::BufferPush),
+            timer(RelayTimers::BufferPush, sample = 0.01),
             partition_id = self.partition_tag(),
             {
                 match self {
@@ -100,7 +100,7 @@ impl PolymorphicEnvelopeBuffer {
     /// Returns a reference to the next-in-line envelope.
     pub async fn peek(&mut self) -> Result<Peek, EnvelopeBufferError> {
         relay_statsd::metric!(
-            timer(RelayTimers::BufferPeek),
+            timer(RelayTimers::BufferPeek, sample = 0.01),
             partition_id = self.partition_tag(),
             {
                 match self {
@@ -114,7 +114,7 @@ impl PolymorphicEnvelopeBuffer {
     /// Pops the next-in-line envelope.
     pub async fn pop(&mut self) -> Result<Option<Box<Envelope>>, EnvelopeBufferError> {
         let envelope = relay_statsd::metric!(
-            timer(RelayTimers::BufferPop),
+            timer(RelayTimers::BufferPop, sample = 0.01),
             partition_id = self.partition_tag(),
             {
                 match self {
@@ -576,7 +576,7 @@ where
             false => "false",
         };
         relay_statsd::metric!(
-            distribution(RelayDistributions::BufferEnvelopesCount) = total_count,
+            gauge(RelayGauges::BufferEnvelopesCount) = total_count,
             initialized = initialized,
             stack_type = self.stack_provider.stack_type(),
             partition_id = &self.partition_tag

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -78,49 +78,51 @@ impl PolymorphicEnvelopeBuffer {
 
     /// Adds an envelope to the buffer.
     pub async fn push(&mut self, envelope: Box<Envelope>) -> Result<(), EnvelopeBufferError> {
-        let partition_tag = self.partition_tag().to_owned();
-        match self {
-            Self::Sqlite(buffer) => {
-                relay_statsd::metric!(
-                    distribution(RelayDistributions::BufferEnvelopeBodySize) =
-                        envelope.items().map(Item::len).sum::<usize>() as u64,
-                    partition_id = &partition_tag
-                );
-                relay_statsd::metric!(
-                    timer(RelayTimers::BufferPush),
-                    partition_id = &partition_tag,
-                    { buffer.push(envelope).await }
-                )
-            }
-            Self::InMemory(buffer) => buffer.push(envelope).await,
-        }?;
+        relay_statsd::metric!(
+            distribution(RelayDistributions::BufferEnvelopeBodySize) =
+                envelope.items().map(Item::len).sum::<usize>() as u64,
+            partition_id = self.partition_tag()
+        );
 
+        relay_statsd::metric!(
+            timer(RelayTimers::BufferPush),
+            partition_id = self.partition_tag(),
+            {
+                match self {
+                    Self::Sqlite(buffer) => buffer.push(envelope).await,
+                    Self::InMemory(buffer) => buffer.push(envelope).await,
+                }?;
+            }
+        );
         Ok(())
     }
 
     /// Returns a reference to the next-in-line envelope.
     pub async fn peek(&mut self) -> Result<Peek, EnvelopeBufferError> {
-        match self {
-            Self::Sqlite(buffer) => relay_statsd::metric!(
-                timer(RelayTimers::BufferPeek),
-                partition_id = self.partition_tag(),
-                { buffer.peek().await }
-            ),
-            Self::InMemory(buffer) => buffer.peek().await,
-        }
+        relay_statsd::metric!(
+            timer(RelayTimers::BufferPeek),
+            partition_id = self.partition_tag(),
+            {
+                match self {
+                    Self::Sqlite(buffer) => buffer.peek().await,
+                    Self::InMemory(buffer) => buffer.peek().await,
+                }
+            }
+        )
     }
 
     /// Pops the next-in-line envelope.
     pub async fn pop(&mut self) -> Result<Option<Box<Envelope>>, EnvelopeBufferError> {
-        let envelope = match self {
-            Self::Sqlite(buffer) => relay_statsd::metric!(
-                timer(RelayTimers::BufferPop),
-                partition_id = self.partition_tag(),
-                { buffer.pop().await }
-            ),
-            Self::InMemory(buffer) => buffer.pop().await,
-        }?;
-
+        let envelope = relay_statsd::metric!(
+            timer(RelayTimers::BufferPop),
+            partition_id = self.partition_tag(),
+            {
+                match self {
+                    Self::Sqlite(buffer) => buffer.pop().await,
+                    Self::InMemory(buffer) => buffer.pop().await,
+                }?
+            }
+        );
         Ok(envelope)
     }
 
@@ -574,7 +576,7 @@ where
             false => "false",
         };
         relay_statsd::metric!(
-            gauge(RelayGauges::BufferEnvelopesCount) = total_count,
+            distribution(RelayDistributions::BufferEnvelopesCount) = total_count,
             initialized = initialized,
             stack_type = self.stack_provider.stack_type(),
             partition_id = &self.partition_tag

--- a/relay-server/src/services/buffer/envelope_buffer/mod.rs
+++ b/relay-server/src/services/buffer/envelope_buffer/mod.rs
@@ -91,10 +91,9 @@ impl PolymorphicEnvelopeBuffer {
                 match self {
                     Self::Sqlite(buffer) => buffer.push(envelope).await,
                     Self::InMemory(buffer) => buffer.push(envelope).await,
-                }?;
+                }
             }
-        );
-        Ok(())
+        )
     }
 
     /// Returns a reference to the next-in-line envelope.
@@ -113,17 +112,16 @@ impl PolymorphicEnvelopeBuffer {
 
     /// Pops the next-in-line envelope.
     pub async fn pop(&mut self) -> Result<Option<Box<Envelope>>, EnvelopeBufferError> {
-        let envelope = relay_statsd::metric!(
+        relay_statsd::metric!(
             timer(RelayTimers::BufferPop, sample = 0.01),
             partition_id = self.partition_tag(),
             {
                 match self {
                     Self::Sqlite(buffer) => buffer.pop().await,
                     Self::InMemory(buffer) => buffer.pop().await,
-                }?
+                }
             }
-        );
-        Ok(envelope)
+        )
     }
 
     /// Marks a project as ready or not ready.

--- a/relay-server/src/services/buffer/envelope_stack/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_stack/sqlite.rs
@@ -159,7 +159,7 @@ impl EnvelopeStack for SqliteEnvelopeStack {
         }
 
         let encoded_envelope = relay_statsd::metric!(
-            timer(RelayTimers::BufferEnvelopesSerialization),
+            timer(RelayTimers::BufferEnvelopesSerialization, sample = 0.01),
             partition_id = &self.partition_tag,
             { DatabaseEnvelope::try_from(envelope.as_ref())? }
         );

--- a/relay-server/src/services/buffer/envelope_store/sqlite.rs
+++ b/relay-server/src/services/buffer/envelope_store/sqlite.rs
@@ -113,9 +113,12 @@ impl TryFrom<DatabaseEnvelope> for Box<Envelope> {
         } = value;
 
         if encoded_envelope.starts_with(ZSTD_MAGIC_WORD) {
-            relay_statsd::metric!(timer(RelayTimers::BufferEnvelopeDecompression), {
-                encoded_envelope = zstd::decode_all(&*encoded_envelope)?.into_boxed_slice();
-            });
+            relay_statsd::metric!(
+                timer(RelayTimers::BufferEnvelopeDecompression, sample = 0.01),
+                {
+                    encoded_envelope = zstd::decode_all(&*encoded_envelope)?.into_boxed_slice();
+                }
+            );
         }
 
         let mut envelope = Envelope::parse_bytes(Bytes::from(encoded_envelope))?;
@@ -141,16 +144,19 @@ impl<'a> TryFrom<&'a Envelope> for DatabaseEnvelope {
 
         let serialized_envelope = value.to_vec()?;
         relay_statsd::metric!(
-            distribution(RelayDistributions::BufferEnvelopeSize) = serialized_envelope.len() as u64
+            distribution(RelayDistributions::BufferEnvelopeSize, sample = 0.01) =
+                serialized_envelope.len() as u64
         );
 
-        let encoded_envelope =
-            relay_statsd::metric!(timer(RelayTimers::BufferEnvelopeCompression), {
-                zstd::encode_all(serialized_envelope.as_slice(), Self::COMPRESSION_LEVEL)?
-            });
+        let encoded_envelope = relay_statsd::metric!(
+            timer(RelayTimers::BufferEnvelopeCompression, sample = 0.01),
+            { zstd::encode_all(serialized_envelope.as_slice(), Self::COMPRESSION_LEVEL)? }
+        );
         relay_statsd::metric!(
-            distribution(RelayDistributions::BufferEnvelopeSizeCompressed) =
-                encoded_envelope.len() as u64
+            distribution(
+                RelayDistributions::BufferEnvelopeSizeCompressed,
+                sample = 0.01
+            ) = encoded_envelope.len() as u64
         );
 
         Ok(DatabaseEnvelope {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -30,6 +30,11 @@ pub enum RelayGauges {
     /// The state of Relay with respect to the upstream connection.
     /// Possible values are `0` for normal operations and `1` for a network outage.
     NetworkOutage,
+    /// Number of elements in the envelope buffer across all the stacks.
+    ///
+    /// This metric is tagged with:
+    /// - `storage_type`: The type of storage used in the envelope buffer.
+    BufferEnvelopesCount,
     /// The number of individual stacks in the priority queue.
     ///
     /// Per combination of `(own_key, sampling_key)`, a new stack is created.
@@ -85,32 +90,31 @@ pub enum RelayGauges {
 impl GaugeMetric for RelayGauges {
     fn name(&self) -> &'static str {
         match self {
-            RelayGauges::AsyncPoolQueueSize => "async_pool.queue_size",
-            RelayGauges::AsyncPoolUtilization => "async_pool.utilization",
-            RelayGauges::AsyncPoolActivity => "async_pool.activity",
-            RelayGauges::NetworkOutage => "upstream.network_outage",
-            RelayGauges::BufferStackCount => "buffer.stack_count",
-            RelayGauges::BufferDiskUsed => "buffer.disk_used",
-            RelayGauges::SystemMemoryUsed => "health.system_memory.used",
-            RelayGauges::SystemMemoryTotal => "health.system_memory.total",
+            Self::AsyncPoolQueueSize => "async_pool.queue_size",
+            Self::AsyncPoolUtilization => "async_pool.utilization",
+            Self::AsyncPoolActivity => "async_pool.activity",
+            Self::NetworkOutage => "upstream.network_outage",
+            Self::BufferEnvelopesCount => "buffer.envelopes_count",
+            Self::BufferStackCount => "buffer.stack_count",
+            Self::BufferDiskUsed => "buffer.disk_used",
+            Self::SystemMemoryUsed => "health.system_memory.used",
+            Self::SystemMemoryTotal => "health.system_memory.total",
             #[cfg(feature = "processing")]
-            RelayGauges::RedisPoolConnections => "redis.pool.connections",
+            Self::RedisPoolConnections => "redis.pool.connections",
             #[cfg(feature = "processing")]
-            RelayGauges::RedisPoolIdleConnections => "redis.pool.idle_connections",
+            Self::RedisPoolIdleConnections => "redis.pool.idle_connections",
             #[cfg(feature = "processing")]
-            RelayGauges::RedisPoolMaxConnections => "redis.pool.max_connections",
+            Self::RedisPoolMaxConnections => "redis.pool.max_connections",
             #[cfg(feature = "processing")]
-            RelayGauges::RedisPoolWaitingForConnection => "redis.pool.waiting_for_connection",
-            RelayGauges::ProjectCacheNotificationChannel => {
-                "project_cache.notification_channel.size"
-            }
-            RelayGauges::ProjectCacheScheduledFetches => "project_cache.fetches.size",
-            RelayGauges::ServerActiveConnections => "server.http.connections",
+            Self::RedisPoolWaitingForConnection => "redis.pool.waiting_for_connection",
+            Self::ProjectCacheNotificationChannel => "project_cache.notification_channel.size",
+            Self::ProjectCacheScheduledFetches => "project_cache.fetches.size",
+            Self::ServerActiveConnections => "server.http.connections",
             #[cfg(feature = "processing")]
-            RelayGauges::MetricDelayMax => "metrics.delay.max",
-            RelayGauges::ServiceUtilization => "service.utilization",
+            Self::MetricDelayMax => "metrics.delay.max",
+            Self::ServiceUtilization => "service.utilization",
             #[cfg(feature = "processing")]
-            RelayGauges::ConcurrentAttachmentUploads => "attachment.upload.concurrent",
+            Self::ConcurrentAttachmentUploads => "attachment.upload.concurrent",
         }
     }
 }
@@ -226,12 +230,6 @@ pub enum RelayDistributions {
     ///  - `item_type`: The type of the items being counted.
     ///  - `is_container`: Whether this item is a container holding multiple items.
     EnvelopeItemSize,
-
-    /// Number of elements in the envelope buffer across all the stacks.
-    ///
-    /// This metric is tagged with:
-    /// - `storage_type`: The type of storage used in the envelope buffer.
-    BufferEnvelopesCount,
     /// The amount of bytes in the item payloads of an envelope pushed to the envelope buffer.
     ///
     /// This is not quite the same as the actual size of a serialized envelope, because it ignores
@@ -352,7 +350,6 @@ impl DistributionMetric for RelayDistributions {
             Self::EventSpans => "event.spans",
             Self::BatchesPerPartition => "metrics.buckets.batches_per_partition",
             Self::BucketsPerBatch => "metrics.buckets.per_batch",
-            Self::BufferEnvelopesCount => "buffer.envelopes_count",
             Self::BufferEnvelopeBodySize => "buffer.envelope_body_size",
             Self::BufferEnvelopeSize => "buffer.envelope_size",
             Self::BufferEnvelopeSizeCompressed => "buffer.envelope_size.compressed",

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -34,11 +34,6 @@ pub enum RelayGauges {
     ///
     /// Per combination of `(own_key, sampling_key)`, a new stack is created.
     BufferStackCount,
-    /// Number of elements in the envelope buffer across all the stacks.
-    ///
-    /// This metric is tagged with:
-    /// - `storage_type`: The type of storage used in the envelope buffer.
-    BufferEnvelopesCount,
     /// The used disk for the buffer.
     BufferDiskUsed,
     /// The currently used memory by the entire system.
@@ -90,32 +85,32 @@ pub enum RelayGauges {
 impl GaugeMetric for RelayGauges {
     fn name(&self) -> &'static str {
         match self {
-            Self::AsyncPoolQueueSize => "async_pool.queue_size",
-            Self::AsyncPoolUtilization => "async_pool.utilization",
-            Self::AsyncPoolActivity => "async_pool.activity",
-            Self::NetworkOutage => "upstream.network_outage",
-            Self::BufferStackCount => "buffer.stack_count",
-            Self::BufferDiskUsed => "buffer.disk_used",
-            Self::SystemMemoryUsed => "health.system_memory.used",
-            Self::SystemMemoryTotal => "health.system_memory.total",
+            RelayGauges::AsyncPoolQueueSize => "async_pool.queue_size",
+            RelayGauges::AsyncPoolUtilization => "async_pool.utilization",
+            RelayGauges::AsyncPoolActivity => "async_pool.activity",
+            RelayGauges::NetworkOutage => "upstream.network_outage",
+            RelayGauges::BufferStackCount => "buffer.stack_count",
+            RelayGauges::BufferDiskUsed => "buffer.disk_used",
+            RelayGauges::SystemMemoryUsed => "health.system_memory.used",
+            RelayGauges::SystemMemoryTotal => "health.system_memory.total",
             #[cfg(feature = "processing")]
-            Self::RedisPoolConnections => "redis.pool.connections",
+            RelayGauges::RedisPoolConnections => "redis.pool.connections",
             #[cfg(feature = "processing")]
-            Self::RedisPoolIdleConnections => "redis.pool.idle_connections",
+            RelayGauges::RedisPoolIdleConnections => "redis.pool.idle_connections",
             #[cfg(feature = "processing")]
-            Self::RedisPoolMaxConnections => "redis.pool.max_connections",
+            RelayGauges::RedisPoolMaxConnections => "redis.pool.max_connections",
             #[cfg(feature = "processing")]
-            Self::RedisPoolWaitingForConnection => "redis.pool.waiting_for_connection",
-            Self::ProjectCacheNotificationChannel => "project_cache.notification_channel.size",
-            Self::ProjectCacheScheduledFetches => "project_cache.fetches.size",
-            Self::ServerActiveConnections => "server.http.connections",
+            RelayGauges::RedisPoolWaitingForConnection => "redis.pool.waiting_for_connection",
+            RelayGauges::ProjectCacheNotificationChannel => {
+                "project_cache.notification_channel.size"
+            }
+            RelayGauges::ProjectCacheScheduledFetches => "project_cache.fetches.size",
+            RelayGauges::ServerActiveConnections => "server.http.connections",
             #[cfg(feature = "processing")]
-            Self::MetricDelayMax => "metrics.delay.max",
-            Self::ServiceUtilization => "service.utilization",
+            RelayGauges::MetricDelayMax => "metrics.delay.max",
+            RelayGauges::ServiceUtilization => "service.utilization",
             #[cfg(feature = "processing")]
-            Self::ConcurrentAttachmentUploads => "attachment.upload.concurrent",
-
-            Self::BufferEnvelopesCount => "buffer.envelopes_count",
+            RelayGauges::ConcurrentAttachmentUploads => "attachment.upload.concurrent",
         }
     }
 }
@@ -232,6 +227,11 @@ pub enum RelayDistributions {
     ///  - `is_container`: Whether this item is a container holding multiple items.
     EnvelopeItemSize,
 
+    /// Number of elements in the envelope buffer across all the stacks.
+    ///
+    /// This metric is tagged with:
+    /// - `storage_type`: The type of storage used in the envelope buffer.
+    BufferEnvelopesCount,
     /// The amount of bytes in the item payloads of an envelope pushed to the envelope buffer.
     ///
     /// This is not quite the same as the actual size of a serialized envelope, because it ignores
@@ -352,6 +352,7 @@ impl DistributionMetric for RelayDistributions {
             Self::EventSpans => "event.spans",
             Self::BatchesPerPartition => "metrics.buckets.batches_per_partition",
             Self::BucketsPerBatch => "metrics.buckets.per_batch",
+            Self::BufferEnvelopesCount => "buffer.envelopes_count",
             Self::BufferEnvelopeBodySize => "buffer.envelope_body_size",
             Self::BufferEnvelopeSize => "buffer.envelope_size",
             Self::BufferEnvelopeSizeCompressed => "buffer.envelope_size.compressed",

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -28,7 +28,7 @@
 //!     prefix: "myprefix",
 //!     host: "localhost:8125",
 //!     default_tags: BTreeMap::new(),
-//!     sample_rate: 1.0,
+//!     sample_rate: 1.0.into(),
 //!     aggregate: true,
 //!     allow_high_cardinality_tags: false
 //! });
@@ -91,9 +91,9 @@ impl From<f64> for SampleRate {
     }
 }
 
-impl Into<f64> for SampleRate {
-    fn into(self) -> f64 {
-        self.0
+impl From<SampleRate> for f64 {
+    fn from(val: SampleRate) -> Self {
+        val.0
     }
 }
 
@@ -122,7 +122,7 @@ pub struct MetricsClientConfig<'a, A> {
     /// Tags that are added to all metrics.
     pub default_tags: BTreeMap<String, String>,
     /// Default sample rate for metrics, between 0.0 (= 0%) and 1.0 (= 100%)
-    pub default_sample_rate: SampleRate,
+    pub sample_rate: SampleRate,
     /// If metrics should be batched or send immediately upstream.
     pub aggregate: bool,
     /// If high cardinality tags should be removed from metrics.
@@ -297,7 +297,7 @@ pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
         relay_log::info!("reporting metrics to statsd at {}", addrs[0]);
     }
 
-    let sample_rate: f64 = config.default_sample_rate.into();
+    let sample_rate: f64 = config.sample_rate.into();
     relay_log::debug!(
         "metrics sample rate is set to {sample_rate}{}",
         if sample_rate == 0.0 {
@@ -349,7 +349,7 @@ pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
     set_client(MetricsClient {
         statsd_client,
         default_tags: config.default_tags,
-        default_sample_rate: config.default_sample_rate,
+        default_sample_rate: config.sample_rate,
         rx: None,
     });
 }

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -894,23 +894,23 @@ mod tests {
     #[test]
     fn test_distribution_with_explicit_sample_rate() {
         let captures = with_capturing_test_client(|| {
-            metric!(distribution(TestDistribution, sample = 0.5) = 123);
+            metric!(distribution(TestDistribution, sample = 0.999999999) = 123);
         });
-        assert_eq!(captures, ["distribution:123|d|@0.5"]);
+        assert_eq!(captures, ["distribution:123|d|@0.999999999"]);
     }
 
     #[test]
     fn test_distribution_with_explicit_sample_rate_and_tags() {
         let captures = with_capturing_test_client(|| {
             metric!(
-                distribution(TestDistribution, sample = 0.01) = 456,
+                distribution(TestDistribution, sample = 0.999999999) = 456,
                 server = "server1",
                 host = "host1",
             );
         });
         assert_eq!(
             captures,
-            ["distribution:456|d|@0.01|#server:server1,host:host1"]
+            ["distribution:456|d|@0.999999999|#server:server1,host:host1"]
         );
     }
 
@@ -962,9 +962,9 @@ mod tests {
     fn test_timer_with_explicit_sample_rate() {
         let captures = with_capturing_test_client(|| {
             let duration = Duration::from_secs(100);
-            metric!(timer(TestTimer, sample = 0.5) = duration);
+            metric!(timer(TestTimer, sample = 0.999999999) = duration);
         });
-        assert_eq!(captures, ["timer:100000|d|@0.5"]);
+        assert_eq!(captures, ["timer:100000|d|@0.999999999"]);
     }
 
     #[test]
@@ -972,22 +972,22 @@ mod tests {
         let captures = with_capturing_test_client(|| {
             let duration = Duration::from_secs(100);
             metric!(
-                timer(TestTimer, sample = 0.01) = duration,
+                timer(TestTimer, sample = 0.999999999) = duration,
                 server = "server1",
             );
         });
-        assert_eq!(captures, ["timer:100000|d|@0.01|#server:server1"]);
+        assert_eq!(captures, ["timer:100000|d|@0.999999999|#server:server1"]);
     }
 
     #[test]
     fn test_timed_block_with_explicit_sample_rate() {
         let captures = with_capturing_test_client(|| {
-            metric!(timer(TestTimer, sample = 0.5), {
+            metric!(timer(TestTimer, sample = 0.999999999), {
                 // your code could be here
             })
         });
         // just check the sample rate to not make this flaky
-        assert!(captures[0].contains("|d|@0.5"));
+        assert!(captures[0].contains("|d|@0.999999999"));
     }
 
     #[test]
@@ -1013,17 +1013,17 @@ mod tests {
     fn test_local_sample_rate_overrides_global() {
         // With global sample rate of 0.999, no @rate is added to the output
         // With a local override, the local rate should appear in the output
-        let captures = with_capturing_test_client_sample_rate(0.999999, || {
+        let captures = with_capturing_test_client_sample_rate(0.999999999, || {
             // Without explicit sampling, no @rate in output (global is 1.0)
             metric!(distribution(TestDistribution) = 100);
             // With explicit sampling, should use local rate (0.01)
-            metric!(distribution(TestDistribution, sample = 0.01) = 200);
+            metric!(distribution(TestDistribution, sample = 0.999999998) = 200);
         });
         assert_eq!(captures.len(), 2);
         // First metric has no sample rate
-        assert_eq!(&captures[0][..24], "distribution:100|d|@0.99");
+        assert_eq!(captures[0], "distribution:100|d|@0.999999999");
         // Second metric uses local sample rate
-        assert_eq!(captures[1], "distribution:200|d|@0.01");
+        assert_eq!(captures[1], "distribution:200|d|@0.999999998");
     }
 
     #[test]
@@ -1034,21 +1034,21 @@ mod tests {
             let duration = Duration::from_secs(1);
             // Without explicit sampling, no @rate in output (global is 1.0)
             metric!(timer(TestTimer) = duration);
-            // With explicit sampling, should use local rate (0.01)
-            metric!(timer(TestTimer, sample = 0.01) = duration);
+            // With explicit sampling, should use local rate (0.999999999)
+            metric!(timer(TestTimer, sample = 0.999999999) = duration);
         });
 
         assert_eq!(captures.len(), 2);
         // First metric has no sample rate (global is 1.0, so it's omitted)
         assert_eq!(captures[0], "timer:1000|d");
         // Second metric uses local sample rate
-        assert_eq!(captures[1], "timer:1000|d|@0.01");
+        assert_eq!(captures[1], "timer:1000|d|@0.999999999");
     }
 
     #[test]
     fn test_local_sample_rate_capped() {
         let captures = with_capturing_test_client_sample_rate(0.0, || {
-            metric!(distribution(TestDistribution, sample = 0.01) = 200);
+            metric!(distribution(TestDistribution, sample = 0.999999999) = 200);
         });
         assert_eq!(captures.len(), 0);
     }

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -115,7 +115,7 @@ pub fn init_metrics(config: &Config) -> Result<()> {
         prefix: config.metrics_prefix(),
         host: &addrs[..],
         default_tags,
-        default_sample_rate: config.metrics_sample_rate(),
+        default_sample_rate: config.metrics_sample_rate().into(),
         aggregate: config.metrics_aggregate(),
         allow_high_cardinality_tags: config.metrics_allow_high_cardinality_tags(),
     });

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -115,7 +115,7 @@ pub fn init_metrics(config: &Config) -> Result<()> {
         prefix: config.metrics_prefix(),
         host: &addrs[..],
         default_tags,
-        sample_rate: config.metrics_sample_rate(),
+        default_sample_rate: config.metrics_sample_rate(),
         aggregate: config.metrics_aggregate(),
         allow_high_cardinality_tags: config.metrics_allow_high_cardinality_tags(),
     });

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -115,7 +115,7 @@ pub fn init_metrics(config: &Config) -> Result<()> {
         prefix: config.metrics_prefix(),
         host: &addrs[..],
         default_tags,
-        default_sample_rate: config.metrics_sample_rate().into(),
+        sample_rate: config.metrics_sample_rate().into(),
         aggregate: config.metrics_aggregate(),
         allow_high_cardinality_tags: config.metrics_allow_high_cardinality_tags(),
     });


### PR DESCRIPTION
The `metric!(distribution(...))` and `metric!(timer(...))` macros now take an optional `sample` parameter to explicitly set the sampling rate the metric. This allows per-metric control over sampling rates via cadence's `with_sampling_rate`.

Example usage:
```rust
metric!(distribution(MyMetric, sample = 0.01) = value);
```

ref: INGEST-659