### PR TITLE
meta(vscode): Unconfigure clippy for checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
 
   // Rust Analyzer
   "rust-analyzer.cargo.features": "all",
-  "rust-analyzer.check.command": "clippy",
   "rust-analyzer.imports.granularity.group": "module",
   "rust-analyzer.imports.prefix": "crate",
 


### PR DESCRIPTION
It's too slow for my taste, and it being checked in overrides any default.