### PR TITLE
feat(ai): Add ai.generateObject operation type mappings

### DIFF
--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -145,6 +145,9 @@ pub fn infer_ai_operation_type(op_name: &str) -> Option<&'static str> {
         op if op.starts_with("ai.generateText.doGenerate") => "ai_client",
         op if op.starts_with("ai.generateText") => "agent",
 
+        op if op.starts_with("ai.generateObject.doGenerate") => "ai_client",
+        op if op.starts_with("ai.generateObject") => "agent",
+
         op if op.starts_with("ai.toolCall") => "tool",
         // No match:
         _ => return None,


### PR DESCRIPTION
We are still missing handling of these VercelAI legacy operation names, so this PRs adds them.

It adds mappings for:
- ai.generateObject* -> agent
- ai.generateObject.doGenerate* -> ai_client

Closes [TET-1764: Extend `infer_ai_operation_type` with `generateObject`](https://linear.app/getsentry/issue/TET-1764/extend-infer-ai-operation-type-with-generateobject)
