### PR TITLE
ref(system): Generic concurrent service

### DIFF
--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -5,13 +5,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
-use futures::{FutureExt, StreamExt};
+use futures::StreamExt;
 use objectstore_client::{Client, ExpirationPolicy, PutBuilder, Session, Usecase};
 use relay_config::UploadServiceConfig;
 use relay_system::{
-    Addr, AsyncResponse, FromMessage, Interface, NoResponse, Receiver, Sender, Service,
+    Addr, AsyncResponse, FromMessage, Interface, LoadShed, NoResponse, Sender, SimpleService,
 };
 use sentry_protos::snuba::v1::TraceItem;
 use uuid::Uuid;
@@ -25,7 +23,7 @@ use crate::processing::utils::store::item_id_to_uuid;
 use crate::services::outcome::DiscardReason;
 use crate::services::processor::Processed;
 use crate::services::store::{Store, StoreEnvelope, StoreTraceItem};
-use crate::statsd::{RelayCounters, RelayGauges, RelayTimers};
+use crate::statsd::{RelayCounters, RelayTimers};
 use crate::utils::upload;
 
 use super::outcome::Outcome;
@@ -154,9 +152,8 @@ impl fmt::Display for UploadKey {
 /// The service that uploads the attachments.
 ///
 /// Accepts upload requests and maintains a list of concurrent uploads.
+#[derive(Clone)]
 pub struct UploadService {
-    pending_requests: FuturesUnordered<BoxFuture<'static, ()>>,
-    max_concurrent_requests: usize,
     inner: Arc<UploadServiceInner>,
 }
 
@@ -168,7 +165,7 @@ impl UploadService {
         let Some(store) = store else { return Ok(None) };
         let UploadServiceConfig {
             objectstore_url,
-            max_concurrent_requests,
+            max_concurrent_requests: _,
             timeout,
         } = config;
         let Some(objectstore_url) = objectstore_url else {
@@ -192,62 +189,34 @@ impl UploadService {
         };
 
         Ok(Some(Self {
-            pending_requests: FuturesUnordered::new(),
-            max_concurrent_requests: *max_concurrent_requests,
             inner: Arc::new(inner),
         }))
     }
+}
 
-    fn handle_message(&self, message: Upload) {
-        if self.pending_requests.len() >= self.max_concurrent_requests {
-            relay_statsd::metric!(
-                counter(RelayCounters::AttachmentUpload) += message.attachment_count() as u64,
-                result = "load_shed",
-                type = message.ty(),
-            );
-            match message {
-                Upload::Envelope(envelope) => {
-                    // Event attachments can still go the old route.
+impl SimpleService for UploadService {
+    type Interface = Upload;
 
-                    self.inner.store.send(envelope);
-                }
-                Upload::Attachment(managed) => {
-                    let _ = managed.reject_err(Error::LoadShed);
-                }
-                Upload::Stream { message: _, sender } => {
-                    sender.send(Err(Error::LoadShed));
-                }
-            };
-            return;
-        }
-        let inner = self.inner.clone();
-        self.pending_requests
-            .push(async move { inner.handle_message(message).await }.boxed());
+    async fn handle_message(&self, message: Self::Interface) {
+        self.inner.handle_message(message).await
     }
 }
 
-impl Service for UploadService {
-    type Interface = Upload;
+impl LoadShed<Upload> for UploadService {
+    fn handle_loadshed(&self, message: Upload) {
+        match message {
+            Upload::Envelope(envelope) => {
+                // Event attachments can still go the old route.
 
-    async fn run(mut self, mut rx: Receiver<Self::Interface>) {
-        relay_log::info!("Upload service started");
-        loop {
-            relay_log::trace!("Upload loop iteration");
-            tokio::select! {
-                // Bias towards handling responses so that there's space for new incoming requests.
-                biased;
-
-                Some(_) = self.pending_requests.next() => {},
-                Some(message) = rx.recv() => self.handle_message(message),
-
-                else => break,
+                self.inner.store.send(envelope);
             }
-            relay_statsd::metric!(
-                gauge(RelayGauges::ConcurrentAttachmentUploads) =
-                    self.pending_requests.len() as u64
-            );
+            Upload::Attachment(managed) => {
+                let _ = managed.reject_err(Error::LoadShed);
+            }
+            Upload::Stream { message: _, sender } => {
+                sender.send(Err(Error::LoadShed));
+            }
         }
-        relay_log::info!("Upload service stopped");
     }
 }
 

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -204,6 +204,11 @@ impl SimpleService for UploadService {
 
 impl LoadShed<Upload> for UploadService {
     fn handle_loadshed(&self, message: Upload) {
+        relay_statsd::metric!(
+            counter(RelayCounters::AttachmentUpload) += message.attachment_count() as u64,
+            result = "load_shed",
+            type = message.ty(),
+        );
         match message {
             Upload::Envelope(envelope) => {
                 // Event attachments can still go the old route.

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -82,9 +82,6 @@ pub enum RelayGauges {
     /// - `service`: the service name.
     /// - `instance_id`: a for the service name unique identifier for the running service
     ServiceUtilization,
-    /// Number of attachment uploads currently in flight.
-    #[cfg(feature = "processing")]
-    ConcurrentAttachmentUploads,
 }
 
 impl GaugeMetric for RelayGauges {
@@ -113,8 +110,6 @@ impl GaugeMetric for RelayGauges {
             #[cfg(feature = "processing")]
             Self::MetricDelayMax => "metrics.delay.max",
             Self::ServiceUtilization => "service.utilization",
-            #[cfg(feature = "processing")]
-            Self::ConcurrentAttachmentUploads => "attachment.upload.concurrent",
         }
     }
 }

--- a/relay-system/src/service/concurrent.rs
+++ b/relay-system/src/service/concurrent.rs
@@ -6,6 +6,7 @@ use futures::{FutureExt, StreamExt};
 
 use crate::Service;
 use crate::service::simple::SimpleService;
+use crate::statsd::SystemGauges;
 
 /// A service that handles messages concurrently.
 ///
@@ -100,6 +101,11 @@ where
                 },
                 else => break,
             }
+
+            relay_statsd::metric!(
+                gauge(SystemGauges::ServiceConcurrency) = self.pending.len() as u64,
+                service = Self::name()
+            );
         }
     }
 }

--- a/relay-system/src/service/concurrent.rs
+++ b/relay-system/src/service/concurrent.rs
@@ -1,0 +1,154 @@
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
+use futures::{FutureExt, StreamExt};
+
+use crate::Service;
+use crate::service::simple::SimpleService;
+
+#[derive(Debug, Clone, Copy)]
+enum CongestionStrategy {
+    Backpressure,
+    LoadShed,
+}
+
+impl CongestionStrategy {
+    fn is_loadshed(&self) -> bool {
+        matches!(self, Self::LoadShed)
+    }
+}
+
+struct ConcurrentService<S>
+where
+    S: SimpleService + Clone + Send + Sync,
+{
+    inner: S,
+    congestion_strategy: CongestionStrategy,
+    max_concurrency: usize,
+    pending: FuturesUnordered<BoxFuture<'static, ()>>,
+}
+
+impl<S> ConcurrentService<S>
+where
+    S: SimpleService + Clone + Send + Sync,
+{
+    fn new(inner: S, congestion_strategy: CongestionStrategy, max_concurrency: usize) -> Self {
+        Self {
+            inner,
+            congestion_strategy,
+            max_concurrency,
+            pending: FuturesUnordered::new(),
+        }
+    }
+}
+
+impl<S> Service for ConcurrentService<S>
+where
+    S: SimpleService + Clone + Send + Sync + 'static,
+{
+    type Interface = S::Interface;
+
+    async fn run(mut self, mut rx: super::Receiver<Self::Interface>) {
+        loop {
+            // if self.pending.len() >= self.max_concurrency {
+            //     match self.congestion_strategy {
+            //         CongestionStrategy::Backpressure => {
+            //             // just wait for capacity.
+            //         }
+            //         CongestionStrategy::LoadShed => {
+            //             while let Some(x) = rx.recv()
+            //         },
+            //     }
+            //     // Wait for capacity:
+            //     let _ = self.pending.next().await;
+            // }
+            // TODO: self.name()
+            relay_log::trace!("Concurrent service loop iteration");
+
+            let has_capacity = self.pending.len() < self.max_concurrency;
+            let should_consume = has_capacity || self.congestion_strategy.is_loadshed();
+
+            tokio::select! {
+                // Bias towards handling responses so that there's space for new incoming requests.
+                biased;
+
+                Some(_) = self.pending.next() => {},
+                Some(message) = rx.recv(), if should_consume => {
+                    if has_capacity {
+                        let inner = self.inner.clone();
+                        self.pending
+                            .push(async move { inner.handle_message(message).await }.boxed());
+                    } else {
+                        relay_log::error!("Dropping");
+                    }
+                },
+            //     // TODO: what if pending.next returns None?
+                else => break,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use crate::{FromMessage, Interface, NoResponse};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct CountingService(Arc<AtomicUsize>);
+    struct Incr;
+    impl Interface for Incr {}
+    impl FromMessage<()> for Incr {
+        type Response = NoResponse;
+        fn from_message(_message: (), _sender: ()) -> Self {
+            Self
+        }
+    }
+    impl SimpleService for CountingService {
+        type Interface = Incr;
+
+        async fn handle_message(&self, _message: Incr) {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn loadshed() {
+        let inner = CountingService(Arc::new(AtomicUsize::new(0)));
+        let service = ConcurrentService::new(inner.clone(), CongestionStrategy::LoadShed, 5);
+        let addr = service.start_detached();
+
+        for _ in 0..10 {
+            addr.send(());
+        }
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        // Only half of the items have been processed
+        assert_eq!(inner.0.load(Ordering::Relaxed), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backpressure() {
+        let inner = CountingService(Arc::new(AtomicUsize::new(0)));
+        let service = ConcurrentService::new(inner.clone(), CongestionStrategy::Backpressure, 5);
+        let addr = service.start_detached();
+
+        for _ in 0..10 {
+            addr.send(());
+        }
+
+        // After 3 seconds, only half the messages have been handled:
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert_eq!(inner.0.load(Ordering::Relaxed), 5);
+
+        // After 5 seconds, everything's been handled:
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(inner.0.load(Ordering::Relaxed), 10);
+    }
+}

--- a/relay-system/src/service/concurrent.rs
+++ b/relay-system/src/service/concurrent.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
@@ -13,21 +11,24 @@ use crate::statsd::SystemGauges;
 /// When the service reaches its maximum concurrency, it either drops messages
 /// or keeps them in the input queue.
 ///
-/// ```rust
+/// ```
+/// use relay_system::{Interface, SimpleService, LoadShed, ConcurrentService};
+///
+/// #[derive(Clone)]
 /// struct MyService;
 ///
 /// struct MyMessage;
-/// impl Interface for MyMessage;
+/// impl Interface for MyMessage {}
 ///
 /// impl SimpleService for MyService {
 ///     type Interface = MyMessage;
-///     async fn handle_message(message: MyMessage) {
+///     async fn handle_message(&self, message: MyMessage) {
 ///         // do your thing
 ///     }
 /// }
 ///
 /// // `Loadshed` implementation is required but can be empty.
-/// impl LoadShed for MyService {}
+/// impl LoadShed<MyMessage> for MyService {}
 ///
 /// let concurrent_service = ConcurrentService::new(MyService).with_concurrency_limit(5);
 /// ```

--- a/relay-system/src/service/mod.rs
+++ b/relay-system/src/service/mod.rs
@@ -20,7 +20,7 @@ mod registry;
 mod simple;
 mod status;
 
-pub use self::concurrent::{ConcurrentService, CongestionControl};
+pub use self::concurrent::{ConcurrentService, CongestionControl, LoadShed};
 pub(crate) use self::registry::Registry as ServiceRegistry;
 pub use self::registry::{ServiceId, ServiceMetrics, ServicesMetrics};
 pub use self::simple::SimpleService;

--- a/relay-system/src/service/mod.rs
+++ b/relay-system/src/service/mod.rs
@@ -20,8 +20,10 @@ mod registry;
 mod simple;
 mod status;
 
+pub use self::concurrent::{ConcurrentService, CongestionControl};
 pub(crate) use self::registry::Registry as ServiceRegistry;
 pub use self::registry::{ServiceId, ServiceMetrics, ServicesMetrics};
+pub use self::simple::SimpleService;
 pub use self::status::{
     ServiceError, ServiceJoinHandle, ServiceStatusError, ServiceStatusJoinHandle,
 };

--- a/relay-system/src/service/mod.rs
+++ b/relay-system/src/service/mod.rs
@@ -15,7 +15,9 @@ use tokio::time::MissedTickBehavior;
 use crate::statsd::SystemGauges;
 use crate::{TaskId, spawn};
 
+mod concurrent;
 mod registry;
+mod simple;
 mod status;
 
 pub(crate) use self::registry::Registry as ServiceRegistry;

--- a/relay-system/src/service/simple.rs
+++ b/relay-system/src/service/simple.rs
@@ -1,0 +1,17 @@
+use crate::{Interface, Service};
+
+pub trait SimpleService {
+    type Interface: Interface;
+
+    fn handle_message(&self, message: Self::Interface) -> impl Future<Output = ()> + Send;
+}
+
+impl<T: SimpleService + Send + 'static> Service for T {
+    type Interface = T::Interface;
+
+    async fn run(self, mut rx: super::Receiver<Self::Interface>) {
+        while let Some(message) = rx.recv().await {
+            self.handle_message(message).await;
+        }
+    }
+}

--- a/relay-system/src/service/simple.rs
+++ b/relay-system/src/service/simple.rs
@@ -1,8 +1,14 @@
 use crate::{Interface, Service};
 
+/// A service that handles messages one at a time.
+///
+/// When the message handler cannot keep up with incoming messages,
+/// it applies backpressure into the input queue.
 pub trait SimpleService {
+    /// The message interface (see [`Service::Interface`]).
     type Interface: Interface;
 
+    /// The asynchronous message handler for this service.
     fn handle_message(&self, message: Self::Interface) -> impl Future<Output = ()> + Send;
 }
 

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -33,7 +33,7 @@ pub enum SystemGauges {
     /// This metric is tagged with:
     ///  - `service`: The fully qualified type name of the service implementation.
     ServiceBackPressure,
-    /// Number of messages currently being handled concurrently by a [`ConcurrentService`].
+    /// Number of messages currently being handled concurrently by a [`ConcurrentService`](crate::ConcurrentService).
     /// This metric is tagged with:
     /// - `service`: The fully qualified type name of the service implementation.
     ServiceConcurrency,

--- a/relay-system/src/statsd.rs
+++ b/relay-system/src/statsd.rs
@@ -33,12 +33,17 @@ pub enum SystemGauges {
     /// This metric is tagged with:
     ///  - `service`: The fully qualified type name of the service implementation.
     ServiceBackPressure,
+    /// Number of messages currently being handled concurrently by a [`ConcurrentService`].
+    /// This metric is tagged with:
+    /// - `service`: The fully qualified type name of the service implementation.
+    ServiceConcurrency,
 }
 
 impl GaugeMetric for SystemGauges {
     fn name(&self) -> &'static str {
         match *self {
             Self::ServiceBackPressure => "service.back_pressure",
+            Self::ServiceConcurrency => "service.concurrency",
         }
     }
 }


### PR DESCRIPTION
This PR adds utilities to facilitate service creation and introduces a re-usable type that adds concurrency to an existing service:

```mermaid
classDiagram
    class Service
    <<Trait>> Service

    Service  <|-- "implements" SimpleService
    Service <|-- "implements" ConcurrentService~S~

    
    class SimpleService {
        +handle_message()
    }
    <<Trait>> SimpleService

    ConcurrentService "1" *-- "1" SimpleService
```

ref: INGEST-758