### PR TITLE
feat(statsd): Implement support for unix domain sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Features**:
 
 - Populate gen_ai.response.model from gen_ai.request.model if not already set. ([#5654](https://github.com/getsentry/relay/pull/5654))
+- Add support for Unix domain sockets for statsd metrics. ([#5668](https://github.com/getsentry/relay/pull/5668))
 
 ## 26.2.1
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::io::Write;
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU8;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -2161,20 +2161,9 @@ impl Config {
         &self.values.sentry
     }
 
-    /// Returns the socket addresses for statsd.
-    ///
-    /// If stats is disabled an empty vector is returned.
-    pub fn statsd_addrs(&self) -> anyhow::Result<Vec<SocketAddr>> {
-        if let Some(ref addr) = self.values.metrics.statsd {
-            let addrs = addr
-                .as_str()
-                .to_socket_addrs()
-                .with_context(|| ConfigError::file(ConfigErrorKind::InvalidValue, &self.path))?
-                .collect();
-            Ok(addrs)
-        } else {
-            Ok(vec![])
-        }
+    /// Returns the addresses for statsd metrics.
+    pub fn statsd_addr(&self) -> Option<&str> {
+        self.values.metrics.statsd.as_deref()
     }
 
     /// Return the prefix for statsd metrics.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -557,6 +557,10 @@ pub struct Metrics {
     ///
     /// Defaults to `None`.
     pub statsd: Option<String>,
+    /// Buffer size used for metrics sent to the statsd socket.
+    ///
+    /// Defaults to `None`.
+    pub statsd_buffer_size: Option<usize>,
     /// Common prefix that should be added to all metrics.
     ///
     /// Defaults to `"sentry.relay"`.
@@ -593,6 +597,7 @@ impl Default for Metrics {
     fn default() -> Self {
         Metrics {
             statsd: None,
+            statsd_buffer_size: None,
             prefix: "sentry.relay".into(),
             default_tags: BTreeMap::new(),
             hostname_tag: None,
@@ -2164,6 +2169,11 @@ impl Config {
     /// Returns the addresses for statsd metrics.
     pub fn statsd_addr(&self) -> Option<&str> {
         self.values.metrics.statsd.as_deref()
+    }
+
+    /// Returns the addresses for statsd metrics.
+    pub fn statsd_buffer_size(&self) -> Option<usize> {
+        self.values.metrics.statsd_buffer_size
     }
 
     /// Return the prefix for statsd metrics.

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -26,7 +26,8 @@
 //!
 //! relay_statsd::init(MetricsClientConfig {
 //!     prefix: "myprefix",
-//!     host: "localhost:8125",
+//!     host: "localhost:8125".to_owned(),
+//!     buffer_size: None,
 //!     default_tags: BTreeMap::new(),
 //!     sample_rate: 1.0.into(),
 //!     aggregate: true,

--- a/relay-statsd/src/lib.rs
+++ b/relay-statsd/src/lib.rs
@@ -74,10 +74,11 @@ use statsdproxy::cadence::StatsdProxyMetricSink;
 use statsdproxy::config::AggregateMetricsConfig;
 use statsdproxy::middleware::deny_tag::DenyTag;
 use std::collections::BTreeMap;
-use std::net::ToSocketAddrs;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::time::Duration;
+
+mod upstream;
 
 /// Maximum number of metric events that can be queued before we start dropping them
 const METRICS_MAX_QUEUE_SIZE: usize = 100_000;
@@ -114,11 +115,11 @@ pub struct MetricsClient {
 
 /// Client configuration used for initialization of [`MetricsClient`].
 #[derive(Debug)]
-pub struct MetricsClientConfig<'a, A> {
+pub struct MetricsClientConfig<'a> {
     /// Prefix which is appended to all metric names.
     pub prefix: &'a str,
     /// Host of the metrics upstream.
-    pub host: A,
+    pub host: String,
     /// Tags that are added to all metrics.
     pub default_tags: BTreeMap<String, String>,
     /// Default sample rate for metrics, between 0.0 (= 0%) and 1.0 (= 100%)
@@ -291,10 +292,17 @@ pub fn disable() {
 }
 
 /// Tell the metrics system to report to statsd.
-pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
-    let addrs: Vec<_> = config.host.to_socket_addrs().unwrap().collect();
-    if !addrs.is_empty() {
-        relay_log::info!("reporting metrics to statsd at {}", addrs[0]);
+pub fn init(config: MetricsClientConfig<'_>) -> std::io::Result<()> {
+    relay_log::info!("reporting metrics to statsd at {}", config.host);
+
+    // Probe the connection to catch misconfigurations early.
+    if let Err(err) = upstream::Upstream::connect(&config.host) {
+        relay_log::error!(
+            error = &err as &dyn std::error::Error,
+            "failed to connect to statsd sink at {}",
+            config.host
+        );
+        return Err(err);
     }
 
     let sample_rate: f64 = config.sample_rate.into();
@@ -318,9 +326,6 @@ pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
 
     let statsd_client = if config.aggregate {
         let statsdproxy_sink = StatsdProxyMetricSink::new(move || {
-            let upstream = statsdproxy::middleware::upstream::Upstream::new(addrs[0])
-                .expect("failed to create statsdproxy metric sink");
-
             let aggregate = statsdproxy::middleware::aggregate::AggregateMetrics::new(
                 AggregateMetricsConfig {
                     aggregate_gauges: true,
@@ -329,7 +334,7 @@ pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
                     flush_offset: 0,
                     max_map_size: None,
                 },
-                upstream,
+                upstream::TryUpstream::connect(&config.host),
             );
 
             DenyTag::new(deny_config.clone(), aggregate)
@@ -338,9 +343,7 @@ pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
         StatsdClient::from_sink(config.prefix, statsdproxy_sink)
     } else {
         let statsdproxy_sink = StatsdProxyMetricSink::new(move || {
-            let upstream = statsdproxy::middleware::upstream::Upstream::new(addrs[0])
-                .expect("failed to create statsdproxy metric sind");
-
+            let upstream = upstream::TryUpstream::connect(&config.host);
             DenyTag::new(deny_config.clone(), upstream)
         });
         StatsdClient::from_sink(config.prefix, statsdproxy_sink)
@@ -352,6 +355,8 @@ pub fn init<A: ToSocketAddrs>(config: MetricsClientConfig<A>) {
         default_sample_rate: config.sample_rate,
         rx: None,
     });
+
+    Ok(())
 }
 
 /// Invoke a callback with the current statsd client.

--- a/relay-statsd/src/upstream.rs
+++ b/relay-statsd/src/upstream.rs
@@ -171,5 +171,10 @@ impl Middleware for TryUpstream {
         }
     }
 
-    fn poll(&mut self) {}
+    fn poll(&mut self) {
+        match self {
+            Self::Upstream(upstream) => upstream.poll(),
+            Self::Error => {}
+        }
+    }
 }

--- a/relay-statsd/src/upstream.rs
+++ b/relay-statsd/src/upstream.rs
@@ -34,7 +34,7 @@ impl Remote {
                     Ok(Self::UnixDatagram(socket))
                 }
                 _ => Err(io::Error::other(format!(
-                    "invalid scheme '{scheme}', expected one of 'udp', 'unixstream', 'unixgram'"
+                    "invalid scheme '{scheme}', expected one of 'udp', 'unixgram'"
                 ))),
             };
         }

--- a/relay-statsd/src/upstream.rs
+++ b/relay-statsd/src/upstream.rs
@@ -64,7 +64,9 @@ impl Remote {
             //
             // See: <https://docs.datadoghq.com/extend/dogstatsd/high_throughput/?tab=go#ensure-proper-packet-sizes>
             #[cfg(unix)]
-            Self::UnixStream(_) | Self::UnixDatagram(_) => 8192,
+            Self::UnixStream(_) => 8192,
+            #[cfg(unix)]
+            Self::UnixDatagram(_) => 1024,
         }
     }
 
@@ -78,7 +80,7 @@ impl Remote {
         };
 
         if let Err(err) = result {
-            relay_log::error!("failed to send to upstream: {err}");
+            relay_log::warn!("failed to send metrics to upstream: {err}");
         }
     }
 }

--- a/relay-statsd/src/upstream.rs
+++ b/relay-statsd/src/upstream.rs
@@ -1,0 +1,174 @@
+use std::io::{self, Write};
+use std::net::{Ipv4Addr, UdpSocket};
+use std::os::unix::net::UnixStream;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use statsdproxy::middleware::Middleware;
+use statsdproxy::types::Metric;
+
+pub enum Remote {
+    Udp(UdpSocket),
+    #[cfg(unix)]
+    Unix(UnixStream),
+}
+
+impl Remote {
+    fn connect(addr: &str) -> io::Result<Self> {
+        // Try treating the address as a fully-qualified URL, where the scheme is the transport identifier.
+        if let Some((scheme, path)) = addr.split_once("://") {
+            return match scheme {
+                #[cfg(unix)]
+                "unix" => {
+                    let socket = UnixStream::connect(path)?;
+                    socket.set_nonblocking(true)?;
+
+                    Ok(Self::Unix(socket))
+                }
+                "udp" => {
+                    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?;
+                    socket.connect(path)?;
+                    socket.set_nonblocking(true)?;
+
+                    Ok(Self::Udp(socket))
+                }
+                _ => Err(io::Error::other(format!(
+                    "invalid scheme '{scheme}', expected 'udp' or 'unix'"
+                ))),
+            };
+        }
+
+        // If there is no scheme, fall back to a UDP socket
+        let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?;
+        socket.connect(addr)?;
+        socket.set_nonblocking(true)?;
+
+        Ok(Self::Udp(socket))
+    }
+
+    fn bufsize(&self) -> usize {
+        match self {
+            // The original statsdproxy uses.
+            Self::Udp(_) => 512,
+            // Datadog recommends 8192 for unix sockets.
+            //
+            // See: <https://docs.datadoghq.com/extend/dogstatsd/high_throughput/?tab=go#ensure-proper-packet-sizes>
+            #[cfg(unix)]
+            Self::Unix(_) => 8192,
+        }
+    }
+
+    fn send(&mut self, buf: &[u8]) {
+        let result = match self {
+            Self::Udp(socket) => socket.send(buf).map(drop),
+            #[cfg(unix)]
+            Self::Unix(socket) => socket.write_all(buf),
+        };
+
+        if let Err(err) = result {
+            relay_log::error!("failed to send to upstream: {err}");
+        }
+    }
+}
+
+pub struct Upstream {
+    remote: Remote,
+    buffer: Vec<u8>,
+    buf_used: usize,
+    last_sent_at: SystemTime,
+}
+
+impl Upstream {
+    pub fn connect(upstream: &str) -> io::Result<Self> {
+        let remote = Remote::connect(upstream)?;
+
+        Ok(Upstream {
+            buffer: vec![0; remote.bufsize()],
+            remote,
+            buf_used: 0,
+            last_sent_at: UNIX_EPOCH,
+        })
+    }
+
+    fn flush(&mut self) {
+        if self.buf_used > 0 {
+            self.remote.send(&self.buffer[..self.buf_used]);
+            self.buf_used = 0;
+        }
+        self.last_sent_at = SystemTime::now(); // Annoyingly superfluous call to now().
+    }
+
+    fn timed_flush(&mut self) {
+        let now = SystemTime::now();
+        if now
+            .duration_since(self.last_sent_at)
+            .map_or(true, |x| x > Duration::from_secs(1))
+        {
+            // We have not sent any metrics in a while. Flush the buffer.
+            self.flush();
+        }
+    }
+}
+
+impl Drop for Upstream {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+impl Middleware for Upstream {
+    fn submit(&mut self, metric: &mut Metric) {
+        let metric_len = metric.raw.len();
+        if metric_len + 1 > self.buffer.len() - self.buf_used {
+            // Message bigger than space left in buffer. Flush the buffer.
+            self.flush();
+        }
+        if metric_len > self.buffer.len() {
+            // Message too big for the entire buffer, send it and pray.
+            self.remote.send(&metric.raw);
+        } else {
+            // Put the message in the buffer, separating it from the previous message if any.
+            if self.buf_used > 0 {
+                self.buffer[self.buf_used] = b'\n';
+                self.buf_used += 1;
+            }
+            self.buffer[self.buf_used..self.buf_used + metric_len].copy_from_slice(&metric.raw);
+            self.buf_used += metric_len;
+        }
+        // poll gets called before submit, so if the buffer needed to be flushed for time reasons,
+        // it already was.
+    }
+
+    fn poll(&mut self) {
+        self.timed_flush();
+    }
+}
+
+/// A [`Upstream`] which falls back to noop operations if connecting to the statsd sink fails.
+pub enum TryUpstream {
+    Upstream(Upstream),
+    Error,
+}
+
+impl TryUpstream {
+    pub fn connect(upstream: &str) -> Self {
+        match Upstream::connect(upstream) {
+            Ok(upstream) => Self::Upstream(upstream),
+            Err(err) => {
+                relay_log::error!(
+                    error = &err as &dyn std::error::Error,
+                    "failed to connect to statsd sink at {upstream}"
+                );
+                Self::Error
+            }
+        }
+    }
+}
+
+impl Middleware for TryUpstream {
+    fn submit(&mut self, metric: &mut Metric) {
+        match self {
+            Self::Upstream(upstream) => upstream.submit(metric),
+            Self::Error => {}
+        }
+    }
+}

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -113,6 +113,7 @@ pub fn init_metrics(config: &Config) -> Result<()> {
     relay_statsd::init(MetricsClientConfig {
         prefix: config.metrics_prefix(),
         host: host.to_owned(),
+        buffer_size: config.statsd_buffer_size(),
         default_tags,
         sample_rate: config.metrics_sample_rate().into(),
         aggregate: config.metrics_aggregate(),

--- a/relay/src/setup.rs
+++ b/relay/src/setup.rs
@@ -100,10 +100,9 @@ pub fn dump_credentials(config: &Config) {
 
 /// Initialize the metric system.
 pub fn init_metrics(config: &Config) -> Result<()> {
-    let addrs = config.statsd_addrs()?;
-    if addrs.is_empty() {
+    let Some(host) = config.statsd_addr() else {
         return Ok(());
-    }
+    };
 
     let mut default_tags = config.metrics_default_tags().clone();
     if let Some(hostname_tag) = config.metrics_hostname_tag()
@@ -113,12 +112,12 @@ pub fn init_metrics(config: &Config) -> Result<()> {
     }
     relay_statsd::init(MetricsClientConfig {
         prefix: config.metrics_prefix(),
-        host: &addrs[..],
+        host: host.to_owned(),
         default_tags,
         sample_rate: config.metrics_sample_rate().into(),
         aggregate: config.metrics_aggregate(),
         allow_high_cardinality_tags: config.metrics_allow_high_cardinality_tags(),
-    });
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
Implements support for Unix Domain Sockets for Statsd metrics.

Also removes some panics if the statsd server disappears.

The core impl of `Upstream` is taken from the `statsdproxy` crate, with the intention of upstreaming this eventually.