### PR TITLE
fix(forward): Respond with 413 if request body too large

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,12 +1872,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -4506,6 +4506,7 @@ dependencies = [
  "futures",
  "hashbrown 0.15.4",
  "http",
+ "http-body-util",
  "hyper",
  "hyper-util",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ hex = "0.4.3"
 hmac = "0.12.1"
 hostname = "0.4.1"
 http = "1.3.1"
+http-body-util = "0.1.3"
 human-size = "0.4.3"
 hyper = "1.7.0"
 hyper-util = { version = "0.1.17", features = ["tokio"] }

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -48,6 +48,7 @@ either = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true, features = ["async-await"] }
 hashbrown = { workspace = true }
+http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 itertools = { workspace = true }

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -301,7 +301,11 @@ def mini_sentry(request):  # noqa
     def count_hits():
         # Consume POST body even if we don't like this request
         # to no clobber the socket and buffers
-        _ = flask_request.data
+        try:
+            _ = flask_request.data
+        except Exception:
+            # stream might be invalid
+            pass
 
         if flask_request.url_rule:
             sentry.hit(flask_request.url_rule.rule)

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -247,7 +247,7 @@ def test_store_allowed_origins_passes(mini_sentry, relay, allowed_origins):
     [
         "/api/42/store/",
         "/api/42/envelope/",
-        "/api/666/envelope/",
+        "/api/42/attachment/",
         "/api/42/minidump/",
     ],
 )


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/5624#discussion_r2791673752

I verified that the server indeed responds with 502. Fixed by checking the error source in `ForwardError::into_response`.