### PR TITLE
Revert "ref(observability): Send all logs to Sentry"

### DIFF
--- a/relay-log/src/setup.rs
+++ b/relay-log/src/setup.rs
@@ -336,7 +336,8 @@ pub unsafe fn init(config: &LogConfig, sentry: &SentryConfig) {
                 tracing::Level::ERROR | tracing::Level::WARN => {
                     EventFilter::Event | EventFilter::Log
                 }
-                _ => EventFilter::Log,
+                tracing::Level::INFO => EventFilter::Log,
+                tracing::Level::DEBUG | tracing::Level::TRACE => EventFilter::Ignore,
             }),
         )
         .with(match env::var(EnvFilter::DEFAULT_ENV) {


### PR DESCRIPTION
Reverts getsentry/relay#5628
