### PR TITLE
fix(event-normalization): Populate `gen_ai.response.model` from `gen_ai.request.model` if not already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Populate gen_ai.response.model from gen_ai.request.model if not already set. ([#5654](https://github.com/getsentry/relay/pull/5654))
+
 ## 26.2.1
 
 **Bug Fixes**:

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -409,6 +409,7 @@ mod tests {
             "gen_ai.usage.input_tokens" => 1000,
             "gen_ai.usage.output_tokens" => 2000,
             "gen_ai.request.model" => "gpt4-21-04".to_owned(),
+            "gen_ai.response.model" => "gpt4-21-04-abcd".to_owned(),
 
             "gen_ai.cost.input_tokens" => 999.0,
         });
@@ -443,7 +444,7 @@ mod tests {
           },
           "gen_ai.response.model": {
             "type": "string",
-            "value": "gpt4-21-04"
+            "value": "gpt4-21-04-abcd"
           },
           "gen_ai.response.tokens_per_second": {
             "type": "double",

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -408,8 +408,8 @@ mod tests {
             "gen_ai.operation.type" => "ai_client".to_owned(),
             "gen_ai.usage.input_tokens" => 1000,
             "gen_ai.usage.output_tokens" => 2000,
-            "gen_ai.request.model" => "gpt4-21-04".to_owned(),
-            "gen_ai.response.model" => "gpt4-21-04-abcd".to_owned(),
+            "gen_ai.request.model" => "gpt4".to_owned(),
+            "gen_ai.response.model" => "gpt4-21-04".to_owned(),
 
             "gen_ai.cost.input_tokens" => 999.0,
         });
@@ -440,11 +440,11 @@ mod tests {
           },
           "gen_ai.request.model": {
             "type": "string",
-            "value": "gpt4-21-04"
+            "value": "gpt4"
           },
           "gen_ai.response.model": {
             "type": "string",
-            "value": "gpt4-21-04-abcd"
+            "value": "gpt4-21-04"
           },
           "gen_ai.response.tokens_per_second": {
             "type": "double",

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -64,14 +64,16 @@ fn is_ai_item(attributes: &mut Attributes) -> bool {
 
 /// Normalizes the [`GEN_AI_RESPONSE_MODEL`] attribute by defaulting to the [`GEN_AI_REQUEST_MODEL`] if it is missing.
 fn normalize_model(attributes: &mut Attributes) {
+    if attributes.contains_key(GEN_AI_RESPONSE_MODEL) {
+        return;
+    }
     let Some(model) = attributes
         .get_value(GEN_AI_REQUEST_MODEL)
         .and_then(|v| v.as_str())
     else {
         return;
     };
-    let model = model.to_owned();
-    attributes.insert_if_missing(GEN_AI_RESPONSE_MODEL, || model);
+    attributes.insert(GEN_AI_RESPONSE_MODEL, model.to_owned());
 }
 
 /// Normalizes the [`GEN_AI_OPERATION_TYPE`] and infers it from the AI operation if it is missing.

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2325,6 +2325,7 @@ mod tests {
           "gen_ai.usage.total_tokens": 3000.0,
           "gen_ai.usage.input_tokens": 1000.0,
           "gen_ai.usage.output_tokens": 2000.0,
+          "gen_ai.response.model": "claude-2.1",
           "gen_ai.request.model": "claude-2.1",
           "gen_ai.cost.total_tokens": 50.0,
           "gen_ai.cost.input_tokens": 10.0,
@@ -2338,6 +2339,7 @@ mod tests {
           "gen_ai.usage.total_tokens": 3000.0,
           "gen_ai.usage.input_tokens": 1000.0,
           "gen_ai.usage.output_tokens": 2000.0,
+          "gen_ai.response.model": "gpt4-21-04",
           "gen_ai.request.model": "gpt4-21-04",
           "gen_ai.cost.total_tokens": 80.0,
           "gen_ai.cost.input_tokens": 20.0,
@@ -2444,6 +2446,7 @@ mod tests {
           "gen_ai.usage.input_tokens.cached": 500,
           "gen_ai.usage.output_tokens": 2000,
           "gen_ai.usage.output_tokens.reasoning": 1000,
+          "gen_ai.response.model": "claude-2.1",
           "gen_ai.request.model": "claude-2.1",
           "gen_ai.cost.total_tokens": 75.0,
           "gen_ai.cost.input_tokens": 25.0,
@@ -2457,6 +2460,7 @@ mod tests {
           "gen_ai.usage.total_tokens": 3000.0,
           "gen_ai.usage.input_tokens": 1000,
           "gen_ai.usage.output_tokens": 2000,
+          "gen_ai.response.model": "gpt4-21-04",
           "gen_ai.request.model": "gpt4-21-04",
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.cost.input_tokens": 90.0,
@@ -2527,6 +2531,7 @@ mod tests {
 
         assert_annotated_snapshot!(span, @r#"
         {
+          "gen_ai.response.model": "claude-2.1",
           "gen_ai.request.model": "claude-2.1",
           "gen_ai.operation.type": "agent"
         }
@@ -2615,6 +2620,7 @@ mod tests {
           "gen_ai.usage.input_tokens.cached": 500,
           "gen_ai.usage.output_tokens": 2000,
           "gen_ai.usage.output_tokens.reasoning": 1000,
+          "gen_ai.response.model": "claude-2.1",
           "gen_ai.request.model": "claude-2.1",
           "gen_ai.cost.total_tokens": 65.0,
           "gen_ai.cost.input_tokens": 25.0,
@@ -2628,6 +2634,7 @@ mod tests {
           "gen_ai.usage.total_tokens": 3000.0,
           "gen_ai.usage.input_tokens": 1000,
           "gen_ai.usage.output_tokens": 2000,
+          "gen_ai.response.model": "gpt4-21-04",
           "gen_ai.request.model": "gpt4-21-04",
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.cost.input_tokens": 90.0,

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -678,6 +678,43 @@ mod tests {
         "#);
     }
 
+    /// Test that the response model is defaulted to the request model if not set.
+    #[test]
+    fn test_default_response_model_from_request_model() {
+        let mut span = ai_span_with_data(json!({
+            "gen_ai.request.model": "gpt-4",
+        }));
+
+        enrich_ai_span(&mut span, None);
+
+        assert_annotated_snapshot!(&span.data, @r#"
+        {
+          "gen_ai.response.model": "gpt-4",
+          "gen_ai.request.model": "gpt-4",
+          "gen_ai.operation.type": "ai_client"
+        }
+        "#);
+    }
+
+    /// Test that the response model is defaulted to the request model if not set.
+    #[test]
+    fn test_default_response_model_not_overridden() {
+        let mut span = ai_span_with_data(json!({
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.response.model": "gpt-4-abcd",
+        }));
+
+        enrich_ai_span(&mut span, None);
+
+        assert_annotated_snapshot!(&span.data, @r#"
+        {
+          "gen_ai.response.model": "gpt-4-abcd",
+          "gen_ai.request.model": "gpt-4",
+          "gen_ai.operation.type": "ai_client"
+        }
+        "#);
+    }
+
     /// Test that an AI span is detected from a gen_ai.operation.name attribute.
     #[test]
     fn test_is_ai_span_from_gen_ai_operation_name() {

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -324,10 +324,10 @@ fn enrich_ai_span_data(
     set_total_tokens(data);
 
     // Default response model to request model if not set.
-    if data.gen_ai_response_model.value().is_none() {
-        if let Some(request_model) = data.gen_ai_request_model.value().cloned() {
-            data.gen_ai_response_model.set_value(Some(request_model));
-        }
+    if data.gen_ai_response_model.value().is_none()
+        && let Some(request_model) = data.gen_ai_request_model.value().cloned()
+    {
+        data.gen_ai_response_model.set_value(Some(request_model));
     }
 
     if let Some(model_costs) = model_costs {

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -283,14 +283,9 @@ fn extract_ai_data(
 
     // Extracts the total cost of the AI model used
     if let Some(model_id) = data
-        .gen_ai_request_model
+        .gen_ai_response_model
         .value()
         .and_then(|val| val.as_str())
-        .or_else(|| {
-            data.gen_ai_response_model
-                .value()
-                .and_then(|val| val.as_str())
-        })
     {
         extract_ai_model_cost_data(
             ai_model_costs.cost_per_token(model_id),
@@ -327,6 +322,13 @@ fn enrich_ai_span_data(
     map_ai_measurements_to_data(data, measurements.value());
 
     set_total_tokens(data);
+
+    // Default response model to request model if not set.
+    if data.gen_ai_response_model.value().is_none() {
+        if let Some(request_model) = data.gen_ai_request_model.value().cloned() {
+            data.gen_ai_response_model.set_value(Some(request_model));
+        }
+    }
 
     if let Some(model_costs) = model_costs {
         extract_ai_data(data, duration, model_costs, origin, platform);


### PR DESCRIPTION
Using response model only for cost calculation since it is guaranteed to be set.

Closes https://linear.app/getsentry/issue/TET-2012/set-gen-airesponsemodel-from-gen-airequestmodel-if-not-set-in-relay