### PR TITLE
ref: Add log message to errors

### DIFF
--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -149,7 +149,11 @@ pub fn parse_metadata(payload: &[u8]) -> Result<ProfileMetadata, ProfileError> {
     let profile = match minimal_profile_from_json(payload) {
         Ok(profile) => profile,
         Err(err) => {
-            relay_log::debug!(error = &err as &dyn Error, from = "minimal",);
+            relay_log::debug!(
+                error = &err as &dyn Error,
+                from = "minimal",
+                "invalid profile"
+            );
             return Err(ProfileError::InvalidJson(err));
         }
     };

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -86,7 +86,10 @@ impl IntoResponse for Error {
                 upload::Error::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
                 upload::Error::Internal => {
                     debug_assert!(false);
-                    relay_log::error!(error = &error as &dyn std::error::Error);
+                    relay_log::error!(
+                        error = &error as &dyn std::error::Error,
+                        "internal upload error"
+                    );
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
             },

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -269,7 +269,7 @@ impl ObjectstoreServiceInner {
 
         match session {
             Err(error) => {
-                relay_log::error!(error = &error as &dyn std::error::Error);
+                relay_log::error!(error = &error as &dyn std::error::Error, "session error");
                 relay_statsd::metric!(
                     counter(RelayCounters::AttachmentUpload) += attachments.count() as u64,
                     result = error.to_string().as_str(),
@@ -424,9 +424,12 @@ impl ObjectstoreServiceInner {
     }
 
     async fn upload(&self, ty: &str, request: PutBuilder) -> Result<ObjectstoreKey, Error> {
-        self.upload_inner(ty, request)
-            .await
-            .inspect_err(|e| relay_log::error!(error = e as &dyn std::error::Error))
+        self.upload_inner(ty, request).await.inspect_err(|e| {
+            relay_log::error!(
+                error = e as &dyn std::error::Error,
+                "objectstore upload failed"
+            )
+        })
     }
 
     async fn upload_inner(&self, ty: &str, request: PutBuilder) -> Result<ObjectstoreKey, Error> {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -2270,7 +2270,9 @@ impl EnvelopeProcessorService {
                             is_limited = limits.is_limited();
                             rate_limits.merge(limits)
                         }
-                        Err(e) => relay_log::error!(error = &e as &dyn Error),
+                        Err(e) => {
+                            relay_log::error!(error = &e as &dyn Error, "rate limiting error")
+                        }
                     }
                 }
 


### PR DESCRIPTION
Logging an error without a message works and generates useful Sentry issues, but they show up as empty lines in console output and the Logs product.