### PR TITLE
ref(objectstore): Let reqwest handle total timeout

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -75,6 +75,7 @@ impl IntoResponse for Error {
                     objectstore::Error::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
                     objectstore::Error::UploadFailed(error) => match error {
                         objectstore_client::Error::Reqwest(error) => match error.status() {
+                            _ if error.is_timeout() => StatusCode::GATEWAY_TIMEOUT,
                             Some(status) => status,
                             None => StatusCode::INTERNAL_SERVER_ERROR,
                         },

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -72,7 +72,6 @@ impl IntoResponse for Error {
                 upload::Error::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
                 #[cfg(feature = "processing")]
                 upload::Error::Objectstore(service_error) => match service_error {
-                    objectstore::Error::Timeout => StatusCode::GATEWAY_TIMEOUT,
                     objectstore::Error::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
                     objectstore::Error::UploadFailed(error) => match error {
                         objectstore_client::Error::Reqwest(error) => match error.status() {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -106,8 +106,6 @@ impl Counted for StoreAttachment {
 /// Errors that can occur when trying to upload an attachment.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("timeout")]
-    Timeout,
     #[error("load shed")]
     LoadShed,
     #[error("upload failed: {0}")]
@@ -119,7 +117,6 @@ pub enum Error {
 impl Error {
     fn as_str(&self) -> &'static str {
         match self {
-            Error::Timeout => "timeout",
             Error::LoadShed => "load-shed",
             Error::UploadFailed(_) => "upload_failed",
             Error::Uuid(_) => "uuid",

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -175,17 +175,16 @@ impl ObjectstoreService {
             return Ok(None);
         };
 
-        let objectstore_client = Client::builder(objectstore_url).build()?;
+        let objectstore_client = Client::builder(objectstore_url)
+            .configure_reqwest(|builder| builder.timeout(Duration::from_secs(*timeout)))
+            .build()?;
         let event_attachments = Usecase::new("attachments")
             .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
         let trace_attachments = Usecase::new("trace_attachments")
             .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
 
         let inner = ObjectstoreServiceInner {
-            timeout: Duration::from_secs(*timeout),
-
             store,
-
             objectstore_client,
             event_attachments,
             trace_attachments,
@@ -229,7 +228,6 @@ impl LoadShed<Objectstore> for ObjectstoreService {
 }
 
 struct ObjectstoreServiceInner {
-    timeout: Duration,
     store: Addr<Store>,
 
     objectstore_client: Client,
@@ -438,9 +436,8 @@ impl ObjectstoreServiceInner {
             timer(RelayTimers::AttachmentUploadDuration),
             type = ty,
             {
-                tokio::time::timeout(self.timeout, request.send())
+                request.send()
                     .await
-                    .map_err(|_elapsed| Error::Timeout)?
                     .map_err(Error::UploadFailed)?
             }
         );


### PR DESCRIPTION
Two reasons for this PR:

1. No need to wrap the request by hand if `reqwest` already has an API for a total request timeout.
2. We're seeing "operation timed out" originating from the `reqwest` library in prod, and even though objectstore does not set this timeout, and there are other potential sources for this error, I want to rule out a configuration problem.

ref: INGEST-784