### PR TITLE
ref(profile-chunks): Count profile chunks without platform

### DIFF
--- a/relay-server/src/envelope/meta.rs
+++ b/relay-server/src/envelope/meta.rs
@@ -26,9 +26,11 @@ pub enum ClientName<'a> {
 }
 
 impl<'a> ClientName<'a> {
-    /// Returns the client name as a string.
-    pub fn as_str(&self) -> &'a str {
-        match self {
+    /// Returns the client name as a `str` with a static lifetime.
+    ///
+    /// Returns `None` if the client name is not a well known client.
+    pub fn as_static_str(&self) -> Option<&'static str> {
+        Some(match self {
             Self::Relay => "sentry.relay",
             Self::Ruby => "sentry-ruby",
             Self::CocoaFlutter => "sentry.cocoa.flutter",
@@ -50,8 +52,8 @@ impl<'a> ClientName<'a> {
             Self::Symfony => "sentry.php.symfony",
             Self::Php => "sentry.php",
             Self::Python => "sentry.python",
-            Self::Other(other) => other,
-        }
+            Self::Other(_) => return None,
+        })
     }
 }
 
@@ -93,6 +95,6 @@ mod tests {
         let name = crate::constants::CLIENT.split_once('/').unwrap().0;
 
         assert_eq!(ClientName::from(name), ClientName::Relay);
-        assert_eq!(ClientName::Relay.as_str(), name);
+        assert_eq!(ClientName::Relay.as_static_str(), Some(name));
     }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -956,6 +956,11 @@ pub enum RelayCounters {
     /// - `dsc`: yes or no
     /// - `sdk`: low-cardinality client name
     EnvelopeWithLogs,
+    /// Amount of profile chunks without a platform item header.
+    ///
+    /// The metric is emitted when processing profile chunks, profile chunks which are fast path
+    /// rate limited are not counted in this metric.
+    ProfileChunksWithoutPlatform,
 }
 
 impl CounterMetric for RelayCounters {
@@ -1014,6 +1019,7 @@ impl CounterMetric for RelayCounters {
             #[cfg(feature = "processing")]
             RelayCounters::AttachmentUpload => "attachment.upload",
             RelayCounters::EnvelopeWithLogs => "logs.envelope",
+            RelayCounters::ProfileChunksWithoutPlatform => "profile_chunk.no_platform",
         }
     }
 }

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -44,7 +44,7 @@ pub fn platform_tag(event: &Event) -> &'static str {
 }
 
 /// Maps a client name to a low-cardinality statsd tag.
-pub fn client_name_tag(client_name: ClientName<'_>) -> &str {
+pub fn client_name_tag(client_name: ClientName<'_>) -> &'static str {
     match client_name {
         ClientName::Other(_) => "other",
         well_known => well_known.as_str(),

--- a/relay-server/src/utils/statsd.rs
+++ b/relay-server/src/utils/statsd.rs
@@ -45,10 +45,7 @@ pub fn platform_tag(event: &Event) -> &'static str {
 
 /// Maps a client name to a low-cardinality statsd tag.
 pub fn client_name_tag(client_name: ClientName<'_>) -> &'static str {
-    match client_name {
-        ClientName::Other(_) => "other",
-        well_known => well_known.as_str(),
-    }
+    client_name.as_static_str().unwrap_or("other")
 }
 
 /// Log statsd metrics about transaction name modifications.


### PR DESCRIPTION
We originally wanted to forbid profile chunks without platform, but there are SDKs sending profile chunks without a platform, let's figure out which SDKs and how many are affected.