### PR TITLE
feat(replay): Remove support for standalone `replay_event`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Emit outcomes for spans trimmed from a transaction. ([#5410](https://github.com/getsentry/relay/pull/5410))
 - Support `sample` alias in CSP reports. ([#5554](https://github.com/getsentry/relay/pull/5554))
 - Fix inconsistencies with Insights' expected attributes. ([#5561](https://github.com/getsentry/relay/pull/5561))
+- Emit outcomes for dropped standalone `replay_event` items. ([#5634](https://github.com/getsentry/relay/pull/5634))
 
 **Features**:
 

--- a/relay-server/src/processing/replays/forward.rs
+++ b/relay-server/src/processing/replays/forward.rs
@@ -108,10 +108,6 @@ fn serialize_replay(replay: &ExpandedReplay) -> Result<SmallVec<[Item; 2]>, Seri
             let payload = rmp_serde::to_vec_named(&video_event)?;
             Ok(smallvec![create_replay_video_item(payload.into())])
         }
-        ExpandedReplay::StandaloneEvent { event } => {
-            let event_bytes: Bytes = event.to_json()?.into_bytes().into();
-            Ok(smallvec![create_replay_event_item(event_bytes),])
-        }
         ExpandedReplay::StandaloneRecording { recording } => {
             Ok(smallvec![create_replay_recording_item(recording.clone()),])
         }

--- a/relay-server/src/processing/replays/mod.rs
+++ b/relay-server/src/processing/replays/mod.rs
@@ -31,10 +31,14 @@ pub enum Error {
 
     /// There is an invalid amount of `replay_event` and `replay_recording` items in the envelope.
     ///
-    /// Valid quantity combinations: (0, 0), (1, 1), (1, 0), or (0, 1).
+    /// Valid quantity combinations: (0, 0), (1, 1) or (0, 1).
     /// Standalone events and recordings are supported for SDK compatibility.
     #[error("invalid item count")]
     InvalidItemCount,
+
+    /// Relay event without a recording.
+    #[error("replay event without recording")]
+    EventWithoutRecording,
 
     /// The Replay event could not be parsed from JSON.
     #[error("invalid json: {0}")]
@@ -84,6 +88,9 @@ impl OutcomeError for Error {
         let outcome = match &self {
             Self::FilterFeatureFlag => None,
             Self::InvalidItemCount => Some(Outcome::Invalid(DiscardReason::DuplicateItem)),
+            Self::EventWithoutRecording => Some(Outcome::Invalid(
+                DiscardReason::InvalidReplayMissingRecording,
+            )),
             Self::CouldNotParseEvent(_) => {
                 Some(Outcome::Invalid(DiscardReason::InvalidReplayEvent))
             }

--- a/relay-server/src/processing/replays/mod.rs
+++ b/relay-server/src/processing/replays/mod.rs
@@ -266,11 +266,6 @@ enum ExpandedReplay {
         recording: Bytes,
         video: Bytes,
     },
-    /// A standalone replay event.
-    ///
-    /// Although a `replay_event` and `replay_recording` should always be send together in an
-    /// envelope, this is not the case for some SDKs. As such, support this to not break them.
-    StandaloneEvent { event: Annotated<Replay> },
     /// A standalone replay recording.
     ///
     /// Although a `replay_event` and `replay_recording` should always be send together in an
@@ -284,9 +279,7 @@ impl Counted for ExpandedReplay {
             ExpandedReplay::WebReplay { .. } => {
                 smallvec::smallvec![(DataCategory::Replay, 2)]
             }
-            ExpandedReplay::NativeReplay { .. }
-            | ExpandedReplay::StandaloneEvent { .. }
-            | ExpandedReplay::StandaloneRecording { .. } => {
+            ExpandedReplay::NativeReplay { .. } | ExpandedReplay::StandaloneRecording { .. } => {
                 smallvec::smallvec![(DataCategory::Replay, 1)]
             }
         }
@@ -298,17 +291,15 @@ impl ExpandedReplay {
         match self {
             ExpandedReplay::WebReplay { event, .. } => Some(event),
             ExpandedReplay::NativeReplay { event, .. } => Some(event),
-            ExpandedReplay::StandaloneEvent { event } => Some(event),
             ExpandedReplay::StandaloneRecording { .. } => None,
         }
     }
 
-    fn recording_mut(&mut self) -> Option<&mut Bytes> {
+    fn recording_mut(&mut self) -> &mut Bytes {
         match self {
-            ExpandedReplay::WebReplay { recording, .. } => Some(recording),
-            ExpandedReplay::NativeReplay { recording, .. } => Some(recording),
-            ExpandedReplay::StandaloneEvent { .. } => None,
-            ExpandedReplay::StandaloneRecording { recording } => Some(recording),
+            ExpandedReplay::WebReplay { recording, .. } => recording,
+            ExpandedReplay::NativeReplay { recording, .. } => recording,
+            ExpandedReplay::StandaloneRecording { recording } => recording,
         }
     }
 }

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -70,7 +70,12 @@ pub fn expand(replays: Managed<SerializedReplays>) -> Managed<ExpandedReplays> {
                     }
                 }
             }
-            // Handle SDKs that send standalone `replay_recording`.
+            // Handle SDKs that send standalone `replay_event` and `replay_recording`.
+            ([event], []) => {
+                // Since standalone events previously already got dropped in the store we can drop
+                // them here without breaking any SDKs.
+                records.reject_err(Error::EventWithoutRecording, event);
+            }
             ([], [recording]) => {
                 replays.push(ExpandedReplay::StandaloneRecording {
                     recording: recording.payload(),

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -472,6 +472,7 @@ pub enum DiscardReason {
     InvalidReplayEventPii,
     InvalidReplayRecordingEvent,
     InvalidReplayVideoEvent,
+    InvalidReplayMissingRecording,
 
     /// (Relay) Profiling related discard reasons
     Profiling(&'static str),
@@ -554,6 +555,7 @@ impl DiscardReason {
             DiscardReason::InvalidReplayEventPii => "invalid_replay_pii_scrubber_failed",
             DiscardReason::InvalidReplayRecordingEvent => "invalid_replay_recording",
             DiscardReason::InvalidReplayVideoEvent => "invalid_replay_video",
+            DiscardReason::InvalidReplayMissingRecording => "invalid_replay_missing_recording",
             DiscardReason::Profiling(reason) => reason,
             DiscardReason::InvalidLog => "invalid_log",
             DiscardReason::InvalidTraceMetric => "invalid_trace_metric",


### PR DESCRIPTION
As noted here (https://github.com/getsentry/relay/pull/5629) we already drop standalone `replay_event`s in the store.  
This now updates the logic to drop them early to avoid processing.  
**Note:** Instead of dropping them silently we now drop them with `DiscardReason::InvalidReplayMissingRecording`.