### PR TITLE
ref(server): Streaming forward requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Apply clock drift correction to logs and trace metrics. ([#5609](https://github.com/getsentry/relay/pull/5609))
 - Add Culture context to event schema. ([#5615](https://github.com/getsentry/relay/pull/5615))
 - Trim spans with a new EAP trimming processor. ([#5616](https://github.com/getsentry/relay/pull/5616))
+- Forwarded requests are now streamed instead of buffered in-memory. ([#5624](https://github.com/getsentry/relay/pull/5624))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,6 +4569,7 @@ dependencies = [
  "sqlx",
  "symbolic-common",
  "symbolic-unreal",
+ "sync_wrapper",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,7 @@ statsdproxy = { version = "0.4.1", default-features = false }
 symbolic-common = { version = "12.12.3", default-features = false }
 symbolic-unreal = { version = "12.12.3", default-features = false }
 syn = { version = "2.0.106" }
+sync_wrapper = { version = "1.0.2" }
 synstructure = { version = "0.13.2" }
 sysinfo = "0.35.1"
 tempfile = "3.23.0"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -137,6 +137,7 @@ tower-http = { workspace = true, default-features = false, features = [
   "decompression-deflate",
   "decompression-gzip",
   "decompression-zstd",
+  "limit",
   "set-header",
   "trace",
 ] }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -120,6 +120,7 @@ symbolic-common = { workspace = true, optional = true, default-features = false 
 symbolic-unreal = { workspace = true, optional = true, default-features = false, features = [
   "serde",
 ] }
+sync_wrapper = { workspace = true }
 sysinfo = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -25,7 +25,7 @@ pub enum HttpError {
     Io(#[from] io::Error),
     #[error("failed to parse JSON response")]
     Json(#[from] serde_json::Error),
-    #[error("request was misconfigured")]
+    #[error("request was retried or not initialized")]
     Misconfigured,
 }
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -10,7 +10,6 @@
 //! logic.
 use std::io;
 
-use bytes::Bytes;
 use relay_config::HttpEncoding;
 pub use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -93,7 +92,7 @@ impl RequestBuilder {
         self.header_opt("content-encoding", encoding.name())
     }
 
-    pub fn body(&mut self, body: Bytes) -> &mut Self {
+    pub fn body(&mut self, body: impl Into<reqwest::Body>) -> &mut Self {
         self.build(|builder| builder.body(body))
     }
 }

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -25,6 +25,8 @@ pub enum HttpError {
     Io(#[from] io::Error),
     #[error("failed to parse JSON response")]
     Json(#[from] serde_json::Error),
+    #[error("request was misconfigured")]
+    Misconfigured,
 }
 
 impl HttpError {
@@ -36,7 +38,8 @@ impl HttpError {
             // logic is part of upstream service.
             Self::Reqwest(error) => error.is_timeout(),
             Self::Json(_) => false,
-            HttpError::Overflow => false,
+            Self::Overflow => false,
+            Self::Misconfigured => false,
         }
     }
 }

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -193,6 +193,7 @@ impl UpstreamRequestError {
             UpstreamRequestError::Http(HttpError::Json(_)) => "invalid_json",
             UpstreamRequestError::Http(HttpError::Reqwest(_)) => "reqwest_error",
             UpstreamRequestError::Http(HttpError::Overflow) => "overflow",
+            UpstreamRequestError::Http(HttpError::Misconfigured) => "misconfigured",
             UpstreamRequestError::RateLimited(_) => "rate_limited",
             UpstreamRequestError::ResponseError(_, _) => "response_error",
             UpstreamRequestError::ChannelClosed => "channel_closed",

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -305,6 +305,11 @@ def mini_sentry(request):  # noqa
         if flask_request.url_rule:
             sentry.hit(flask_request.url_rule.rule)
 
+        # Store endpoints theoretically support chunked transfer encoding,
+        # but for now, we're conservative and don't allow that anywhere.
+        if flask_request.headers.get("transfer-encoding"):
+            abort(400, "transfer encoding not supported")
+
         sentry.request_log.append((flask_request.headers, flask_request.url))
 
     @app.route("/api/0/relays/register/challenge/", methods=["POST"])

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -49,6 +49,7 @@ class Sentry(SentryLike):
         self.request_log = []
         self.project_config_simulate_pending = False
         self.project_config_ignore_revision = False
+        self.allow_chunked = False
 
         self.timeout = 10
 
@@ -307,7 +308,7 @@ def mini_sentry(request):  # noqa
 
         # Store endpoints theoretically support chunked transfer encoding,
         # but for now, we're conservative and don't allow that anywhere.
-        if flask_request.headers.get("transfer-encoding"):
+        if not sentry.allow_chunked and flask_request.headers.get("transfer-encoding"):
             abort(400, "transfer encoding not supported")
 
         sentry.request_log.append((flask_request.headers, flask_request.url))

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -305,11 +305,6 @@ def mini_sentry(request):  # noqa
         if flask_request.url_rule:
             sentry.hit(flask_request.url_rule.rule)
 
-        # Store endpoints theoretically support chunked transfer encoding,
-        # but for now, we're conservative and don't allow that anywhere.
-        if flask_request.headers.get("transfer-encoding"):
-            abort(400, "transfer encoding not supported")
-
         sentry.request_log.append((flask_request.headers, flask_request.url))
 
     @app.route("/api/0/relays/register/challenge/", methods=["POST"])

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -247,13 +247,14 @@ def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     [
         "/api/42/store/",
         "/api/42/envelope/",
-        "/api/42/attachment/",
+        "/api/666/envelope/",
         "/api/42/minidump/",
     ],
 )
 def test_zipbomb_content_encoding(mini_sentry, relay, route):
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
+    mini_sentry.allow_chunked = True
     relay = relay(
         mini_sentry,
         options={

--- a/tests/integration/test_forwarding.py
+++ b/tests/integration/test_forwarding.py
@@ -21,6 +21,8 @@ def test_forwarding_content_encoding(
 ):
     data = b"foobar"
 
+    mini_sentry.allow_chunked = True
+
     @mini_sentry.app.route("/api/test/reflect", methods=["POST"])
     def test():
         _data = request.data


### PR DESCRIPTION
When outdated external Relays get a request to an unknown endpoint, they should forward it to our internal Relays for compatibility. However, they should not be forced to buffer the entire request in-memory, especially not for the upcoming large file uploads.

This PR changes the forward endpoint to stream the request upstream without buffering the full body, and lays the foundation for other streaming endpoints.

Fixes INGEST-679.