### PR TITLE
WIP: Introduce `item_configs` on `ProjectConfig`

### DIFF
--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -50,6 +50,8 @@ pub struct ProjectConfig {
     /// Retention settings for different products.
     #[serde(default, skip_serializing_if = "RetentionsConfig::is_empty")]
     pub retentions: RetentionsConfig,
+    #[serde(default, skip_serializing_if = "ItemConfigs::is_empty")]
+    pub item_configs: ItemConfigs,
     /// Usage quotas for this project.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub quotas: Vec<Quota>,
@@ -159,6 +161,7 @@ impl Default for ProjectConfig {
             event_retention: None,
             downsampled_event_retention: None,
             retentions: Default::default(),
+            item_configs: Default::default(),
             quotas: Vec::new(),
             sampling: None,
             measurements: None,
@@ -274,6 +277,44 @@ impl RetentionsConfig {
         } = self;
 
         log.is_none() && span.is_none() && trace_metric.is_none() && trace_attachment.is_none()
+    }
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Default)]
+pub struct ItemConfig {
+    pub retention: Option<RetentionConfig>,
+}
+
+impl ItemConfig {
+    fn is_empty(&self) -> bool {
+        let Self { retention } = self;
+        retention.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ItemConfigs {
+    #[serde(default, skip_serializing_if = "ItemConfig::is_empty")]
+    pub log: ItemConfig,
+    #[serde(default, skip_serializing_if = "ItemConfig::is_empty")]
+    pub span: ItemConfig,
+    #[serde(default, skip_serializing_if = "ItemConfig::is_empty")]
+    pub trace_metric: ItemConfig,
+    #[serde(default, skip_serializing_if = "ItemConfig::is_empty")]
+    pub trace_attachment: ItemConfig,
+}
+
+impl ItemConfigs {
+    fn is_empty(&self) -> bool {
+        let Self {
+            log,
+            span,
+            trace_metric,
+            trace_attachment,
+        } = self;
+
+        log.is_empty() && span.is_empty() && trace_metric.is_empty() && trace_attachment.is_empty()
     }
 }
 

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -192,7 +192,7 @@ impl Forward for LogOutput {
         let ctx = store::Context {
             scoping: logs.scoping(),
             received_at: logs.received_at(),
-            retention: ctx.retention(|r| r.log.as_ref()),
+            retention: retention!(ctx, log),
         };
 
         for log in logs.split(|logs| logs.logs) {

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -16,6 +16,7 @@ use crate::metrics_extraction::transactions::ExtractedMetrics;
 use crate::services::projects::project::ProjectInfo;
 
 mod common;
+#[macro_use]
 mod forward;
 mod limits;
 

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -252,7 +252,7 @@ impl Forward for SpanOutput {
 
         let ctx = store::Context {
             server_sample_rate: spans.server_sample_rate,
-            retention: ctx.retention(|r| r.span.as_ref()),
+            retention: retention!(ctx, span),
         };
 
         let spans_and_attachments = spans.split(|spans| spans.into_parts());

--- a/relay-server/src/processing/trace_attachments/forward.rs
+++ b/relay-server/src/processing/trace_attachments/forward.rs
@@ -41,7 +41,7 @@ impl Forward for Managed<ExpandedAttachments> {
         s: StoreHandle<'_>,
         ctx: ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
-        let retention = ctx.retention(|r| r.trace_attachment.as_ref());
+        let retention = retention!(ctx, trace_attachment);
         let server_sample_rate = self.server_sample_rate;
         for attachment in self.split(|work| work.attachments) {
             if let Ok(message) = store::convert(attachment, retention, server_sample_rate) {

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -176,7 +176,7 @@ impl Forward for TraceMetricOutput {
         let ctx = store::Context {
             scoping: metrics.scoping(),
             received_at: metrics.received_at(),
-            retention: ctx.retention(|r| r.trace_metric.as_ref()),
+            retention: retention!(ctx, trace_metric),
         };
 
         for metric in metrics.split(|metrics| metrics.metrics) {

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -1,3 +1,5 @@
+import pytest
+
 from datetime import datetime, timezone, timedelta
 from unittest import mock
 
@@ -13,8 +15,14 @@ TEST_CONFIG = {
 }
 
 
+@pytest.mark.parametrize("retention_config_field", ("retentions", "item_configs"))
 def test_otlp_logs_conversion(
-    mini_sentry, relay, relay_with_processing, outcomes_consumer, items_consumer
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    outcomes_consumer,
+    items_consumer,
+    retention_config_field,
 ):
     """Test OTLP logs conversion including basic and complex attributes."""
     items_consumer = items_consumer()
@@ -25,9 +33,20 @@ def test_otlp_logs_conversion(
         "organizations:ourlogs-ingestion",
         "organizations:relay-otel-logs-endpoint",
     ]
-    project_config["config"]["retentions"] = {
-        "log": {"standard": 30, "downsampled": 13 * 30},
-    }
+
+    if retention_config_field == "retentions":
+        project_config["config"]["retentions"] = {
+            "log": {"standard": 30, "downsampled": 13 * 30},
+        }
+    elif retention_config_field == "item_configs":
+        project_config["config"]["itemConfigs"] = {
+            "log": {"retention": {"standard": 30, "downsampled": 13 * 30}}
+        }
+        # Put a bogus value in `"retentions"`. The one in `"item_configs"` should
+        # take precedence.
+        project_config["config"]["retentions"] = {
+            "log": {"standard": 1, "downsampled": 1},
+        }
 
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
 
@@ -182,8 +201,14 @@ def test_otlp_logs_conversion(
     ]
 
 
+@pytest.mark.parametrize("retention_config_field", ("retentions", "item_configs"))
 def test_otlp_logs_multiple_records(
-    mini_sentry, relay, relay_with_processing, outcomes_consumer, items_consumer
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    outcomes_consumer,
+    items_consumer,
+    retention_config_field,
 ):
     """Test multiple log records in a single payload."""
     items_consumer = items_consumer()
@@ -194,9 +219,20 @@ def test_otlp_logs_multiple_records(
         "organizations:ourlogs-ingestion",
         "organizations:relay-otel-logs-endpoint",
     ]
-    project_config["config"]["retentions"] = {
-        "log": {"standard": 30, "downsampled": 13 * 30},
-    }
+
+    if retention_config_field == "retentions":
+        project_config["config"]["retentions"] = {
+            "log": {"standard": 30, "downsampled": 13 * 30},
+        }
+    elif retention_config_field == "item_configs":
+        project_config["config"]["itemConfigs"] = {
+            "log": {"retention": {"standard": 30, "downsampled": 13 * 30}}
+        }
+        # Put a bogus value in `"retentions"`. The one in `"item_configs"` should
+        # take precedence.
+        project_config["config"]["retentions"] = {
+            "log": {"standard": 1, "downsampled": 1},
+        }
 
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
 


### PR DESCRIPTION
This adds a field `item_configs` on the `ProjectConfig` that is eventually intended to subsume both retention and trimming configs for logs, spans, trace metrics, and trace attachments (and possibly further configuration we may introduce). Currently, the logic is set up such that retention configs are pulled from the new `item_configs` if it's defined and from `retentions` otherwise. This means that so long as the new field isn't set, no behavior changes.

I adapted a number of integration tests to validate this logic.

Questions:
* Is this something we even want to do?
* Should the fallback logic for retentions be reversed, i.e. should we prefer `retentions` when it's set?
* Is the structure sensible (`RetentionConfig` nested in an `ItemConfig`)?
* Are the names sensible?