### PR TITLE
feat(minidumps): Log request sizes

### DIFF
--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -20,6 +20,7 @@ use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
 use crate::envelope::ContentType::Minidump;
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::extractors::{RawContentType, RequestMeta};
+use crate::middlewares;
 use crate::service::ServiceState;
 use crate::utils::{self, ConstrainedMultipart};
 
@@ -249,7 +250,9 @@ async fn handle(
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
     // Set the single-attachment limit that applies only for raw minidumps. Multipart bypasses the
     // limited body and applies its own limits.
-    post(handle).route_layer(DefaultBodyLimit::max(config.max_attachment_size()))
+    post(handle)
+        .route_layer(DefaultBodyLimit::max(config.max_attachment_size()))
+        .route_layer(axum::middleware::from_fn(middlewares::content_length))
 }
 
 #[cfg(test)]

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -11,6 +11,7 @@ use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
 use crate::envelope::ContentType::OctetStream;
 use crate::envelope::{AttachmentType, Envelope};
 use crate::extractors::{RawContentType, RequestMeta};
+use crate::middlewares;
 use crate::service::ServiceState;
 use crate::utils::UnconstrainedMultipart;
 
@@ -134,5 +135,7 @@ async fn handle(
 }
 
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-    post(handle).route_layer(DefaultBodyLimit::max(config.max_attachments_size()))
+    post(handle)
+        .route_layer(DefaultBodyLimit::max(config.max_attachments_size()))
+        .route_layer(axum::middleware::from_fn(middlewares::content_length))
 }

--- a/relay-server/src/middlewares/content_length.rs
+++ b/relay-server/src/middlewares/content_length.rs
@@ -1,0 +1,34 @@
+use axum::RequestExt;
+use axum::extract::{MatchedPath, Request};
+use axum::http::header;
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::statsd::RelayDistributions;
+
+/// A middleware that logs request Content-Length as a statsd distribution metric.
+///
+/// Use this with [`axum::middleware::from_fn`].
+pub async fn content_length(mut request: Request, next: Next) -> Response {
+    let matched_path = request.extract_parts::<MatchedPath>().await;
+    let route = matched_path.as_ref().map_or("unknown", |m| m.as_str());
+
+    let (has_content_length, content_length) = request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(|len| ("true", len))
+        .unwrap_or(("false", 0));
+
+    let response = next.run(request).await;
+
+    relay_statsd::metric!(
+        distribution(RelayDistributions::ContentLength) = content_length,
+        has_content_length = has_content_length,
+        route = route,
+        status_code = response.status().as_str(),
+    );
+
+    response
+}

--- a/relay-server/src/middlewares/mod.rs
+++ b/relay-server/src/middlewares/mod.rs
@@ -7,6 +7,7 @@
 //! See the server startup in [`HttpServer`](crate::services::server::HttpServer) for where these
 //! middlewares are registered.
 
+mod content_length;
 mod cors;
 mod decompression;
 mod handle_panic;
@@ -14,6 +15,7 @@ mod metrics;
 mod normalize_path;
 mod trace;
 
+pub use self::content_length::*;
 pub use self::cors::*;
 pub use self::decompression::*;
 pub use self::handle_panic::*;

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -63,6 +63,7 @@ fn make_app(service: ServiceState, f: impl FnOnce(&Config) -> axum::Router<Servi
     //  - Responses go from bottom to top
     let middleware = ServiceBuilder::new()
         .layer(axum::middleware::from_fn(middlewares::metrics))
+        .layer(axum::middleware::from_fn(middlewares::content_length))
         .layer(CatchPanicLayer::custom(middlewares::handle_panic))
         .layer(SetResponseHeaderLayer::overriding(
             header::SERVER,

--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -63,7 +63,6 @@ fn make_app(service: ServiceState, f: impl FnOnce(&Config) -> axum::Router<Servi
     //  - Responses go from bottom to top
     let middleware = ServiceBuilder::new()
         .layer(axum::middleware::from_fn(middlewares::metrics))
-        .layer(axum::middleware::from_fn(middlewares::content_length))
         .layer(CatchPanicLayer::custom(middlewares::handle_panic))
         .layer(SetResponseHeaderLayer::overriding(
             header::SERVER,

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -341,6 +341,13 @@ pub enum RelayDistributions {
     ///  - `item`: the trace item type.
     ///  - `too_large`: `true` or `false`, whether the item is bigger than the allowed size limit.
     TraceItemCanonicalSize,
+    /// The Content-Length of incoming HTTP requests in bytes.
+    ///
+    /// This metric is tagged with:
+    ///  - `has_content_length`: Whether the Content-Length header was present ("true"/"false").
+    ///  - `route`: The matched route pattern.
+    ///  - `status_code`: The HTTP response status code.
+    ContentLength,
 }
 
 impl DistributionMetric for RelayDistributions {
@@ -370,6 +377,7 @@ impl DistributionMetric for RelayDistributions {
             Self::PartitionKeys => "metrics.buckets.partition_keys",
             Self::PartitionSplits => "partition_splits",
             Self::TraceItemCanonicalSize => "trace_item.canonical_size",
+            Self::ContentLength => "requests.content_length",
         }
     }
 }


### PR DESCRIPTION
We know how many requests are rejected because of size limits, but we do not know how large they were. If requests have a `Content-Length` header, we can record the would-be size. This PR does that for the `/minidump` and `/playstation` endpoints.

Note that this does not take into account size limits that were applied before relay, but there's a chance we can still estimate the distribution from the recorded samples.

ref: INGEST-707