### PR TITLE
chore(ai): Add manual category to cost calculation metric origin tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Use new processor architecture to process replays. ([#5580](https://github.com/getsentry/relay/pull/5580))
 - Add `gen_ai.cost_calculation.result` metric to track AI cost calculation outcomes by integration and platform. ([#5560](https://github.com/getsentry/relay/pull/5560))
 - Normalizes and validates trace metric names. ([#5589](https://github.com/getsentry/relay/pull/5589))
+- Add manual category to cost calculation metric origin tag ([#5603](https://github.com/getsentry/relay/pull/5603))
 
 ## 26.1.0
 

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -58,7 +58,7 @@ pub fn map_origin_to_integration(origin: Option<&str>) -> &'static str {
         Some(o) if o.starts_with("auto.ai.mcp_server") => "mcp_server",
         Some(o) if o.starts_with("auto.ai.mcp") => "mcp",
         Some(o) if o.starts_with("auto.ai.claude_agent_sdk") => "claude_agent_sdk",
-        Some(o) if o.starts_with("auto.ai.") => "other",
+        Some(o) if o.starts_with("auto.ai.") => "other_ai",
         Some(o) if o.starts_with("manual") => "manual",
         Some(_) => "other",
         None => "unknown",

--- a/relay-event-normalization/src/statsd.rs
+++ b/relay-event-normalization/src/statsd.rs
@@ -59,6 +59,7 @@ pub fn map_origin_to_integration(origin: Option<&str>) -> &'static str {
         Some(o) if o.starts_with("auto.ai.mcp") => "mcp",
         Some(o) if o.starts_with("auto.ai.claude_agent_sdk") => "claude_agent_sdk",
         Some(o) if o.starts_with("auto.ai.") => "other",
+        Some(o) if o.starts_with("manual") => "manual",
         Some(_) => "other",
         None => "unknown",
     }


### PR DESCRIPTION
- Add the manual category to cover manual instrumentation explicitly, and not bunch it in with the generic other category
- Also add a differentiation between auto instrumentation in the AI namespace and generic other