### PR TITLE
ref(upload): Implement `UpstreamRequest`, not `ForwardRequest`

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -50,7 +50,8 @@ impl IntoResponse for Error {
             Error::Tus(_) => StatusCode::BAD_REQUEST,
             Error::Request(error) => return error.into_response(),
             Error::Upload(error) => match error {
-                upload::Error::Forward(error) => return error.into_response(),
+                upload::Error::Send(_) => StatusCode::SERVICE_UNAVAILABLE,
+                upload::Error::UpstreamRequest(e) => return e.into_response(),
                 upload::Error::Upstream(status) => status,
                 upload::Error::InvalidLocation | upload::Error::SigningFailed => {
                     StatusCode::INTERNAL_SERVER_ERROR

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -106,7 +106,7 @@ async fn handle(
     headers: HeaderMap,
     body: Body,
 ) -> axum::response::Result<impl IntoResponse> {
-    let upload_length = tus::validate_headers(&headers).map_err(Error::from)?;
+    let upload_length = dbg!(tus::validate_headers(&headers).map_err(Error::from)?);
     let config = state.config();
 
     if upload_length > config.max_upload_size() {
@@ -121,19 +121,21 @@ async fn handle(
         .await
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let scoping = check_request(&state, meta, upload_length, project).await?;
+    let scoping = dbg!(check_request(&state, meta, upload_length, project).await?);
     let stream = body
         .into_data_stream()
         .map(|result| result.map_err(io::Error::other))
         .boxed();
     let stream = ExactStream::new(stream, upload_length);
 
-    let location = upload::Sink::new(&state)
-        .upload(config, upload::Stream { scoping, stream })
-        .await
-        .map_err(Error::from)?;
+    let location = dbg!(
+        upload::Sink::new(&state)
+            .upload(config, upload::Stream { scoping, stream })
+            .await
+            .map_err(Error::from)
+    )?;
 
-    let mut response = location.into_response();
+    let mut response = dbg!(location.into_response());
     response
         .headers_mut()
         .insert(tus::UPLOAD_OFFSET, upload_length.into());

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -60,6 +60,7 @@ impl IntoResponse for Error {
                     }
                     _ => return e.into_response(),
                 },
+                upload::Error::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
                 upload::Error::Upstream(status) => status,
                 upload::Error::InvalidLocation | upload::Error::SigningFailed => {
                     StatusCode::INTERNAL_SERVER_ERROR

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -100,6 +100,7 @@ impl RequestBuilder {
     }
 }
 
+#[derive(Debug)]
 pub struct Response(pub reqwest::Response);
 
 impl Response {

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -100,7 +100,6 @@ impl RequestBuilder {
     }
 }
 
-#[derive(Debug)]
 pub struct Response(pub reqwest::Response);
 
 impl Response {

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -136,7 +136,7 @@ impl UpstreamRequestError {
     /// with the status code. If the request could not be made or the error originates elsewhere,
     /// this returns `None`.
     fn status_code(&self) -> Option<StatusCode> {
-        match self {
+        match dbg!(self) {
             UpstreamRequestError::ResponseError(code, _) => Some(*code),
             UpstreamRequestError::Http(HttpError::Reqwest(e)) => e.status(),
             _ => None,

--- a/relay-server/src/utils/error.rs
+++ b/relay-server/src/utils/error.rs
@@ -1,0 +1,20 @@
+use std::error::Error;
+
+/// Find an error source with the given predicate.
+///
+/// Will become redundant once [`Error::sources`](https://doc.rust-lang.org/std/error/trait.Error.html#method.sources)
+/// is stable.
+pub fn find_error_source<E, P>(error: &E, predicate: P) -> Option<&dyn Error>
+where
+    E: Error + ?Sized,
+    P: Fn(&(dyn Error + 'static)) -> bool,
+{
+    let mut source = error.source();
+    while let Some(s) = source {
+        if predicate(s) {
+            return Some(s);
+        }
+        source = s.source();
+    }
+    None
+}

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod dynamic_sampling;
+mod error;
 mod multipart;
 mod param_parser;
 mod pick;
@@ -25,6 +26,7 @@ mod unreal;
 
 pub use self::api::*;
 pub use self::dynamic_sampling::*;
+pub use self::error::*;
 pub use self::forward::*;
 pub use self::memory::*;
 pub use self::multipart::*;

--- a/relay-server/src/utils/upload.rs
+++ b/relay-server/src/utils/upload.rs
@@ -114,6 +114,7 @@ impl Sink {
 ///
 /// Calling [`Self::try_sign`] appends a `&signature=` query parameter that can later be used
 /// to validate whether the URI (especially the length) has been tempered with.
+#[derive(Debug)]
 pub struct Location {
     pub project_id: ProjectId,
     pub key: String,
@@ -153,6 +154,7 @@ impl Location {
 }
 
 /// A verifiable [`Location`] signed by this Relay or an upstream Relay.
+#[derive(Debug)]
 pub enum SignedLocation {
     FromUpstream(HeaderValue),
     #[cfg_attr(not(feature = "processing"), expect(unused))]
@@ -181,7 +183,7 @@ impl SignedLocation {
     }
 
     fn try_from_response(response: Response) -> Result<Self, Error> {
-        match response.status() {
+        match dbg!(&response).status() {
             status if status.is_success() => {
                 let location = response
                     .headers()
@@ -236,7 +238,7 @@ impl UpstreamRequest for UploadRequest {
 
     fn path(&self) -> std::borrow::Cow<'_, str> {
         let project_id = self.scoping.project_id;
-        format!("/api/upload/{project_id}/").into()
+        format!("/api/{project_id}/upload/").into()
     }
 
     fn route(&self) -> &'static str {
@@ -276,6 +278,8 @@ impl UpstreamRequest for UploadRequest {
             let Some(key) = key else { continue };
             builder.header(key, value);
         }
+
+        builder.body(reqwest::Body::wrap_stream(body));
 
         Ok(())
     }

--- a/relay-server/src/utils/upload.rs
+++ b/relay-server/src/utils/upload.rs
@@ -183,7 +183,7 @@ impl SignedLocation {
     }
 
     fn try_from_response(response: Response) -> Result<Self, Error> {
-        match dbg!(&response).status() {
+        match response.status() {
             status if status.is_success() => {
                 let location = response
                     .headers()

--- a/relay-server/src/utils/upload.rs
+++ b/relay-server/src/utils/upload.rs
@@ -196,6 +196,7 @@ impl SignedLocation {
     }
 }
 
+/// An upstream request made to the `/upload` endpoint.
 struct UploadRequest {
     scoping: Scoping,
     body: Option<ExactStream<BoxStream<'static, std::io::Result<Bytes>>>>,

--- a/relay-server/src/utils/upload.rs
+++ b/relay-server/src/utils/upload.rs
@@ -263,7 +263,7 @@ impl UpstreamRequest for UploadRequest {
     }
 
     fn set_relay_id(&self) -> bool {
-        false // same as ForwardRequest
+        true // needed for trusted requests with `Upload-Defer-Length: 1`
     }
 
     fn build(&mut self, builder: &mut RequestBuilder) -> Result<(), HttpError> {

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -120,9 +120,9 @@ def test_upload_missing_upload_length(mini_sentry, relay, dummy_upload, project_
 @pytest.mark.parametrize(
     "size,expected_status_code",
     [
-        (9, 400),  # smaller than announced
-        (11, 400),  # larger than announced
-        (101, 413),  # larger than allowed
+        pytest.param(9, 400, id="smaller_than_announced"),
+        pytest.param(11, 400, id="larger_than_announced"),
+        pytest.param(101, 413, id="larger_than_allowed"),
     ],
 )
 def test_upload_body_size(


### PR DESCRIPTION
We need to set the relay ID in the request header in order to distinguish between uploads from trusted relays and uploads from clients.

Closes INGEST-759