### PR TITLE
test: Do not use a requests session

### DIFF
--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -1,4 +1,5 @@
 import time
+from collections import defaultdict
 
 import requests
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
@@ -7,7 +8,6 @@ from sentry_relay.auth import SecretKey
 
 
 class SentryLike:
-    _health_check_passed = False
 
     default_dsn_public_key = "31a5a894b4524f74a9a8d0e27e21ba91"
 
@@ -22,6 +22,8 @@ class SentryLike:
         self.internal_server_address = internal_server_address or server_address
         self.upstream = upstream
         self.public_key = public_key
+
+        self._health_check_passed = defaultdict(lambda: False)
 
     def get_dsn_public_key_configs(self, project_id):
         """
@@ -104,12 +106,12 @@ class SentryLike:
                     raise
                 backoff *= 2
 
-    def wait_relay_health_check(self):
-        if self._health_check_passed:
+    def wait_relay_health_check(self, mode="ready"):
+        if self._health_check_passed[mode]:
             return
 
-        self._wait("/api/relay/healthcheck/ready/", is_internal=True)
-        self._health_check_passed = True
+        self._wait(f"/api/relay/healthcheck/{mode}/", is_internal=True)
+        self._health_check_passed[mode] = True
 
     def __repr__(self):
         return f"<{self.__class__.__name__}({repr(self.upstream)})>"

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -1,9 +1,7 @@
 import time
 
-from requests import Session
-from requests.adapters import HTTPAdapter
+import requests
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
-from urllib3.util import Retry
 
 from sentry_relay.auth import SecretKey
 
@@ -24,11 +22,6 @@ class SentryLike:
         self.internal_server_address = internal_server_address or server_address
         self.upstream = upstream
         self.public_key = public_key
-
-        self.session = Session()
-        self.session.mount(
-            "http://", HTTPAdapter(max_retries=Retry(total=5, backoff_factor=0.1))
-        )
 
     def get_dsn_public_key_configs(self, project_id):
         """
@@ -569,7 +562,7 @@ class SentryLike:
             timeout = 10
 
         url = self.url if not is_internal else self.internal_url
-        return self.session.request(method, url + path, timeout=timeout, **kwargs)
+        return requests.request(method, url + path, timeout=timeout, **kwargs)
 
     def post(self, path, **kwargs):
         return self.request("post", path, **kwargs)

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -509,7 +509,7 @@ def mini_sentry(request):  # noqa
 
     @app.errorhandler(500)
     def fail(e):
-        sentry.test_failures.append((flask_request.url, e))
+        sentry.test_failures.put((flask_request.url, e))
         raise e
 
     def reraise_test_failures():

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -225,8 +225,9 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             version,
         )
 
+        relay.wait_relay_health_check("live")
         if wait_health_check:
-            relay.wait_relay_health_check()
+            relay.wait_relay_health_check("ready")
 
             # Filter out health check failures, which can happen during startup
             filtered_test_failures = Queue()

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -124,7 +124,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
         options=None,
         prepare=None,
         external=None,
-        wait_health_check=True,
+        wait_health_check="ready",
         static_relays=None,
         static_credentials=None,
         credentials=None,
@@ -225,9 +225,10 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             version,
         )
 
-        relay.wait_relay_health_check("live")
         if wait_health_check:
-            relay.wait_relay_health_check("ready")
+            relay.wait_relay_health_check("live")
+            if wait_health_check == "ready":
+                relay.wait_relay_health_check("ready")
 
             # Filter out health check failures, which can happen during startup
             filtered_test_failures = Queue()

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import pytest
 
-from requests import HTTPError
+from requests import HTTPError, ConnectionError
 
 
 def failing_check_challenge(*args, **kwargs):
@@ -37,8 +37,12 @@ def cli_healthcheck(relay_binary, relay, mode):
 
 
 def http_healthcheck(_, relay, mode):
-    response = relay.get(f"/api/relay/healthcheck/{mode}/", is_internal=True)
-    return response.status_code == 200
+    try:
+        response = relay.get(f"/api/relay/healthcheck/{mode}/", is_internal=True)
+    except ConnectionError:
+        return False
+    else:
+        return response.status_code == 200
 
 
 @pytest.mark.parametrize("port", [None, "random"])

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -202,6 +202,7 @@ def test_store_with_low_memory(mini_sentry, relay):
 
     try:
         with pytest.raises(HTTPError):
+            print("SENDING")
             relay.send_event(project_id, {"message": "pls ignore"})
         pytest.raises(queue.Empty, lambda: mini_sentry.get_captured_envelope(timeout=1))
 

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -195,14 +195,13 @@ def test_store_proxy_config(mini_sentry, relay):
 
 def test_store_with_low_memory(mini_sentry, relay):
     relay = relay(
-        mini_sentry, {"health": {"max_memory_percent": 0.0}}, wait_health_check=False
+        mini_sentry, {"health": {"max_memory_percent": 0.0}}, wait_health_check="live"
     )
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
 
     try:
         with pytest.raises(HTTPError):
-            print("SENDING")
             relay.send_event(project_id, {"message": "pls ignore"})
         pytest.raises(queue.Empty, lambda: mini_sentry.get_captured_envelope(timeout=1))
 
@@ -906,7 +905,7 @@ def test_events_buffered_before_auth(relay, mini_sentry):
 
     # keep max backoff as short as the configuration allows (1 sec)
     relay_options = {"http": {"max_retry_interval": 1}}
-    relay = relay(mini_sentry, relay_options, wait_health_check=False)
+    relay = relay(mini_sentry, relay_options, wait_health_check="live")
 
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)


### PR DESCRIPTION
As part of RELAY-178 I looked into spurious connection errors in integration tests, and noticed that they no longer occur when the test suite does not use a requests session with connection pooling (see [test run 1](https://github.com/getsentry/relay/actions/runs/21445366867/job/61759527519?pr=5585#step:11:2221) vs [test run 2](https://github.com/getsentry/relay/actions/runs/21470725839/job/61844117516?pr=5585#step:11:627)).

A side effect of removing the `requests.Session` is that we have no more automatic retries, which are now replaced by waiting for service liveness / readiness explicitly.