### PR TITLE
feat(upload): Loadshed and Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@
 - Populate gen_ai.response.model from gen_ai.request.model if not already set. ([#5654](https://github.com/getsentry/relay/pull/5654))
 - Add support for Unix domain sockets for statsd metrics. ([#5668](https://github.com/getsentry/relay/pull/5668))
 
-**Internal**
+**Internal**:
 
 - Allow deferred lengths to the `/upload` endpoint when the sender is trusted. ([#5658](https://github.com/getsentry/relay/pull/5658))
+- Handle traffic bursts in the objectstore service. ([#5689](https://github.com/getsentry/relay/pull/5689))
 
 ## 26.2.1
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1289,6 +1289,11 @@ pub struct ObjectstoreServiceConfig {
     /// Maximum concurrency of uploads.
     pub max_concurrent_requests: usize,
 
+    /// Maximum size of the service input queue when `max_concurrent_requests` is saturated.
+    ///
+    /// The service will loadshed if this threshold is reached.
+    pub max_backlog: usize,
+
     /// Maximum duration of an attachment upload in seconds. Uploads that take longer are discarded.
     pub timeout: u64,
 }
@@ -1298,6 +1303,7 @@ impl Default for ObjectstoreServiceConfig {
         Self {
             objectstore_url: None,
             max_concurrent_requests: 10,
+            max_backlog: 20,
             timeout: 60,
         }
     }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -244,7 +244,7 @@ impl ServiceState {
         #[cfg(feature = "processing")]
         let objectstore = ObjectstoreService::new(config.objectstore(), store.clone())?.map(|s| {
             let concurrent = ConcurrentService::new(s)
-                .with_loadshedding()
+                .with_backlog_limit(0)
                 .with_concurrency_limit(config.objectstore().max_concurrent_requests);
             services.start(concurrent)
         });

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -244,7 +244,7 @@ impl ServiceState {
         #[cfg(feature = "processing")]
         let objectstore = ObjectstoreService::new(config.objectstore(), store.clone())?.map(|s| {
             let concurrent = ConcurrentService::new(s)
-                .with_backlog_limit(0)
+                .with_backlog_limit(config.objectstore().max_backlog)
                 .with_concurrency_limit(config.objectstore().max_concurrent_requests);
             services.start(concurrent)
         });

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -169,6 +169,7 @@ impl ObjectstoreService {
         let ObjectstoreServiceConfig {
             objectstore_url,
             max_concurrent_requests: _,
+            max_backlog: _,
             timeout,
         } = config;
         let Some(objectstore_url) = objectstore_url else {

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -95,7 +95,7 @@ pub fn create_service(
         objectstore,
     );
     ConcurrentService::new(service)
-        .with_loadshedding()
+        .with_backlog_limit(0)
         .with_concurrency_limit(config.upload().max_concurrent_requests)
 }
 

--- a/relay-system/src/service/concurrent.rs
+++ b/relay-system/src/service/concurrent.rs
@@ -37,8 +37,8 @@ where
     S: SimpleService + Clone + Send + Sync,
 {
     inner: S,
-    congestion_control: CongestionControl,
     max_concurrency: usize,
+    max_backlog: usize,
     pending: FuturesUnordered<BoxFuture<'static, ()>>,
 }
 
@@ -52,8 +52,8 @@ where
     pub fn new(inner: S) -> Self {
         Self {
             inner,
-            congestion_control: CongestionControl::Backpressure,
             max_concurrency: usize::MAX,
+            max_backlog: usize::MAX,
             pending: FuturesUnordered::new(),
         }
     }
@@ -64,11 +64,11 @@ where
         self
     }
 
-    /// Changes the congestion control strategy to load-shedding.
+    /// Limits the amount of messages that wait in the queue by loadshedding.
     ///
     /// This will drop messages.
-    pub fn with_loadshedding(mut self) -> Self {
-        self.congestion_control = CongestionControl::LoadShed;
+    pub fn with_backlog_limit(mut self, limit: usize) -> Self {
+        self.max_backlog = limit;
         self
     }
 }
@@ -84,7 +84,10 @@ where
             relay_log::trace!("Concurrent service loop iteration");
 
             let has_capacity = self.pending.len() < self.max_concurrency;
-            let should_consume = has_capacity || self.congestion_control.is_loadshed();
+            let should_consume = has_capacity || {
+                let backlog = rx.queue_size.load(std::sync::atomic::Ordering::Relaxed);
+                backlog > self.max_backlog as u64
+            };
 
             tokio::select! {
                 // Bias towards handling responses so that there's space for new incoming requests.
@@ -112,28 +115,9 @@ where
 }
 
 /// A trait describing what to do with a message that was load-shed.
-///
-/// The default implementation is to do nothing, so implementations may be empty,
-/// especially when the congestion control mechanism is backpressure.
 pub trait LoadShed<T> {
     /// Gets called for every message that gets dropped by loadshedding.
-    fn handle_loadshed(&self, _message: T) {}
-}
-
-/// Represents whether the [`ConcurrentService`] should load-shed or apply
-/// backpressure when it's maximum concurrency has been reached.
-#[derive(Debug, Clone, Copy)]
-pub enum CongestionControl {
-    /// Leave incoming messages in the queue.
-    Backpressure,
-    /// Drop incoming messages if there is no capacity.
-    LoadShed,
-}
-
-impl CongestionControl {
-    fn is_loadshed(&self) -> bool {
-        matches!(self, Self::LoadShed)
-    }
+    fn handle_loadshed(&self, _message: T);
 }
 
 #[cfg(test)]
@@ -147,7 +131,10 @@ mod tests {
     use super::*;
 
     #[derive(Clone)]
-    struct CountingService(Arc<AtomicUsize>);
+    struct CountingService {
+        success: Arc<AtomicUsize>,
+        fail: Arc<AtomicUsize>,
+    }
     struct Incr;
     impl Interface for Incr {}
     impl FromMessage<()> for Incr {
@@ -161,33 +148,47 @@ mod tests {
 
         async fn handle_message(&self, _message: Incr) {
             tokio::time::sleep(Duration::from_secs(2)).await;
-            self.0.fetch_add(1, Ordering::Relaxed);
+            self.success.fetch_add(1, Ordering::Relaxed);
         }
     }
 
-    impl LoadShed<Incr> for CountingService {}
+    impl LoadShed<Incr> for CountingService {
+        fn handle_loadshed(&self, _message: Incr) {
+            self.fail.fetch_add(1, Ordering::Relaxed);
+        }
+    }
 
     #[tokio::test(start_paused = true)]
     async fn loadshed() {
-        let inner = CountingService(Arc::new(AtomicUsize::new(0)));
+        let inner = CountingService {
+            success: Arc::new(AtomicUsize::new(0)),
+            fail: Arc::new(AtomicUsize::new(0)),
+        };
         let service = ConcurrentService::new(inner.clone())
             .with_concurrency_limit(5)
-            .with_loadshedding();
+            .with_backlog_limit(0);
         let addr = service.start_detached();
 
         for _ in 0..10 {
             addr.send(());
         }
 
+        assert_eq!(inner.success.load(Ordering::Relaxed), 0);
+        assert_eq!(inner.fail.load(Ordering::Relaxed), 0);
+
         tokio::time::sleep(Duration::from_secs(10)).await;
 
         // Only half of the items have been processed
-        assert_eq!(inner.0.load(Ordering::Relaxed), 5);
+        assert_eq!(inner.success.load(Ordering::Relaxed), 5);
+        assert_eq!(inner.fail.load(Ordering::Relaxed), 5);
     }
 
     #[tokio::test(start_paused = true)]
     async fn backpressure() {
-        let inner = CountingService(Arc::new(AtomicUsize::new(0)));
+        let inner = CountingService {
+            success: Arc::new(AtomicUsize::new(0)),
+            fail: Arc::new(AtomicUsize::new(0)),
+        };
         let service = ConcurrentService::new(inner.clone()).with_concurrency_limit(5);
         let addr = service.start_detached();
 
@@ -197,10 +198,39 @@ mod tests {
 
         // After 3 seconds, only half the messages have been handled:
         tokio::time::sleep(Duration::from_secs(3)).await;
-        assert_eq!(inner.0.load(Ordering::Relaxed), 5);
+        assert_eq!(inner.success.load(Ordering::Relaxed), 5);
+        assert_eq!(inner.fail.load(Ordering::Relaxed), 0);
 
         // After 5 seconds, everything's been handled:
         tokio::time::sleep(Duration::from_secs(2)).await;
-        assert_eq!(inner.0.load(Ordering::Relaxed), 10);
+        assert_eq!(inner.success.load(Ordering::Relaxed), 10);
+        assert_eq!(inner.fail.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backpressure_and_loadshed() {
+        let inner = CountingService {
+            success: Arc::new(AtomicUsize::new(0)),
+            fail: Arc::new(AtomicUsize::new(0)),
+        };
+        let service = ConcurrentService::new(inner.clone())
+            .with_concurrency_limit(5)
+            .with_backlog_limit(5);
+        let addr = service.start_detached();
+
+        for _ in 0..13 {
+            addr.send(());
+        }
+
+        // After 3 seconds, only 5 messages have been handled.
+        // Three have been dropped due to loadshedding.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert_eq!(inner.success.load(Ordering::Relaxed), 5);
+        assert_eq!(inner.fail.load(Ordering::Relaxed), 3);
+
+        // After 5 seconds, another 5 messages got handled:
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(inner.success.load(Ordering::Relaxed), 10);
+        assert_eq!(inner.fail.load(Ordering::Relaxed), 3);
     }
 }

--- a/relay-system/src/service/concurrent.rs
+++ b/relay-system/src/service/concurrent.rs
@@ -28,7 +28,11 @@ use crate::statsd::SystemGauges;
 /// }
 ///
 /// // `Loadshed` implementation is required but can be empty.
-/// impl LoadShed<MyMessage> for MyService {}
+/// impl LoadShed<MyMessage> for MyService {
+///     fn handle_loadshed(&self, _: MyMessage) {
+///         eprintln!("Dropped a message!");
+///     }
+/// }
 ///
 /// let concurrent_service = ConcurrentService::new(MyService).with_concurrency_limit(5);
 /// ```

--- a/relay-system/src/service/concurrent.rs
+++ b/relay-system/src/service/concurrent.rs
@@ -70,7 +70,10 @@ where
 
     /// Limits the amount of messages that wait in the queue by loadshedding.
     ///
-    /// This will drop messages.
+    /// Setting this limit will cause message loss.
+    ///
+    /// Note that cleanup of the queue may be deferred until the next pending
+    /// future completes.
     pub fn with_backlog_limit(mut self, limit: usize) -> Self {
         self.max_backlog = limit;
         self

--- a/relay-system/src/service/mod.rs
+++ b/relay-system/src/service/mod.rs
@@ -20,7 +20,7 @@ mod registry;
 mod simple;
 mod status;
 
-pub use self::concurrent::{ConcurrentService, CongestionControl, LoadShed};
+pub use self::concurrent::{ConcurrentService, LoadShed};
 pub(crate) use self::registry::Registry as ServiceRegistry;
 pub use self::registry::{ServiceId, ServiceMetrics, ServicesMetrics};
 pub use self::simple::SimpleService;

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -2,9 +2,9 @@
 Tests for the TUS upload endpoint (/api/{project_id}/upload/).
 """
 
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from threading import Event
 
 from flask import Response
 import pytest
@@ -274,19 +274,18 @@ def test_concurrency_limit(mini_sentry, relay, project_config):
     """Exceeding upload.max_concurrent_requests results in 503 Service Unavailable."""
 
     project_id = 42
-    max_concurrent = 1
+    timeout = 2
 
     mini_sentry.allow_chunked = True
-    all_uploads_running = Event()
+    relay.capture_logs = True
 
     @mini_sentry.app.route("/api/<project>/upload/", methods=["POST"])
     def slow_upstream(**opts):
-        all_uploads_running.wait(timeout=10)
-        return Response("", status=201, headers={"Location": "dummy"})
+        time.sleep(timeout + 1)
 
     relay = relay(
         mini_sentry,
-        {"upload": {"max_concurrent_requests": 1}},
+        {"upload": {"max_concurrent_requests": 1, "timeout": 1}},
     )
 
     def do_upload():
@@ -301,10 +300,11 @@ def test_concurrency_limit(mini_sentry, relay, project_config):
             data=b"hello",
         )
 
-    with ThreadPoolExecutor(max_workers=max_concurrent + 1) as pool:
-        futures = [pool.submit(do_upload) for _ in range(max_concurrent + 1)]
-        all_uploads_running.set()
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = [pool.submit(do_upload) for _ in range(10)]
         results = [f.result() for f in as_completed(futures)]
 
-    status_codes = sorted(r.status_code for r in results)
-    assert status_codes == [201, 503]
+    status_codes = {r.status_code for r in results}
+
+    # Some requests hit a timeout, the others are loadshed:
+    assert status_codes == {503, 504}


### PR DESCRIPTION
We want to protect Relay against objectstore outages. Until now, the objectstore service would loadshed immediately when hitting `max_concurrent_requests` to prevent backlogging into the `EnvelopeBuffer` (and worst case, stopping ingestion of all traffic, not just attachments).

However, we also want to average out bursts of traffic to even the load on objectstore itself. The solution is to provide some buffering in-memory before we start loadshedding.

Fixes INGEST-663.