### PR TITLE
ref(profiles): Apply continuous profiling rate limits to transaction profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Internal**:
 
 - Embed AI operation type mappings into Relay. ([#5555](https://github.com/getsentry/relay/pull/5555))
+- Apply continuous profiling rate limits to transaction profiles. ([#5614](https://github.com/getsentry/relay/pull/5614)
 - Use new processor architecture to process transactions. ([#5379](https://github.com/getsentry/relay/pull/5379))
 - Add `gen_ai_response_time_to_first_token` as a `SpanData` attribute. ([#5575](https://github.com/getsentry/relay/pull/5575))
 - Add sampling to expensive envelope buffer statsd metrics. ([#5576](https://github.com/getsentry/relay/pull/5576))

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -1578,7 +1578,9 @@ def test_profile_outcomes_too_many(
     assert profiles_consumer.get_profile()
 
 
-@pytest.mark.parametrize("quota_category", ["transaction", "profile"])
+@pytest.mark.parametrize(
+    "quota_category", ["transaction", "profile", "profile_chunk_ui"]
+)
 def test_profile_outcomes_rate_limited(
     mini_sentry,
     relay_with_processing,
@@ -1607,15 +1609,12 @@ def test_profile_outcomes_rate_limited(
     config = {
         "outcomes": {
             "emit_outcomes": True,
-            "batch_size": 1,
-            "batch_interval": 1,
             "aggregator": {
                 "bucket_interval": 1,
                 "flush_interval": 1,
             },
-        },
+        }
     }
-
     upstream = relay_with_processing(config)
 
     with open(
@@ -1667,7 +1666,7 @@ def test_profile_outcomes_rate_limited(
         for (category, quantity) in expected_categories
     ]
 
-    if quota_category == "profile":
+    if quota_category != "transaction":
         expected_outcomes.append(
             {
                 "category": DataCategory.SPAN_INDEXED,
@@ -1711,10 +1710,6 @@ def test_profile_outcomes_rate_limited_when_dynamic_sampling_drops(
                 "bucket_interval": 1,
                 "flush_interval": 0,
             },
-        },
-        "aggregator": {
-            "bucket_interval": 1,
-            "initial_delay": 0,
         },
     }
 


### PR DESCRIPTION
Implements: RELAY-199

Does *not* implement the fast path rate limiting, only "slow" path. This is practically useless since we cannot determine the category correctly in the fast path and would introduce a lot of additional complexity to track the platform separately.