### PR TITLE
feat(ai): Map processor spans to other gen_ai op type

### DIFF
--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -163,6 +163,7 @@ pub fn infer_ai_operation_type(op_name: &str) -> Option<&'static str> {
         | "create_agent" => "agent",
         "gen_ai.execute_tool" | "execute_tool" => "tool",
         "gen_ai.handoff" | "handoff" => "handoff",
+        "ai.processor" | "processor_run" => "other",
         // Prefix matches:
         op if op.starts_with("ai.streamText.doStream") => "ai_client",
         op if op.starts_with("ai.streamText") => "agent",


### PR DESCRIPTION
Maps processor spans to `gen_ai.operation.type: other`.

This spans are reported by some SDKs as a filler spans, but are not "real" AI spans, so we need a way to display them differently in the UI. This is why it is mapped to a new operation type "other"

Closes [TET-1940: Map processor spans to `gen_ai.operation.type: other`](https://linear.app/getsentry/issue/TET-1940/map-processor-spans-to-gen-aioperationtype-other)