### PR TITLE
fix(objectstore): Log objectstore error on failure

### DIFF
--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -269,6 +269,7 @@ impl ObjectstoreServiceInner {
 
         match session {
             Err(error) => {
+                relay_log::error!(error = &error as &dyn std::error::Error);
                 relay_statsd::metric!(
                     counter(RelayCounters::AttachmentUpload) += attachments.count() as u64,
                     result = error.to_string().as_str(),


### PR DESCRIPTION
Log objectstore error when a file upload fails.

ref: FS-222