### PR TITLE
ref(observability): Send all logs to Sentry

### DIFF
--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -329,10 +329,6 @@ pub unsafe fn init(config: &LogConfig, sentry: &SentryConfig) {
 
     tracing_subscriber::registry()
         .with(format.with_filter(config.level_filter()))
-        .with(match env::var(EnvFilter::DEFAULT_ENV) {
-            Ok(value) => EnvFilter::new(value),
-            Err(_) => get_default_filters(),
-        })
         .with(
             // Same as the default filter, except it converts warnings into events
             // and also sends everything at or above INFO as logs instead of breadcrumbs.
@@ -343,6 +339,10 @@ pub unsafe fn init(config: &LogConfig, sentry: &SentryConfig) {
                 _ => EventFilter::Log,
             }),
         )
+        .with(match env::var(EnvFilter::DEFAULT_ENV) {
+            Ok(value) => EnvFilter::new(value),
+            Err(_) => get_default_filters(),
+        })
         .init();
 
     if let Some(dsn) = sentry.enabled_dsn() {


### PR DESCRIPTION
This sends all logs to Sentry, which aren't filtered by the global env filter.