### PR TITLE
meta(vscode): Remove save on window change

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
   "editor.formatOnType": true,
   "editor.tabSize": 4,
   "editor.rulers": [100],
-  "files.autoSave": "onWindowChange",
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
 


### PR DESCRIPTION
Remove autosave onWindowChange from workspace settings as this blocks autosave afterDelay in user settings.