### PR TITLE
feat(eap): Trim spans with new trimming processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add new frame fields for MetricKit flamegraphs. ([#5539](https://github.com/getsentry/relay/pull/5539))
 - Apply clock drift correction to logs and trace metrics. ([#5609](https://github.com/getsentry/relay/pull/5609))
+- Trim spans with a new EAP trimming processor. ([#5616](https://github.com/getsentry/relay/pull/5616))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -709,7 +709,7 @@ pub struct Limits {
     /// against excessive metadata sizes.
     ///
     /// Defaults to 10KiB.
-    pub max_removed_attribute_key_bytes: ByteSize,
+    pub max_removed_attribute_key_size: ByteSize,
 }
 
 impl Default for Limits {
@@ -745,7 +745,7 @@ impl Default for Limits {
             idle_timeout: None,
             max_connections: None,
             tcp_listen_backlog: 1024,
-            max_removed_attribute_key_bytes: ByteSize::kibibytes(10),
+            max_removed_attribute_key_size: ByteSize::kibibytes(10),
         }
     }
 }
@@ -2481,11 +2481,8 @@ impl Config {
     }
 
     /// Returns the maximum combined size of keys of invalid attributes.
-    pub fn max_removed_attribute_key_bytes(&self) -> usize {
-        self.values
-            .limits
-            .max_removed_attribute_key_bytes
-            .as_bytes()
+    pub fn max_removed_attribute_key_size(&self) -> usize {
+        self.values.limits.max_removed_attribute_key_size.as_bytes()
     }
 
     /// The maximum number of seconds a query is allowed to take across retries.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -657,6 +657,16 @@ pub struct Limits {
     max_replay_uncompressed_size: ByteSize,
     /// The maximum size for a replay recording Kafka message.
     pub max_replay_message_size: ByteSize,
+    /// The byte size limit up to which Relay will retain
+    /// keys of invalid/removed attributes.
+    ///
+    /// This is only relevant for EAP items (spans, logs, …).
+    /// In principle, we want to record all deletions of attributes,
+    /// but we have to institute some limit to protect our infrastructure
+    /// against excessive metadata sizes.
+    ///
+    /// Defaults to 10KiB.
+    pub max_removed_attribute_key_size: ByteSize,
     /// The maximum number of threads to spawn for CPU and web work, each.
     ///
     /// The total number of threads spawned will roughly be `2 * max_thread_count`. Defaults to
@@ -700,16 +710,6 @@ pub struct Limits {
     ///
     /// Defaults to `1024`, a value [google has been using for a long time](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=19f92a030ca6d772ab44b22ee6a01378a8cb32d4).
     pub tcp_listen_backlog: u32,
-    /// The byte size limit up to which Relay will retain
-    /// keys of invalid/removed attributes.
-    ///
-    /// This is only relevant for EAP items (spans, logs, …).
-    /// In principle, we want to record all deletions of attributes,
-    /// but we have to institute some limit to protect our infrastructure
-    /// against excessive metadata sizes.
-    ///
-    /// Defaults to 10KiB.
-    pub max_removed_attribute_key_size: ByteSize,
 }
 
 impl Default for Limits {

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -700,6 +700,16 @@ pub struct Limits {
     ///
     /// Defaults to `1024`, a value [google has been using for a long time](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=19f92a030ca6d772ab44b22ee6a01378a8cb32d4).
     pub tcp_listen_backlog: u32,
+    /// The byte size limit up to which Relay will retain
+    /// keys of invalid/removed attributes.
+    ///
+    /// This is only relevant for EAP items (spans, logs, …).
+    /// In principle, we want to record all deletions of attributes,
+    /// but we have to institute some limit to protect our infrastructure
+    /// against excessive metadata sizes.
+    ///
+    /// Defaults to 10KiB.
+    pub max_removed_attribute_key_bytes: ByteSize,
 }
 
 impl Default for Limits {
@@ -735,6 +745,7 @@ impl Default for Limits {
             idle_timeout: None,
             max_connections: None,
             tcp_listen_backlog: 1024,
+            max_removed_attribute_key_bytes: ByteSize::kibibytes(10),
         }
     }
 }
@@ -2467,6 +2478,14 @@ impl Config {
     /// Returns the maximum number of active queries
     pub fn max_concurrent_queries(&self) -> usize {
         self.values.limits.max_concurrent_queries
+    }
+
+    /// Returns the maximum combined size of keys of invalid attributes.
+    pub fn max_removed_attribute_key_bytes(&self) -> usize {
+        self.values
+            .limits
+            .max_removed_attribute_key_bytes
+            .as_bytes()
     }
 
     /// The maximum number of seconds a query is allowed to take across retries.

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -287,7 +287,7 @@ impl RetentionsConfig {
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct TrimmingConfig {
     /// The maximum size in bytes above which an item should be trimmed.
-    pub max_bytes: u32,
+    pub max_size: u32,
 }
 
 /// Settings for item trimming.

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -285,6 +285,7 @@ impl RetentionsConfig {
 
 /// Per-category settings for item trimming.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TrimmingConfig {
     /// The maximum size in bytes above which an item should be trimmed.
     pub max_size: u32,

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -26,11 +26,11 @@ mod ai;
 mod size;
 pub mod time;
 pub mod trace_metric;
-#[allow(unused)]
 mod trimming;
 
 pub use self::ai::normalize_ai;
 pub use self::size::*;
+pub use self::trimming::{REMOVED_KEY_BYTE_BUDGET, TrimmingProcessor};
 
 /// Infers the sentry.op attribute and inserts it into [`Attributes`] if not already set.
 pub fn normalize_sentry_op(attributes: &mut Annotated<Attributes>) {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -30,7 +30,7 @@ mod trimming;
 
 pub use self::ai::normalize_ai;
 pub use self::size::*;
-pub use self::trimming::{REMOVED_KEY_BYTE_BUDGET, TrimmingProcessor};
+pub use self::trimming::TrimmingProcessor;
 
 /// Infers the sentry.op attribute and inserts it into [`Attributes`] if not already set.
 pub fn normalize_sentry_op(attributes: &mut Annotated<Attributes>) {

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -9,6 +9,11 @@ use relay_protocol::{Array, Empty, Meta, Object};
 
 use crate::eap::size;
 
+/// Default value for a [`TrimmingProcessor`]'s `removed_key_byte_budget` field.
+///
+/// This determines the limit up to which the keys of discarded items will be kept.
+pub const REMOVED_KEY_BYTE_BUDGET: usize = 10 * 1024;
+
 #[derive(Clone, Debug)]
 struct SizeState {
     max_depth: Option<usize>,

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -364,6 +364,12 @@ impl Processor for TrimmingProcessor {
             return Ok(());
         }
 
+        // This counts the lengths of all attribute keys regardless of whether
+        // the attribute itself is valid or invalid. Strictly speaking, this is
+        // inconsistent with the trimming logic, which only counts keys of valid
+        // attributes. However, this value is only used to set the `original_value`
+        // on the attributes collection for documentation purposes, we accept this
+        // discrepancy for now. In any case this is fine to change.
         let original_length = size::attributes_size(attributes);
 
         // Sort attributes by key + value size so small attributes are more likely to be preserved.

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -9,11 +9,6 @@ use relay_protocol::{Array, Empty, Meta, Object};
 
 use crate::eap::size;
 
-/// Default value for a [`TrimmingProcessor`]'s `removed_key_byte_budget` field.
-///
-/// This determines the limit up to which the keys of discarded items will be kept.
-pub const REMOVED_KEY_BYTE_BUDGET: usize = 10 * 1024;
-
 #[derive(Clone, Debug)]
 struct SizeState {
     max_depth: Option<usize>,

--- a/relay-event-normalization/src/eap/trimming.rs
+++ b/relay-event-normalization/src/eap/trimming.rs
@@ -445,12 +445,7 @@ impl Processor for TrimmingProcessor {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
-    use relay_event_schema::{
-        processor::FieldAttrs,
-        protocol::{AttributeType, AttributeValue},
-    };
+    use relay_event_schema::protocol::{AttributeType, AttributeValue};
     use relay_protocol::{Annotated, FromValue, IntoValue, SerializableAnnotated, Value};
 
     use super::*;

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -11,35 +11,35 @@ use crate::protocol::{Attributes, OperationType, SpanId, Timestamp, TraceId};
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 pub struct SpanV2 {
     /// The ID of the trace to which this span belongs.
-    #[metastructure(required = true, nonempty = true, trim = false, bytes_size = 0)]
+    #[metastructure(required = true, nonempty = true, trim = false)]
     pub trace_id: Annotated<TraceId>,
 
     /// The ID of the span enclosing this span.
-    #[metastructure(trim = false, bytes_size = 0)]
+    #[metastructure(trim = false)]
     pub parent_span_id: Annotated<SpanId>,
 
     /// The Span ID.
-    #[metastructure(required = true, nonempty = true, trim = false, bytes_size = 0)]
+    #[metastructure(required = true, nonempty = true, trim = false)]
     pub span_id: Annotated<SpanId>,
 
     /// Span type (see `OperationType` docs).
-    #[metastructure(required = true, bytes_size = 0)]
+    #[metastructure(required = true, trim = false)]
     pub name: Annotated<OperationType>,
 
     /// The span's status.
-    #[metastructure(required = true, bytes_size = 0)]
+    #[metastructure(required = true, trim = false)]
     pub status: Annotated<SpanV2Status>,
 
     /// Whether this span is the root span of a segment.
-    #[metastructure(trim = false, bytes_size = 0)]
+    #[metastructure(trim = false)]
     pub is_segment: Annotated<bool>,
 
     /// Timestamp when the span started.
-    #[metastructure(required = true, trim = false, bytes_size = 0)]
+    #[metastructure(required = true, trim = false)]
     pub start_timestamp: Annotated<Timestamp>,
 
     /// Timestamp when the span was ended.
-    #[metastructure(required = true, trim = false, bytes_size = 0)]
+    #[metastructure(required = true, trim = false)]
     pub end_timestamp: Annotated<Timestamp>,
 
     /// Links from this span to other spans.
@@ -167,15 +167,15 @@ impl IntoValue for SpanV2Status {
 #[metastructure(trim = false)]
 pub struct SpanV2Link {
     /// The trace id of the linked span.
-    #[metastructure(required = true, trim = false, bytes_size = 0)]
+    #[metastructure(required = true, trim = false)]
     pub trace_id: Annotated<TraceId>,
 
     /// The span id of the linked span.
-    #[metastructure(required = true, trim = false, bytes_size = 0)]
+    #[metastructure(required = true, trim = false)]
     pub span_id: Annotated<SpanId>,
 
     /// Whether the linked span was positively/negatively sampled.
-    #[metastructure(trim = false, bytes_size = 0)]
+    #[metastructure(trim = false)]
     pub sampled: Annotated<bool>,
 
     /// Span link attributes, similar to span attributes/data.

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -167,23 +167,23 @@ impl IntoValue for SpanV2Status {
 #[metastructure(trim = false)]
 pub struct SpanV2Link {
     /// The trace id of the linked span.
-    #[metastructure(required = true, trim = false)]
+    #[metastructure(required = true, trim = false, bytes_size = 0)]
     pub trace_id: Annotated<TraceId>,
 
     /// The span id of the linked span.
-    #[metastructure(required = true, trim = false)]
+    #[metastructure(required = true, trim = false, bytes_size = 0)]
     pub span_id: Annotated<SpanId>,
 
     /// Whether the linked span was positively/negatively sampled.
-    #[metastructure(trim = false)]
+    #[metastructure(trim = false, bytes_size = 0)]
     pub sampled: Annotated<bool>,
 
     /// Span link attributes, similar to span attributes/data.
-    #[metastructure(pii = "maybe", trim = false)]
+    #[metastructure(pii = "maybe", trim = true)]
     pub attributes: Annotated<Attributes>,
 
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(additional_properties, pii = "maybe", trim = false)]
+    #[metastructure(additional_properties, pii = "maybe")]
     pub other: Object<Value>,
 }
 

--- a/relay-event-schema/src/protocol/span_v2.rs
+++ b/relay-event-schema/src/protocol/span_v2.rs
@@ -11,41 +11,43 @@ use crate::protocol::{Attributes, OperationType, SpanId, Timestamp, TraceId};
 #[derive(Clone, Debug, Default, PartialEq, Empty, FromValue, IntoValue, ProcessValue)]
 pub struct SpanV2 {
     /// The ID of the trace to which this span belongs.
-    #[metastructure(required = true, nonempty = true, trim = false)]
+    #[metastructure(required = true, nonempty = true, trim = false, bytes_size = 0)]
     pub trace_id: Annotated<TraceId>,
 
     /// The ID of the span enclosing this span.
+    #[metastructure(trim = false, bytes_size = 0)]
     pub parent_span_id: Annotated<SpanId>,
 
     /// The Span ID.
-    #[metastructure(required = true, nonempty = true, trim = false)]
+    #[metastructure(required = true, nonempty = true, trim = false, bytes_size = 0)]
     pub span_id: Annotated<SpanId>,
 
     /// Span type (see `OperationType` docs).
-    #[metastructure(required = true)]
+    #[metastructure(required = true, bytes_size = 0)]
     pub name: Annotated<OperationType>,
 
     /// The span's status.
-    #[metastructure(required = true)]
+    #[metastructure(required = true, bytes_size = 0)]
     pub status: Annotated<SpanV2Status>,
 
     /// Whether this span is the root span of a segment.
+    #[metastructure(trim = false, bytes_size = 0)]
     pub is_segment: Annotated<bool>,
 
     /// Timestamp when the span started.
-    #[metastructure(required = true)]
+    #[metastructure(required = true, trim = false, bytes_size = 0)]
     pub start_timestamp: Annotated<Timestamp>,
 
     /// Timestamp when the span was ended.
-    #[metastructure(required = true)]
+    #[metastructure(required = true, trim = false, bytes_size = 0)]
     pub end_timestamp: Annotated<Timestamp>,
 
     /// Links from this span to other spans.
-    #[metastructure(pii = "maybe")]
+    #[metastructure(pii = "maybe", trim = true)]
     pub links: Annotated<Array<SpanV2Link>>,
 
     /// Arbitrary attributes on a span.
-    #[metastructure(pii = "true", trim = false)]
+    #[metastructure(pii = "true", trim = true)]
     pub attributes: Annotated<Attributes>,
 
     /// Additional arbitrary fields for forwards compatibility.

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -1,9 +1,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use relay_event_normalization::{
-    GeoIpLookup, RequiredMode, SchemaProcessor, TrimmingProcessor, eap,
-};
+use relay_event_normalization::{GeoIpLookup, RequiredMode, SchemaProcessor, eap};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
 use relay_event_schema::protocol::{Span, SpanId, SpanV2};
 use relay_protocol::Annotated;
@@ -190,7 +188,12 @@ fn normalize_span(
         eap::write_legacy_attributes(&mut span.attributes);
     };
 
-    process_value(span, &mut TrimmingProcessor::new(), ProcessingState::root())?;
+    process_value(
+        span,
+        &mut eap::TrimmingProcessor::new(eap::REMOVED_KEY_BYTE_BUDGET),
+        // TODO: Provide the total item size limit
+        ProcessingState::root(),
+    )?;
     process_value(
         span,
         &mut SchemaProcessor::new().with_required(RequiredMode::DeleteParent),

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -194,14 +194,14 @@ fn normalize_span(
     let trimming_root_state = {
         let mut attrs = FieldAttrs::default();
         if let Some(span_config) = ctx.project_info.config().trimming.span {
-            attrs = attrs.max_bytes(span_config.max_bytes as usize);
+            attrs = attrs.max_bytes(span_config.max_size as usize);
         }
         ProcessingState::new_root(Some(Cow::Owned(attrs)), [])
     };
 
     process_value(
         span,
-        &mut eap::TrimmingProcessor::new(ctx.config.max_removed_attribute_key_bytes()),
+        &mut eap::TrimmingProcessor::new(ctx.config.max_removed_attribute_key_size()),
         &trimming_root_state,
     )?;
 

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -189,6 +189,7 @@ fn normalize_span(
         eap::write_legacy_attributes(&mut span.attributes);
     };
 
+    // TODO: Clean this up before merging.
     // Set a max_bytes value on the root state if it's defined in the project config.
     // This causes the whole item to be trimmed down to the limit.
     let trimming_root_state = {

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -201,7 +201,7 @@ fn normalize_span(
 
     process_value(
         span,
-        &mut eap::TrimmingProcessor::new(eap::REMOVED_KEY_BYTE_BUDGET),
+        &mut eap::TrimmingProcessor::new(ctx.config.max_removed_attribute_key_bytes()),
         &trimming_root_state,
     )?;
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -253,7 +253,6 @@ def test_spansv2_trimming_basic(
     relay.send_envelope(project_id, envelope)
 
     span = spans_consumer.get_span()
-    print(span["attributes"])
 
     assert span == {
         "trace_id": "5b8efff798038103d269b633813fc60c",

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -197,8 +197,9 @@ def test_spansv2_trimming_basic(
             ],
             "retentions": {"span": {"standard": 42, "downsampled": 1337}},
             # This is sufficient for all builtin attributes not
-            # to be trimmed.
-            "trimming": {"span": {"maxSize": 445}},
+            # to be trimmed. The span fields that aren't trimmed
+            # also still count for the size limit.
+            "trimming": {"span": {"maxSize": 453}},
         }
     )
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -204,7 +204,7 @@ def test_spansv2_trimming_basic(
 
     config = {
         "limits": {
-            "max_removed_attribute_key_bytes": 30,
+            "max_removed_attribute_key_size": 30,
         },
         **TEST_CONFIG,
     }

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -198,7 +198,7 @@ def test_spansv2_trimming_basic(
             "retentions": {"span": {"standard": 42, "downsampled": 1337}},
             # This is sufficient for all builtin attributes not
             # to be trimmed.
-            "trimming": {"span": {"max_bytes": 445}},
+            "trimming": {"span": {"max_size": 445}},
         }
     )
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -198,7 +198,7 @@ def test_spansv2_trimming_basic(
             "retentions": {"span": {"standard": 42, "downsampled": 1337}},
             # This is sufficient for all builtin attributes not
             # to be trimmed.
-            "trimming": {"span": {"max_size": 445}},
+            "trimming": {"span": {"maxSize": 445}},
         }
     )
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -173,6 +173,188 @@ def test_spansv2_basic(
     ]
 
 
+def test_spansv2_trimming_basic(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    spans_consumer,
+    metrics_consumer,
+):
+    """
+    An adaptation of `test_spansv2_basic` that has a size limit for spans and attributes large enough
+    to demonstrate that trimming works.
+    """
+    spans_consumer = spans_consumer()
+    metrics_consumer = metrics_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"].update(
+        {
+            "features": [
+                "organizations:standalone-span-ingestion",
+                "projects:span-v2-experimental-processing",
+            ],
+            "retentions": {"span": {"standard": 42, "downsampled": 1337}},
+            # This is sufficient for all builtin attributes not
+            # to be trimmed.
+            "trimming": {"span": {"max_bytes": 510}},
+        }
+    )
+
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+
+    ts = datetime.now(timezone.utc)
+    envelope = envelope_with_spans(
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.5,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b175",
+            "is_segment": True,
+            "name": "some op",
+            "status": "ok",
+            "attributes": {
+                "custom.string.attribute": {
+                    "value": "This is actually a pretty long string",
+                    "type": "string",
+                },
+                # This attribute will get trimmed in the middle of the third string.
+                "custom.array.attribute": {
+                    "value": [
+                        "A string",
+                        "Another longer string",
+                        "Yet another string",
+                    ],
+                    "type": "array",
+                },
+                "custom.invalid.attribute": {"value": True, "type": "string"},
+                "http.response_content_length": {"value": 17, "type": "integer"},
+            },
+        },
+        trace_info={
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "public_key": project_config["publicKeys"][0]["publicKey"],
+            "release": "foo@1.0",
+            "environment": "prod",
+            "transaction": "/my/fancy/endpoint",
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    span = spans_consumer.get_span()
+    print(span["attributes"])
+
+    assert span == {
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "span_id": "eee19b7ec3c1b175",
+        "attributes": {
+            "custom.array.attribute": {
+                "type": "array",
+                "value": ["A string", "Another longer string", "Yet anot..."],
+            },
+            "custom.string.attribute": {
+                "type": "string",
+                "value": "This is actually a pretty long string",
+            },
+            "http.response_content_length": {"value": 17, "type": "integer"},
+            "http.response.body.size": {"value": 17, "type": "integer"},
+            "custom.invalid.attribute": None,
+            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
+            "sentry.browser.version": {"type": "string", "value": "2.32"},
+            "sentry.dsc.environment": {"type": "string", "value": "prod"},
+            "sentry.dsc.public_key": {
+                "type": "string",
+                "value": project_config["publicKeys"][0]["publicKey"],
+            },
+            "sentry.dsc.release": {"type": "string", "value": "foo@1.0"},
+            "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "5b8efff798038103d269b633813fc60c",
+            },
+            "sentry.observed_timestamp_nanos": {
+                "type": "string",
+                "value": time_within(ts, expect_resolution="ns"),
+            },
+            "sentry.op": {"type": "string", "value": "default"},
+        },
+        "_meta": {
+            "attributes": {
+                "": {"len": 541},
+                "custom.array.attribute": {
+                    "value": {
+                        "2": {
+                            "": {
+                                "len": 18,
+                                "rem": [
+                                    [
+                                        "!limit",
+                                        "s",
+                                        8,
+                                        11,
+                                    ],
+                                ],
+                            },
+                        },
+                    },
+                },
+                "custom.invalid.attribute": {
+                    "": {
+                        "err": ["invalid_data"],
+                        "val": {"type": "string", "value": True},
+                    }
+                },
+            }
+        },
+        "name": "some op",
+        "received": time_within(ts),
+        "start_timestamp": time_is(ts),
+        "end_timestamp": time_is(ts.timestamp() + 0.5),
+        "is_segment": True,
+        "status": "ok",
+        "retention_days": 42,
+        "downsampled_retention_days": 1337,
+        "key_id": 123,
+        "organization_id": 1,
+        "project_id": 42,
+    }
+
+    assert metrics_consumer.get_metrics(n=2, with_headers=False) == [
+        {
+            "name": "c:spans/count_per_root_project@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within(ts, precision="s"),
+            "retention_days": 90,
+            "tags": {
+                "decision": "keep",
+                "is_segment": "true",
+                "target_project_id": "42",
+                "transaction": "/my/fancy/endpoint",
+            },
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+        {
+            "name": "c:spans/usage@none",
+            "org_id": 1,
+            "project_id": 42,
+            "received_at": time_within(ts, precision="s"),
+            "retention_days": 90,
+            "tags": {
+                "was_transaction": "false",
+                "is_segment": "true",
+            },
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 1.0,
+        },
+    ]
+
+
 @pytest.mark.parametrize(
     "rule_type",
     ["project", "trace"],


### PR DESCRIPTION
This puts the new trimming processor into practice by enabling it for spans. It also introduces some necessary configuration:
- A new `max_removed_attribute_key_bytes` (default 10KiB) that controls up to which limit Relay will store invalid/removed attribute keys.
- A `trimming` section in the project config which (for now) allows configuring the maximum bytes size above which spans should be trimmed. If this is not set, spans will not be trimmed.
- Field attributes on spans that exclude everything but attributes from trimming and size calculations.

ref: INGEST-732.