### PR TITLE
chore: Bump `sentry-kafka-schemas` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5075,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "2.1.23"
+version = "2.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e5223681aafffe1d97fe54ce0808e2ea642bea0ef1ce568ed966a03e3193ff"
+checksum = "c70862ad35fe018f967e8fb1571b1f0b2efe3c4fe687c8cc983d4416c84030aa"
 dependencies = [
  "jsonschema",
  "prost 0.14.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ sentry = { version = "0.41.0", default-features = false, features = [
   "transport",
 ] }
 sentry-core = "0.41.0"
-sentry-kafka-schemas = { version = "2.1.23", default-features = false }
+sentry-kafka-schemas = { version = "2.1.24", default-features = false }
 sentry-release-parser = { version = "1.4.0", default-features = false, features = [
   "semver-1",
 ] }


### PR DESCRIPTION
In preparation for this change (https://github.com/getsentry/relay/pull/5652) bump the `sentry-kafka-schemas` version to include the `accepted_outcome_emitted` property on spans added here (https://github.com/getsentry/sentry-kafka-schemas/pull/472).