### PR TITLE
ref: Add streaming-platform as codeowner for kafka metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 *   @getsentry/ingest
 
 # Kafka metrics
-/relay-kafka/src/statsd.rs  @getsentry/streaming-platform
+/relay-kafka/src/statsd.rs  @getsentry/streaming-platform @getsentry/ingest
 
 # Legal
 /LICENSE.md  @getsentry/owners-legal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # Default code owners
 *   @getsentry/ingest
 
+# Kafka metrics
+/relay-kafka/src/statsd.rs  @getsentry/streaming-platform
+
 # Legal
 /LICENSE.md  @getsentry/owners-legal


### PR DESCRIPTION
as part of INC-2054, we realized that these metrics are part of streaming team's SLOs and alerts.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


#skip-changelog
