### PR TITLE
ref(server): Reduce size of item headers struct

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -237,7 +237,7 @@ pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreReq
 
     if let Some(item) = items
         .iter()
-        .find(|item| item.attachment_type() == Some(&AttachmentType::EventPayload))
+        .find(|item| item.attachment_type() == Some(AttachmentType::EventPayload))
         && let Some(event_id) = event_id_from_msgpack(&item.payload())?
     {
         return Ok(Some(event_id));

--- a/relay-server/src/endpoints/integrations/otlp.rs
+++ b/relay-server/src/endpoints/integrations/otlp.rs
@@ -32,9 +32,9 @@ mod traces {
         state: ServiceState,
         builder: IntegrationBuilder,
     ) -> axum::response::Result<impl IntoResponse> {
-        let format = match ContentType::from(content_type.as_ref()) {
-            ContentType::Json => OtelFormat::Json,
-            ContentType::Protobuf => OtelFormat::Protobuf,
+        let format = match content_type.as_ref().parse::<ContentType>() {
+            Ok(ContentType::Json) => OtelFormat::Json,
+            Ok(ContentType::Protobuf) => OtelFormat::Protobuf,
             _ => return Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE),
         };
 
@@ -63,9 +63,9 @@ mod logs {
         state: ServiceState,
         builder: IntegrationBuilder,
     ) -> axum::response::Result<impl IntoResponse> {
-        let format = match ContentType::from(content_type.as_ref()) {
-            ContentType::Json => OtelFormat::Json,
-            ContentType::Protobuf => OtelFormat::Protobuf,
+        let format = match content_type.as_ref().parse::<ContentType>() {
+            Ok(ContentType::Json) => OtelFormat::Json,
+            Ok(ContentType::Protobuf) => OtelFormat::Protobuf,
             _ => return Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE),
         };
 

--- a/relay-server/src/endpoints/integrations/vercel.rs
+++ b/relay-server/src/endpoints/integrations/vercel.rs
@@ -28,9 +28,9 @@ mod logs {
         state: ServiceState,
         builder: IntegrationBuilder,
     ) -> axum::response::Result<impl IntoResponse> {
-        let format = match ContentType::from(content_type.as_ref()) {
-            ContentType::Json => VercelLogDrainFormat::Json,
-            ContentType::NdJson => VercelLogDrainFormat::NdJson,
+        let format = match content_type.as_ref().parse::<ContentType>() {
+            Ok(ContentType::Json) => VercelLogDrainFormat::Json,
+            Ok(ContentType::NdJson) => VercelLogDrainFormat::NdJson,
             _ => return Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE),
         };
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -185,7 +185,7 @@ async fn extract_multipart(
 
     let minidump_item = items
         .iter_mut()
-        .find(|item| item.attachment_type() == Some(&AttachmentType::Minidump))
+        .find(|item| item.attachment_type() == Some(AttachmentType::Minidump))
         .ok_or(BadStoreRequest::MissingMinidump)?;
 
     let embedded_opt = extract_embedded_minidump(minidump_item.payload()).await?;
@@ -459,57 +459,51 @@ mod tests {
         assert_eq!(item.filename().unwrap(), "config.json");
         assert!(item.content_type().is_none());
         assert_eq!(item.ty(), &ItemType::Attachment);
-        assert_eq!(item.attachment_type().unwrap(), &AttachmentType::Attachment);
+        assert_eq!(item.attachment_type().unwrap(), AttachmentType::Attachment);
         assert_eq!(item.payload().len(), 95);
 
         // the first breadcrumb buffer
         let item = &items[1];
         assert_eq!(item.filename().unwrap(), "__sentry-breadcrumb1");
-        assert_eq!(item.content_type().unwrap(), &ContentType::OctetStream);
+        assert_eq!(item.content_type().unwrap(), ContentType::OctetStream);
         assert_eq!(item.ty(), &ItemType::Attachment);
-        assert_eq!(
-            item.attachment_type().unwrap(),
-            &AttachmentType::Breadcrumbs
-        );
+        assert_eq!(item.attachment_type().unwrap(), AttachmentType::Breadcrumbs);
         assert_eq!(item.payload().len(), 66);
 
         // the second breadcrumb buffer is empty since we haven't reached our max in the first
         let item = &items[2];
         assert_eq!(item.filename().unwrap(), "__sentry-breadcrumb2");
-        assert_eq!(item.content_type().unwrap(), &ContentType::OctetStream);
+        assert_eq!(item.content_type().unwrap(), ContentType::OctetStream);
         assert_eq!(item.ty(), &ItemType::Attachment);
-        assert_eq!(
-            item.attachment_type().unwrap(),
-            &AttachmentType::Breadcrumbs
-        );
+        assert_eq!(item.attachment_type().unwrap(), AttachmentType::Breadcrumbs);
         assert_eq!(item.payload().len(), 0);
 
         // the msg-pack encoded event file
         let item = &items[3];
         assert_eq!(item.filename().unwrap(), "__sentry-event");
-        assert_eq!(item.content_type().unwrap(), &ContentType::OctetStream);
+        assert_eq!(item.content_type().unwrap(), ContentType::OctetStream);
         assert_eq!(item.ty(), &ItemType::Attachment);
         assert_eq!(
             item.attachment_type().unwrap(),
-            &AttachmentType::EventPayload
+            AttachmentType::EventPayload
         );
         assert_eq!(item.payload().len(), 29);
 
         // the next item is the view-hierarchy file
         let item = &items[4];
         assert_eq!(item.filename().unwrap(), "view-hierarchy.json");
-        assert_eq!(item.content_type().unwrap(), &ContentType::Json);
+        assert_eq!(item.content_type().unwrap(), ContentType::Json);
         assert_eq!(item.ty(), &ItemType::Attachment);
         assert_eq!(
             item.attachment_type().unwrap(),
-            &AttachmentType::ViewHierarchy
+            AttachmentType::ViewHierarchy
         );
         assert_eq!(item.payload().len(), 184);
 
         // the last item is the form-data if any and contains a `guid` from the `crashpad_handler`
         let item = &items[5];
         assert!(item.filename().is_none());
-        assert_eq!(item.content_type().unwrap(), &ContentType::Text);
+        assert_eq!(item.content_type().unwrap(), ContentType::Text);
         assert_eq!(item.ty(), &ItemType::FormData);
         assert!(item.attachment_type().is_none());
         let form_payload = item.payload();

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -87,7 +87,7 @@ async fn extract_multipart(
 
     let prosperodump_item = items
         .iter_mut()
-        .find(|item| item.attachment_type() == Some(&AttachmentType::Prosperodump))
+        .find(|item| item.attachment_type() == Some(AttachmentType::Prosperodump))
         .ok_or(BadStoreRequest::MissingProsperodump)?;
 
     prosperodump_item.set_payload(OctetStream, prosperodump_item.payload());

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -36,11 +36,11 @@ impl SecurityReportParams {
         report_item.set_payload(ContentType::Json, item);
 
         if let Some(sentry_release) = &query.sentry_release {
-            report_item.set_header("sentry_release", sentry_release.clone());
+            report_item.set_sentry_release(sentry_release.clone());
         }
 
         if let Some(sentry_environment) = &query.sentry_environment {
-            report_item.set_header("sentry_environment", sentry_environment.clone());
+            report_item.set_sentry_environment(sentry_environment.clone());
         }
 
         report_item

--- a/relay-server/src/envelope/attachment.rs
+++ b/relay-server/src/envelope/attachment.rs
@@ -3,7 +3,7 @@ use std::fmt;
 /// The type of an event attachment.
 ///
 /// These item types must align with the Sentry processing pipeline.
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub enum AttachmentType {
     /// A regular attachment without special meaning.
     #[default]
@@ -49,10 +49,6 @@ pub enum AttachmentType {
 
     /// An application UI view hierarchy (json payload).
     ViewHierarchy,
-
-    /// Unknown attachment type, forwarded for compatibility.
-    /// Attachments with this type will be dropped if `accept_unknown_items` is set to false.
-    Unknown(String),
 }
 
 impl fmt::Display for AttachmentType {
@@ -67,13 +63,15 @@ impl fmt::Display for AttachmentType {
             AttachmentType::UnrealContext => write!(f, "unreal.context"),
             AttachmentType::UnrealLogs => write!(f, "unreal.logs"),
             AttachmentType::ViewHierarchy => write!(f, "event.view_hierarchy"),
-            AttachmentType::Unknown(s) => s.fmt(f),
         }
     }
 }
 
+#[derive(Debug)]
+pub struct UnknownAttachmentType;
+
 impl std::str::FromStr for AttachmentType {
-    type Err = std::convert::Infallible;
+    type Err = UnknownAttachmentType;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
@@ -86,7 +84,7 @@ impl std::str::FromStr for AttachmentType {
             "event.view_hierarchy" => AttachmentType::ViewHierarchy,
             "unreal.context" => AttachmentType::UnrealContext,
             "unreal.logs" => AttachmentType::UnrealLogs,
-            other => AttachmentType::Unknown(other.to_owned()),
+            _ => return Err(UnknownAttachmentType),
         })
     }
 }

--- a/relay-server/src/envelope/container.rs
+++ b/relay-server/src/envelope/container.rs
@@ -199,10 +199,10 @@ impl<T: ContainerItem> ItemContainer<T> {
     /// This function also validates metadata of the container, specifically the content type
     /// and amount of contained items.
     pub fn parse(item: &Item) -> Result<Self, ContainerParseError> {
-        if item.content_type() != Some(&T::CONTENT_TYPE) {
+        if item.content_type() != Some(T::CONTENT_TYPE) {
             return Err(ContainerParseError::MismatchedContentType {
                 expected: T::CONTENT_TYPE,
-                actual: item.content_type().cloned(),
+                actual: item.content_type(),
             });
         }
 
@@ -249,7 +249,7 @@ impl<T: ContainerItem> ItemContainer<T> {
 
     /// Checks whether a given item is a container of `T`s, according to its item and content types.
     pub fn is_container(item: &Item) -> bool {
-        item.ty() == &T::ITEM_TYPE && item.content_type() == Some(&T::CONTENT_TYPE)
+        item.ty() == &T::ITEM_TYPE && item.content_type() == Some(T::CONTENT_TYPE)
     }
 
     fn deserialize<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -357,7 +357,7 @@ mod tests {
         let mut item = Item::new(ItemType::Log);
         container.write_to(&mut item).unwrap();
 
-        assert_eq!(item.content_type(), Some(&ContentType::LogContainer));
+        assert_eq!(item.content_type(), Some(ContentType::LogContainer));
         assert_eq!(item.item_count(), Some(2));
 
         let payload = item.payload();

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -904,7 +904,7 @@ mod tests {
             items[0].payload(),
             Bytes::from(&b"\xef\xbb\xbfHello\r\n"[..])
         );
-        assert_eq!(items[0].content_type(), Some(&ContentType::Text));
+        assert_eq!(items[0].content_type(), Some(ContentType::Text));
 
         assert_eq!(items[1].ty(), &ItemType::Event);
         assert_eq!(items[1].len(), 41);
@@ -912,7 +912,7 @@ mod tests {
             items[1].payload(),
             Bytes::from("{\"message\":\"hello world\",\"level\":\"error\"}")
         );
-        assert_eq!(items[1].content_type(), Some(&ContentType::Json));
+        assert_eq!(items[1].content_type(), Some(ContentType::Json));
         assert_eq!(items[1].filename(), Some("application.log"));
     }
 
@@ -982,7 +982,7 @@ mod tests {
         assert_eq!(items[0].ty(), &ItemType::Attachment);
         assert_eq!(
             items[0].attachment_type(),
-            Some(&AttachmentType::ViewHierarchy)
+            Some(AttachmentType::ViewHierarchy)
         );
     }
 

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -119,7 +119,7 @@ fn expand_legacy_span(item: &Item) -> Result<WithHeader<SpanV2>> {
 /// Parses and validates a span attachment, converting it into a structured type.
 fn parse_and_validate_span_attachment(item: &Item) -> Result<(Option<SpanId>, ExpandedAttachment)> {
     let associated_span_id = match item.parent_id() {
-        Some(ParentId::SpanId(span_id)) => *span_id,
+        Some(ParentId::SpanId(span_id)) => span_id,
         None => {
             relay_log::debug!("span attachment missing associated span id");
             return Err(Error::Invalid(DiscardReason::InvalidSpanAttachment));

--- a/relay-server/src/processing/trace_attachments/process.rs
+++ b/relay-server/src/processing/trace_attachments/process.rs
@@ -65,7 +65,7 @@ pub fn parse_and_validate(item: &Item) -> Result<ExpandedAttachment, DiscardReas
     })?;
 
     Ok(ExpandedAttachment {
-        parent_id: item.parent_id().cloned(),
+        parent_id: item.parent_id(),
         meta,
         body: payload.slice_ref(body),
     })

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -663,7 +663,6 @@ impl DiscardItemType {
             Self::Attachment(DiscardAttachmentType::UnrealContext) => "attachment:unreal_context",
             Self::Attachment(DiscardAttachmentType::UnrealLogs) => "attachment:unreal_logs",
             Self::Attachment(DiscardAttachmentType::ViewHierarchy) => "attachment:view_hierarchy",
-            Self::Attachment(DiscardAttachmentType::Unknown) => "attachment:unknown",
             Self::FormData => "form_data",
             Self::RawSecurity => "raw_security",
             Self::Nel => "nel",
@@ -763,8 +762,6 @@ pub enum DiscardAttachmentType {
     UnrealLogs,
     /// An application UI view hierarchy (json payload).
     ViewHierarchy,
-    /// Unknown attachment type, forwarded for compatibility.
-    Unknown,
 }
 
 impl From<&AttachmentType> for DiscardAttachmentType {
@@ -779,7 +776,6 @@ impl From<&AttachmentType> for DiscardAttachmentType {
             AttachmentType::UnrealContext => Self::UnrealContext,
             AttachmentType::UnrealLogs => Self::UnrealLogs,
             AttachmentType::ViewHierarchy => Self::ViewHierarchy,
-            AttachmentType::Unknown(_) => Self::Unknown,
         }
     }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1348,7 +1348,7 @@ impl EnvelopeProcessorService {
         let attachments = managed_envelope
             .envelope()
             .items()
-            .filter(|item| item.attachment_type() == Some(&AttachmentType::Attachment));
+            .filter(|item| item.attachment_type() == Some(AttachmentType::Attachment));
         processing::utils::event::finalize(
             managed_envelope.envelope().headers(),
             &mut event,

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -25,9 +25,9 @@ pub fn create_placeholders(
 ) -> Option<EventFullyNormalized> {
     let envelope = managed_envelope.envelope();
     let minidump_attachment =
-        envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::Minidump));
+        envelope.get_item_by(|item| item.attachment_type() == Some(AttachmentType::Minidump));
     let apple_crash_report_attachment = envelope
-        .get_item_by(|item| item.attachment_type() == Some(&AttachmentType::AppleCrashReport));
+        .get_item_by(|item| item.attachment_type() == Some(AttachmentType::AppleCrashReport));
 
     if let Some(item) = minidump_attachment {
         let event = event.get_or_insert_with(Event::default);

--- a/relay-server/src/services/processor/event.rs
+++ b/relay-server/src/services/processor/event.rs
@@ -8,7 +8,7 @@ use relay_event_schema::protocol::{
     Breadcrumb, Csp, Event, ExpectCt, ExpectStaple, Hpkp, LenientString, Metrics,
     SecurityReportType, Values,
 };
-use relay_protocol::{Annotated, Array, Empty, Object, Value};
+use relay_protocol::{Annotated, Array, Empty, Object};
 use relay_statsd::metric;
 use serde_json::Value as SerdeValue;
 
@@ -47,11 +47,11 @@ pub fn extract<Group: EventProcessing>(
     let user_report_v2_item = envelope.take_item_by(|item| item.ty() == &ItemType::UserReportV2);
     let form_item = envelope.take_item_by(|item| item.ty() == &ItemType::FormData);
     let attachment_item =
-        envelope.take_item_by(|item| item.attachment_type() == Some(&AttachmentType::EventPayload));
+        envelope.take_item_by(|item| item.attachment_type() == Some(AttachmentType::EventPayload));
     let breadcrumbs1 =
-        envelope.take_item_by(|item| item.attachment_type() == Some(&AttachmentType::Breadcrumbs));
+        envelope.take_item_by(|item| item.attachment_type() == Some(AttachmentType::Breadcrumbs));
     let breadcrumbs2 =
-        envelope.take_item_by(|item| item.attachment_type() == Some(&AttachmentType::Breadcrumbs));
+        envelope.take_item_by(|item| item.attachment_type() == Some(AttachmentType::Breadcrumbs));
 
     // Event items can never occur twice in an envelope.
     if let Some(duplicate) =
@@ -257,14 +257,11 @@ fn event_from_security_report(
         return Err(ProcessingError::InvalidSecurityReport(json_error));
     }
 
-    if let Some(release) = item.get_header("sentry_release").and_then(Value::as_str) {
+    if let Some(release) = item.sentry_release() {
         event.release = Annotated::from(LenientString(release.to_owned()));
     }
 
-    if let Some(env) = item
-        .get_header("sentry_environment")
-        .and_then(Value::as_str)
-    {
+    if let Some(env) = item.sentry_environment() {
         event.environment = Annotated::from(env.to_owned());
     }
 

--- a/relay-server/src/services/processor/playstation.rs
+++ b/relay-server/src/services/processor/playstation.rs
@@ -36,7 +36,7 @@ pub fn expand(
     // Get instead of take as we want to keep the dump as an attachment
     if let Some(item) = envelope.get_item_by(|item| {
         item.ty() == &ItemType::Attachment
-            && item.attachment_type() == Some(&AttachmentType::Prosperodump)
+            && item.attachment_type() == Some(AttachmentType::Prosperodump)
     }) {
         let data = relay_prosperoconv::extract_data(&item.payload()).map_err(|err| {
             ProcessingError::InvalidPlaystationDump(format!("Failed to extract data: {err}"))
@@ -75,7 +75,7 @@ pub fn process(
 
     if let Some(item) = envelope.get_item_by(|item| {
         item.ty() == &ItemType::Attachment
-            && item.attachment_type() == Some(&AttachmentType::Prosperodump)
+            && item.attachment_type() == Some(AttachmentType::Prosperodump)
     }) {
         metric!(counter(RelayCounters::PlaystationProcessing) += 1);
         let event = event.get_or_insert_with(Event::default);

--- a/relay-server/src/services/projects/cache/project.rs
+++ b/relay-server/src/services/projects/cache/project.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     fn get_span_count(envelope: &Envelope) -> usize {
-        envelope.items().next().unwrap().span_count()
+        envelope.items().next().unwrap().span_count() as usize
     }
 
     #[tokio::test]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -407,7 +407,7 @@ impl StoreService {
                     let client = envelope.meta().client();
                     self.produce_check_in(scoping.project_id, received_at, client, retention, item)?
                 }
-                ItemType::Span if content_type == Some(&ContentType::Json) => self.produce_span(
+                ItemType::Span if content_type == Some(ContentType::Json) => self.produce_span(
                     scoping,
                     received_at,
                     event_id,
@@ -894,10 +894,8 @@ impl StoreService {
                 None => UNNAMED_ATTACHMENT.to_owned(),
             },
             rate_limited: item.rate_limited(),
-            content_type: item
-                .content_type()
-                .map(|content_type| content_type.as_str().to_owned()),
-            attachment_type: item.attachment_type().cloned().unwrap_or_default(),
+            content_type: item.raw_content_type().map(|s| s.to_ascii_lowercase()),
+            attachment_type: item.attachment_type().unwrap_or_default(),
             size,
             payload,
         };
@@ -1034,7 +1032,7 @@ impl StoreService {
         item: &Item,
     ) -> Result<(), StoreError> {
         debug_assert_eq!(item.ty(), &ItemType::Span);
-        debug_assert_eq!(item.content_type(), Some(&ContentType::Json));
+        debug_assert_eq!(item.content_type(), Some(ContentType::Json));
 
         let Scoping {
             organization_id,

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -235,7 +235,11 @@ where
                     }
 
                     if let Some(content_type) = content_type {
-                        item.set_payload(content_type.as_ref().into(), bytes);
+                        let ct = content_type
+                            .as_ref()
+                            .parse()
+                            .unwrap_or(ContentType::OctetStream);
+                        item.set_payload(ct, bytes);
                     } else {
                         item.set_payload_without_content_type(bytes);
                     }

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -351,10 +351,10 @@ pub fn process_unreal_envelope(
         .get_header(UNREAL_USER_HEADER)
         .and_then(Value::as_str);
     let context_item =
-        envelope.get_item_by(|item| item.attachment_type() == Some(&AttachmentType::UnrealContext));
+        envelope.get_item_by(|item| item.attachment_type() == Some(AttachmentType::UnrealContext));
     let mut logs_items = envelope
         .items()
-        .filter(|item| item.attachment_type() == Some(&AttachmentType::UnrealLogs))
+        .filter(|item| item.attachment_type() == Some(AttachmentType::UnrealLogs))
         .map(|item| item.payload())
         .peekable();
 

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -52,7 +52,7 @@ def test_relay_with_full_normalization(mini_sentry, relay, config_full_normaliza
         assert "fully_normalized" in envelope.items[0].headers
         assert drop_props(expected) == drop_props(envelope.get_event())
     else:
-        assert "fully_normalized" not in envelope.items[0].headers
+        assert not envelope.items[0].headers.get("fully_normalized")
         assert drop_props(expected) != drop_props(envelope.get_event())
 
 


### PR DESCRIPTION
Reduces the size of the item headers struct by (de-)serializing on demand.

Some leftover fields are fields which are not serialized, we can either also serialize them or some of them can already be removed in a follow-up.

A nice simplification is that, `ContentType` and `AttachmentType` are now `Copy`. In another follow-up the item type can also be moved into the `inner` value and `Unknown(String)` changed to `Unknown`.

Without any further changes this reduces the `ItemHeaders` size from 320 bytes to 128.