### PR TITLE
docs(readme): Update instructions for starting relay's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ create a virtualenv, build the Relay binary with processing enabled, and run
 a set of integration tests:
 
 ```bash
-# Make sure that kafka and redis are running
-devservices up kafka redis
+# Make sure that all dependencies are running
+devservices up relay
 
 # Create a new virtualenv, build Relay and run integration tests
 make test-integration


### PR DESCRIPTION
Update the existing cmd for starting kafka and redis which fails because: 1) `devservices up` only accepts a single service argument and 2) kafka and redis can't be started explicitly (e.g. `devservices up kafka`) with the setup obtained by following the previous instructions of this readme. The new cmd starts redis, kafka, and objectstore correctly as verified by successfully running the integration tests.