### PR TITLE
feat(upload): Log all errors

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -141,7 +141,7 @@ async fn handle(
         .upload(config, upload::Stream { scoping, stream })
         .await
         .map_err(|e| {
-            relay_log::warn!(error = &e as &dyn std::error::Error);
+            relay_log::warn!(error = &e as &dyn std::error::Error, "upload failed");
             Error::from(e)
         })?;
 

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -140,7 +140,10 @@ async fn handle(
     let location = upload::Sink::new(&state)
         .upload(config, upload::Stream { scoping, stream })
         .await
-        .map_err(Error::from)?;
+        .map_err(|e| {
+            relay_log::warn!(error = &e as &dyn std::error::Error);
+            Error::from(e)
+        })?;
 
     let mut response = location.into_response();
     response


### PR DESCRIPTION
Temporarily log all errors in the upload endpoint to debug failures.