### PR TITLE
feat(replay): Remove the quantities logic from the store

### DIFF
--- a/relay-server/src/processing/replays/store.rs
+++ b/relay-server/src/processing/replays/store.rs
@@ -3,6 +3,7 @@ use relay_event_schema::protocol::{EventId, Replay};
 
 use relay_protocol::Annotated;
 
+use crate::managed::Counted;
 use crate::processing::replays::{Error, ExpandedReplay};
 use crate::services::store::StoreReplay;
 
@@ -24,6 +25,7 @@ pub struct Context {
 ///
 /// Fails if the event can not be serialized or the created message is too large for the consumer.
 pub fn convert(replay: ExpandedReplay, ctx: &Context) -> Result<StoreReplay, Error> {
+    let quantities = replay.quantities();
     let (recording, event, video) = match replay {
         ExpandedReplay::StandaloneRecording { recording } => (recording, None, None),
         ExpandedReplay::WebReplay { event, recording } => (recording, Some(event), None),
@@ -53,6 +55,7 @@ pub fn convert(replay: ExpandedReplay, ctx: &Context) -> Result<StoreReplay, Err
         recording,
         event,
         video,
+        quantities,
     })
 }
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -14,7 +14,6 @@ use prost::Message as _;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
-use smallvec::smallvec;
 use uuid::Uuid;
 
 use relay_base_schema::data_category::DataCategory;

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -175,16 +175,15 @@ pub struct StoreReplay {
     pub event: Option<Bytes>,
     /// Optional replay video.
     pub video: Option<Bytes>,
+    /// Outcome quantities associated with this replay.
+    ///
+    /// Quantities are different for web and native replays.
+    pub quantities: Quantities,
 }
 
 impl Counted for StoreReplay {
     fn quantities(&self) -> Quantities {
-        // Web replays currently count as 2 since they are 2 items in the envelope (event + recording).
-        if self.event.is_some() && self.video.is_none() {
-            smallvec![(DataCategory::Replay, 2)]
-        } else {
-            smallvec![(DataCategory::Replay, 1)]
-        }
+        self.quantities.clone()
     }
 }
 


### PR DESCRIPTION
As a follow up to the replay rework https://github.com/getsentry/relay/pull/5580 this moves the quantities logic out of the store.

**Note:** The initial goal was to change the logic to count both web and native replays as 1 `Replay` however all options considered for this proved non-ideal (either not logical or not consistent). As such, we decided to keep the current quantities logic as is but remove it from the store.