### PR TITLE
fix(otlp): Return status code 200, not 202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Return status code 200 instead of 202 for OTLP endpoints. ([#5645](https://github.com/getsentry/relay/pull/5645))
+
 ## 26.2.0
 
 **Bug Fixes**:

--- a/relay-server/src/endpoints/integrations/otlp.rs
+++ b/relay-server/src/endpoints/integrations/otlp.rs
@@ -47,7 +47,7 @@ mod traces {
             .await?
             .check_rate_limits()?;
 
-        Ok(StatusCode::ACCEPTED)
+        Ok(StatusCode::OK)
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
@@ -78,7 +78,7 @@ mod logs {
             .await?
             .ignore_rate_limits();
 
-        Ok(StatusCode::ACCEPTED)
+        Ok(StatusCode::OK)
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {


### PR DESCRIPTION
The [spec](https://opentelemetry.io/docs/specs/otlp/#full-success-1) want's a 200 status code, not sure why we return 202, seems to be a historic artifact.