### PR TITLE
feat(replay): Relax item validation for SDK compatibility 

### DIFF
--- a/relay-server/src/processing/replays/filter.rs
+++ b/relay-server/src/processing/replays/filter.rs
@@ -33,7 +33,7 @@ pub fn filter(replays: &mut Managed<ExpandedReplays>, ctx: Context<'_>) {
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            let Some(event) = replay.get_event() else {
+            let Some(event) = replay.event_mut() else {
                 return Ok(());
             };
             let event = event.value().ok_or(Error::NoEventContent)?;

--- a/relay-server/src/processing/replays/filter.rs
+++ b/relay-server/src/processing/replays/filter.rs
@@ -33,7 +33,10 @@ pub fn filter(replays: &mut Managed<ExpandedReplays>, ctx: Context<'_>) {
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            let event = replay.get_event().value().ok_or(Error::NoEventContent)?;
+            let Some(event) = replay.get_event() else {
+                return Ok(());
+            };
+            let event = event.value().ok_or(Error::NoEventContent)?;
 
             relay_filter::should_filter(
                 event,

--- a/relay-server/src/processing/replays/forward.rs
+++ b/relay-server/src/processing/replays/forward.rs
@@ -108,5 +108,12 @@ fn serialize_replay(replay: &ExpandedReplay) -> Result<SmallVec<[Item; 2]>, Seri
             let payload = rmp_serde::to_vec_named(&video_event)?;
             Ok(smallvec![create_replay_video_item(payload.into())])
         }
+        ExpandedReplay::StandaloneEvent { event } => {
+            let event_bytes: Bytes = event.to_json()?.into_bytes().into();
+            Ok(smallvec![create_replay_event_item(event_bytes),])
+        }
+        ExpandedReplay::StandaloneRecording { recording } => {
+            Ok(smallvec![create_replay_recording_item(recording.clone()),])
+        }
     }
 }

--- a/relay-server/src/processing/replays/mod.rs
+++ b/relay-server/src/processing/replays/mod.rs
@@ -294,7 +294,7 @@ impl Counted for ExpandedReplay {
 }
 
 impl ExpandedReplay {
-    fn get_event(&mut self) -> Option<&mut Annotated<Replay>> {
+    fn event_mut(&mut self) -> Option<&mut Annotated<Replay>> {
         match self {
             ExpandedReplay::WebReplay { event, .. } => Some(event),
             ExpandedReplay::NativeReplay { event, .. } => Some(event),
@@ -303,7 +303,7 @@ impl ExpandedReplay {
         }
     }
 
-    fn get_recording(&mut self) -> Option<&mut Bytes> {
+    fn recording_mut(&mut self) -> Option<&mut Bytes> {
         match self {
             ExpandedReplay::WebReplay { recording, .. } => Some(recording),
             ExpandedReplay::NativeReplay { recording, .. } => Some(recording),

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -134,7 +134,7 @@ pub fn normalize(replays: &mut Managed<ExpandedReplays>, geoip_lookup: &GeoIpLoo
 
     replays.modify(|replay, _| {
         for replay in replay.replays.iter_mut() {
-            if let Some(event) = replay.get_event() {
+            if let Some(event) = replay.event_mut() {
                 replay::normalize(event, client_addr, &user_agent.as_deref(), geoip_lookup)
             }
         }
@@ -174,7 +174,7 @@ fn scrub_recordings(
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            let Some(payload) = replay.get_recording() else {
+            let Some(payload) = replay.recording_mut() else {
                 return Ok(());
             };
 
@@ -219,7 +219,7 @@ pub fn scrub(
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            if let Some(event) = replay.get_event() {
+            if let Some(event) = replay.event_mut() {
                 scrub_event(event, ctx)
                     .inspect_err(|err| relay_log::debug!("failed to scrub pii from replay: {err}"))
             } else {

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -39,7 +39,8 @@ fn expand_video(item: &Item) -> Result<ExpandedReplay, Error> {
 
 /// Parses all serialized replays into their [`ExpandedReplays`] representation.
 ///
-/// Discards items if they are invalid or there is an invalid combination/amount.
+/// Does not enforce `replay_event` and `replay_recording` to be send together in the same envelope
+/// since some SDKs don't do it and enforcing this would break them.
 pub fn expand(replays: Managed<SerializedReplays>) -> Managed<ExpandedReplays> {
     replays.map(|replays, records| {
         let SerializedReplays {
@@ -50,8 +51,6 @@ pub fn expand(replays: Managed<SerializedReplays>) -> Managed<ExpandedReplays> {
         } = replays;
         let mut replays = Vec::new();
 
-        // There should be at most one event and recording and if there is one there needs to be
-        // one of the other
         match (events.as_slice(), recordings.as_slice()) {
             // Valid case (no 'web replays') if the envelope contains some replay_videos ('native replays')
             ([], []) => (),
@@ -71,26 +70,36 @@ pub fn expand(replays: Managed<SerializedReplays>) -> Managed<ExpandedReplays> {
                     }
                 }
             }
-            (a, b) => {
+            // Handle SDKs that send standalone `replay_event` and `replay_recording`.
+            ([event], []) => match Annotated::<Replay>::from_json_bytes(&event.payload()) {
+                Ok(event) => replays.push(ExpandedReplay::StandaloneEvent { event }),
+                Err(err) => drop(records.reject_err(Error::from(err), event)),
+            },
+            ([], [recording]) => {
+                replays.push(ExpandedReplay::StandaloneRecording {
+                    recording: recording.payload(),
+                });
+            }
+            (events, recordings) => {
                 relay_log::error!(
                     sdk = headers.meta().client().unwrap_or("unknown"),
-                    event_count = a.len(),
-                    recording_count = b.len(),
-                    "replay item recording mismatch"
+                    event_count = events.len(),
+                    recording_count = recordings.len(),
+                    "unexpected replay item count"
                 );
 
-                for item in a {
-                    records.reject_err(Error::InvalidItemCount, item);
+                for event in events {
+                    records.reject_err(Error::InvalidItemCount, event);
                 }
-                for item in b {
-                    records.reject_err(Error::InvalidItemCount, item);
+                for recording in recordings {
+                    records.reject_err(Error::InvalidItemCount, recording);
                 }
             }
         }
 
         // From the SDKs it seems like there will only be one video per envelope but that is not
-        // clearly specified anywhere. Also it seems like their will always only be a video or a
-        // (event, recording).
+        // clearly specified anywhere. Also it seems like their will not be native and web replays
+        // in the same envelope.
         // Currently the logic still allows for multiple videos per envelope as well as 'native' and
         // 'web' replays in the same envelope, in the future we could be more strict on this.
         for video in &videos {
@@ -125,12 +134,9 @@ pub fn normalize(replays: &mut Managed<ExpandedReplays>, geoip_lookup: &GeoIpLoo
 
     replays.modify(|replay, _| {
         for replay in replay.replays.iter_mut() {
-            replay::normalize(
-                replay.get_event(),
-                client_addr,
-                &user_agent.as_deref(),
-                geoip_lookup,
-            )
+            if let Some(event) = replay.get_event() {
+                replay::normalize(event, client_addr, &user_agent.as_deref(), geoip_lookup)
+            }
         }
     })
 }
@@ -168,6 +174,10 @@ fn scrub_recordings(
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
+            let Some(payload) = replay.get_recording() else {
+                return Ok(());
+            };
+
             // Has some internal state so don't move out of the retain.
             let mut scrubber = RecordingScrubber::new(
                 ctx.config.max_replay_uncompressed_size(),
@@ -179,7 +189,6 @@ fn scrub_recordings(
                 return Ok::<(), Error>(());
             }
 
-            let payload = replay.get_recording();
             *payload = metric!(timer(RelayTimers::ReplayRecordingProcessing), {
                 scrubber.process_recording(payload)
             })
@@ -210,8 +219,12 @@ pub fn scrub(
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            scrub_event(replay.get_event(), ctx)
-                .inspect_err(|err| relay_log::debug!("failed to scrub pii from replay: {err}"))
+            if let Some(event) = replay.get_event() {
+                scrub_event(event, ctx)
+                    .inspect_err(|err| relay_log::debug!("failed to scrub pii from replay: {err}"))
+            } else {
+                Ok(())
+            }
         },
     );
 

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -39,7 +39,7 @@ fn expand_video(item: &Item) -> Result<ExpandedReplay, Error> {
 
 /// Parses all serialized replays into their [`ExpandedReplays`] representation.
 ///
-/// Does not enforce `replay_event` and `replay_recording` to be send together in the same envelope
+/// Does not enforce `replay_event` and `replay_recording` to be sent together in the same envelope
 /// since some SDKs don't do it and enforcing this would break them.
 pub fn expand(replays: Managed<SerializedReplays>) -> Managed<ExpandedReplays> {
     replays.map(|replays, records| {

--- a/relay-server/src/processing/replays/validate.rs
+++ b/relay-server/src/processing/replays/validate.rs
@@ -8,7 +8,10 @@ pub fn validate(replays: &mut Managed<ExpandedReplays>) {
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            let event = replay.get_event().value().ok_or(Error::NoEventContent)?;
+            let Some(event) = replay.get_event() else {
+                return Ok(());
+            };
+            let event = event.value().ok_or(Error::NoEventContent)?;
             replay::validate(event).map_err(Error::from)
         },
     )

--- a/relay-server/src/processing/replays/validate.rs
+++ b/relay-server/src/processing/replays/validate.rs
@@ -8,7 +8,7 @@ pub fn validate(replays: &mut Managed<ExpandedReplays>) {
     replays.retain(
         |replays| &mut replays.replays,
         |replay, _| {
-            let Some(event) = replay.get_event() else {
+            let Some(event) = replay.event_mut() else {
                 return Ok(());
             };
             let event = event.value().ok_or(Error::NoEventContent)?;

--- a/tests/integration/test_replay_combined_payload.py
+++ b/tests/integration/test_replay_combined_payload.py
@@ -2,7 +2,9 @@ from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
 from .test_replay_recordings import recording_payload
 from .test_replay_events import generate_replay_sdk_event
+
 import json
+import pytest
 
 
 def test_replay_combined_with_processing(
@@ -55,3 +57,67 @@ def test_replay_combined_with_processing(
     assert replay_event["type"] == "replay_event"
     assert replay_event["replay_id"] == replay_id
     assert replay_event_message["retention_days"] == 90
+
+
+@pytest.mark.parametrize(
+    "send_event,send_recording",
+    [(True, False), (False, True)],
+    ids=["standalone_event", "standalone_recording"],
+)
+@pytest.mark.parametrize(
+    "use_new_processing",
+    [False, True],
+    ids=["old_processing_path", "new_processing_path"],
+)
+def test_standalone_replay_item_from_faulty_sdk(
+    mini_sentry,
+    relay_with_processing,
+    replay_events_consumer,
+    replay_recordings_consumer,
+    send_event,
+    send_recording,
+    use_new_processing,
+):
+    project_id = 42
+    replay_id = "515539018c9b4260a6f999572f1661ee"
+    relay = relay_with_processing()
+
+    features = ["organizations:session-replay"]
+    if use_new_processing:
+        features.append("organizations:new-replay-processing")
+
+    mini_sentry.add_basic_project_config(
+        project_id,
+        extra={"config": {"features": features}},
+    )
+
+    replay_events_consumer = replay_events_consumer(timeout=10)
+    replay_recordings_consumer = replay_recordings_consumer()
+
+    envelope = Envelope(headers=[["event_id", replay_id]])
+    payload = recording_payload(b"[]")
+
+    if send_event:
+        replay_event = generate_replay_sdk_event(replay_id=replay_id)
+        envelope.add_item(
+            Item(payload=PayloadRef(json=replay_event), type="replay_event")
+        )
+
+    if send_recording:
+        envelope.add_item(
+            Item(payload=PayloadRef(bytes=payload), type="replay_recording")
+        )
+
+    relay.send_envelope(project_id, envelope)
+
+    if send_event:
+        replay_event, replay_event_message = replay_events_consumer.get_replay_event()
+        assert replay_event["type"] == "replay_event"
+        assert replay_event["replay_id"] == replay_id
+        assert replay_event_message["retention_days"] == 90
+
+    if send_recording:
+        replay_recording = replay_recordings_consumer.get_not_chunked_replay(timeout=10)
+        assert replay_recording["replay_id"] == replay_id
+        assert replay_recording["payload"] == payload
+        assert replay_recording["replay_event"] is None


### PR DESCRIPTION
Follow up to: https://github.com/getsentry/relay/pull/5580 relaxes the validation to also allow for standalone `replay_event` and `replay_recording` since some SDKs send them.