### PR TITLE
feat(replay): Remove `replay_relay_snuba_publish_disabled_sample_rate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add `gen_ai.cost_calculation.result` metric to track AI cost calculation outcomes by integration and platform. ([#5560](https://github.com/getsentry/relay/pull/5560))
 - Normalizes and validates trace metric names. ([#5589](https://github.com/getsentry/relay/pull/5589))
 - Add manual category to cost calculation metric origin tag ([#5603](https://github.com/getsentry/relay/pull/5603))
+- Remove the `ReplayEvents` Kafka topic and the `replay.relay-snuba-publishing-disabled.sample-rate` option. ([#5629](https://github.com/getsentry/relay/pull/5629))
 
 ## 26.1.0
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -157,14 +157,6 @@ pub struct Options {
     )]
     pub http_span_allowed_hosts: Vec<String>,
 
-    /// Disables Relay from sending replay-events to Snuba.
-    #[serde(
-        rename = "replay.relay-snuba-publishing-disabled.sample-rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub replay_relay_snuba_publish_disabled_sample_rate: f32,
-
     /// Instructs relay to store attachments in objectstore instead of sending chunks via kafka.
     ///
     /// Rate needs to be between `0.0` and `1.0`.

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -35,8 +35,6 @@ pub enum KafkaTopic {
     MetricsGeneric,
     /// Profiles
     Profiles,
-    /// ReplayEvents, breadcrumb + session updates for replays
-    ReplayEvents,
     /// ReplayRecordings, large blobs sent by the replay sdk
     ReplayRecordings,
     /// Monitor check-ins.
@@ -54,7 +52,7 @@ impl KafkaTopic {
     /// It will have to be adjusted if the new variants are added.
     pub fn iter() -> std::slice::Iter<'static, Self> {
         use KafkaTopic::*;
-        static TOPICS: [KafkaTopic; 14] = [
+        static TOPICS: [KafkaTopic; 13] = [
             Events,
             Attachments,
             Transactions,
@@ -63,7 +61,6 @@ impl KafkaTopic {
             MetricsSessions,
             MetricsGeneric,
             Profiles,
-            ReplayEvents,
             ReplayRecordings,
             Monitors,
             Spans,
@@ -139,7 +136,6 @@ define_topic_assignments! {
     metrics_sessions: (KafkaTopic::MetricsSessions, "ingest-metrics", "Topic name for metrics extracted from sessions, aka release health."),
     metrics_generic: (KafkaTopic::MetricsGeneric, "ingest-performance-metrics", "Topic name for all other kinds of metrics."),
     profiles: (KafkaTopic::Profiles, "profiles", "Stacktrace topic name"),
-    replay_events: (KafkaTopic::ReplayEvents, "ingest-replay-events", "Replay Events topic name."),
     replay_recordings: (KafkaTopic::ReplayRecordings, "ingest-replay-recordings", "Recordings topic name."),
     monitors: (KafkaTopic::Monitors, "ingest-monitors", "Monitor check-ins."),
     spans: (KafkaTopic::Spans, "ingest-spans", "Standalone spans without a transaction."),
@@ -348,7 +344,7 @@ transactions: "ingest-transactions-kafka-topic"
         );
 
         let topics: TopicAssignments = serde_yaml::from_str(yaml).unwrap();
-        insta::assert_debug_snapshot!(topics, @r###"
+        insta::assert_debug_snapshot!(topics, @r#"
         TopicAssignments {
             events: TopicAssignment(
                 [
@@ -424,15 +420,6 @@ transactions: "ingest-transactions-kafka-topic"
                     },
                 ],
             ),
-            replay_events: TopicAssignment(
-                [
-                    TopicConfig {
-                        topic_name: "ingest-replay-events",
-                        kafka_config_name: None,
-                        key_rate_limit: None,
-                    },
-                ],
-            ),
             replay_recordings: TopicAssignment(
                 [
                     TopicConfig {
@@ -482,7 +469,7 @@ transactions: "ingest-transactions-kafka-topic"
                 [],
             ),
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,6 @@ from .fixtures.processing import (  # noqa
     replay_recordings_consumer,
     sessions_consumer,
     metrics_consumer,
-    replay_events_consumer,
     monitors_consumer,
     spans_consumer,
     items_consumer,

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -62,7 +62,6 @@ def processing_config(get_topic_name):
                 "outcomes_billing": outcomes_topic,
                 "metrics_sessions": metrics_topic,
                 "metrics_generic": metrics_topic,
-                "replay_events": get_topic_name("replay_events"),
                 "replay_recordings": get_topic_name("replay_recordings"),
                 "monitors": get_topic_name("monitors"),
                 "spans": get_topic_name("spans"),
@@ -406,11 +405,6 @@ def metrics_consumer(consumer_fixture):
 @pytest.fixture
 def replay_recordings_consumer(consumer_fixture):
     yield from consumer_fixture(ReplayRecordingsConsumer, "replay_recordings")
-
-
-@pytest.fixture
-def replay_events_consumer(consumer_fixture):
-    yield from consumer_fixture(ReplayEventsConsumer, "replay_events")
 
 
 @pytest.fixture

--- a/tests/integration/test_replay_combined_payload.py
+++ b/tests/integration/test_replay_combined_payload.py
@@ -11,7 +11,6 @@ def test_replay_combined_with_processing(
     mini_sentry,
     relay_with_processing,
     replay_recordings_consumer,
-    replay_events_consumer,
 ):
     project_id = 42
     replay_id = "515539018c9b4260a6f999572f1661ee"
@@ -21,7 +20,6 @@ def test_replay_combined_with_processing(
         extra={"config": {"features": ["organizations:session-replay"]}},
     )
     replay_recordings_consumer = replay_recordings_consumer()
-    replay_events_consumer = replay_events_consumer(timeout=10)
 
     envelope = Envelope(
         headers=[
@@ -53,29 +51,17 @@ def test_replay_combined_with_processing(
 
     assert replay_event["replay_id"] == replay_id
 
-    replay_event, replay_event_message = replay_events_consumer.get_replay_event()
-    assert replay_event["type"] == "replay_event"
-    assert replay_event["replay_id"] == replay_id
-    assert replay_event_message["retention_days"] == 90
 
-
-@pytest.mark.parametrize(
-    "send_event,send_recording",
-    [(True, False), (False, True)],
-    ids=["standalone_event", "standalone_recording"],
-)
 @pytest.mark.parametrize(
     "use_new_processing",
     [False, True],
     ids=["old_processing_path", "new_processing_path"],
 )
-def test_standalone_replay_item_from_faulty_sdk(
+def test_standalone_recording_from_faulty_sdk(
     mini_sentry,
     relay_with_processing,
     replay_events_consumer,
     replay_recordings_consumer,
-    send_event,
-    send_recording,
     use_new_processing,
 ):
     project_id = 42
@@ -97,27 +83,11 @@ def test_standalone_replay_item_from_faulty_sdk(
     envelope = Envelope(headers=[["event_id", replay_id]])
     payload = recording_payload(b"[]")
 
-    if send_event:
-        replay_event = generate_replay_sdk_event(replay_id=replay_id)
-        envelope.add_item(
-            Item(payload=PayloadRef(json=replay_event), type="replay_event")
-        )
-
-    if send_recording:
-        envelope.add_item(
-            Item(payload=PayloadRef(bytes=payload), type="replay_recording")
-        )
+    envelope.add_item(Item(payload=PayloadRef(bytes=payload), type="replay_recording"))
 
     relay.send_envelope(project_id, envelope)
 
-    if send_event:
-        replay_event, replay_event_message = replay_events_consumer.get_replay_event()
-        assert replay_event["type"] == "replay_event"
-        assert replay_event["replay_id"] == replay_id
-        assert replay_event_message["retention_days"] == 90
-
-    if send_recording:
-        replay_recording = replay_recordings_consumer.get_not_chunked_replay(timeout=10)
-        assert replay_recording["replay_id"] == replay_id
-        assert replay_recording["payload"] == payload
-        assert replay_recording["replay_event"] is None
+    replay_recording = replay_recordings_consumer.get_not_chunked_replay(timeout=10)
+    assert replay_recording["replay_id"] == replay_id
+    assert replay_recording["payload"] == payload
+    assert replay_recording["replay_event"] is None

--- a/tests/integration/test_replay_combined_payload.py
+++ b/tests/integration/test_replay_combined_payload.py
@@ -60,7 +60,6 @@ def test_replay_combined_with_processing(
 def test_standalone_recording_from_faulty_sdk(
     mini_sentry,
     relay_with_processing,
-    replay_events_consumer,
     replay_recordings_consumer,
     use_new_processing,
 ):
@@ -77,7 +76,6 @@ def test_standalone_recording_from_faulty_sdk(
         extra={"config": {"features": features}},
     )
 
-    replay_events_consumer = replay_events_consumer(timeout=10)
     replay_recordings_consumer = replay_recordings_consumer()
 
     envelope = Envelope(headers=[["event_id", replay_id]])

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -123,7 +123,6 @@ def test_replay_events_without_processing(mini_sentry, relay_chain):
 def test_replay_events_are_filtered(
     mini_sentry,
     relay_with_processing,
-    replay_events_consumer,
     outcomes_consumer,
 ):
     relay = relay_with_processing()
@@ -134,7 +133,6 @@ def test_replay_events_are_filtered(
     filter_settings["localhost"] = {"isEnabled": True}
     outcomes_consumer = outcomes_consumer()
 
-    replay_events_consumer = replay_events_consumer(timeout=10)
     replay = generate_replay_sdk_event()
     replay["request"]["url"] = "http://localhost:1200"
 
@@ -148,5 +146,4 @@ def test_replay_events_are_filtered(
     assert outcome["category"] == 7
     assert outcome["quantity"] == 2
 
-    replay_events_consumer.assert_empty()
     outcomes_consumer.assert_empty()

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -101,24 +101,6 @@ def assert_replay_payload_matches(produced, consumed):
     }
 
 
-def test_replay_event_with_processing(
-    mini_sentry, relay_with_processing, replay_events_consumer
-):
-    relay = relay_with_processing()
-    mini_sentry.add_basic_project_config(
-        42, extra={"config": {"features": ["organizations:session-replay"]}}
-    )
-
-    replay_events_consumer = replay_events_consumer(timeout=10)
-    replay = generate_replay_sdk_event()
-
-    relay.send_replay_event(42, replay)
-
-    replay_event, replay_event_message = replay_events_consumer.get_replay_event()
-    assert replay_event_message["retention_days"] == 90
-    assert_replay_payload_matches(replay, replay_event)
-
-
 def test_replay_events_without_processing(mini_sentry, relay_chain):
     relay = relay_chain(min_relay_version="latest")
 

--- a/tests/integration/test_replay_videos.py
+++ b/tests/integration/test_replay_videos.py
@@ -79,7 +79,6 @@ def test_replay_recording_with_video_denied(
     relay_with_processing,
     replay_recordings_consumer,
     outcomes_consumer,
-    replay_events_consumer,
 ):
     project_id = 42
     replay_id = "515539018c9b4260a6f999572f1661ee"
@@ -96,7 +95,6 @@ def test_replay_recording_with_video_denied(
         },
     )
     replay = generate_replay_sdk_event(replay_id)
-    replay_events_consumer = replay_events_consumer(timeout=10)
     replay_recordings_consumer = replay_recordings_consumer()
     outcomes_consumer = outcomes_consumer()
 
@@ -125,4 +123,3 @@ def test_replay_recording_with_video_denied(
     # Assert all conumers are empty.
     replay_recordings_consumer.assert_empty()
     outcomes_consumer.assert_empty()
-    replay_events_consumer.assert_empty()


### PR DESCRIPTION
While working on the refactor of the `process_replay` logic we noticed that `relay-snuba-publishing-disabled` is perpetually set to 100%.

This PR replaces the option with a hard coded true value and removes all the code that is dead due to this change. Specifically `produce_replay_event` which currently just early returns and `ReplayEventKafkaMessage` which is only constructed in this function. Furthermore the tests that rely on the option are also modified or removed (if they now test behaviour that is no longer possible).

Follow up:
- [x] Remove support for standalone `replay_events` in the processor since they are dropped silently in the store anyways.
- [ ] Remove the flag on the sentry and options automator side.