### PR TITLE
feat(eap): Implement clock drift corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Support `sample` alias in CSP reports. ([#5554](https://github.com/getsentry/relay/pull/5554))
 - Fix inconsistencies with Insights' expected attributes. ([#5561](https://github.com/getsentry/relay/pull/5561))
 
+**Features**:
+
+- Apply clock drift correction to logs and trace metrics. ([#5609](https://github.com/getsentry/relay/pull/5609))
+
 **Internal**:
 
 - Embed AI operation type mappings into Relay. ([#5555](https://github.com/getsentry/relay/pull/5555))

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -24,6 +24,7 @@ use crate::{ClientHints, FromUserAgentInfo as _, RawUserAgentInfo};
 
 mod ai;
 mod size;
+pub mod time;
 pub mod trace_metric;
 #[allow(unused)]
 mod trimming;

--- a/relay-event-normalization/src/eap/time.rs
+++ b/relay-event-normalization/src/eap/time.rs
@@ -1,0 +1,258 @@
+//! Time normalization for EAP items.
+
+use chrono::{DateTime, Utc};
+use relay_event_schema::{
+    processor::{self, ProcessValue, ProcessingState},
+    protocol::{OurLog, SpanV2, Timestamp, TraceMetric},
+};
+use relay_protocol::{Annotated, ErrorKind};
+use std::time::Duration;
+
+use crate::ClockDriftProcessor;
+
+/// Configuration parameters for [`normalize`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Config {
+    /// Timestamp when the item was received.
+    pub received_at: DateTime<Utc>,
+    /// Client local timestamp when the SDK sent the item.
+    pub sent_at: Option<DateTime<Utc>>,
+    /// Maximum amount of time the timestamp is allowed to be in the past.
+    pub max_in_past: Option<Duration>,
+    /// Maximum amount of time the timestamp is allowed to be in the future.
+    pub max_in_future: Option<Duration>,
+    /// Limits clock drift correction to a minimum duration.
+    pub minimum_clock_drift: Duration,
+}
+
+/// Normalizes and validates timestamps.
+///
+/// Applies a time shift correction to correct for time drift on clients, see [`ClockDriftProcessor`].
+/// Also makes sure timestamps are within boundaries defined by [`Config::max_in_past`] and
+/// [`Config::max_in_future`].
+pub fn normalize<T>(item: &mut Annotated<T>, config: Config)
+where
+    T: TimeNormalize,
+{
+    let received_at = config.received_at;
+    let mut sent_at = config.sent_at;
+    let mut error_kind = ErrorKind::ClockDrift;
+
+    let timestamp = item
+        .value_mut()
+        .as_mut()
+        .and_then(|t| t.reference_timestamp().value().copied());
+
+    if let Some(timestamp) = timestamp {
+        if config
+            .max_in_past
+            .is_some_and(|delta| timestamp < received_at - delta)
+        {
+            error_kind = ErrorKind::PastTimestamp;
+            sent_at = Some(timestamp.into_inner());
+        } else if config
+            .max_in_future
+            .is_some_and(|delta| timestamp > received_at + delta)
+        {
+            error_kind = ErrorKind::FutureTimestamp;
+            sent_at = Some(timestamp.into_inner());
+        }
+    }
+
+    let mut processor = ClockDriftProcessor::new(sent_at, received_at)
+        .at_least(config.minimum_clock_drift)
+        .error_kind(error_kind);
+
+    if processor.is_drifted() {
+        let _ = processor::process_value(item, &mut processor, ProcessingState::root());
+        if let Some(item) = item.value_mut() {
+            processor.apply_correction_meta(item.reference_timestamp().meta_mut());
+        }
+    }
+}
+
+/// Items which can be processed by [`normalize`].
+pub trait TimeNormalize: ProcessValue {
+    /// The base, reference timestamp of the item used for time shifts.
+    ///
+    /// Represents the timestamp when the item was created.
+    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp>;
+}
+
+impl TimeNormalize for OurLog {
+    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+        &mut self.timestamp
+    }
+}
+
+impl TimeNormalize for SpanV2 {
+    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+        &mut self.start_timestamp
+    }
+}
+
+impl TimeNormalize for TraceMetric {
+    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+        &mut self.timestamp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use relay_event_schema::processor::ProcessValue;
+    use relay_protocol::{Annotated, Empty, FromValue, IntoValue, assert_annotated_snapshot};
+
+    #[derive(Debug, Clone, FromValue, IntoValue, Empty, ProcessValue)]
+    struct TestItem {
+        base: Annotated<Timestamp>,
+        other: Annotated<Timestamp>,
+    }
+
+    impl TimeNormalize for TestItem {
+        fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+            &mut self.base
+        }
+    }
+
+    fn ts(secs: i64) -> Timestamp {
+        Timestamp(DateTime::from_timestamp_secs(secs).unwrap())
+    }
+
+    #[test]
+    fn test_normalize_time_no_drift() {
+        let mut item = Annotated::new(TestItem {
+            base: ts(1_000).into(),
+            other: ts(1_010).into(),
+        });
+
+        let config = Config {
+            received_at: ts(1_100).0,
+            ..Default::default()
+        };
+
+        normalize(&mut item, config);
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "base": 1000.0,
+          "other": 1010.0
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_time_client_drift() {
+        let mut item = Annotated::new(TestItem {
+            base: ts(50_000).into(),
+            other: ts(50_010).into(),
+        });
+
+        let config = Config {
+            sent_at: Some(ts(0).0),
+            received_at: ts(51_000).0,
+            ..Default::default()
+        };
+
+        normalize(&mut item, config);
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "base": 101000.0,
+          "other": 101010.0,
+          "_meta": {
+            "base": {
+              "": {
+                "err": [
+                  [
+                    "clock_drift",
+                    {
+                      "sdk_time": "1970-01-01T00:00:00+00:00",
+                      "server_time": "1970-01-01T14:10:00+00:00"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_time_too_far_in_past() {
+        let mut item = Annotated::new(TestItem {
+            base: ts(90_000).into(),
+            other: ts(80_000).into(),
+        });
+
+        let config = Config {
+            received_at: ts(100_000).0,
+            max_in_past: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
+
+        normalize(&mut item, config);
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "base": 100000.0,
+          "other": 90000.0,
+          "_meta": {
+            "base": {
+              "": {
+                "err": [
+                  [
+                    "past_timestamp",
+                    {
+                      "sdk_time": "1970-01-02T01:00:00+00:00",
+                      "server_time": "1970-01-02T03:46:40+00:00"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_time_too_far_in_future() {
+        let mut item = Annotated::new(TestItem {
+            base: ts(90_000).into(),
+            other: ts(80_000).into(),
+        });
+
+        let config = Config {
+            received_at: ts(10_000).0,
+            max_in_future: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
+
+        normalize(&mut item, config);
+
+        assert_annotated_snapshot!(item, @r#"
+        {
+          "base": 10000.0,
+          "other": 0.0,
+          "_meta": {
+            "base": {
+              "": {
+                "err": [
+                  [
+                    "future_timestamp",
+                    {
+                      "sdk_time": "1970-01-02T01:00:00+00:00",
+                      "server_time": "1970-01-01T02:46:40+00:00"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+        "#);
+    }
+}

--- a/relay-event-normalization/src/eap/time.rs
+++ b/relay-event-normalization/src/eap/time.rs
@@ -41,7 +41,7 @@ where
     let timestamp = item
         .value_mut()
         .as_mut()
-        .and_then(|t| t.reference_timestamp().value().copied());
+        .and_then(|t| t.reference_timestamp_mut().value().copied());
 
     if let Some(timestamp) = timestamp {
         if config
@@ -66,7 +66,7 @@ where
     if processor.is_drifted() {
         let _ = processor::process_value(item, &mut processor, ProcessingState::root());
         if let Some(item) = item.value_mut() {
-            processor.apply_correction_meta(item.reference_timestamp().meta_mut());
+            processor.apply_correction_meta(item.reference_timestamp_mut().meta_mut());
         }
     }
 }
@@ -76,23 +76,23 @@ pub trait TimeNormalize: ProcessValue {
     /// The base, reference timestamp of the item used for time shifts.
     ///
     /// Represents the timestamp when the item was created.
-    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp>;
+    fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp>;
 }
 
 impl TimeNormalize for OurLog {
-    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+    fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp> {
         &mut self.timestamp
     }
 }
 
 impl TimeNormalize for SpanV2 {
-    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+    fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp> {
         &mut self.start_timestamp
     }
 }
 
 impl TimeNormalize for TraceMetric {
-    fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+    fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp> {
         &mut self.timestamp
     }
 }
@@ -111,7 +111,7 @@ mod tests {
     }
 
     impl TimeNormalize for TestItem {
-        fn reference_timestamp(&mut self) -> &mut Annotated<Timestamp> {
+        fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp> {
             &mut self.base
         }
     }

--- a/relay-server/src/processing/forward.rs
+++ b/relay-server/src/processing/forward.rs
@@ -1,6 +1,5 @@
 use relay_config::Config;
 use relay_dynamic_config::GlobalConfig;
-#[cfg(feature = "processing")]
 use relay_dynamic_config::{RetentionConfig, RetentionsConfig};
 #[cfg(feature = "processing")]
 use relay_system::{Addr, FromMessage};
@@ -78,11 +77,9 @@ pub struct ForwardContext<'a> {
     #[expect(unused, reason = "not yet used")]
     pub global_config: &'a GlobalConfig,
     /// Project configuration associated with the unit of work.
-    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub project_info: &'a ProjectInfo,
 }
 
-#[cfg(feature = "processing")]
 impl ForwardContext<'_> {
     /// Returns the [`Retention`] for a specific type/product.
     pub fn retention<F>(&self, f: F) -> Retention
@@ -139,15 +136,14 @@ impl From<Nothing> for crate::processing::Outputs {
 
 /// Full retention settings to apply to specific payloads.
 #[derive(Debug, Copy, Clone)]
-#[cfg(feature = "processing")]
 pub struct Retention {
     /// Standard / full fidelity retention policy in days.
     pub standard: u16,
     /// Downsampled retention policy in days.
+    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub downsampled: u16,
 }
 
-#[cfg(feature = "processing")]
 impl From<RetentionConfig> for Retention {
     fn from(value: RetentionConfig) -> Self {
         Self {

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -153,7 +153,7 @@ impl processing::Processor for LogsProcessor {
 
         validate::size(&mut logs, ctx);
 
-        process::normalize(&mut logs);
+        process::normalize(&mut logs, ctx);
         filter::filter(&mut logs, ctx);
 
         let mut logs = self.limiter.enforce_quotas(logs, ctx).await?;

--- a/relay-server/src/processing/utils/mod.rs
+++ b/relay-server/src/processing/utils/mod.rs
@@ -2,5 +2,6 @@ pub mod attachments;
 pub mod dsc;
 pub mod dynamic_sampling;
 pub mod event;
+pub mod normalize;
 #[cfg(feature = "processing")]
 pub mod store;

--- a/relay-server/src/processing/utils/normalize.rs
+++ b/relay-server/src/processing/utils/normalize.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+use relay_dynamic_config::{RetentionConfig, RetentionsConfig};
+use relay_event_normalization::eap;
+
+use crate::envelope::EnvelopeHeaders;
+use crate::processing::Context;
+use crate::services::processor::MINIMUM_CLOCK_DRIFT;
+
+/// Utility to create an [`eap::time::Config`].
+pub fn time_config<F>(headers: &EnvelopeHeaders, f: F, ctx: Context<'_>) -> eap::time::Config
+where
+    F: FnOnce(&RetentionsConfig) -> Option<&RetentionConfig>,
+{
+    eap::time::Config {
+        received_at: headers.meta().received_at(),
+        sent_at: headers.sent_at(),
+        max_in_past: Some(retention_days_to_duration(
+            ctx.to_forward().retention(f).standard,
+        )),
+        max_in_future: ctx
+            .config
+            .max_secs_in_future()
+            .try_into()
+            .ok()
+            .map(Duration::from_secs),
+        minimum_clock_drift: MINIMUM_CLOCK_DRIFT,
+    }
+}
+
+fn retention_days_to_duration(days: u16) -> Duration {
+    const DAYS_TO_SECONDS: u64 = 24 * 60 * 60;
+    Duration::from_secs(days as u64 * DAYS_TO_SECONDS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_days_to_duration() {
+        assert_eq!(retention_days_to_duration(1), Duration::from_secs(86400));
+    }
+}

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -440,8 +440,6 @@ def test_buffer_envelopes_without_global_config(
 
     @mini_sentry.app.endpoint("get_project_config")
     def get_project_config():
-        nonlocal include_global
-
         res = original_endpoint().get_json()
         if not include_global:
             res.pop("global")

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -6,6 +6,9 @@ from sentry_relay.consts import DataCategory
 
 from .asserts import time_within_delta, only_items
 
+import pytest
+import json
+
 
 TEST_CONFIG = {
     "outcomes": {
@@ -321,3 +324,65 @@ def test_trace_metric_size_limits(
             "reason": "too_large:trace_metric",
         },
     ]
+
+
+@pytest.mark.parametrize(
+    "delta,error",
+    [
+        (-timedelta(days=2), "past_timestamp"),
+        (timedelta(days=2), "future_timestamp"),
+    ],
+)
+def test_time_corrections(mini_sentry, relay, delta, error):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = ["organizations:tracemetrics-ingestion"]
+    project_config["config"]["retentions"] = {
+        "traceMetric": {"standard": 1, "downsampled": 100},
+    }
+
+    relay = relay(mini_sentry, options=TEST_CONFIG)
+
+    ts = datetime.now(timezone.utc)
+
+    envelope = envelope_with_trace_metrics(
+        {
+            "timestamp": (ts + delta).timestamp(),
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b175",
+            "name": "http.request.duration",
+            "type": "distribution",
+            "value": 123.45,
+            "unit": "millisecond",
+        }
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    envelope = mini_sentry.get_captured_envelope()
+    item_payload = json.loads(envelope.items[0].payload.bytes.decode())
+    assert item_payload["items"][0] == {
+        "_meta": {
+            "timestamp": {
+                "": {
+                    "err": [
+                        [
+                            error,
+                            {
+                                "sdk_time": time_within_delta(ts + delta),
+                                "server_time": time_within_delta(ts),
+                            },
+                        ]
+                    ]
+                }
+            }
+        },
+        "attributes": mock.ANY,
+        "name": "http.request.duration",
+        "type": "distribution",
+        "value": 123.45,
+        "unit": "millisecond",
+        "span_id": "eee19b7ec3c1b175",
+        "timestamp": time_within_delta(ts),
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+    }

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -1,5 +1,8 @@
+from datetime import datetime, timezone
 from unittest import mock
 import json
+
+from .asserts import time_within_delta
 
 from sentry_relay.consts import DataCategory
 
@@ -9,7 +12,7 @@ VERCEL_LOG_1 = {
     "deploymentId": "dpl_233NRGRjVZX1caZrXWtz5g1TAksD",
     "source": "build",
     "host": "my-app-abc123.vercel.app",
-    "timestamp": 1573817187330,
+    "timestamp": int(datetime.now(timezone.utc).timestamp() * 1000),
     "projectId": "gdufoJxB6b9b1fEqr1jUtFkyavUU",
     "level": "info",
     "message": "Build completed successfully",
@@ -24,7 +27,7 @@ VERCEL_LOG_2 = {
     "deploymentId": "dpl_233NRGRjVZX1caZrXWtz5g1TAksD",
     "source": "lambda",
     "host": "my-app-abc123.vercel.app",
-    "timestamp": 1573817250283,
+    "timestamp": int(datetime.now(timezone.utc).timestamp() * 1000),
     "projectId": "gdufoJxB6b9b1fEqr1jUtFkyavUU",
     "level": "info",
     "message": "API request processed",
@@ -73,7 +76,9 @@ EXPECTED_ITEMS = [
             "vercel.project_name": {"stringValue": "my-app"},
             "sentry.severity_text": {"stringValue": "info"},
             "sentry.observed_timestamp_nanos": {"stringValue": mock.ANY},
-            "sentry.timestamp_precise": {"intValue": "1573817187330000000"},
+            "sentry.timestamp_precise": {
+                "intValue": time_within_delta(expect_resolution="ns")
+            },
             "vercel.build_id": {"stringValue": "bld_cotnkcr76"},
             "sentry.payload_size_bytes": {"intValue": "436"},
             "sentry.browser.name": {"stringValue": "Python Requests"},
@@ -126,7 +131,9 @@ EXPECTED_ITEMS = [
             "sentry.body": {"stringValue": "API request processed"},
             "vercel.proxy.status_code": {"intValue": "200"},
             "sentry.observed_timestamp_nanos": {"stringValue": mock.ANY},
-            "sentry.timestamp_precise": {"intValue": "1573817250283000000"},
+            "sentry.timestamp_precise": {
+                "intValue": time_within_delta(expect_resolution="ns")
+            },
             "sentry.payload_size_bytes": {"intValue": "889"},
             "vercel.proxy.region": {"stringValue": "sfo1"},
         },


### PR DESCRIPTION
Implements [`normalize_timestamps`](https://github.com/getsentry/relay/blob/master/relay-event-normalization/src/validation.rs#L88-L135) for EAP items.

Closes: INGEST-728