### PR TITLE
feat(otel): Support `deployment.environment` resource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Populate gen_ai.response.model from gen_ai.request.model if not already set. ([#5654](https://github.com/getsentry/relay/pull/5654))
 - Add support for Unix domain sockets for statsd metrics. ([#5668](https://github.com/getsentry/relay/pull/5668))
+- Support `deployment.environment` OTLP resource attribute for setting the Sentry environment. ([#5691](https://github.com/getsentry/relay/pull/5691))
 
 **Internal**
 

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -63,7 +63,6 @@ convention_attributes!(
     OP => "sentry.op",
     ORIGIN => "sentry.origin",
     PLATFORM => "sentry.platform",
-    PROFILE_ID => "sentry.profile_id",
     RELEASE => "sentry.release",
     RESOURCE_RENDER_BLOCKING_STATUS => "resource.render_blocking_status",
     RPC_GRPC_STATUS_CODE => "rpc.grpc.status_code",
@@ -103,5 +102,11 @@ mod not_yet_defined {
     pub const LEGACY_HTTP_REQUEST_METHOD: &str = "http.request_method";
 
     pub const WAS_TRANSACTION: &str = "sentry.was_transaction";
+
+    // TODO(mjq): Evaluate and remove usages of this constant, or restore it in
+    // conventions. This was deleted from conventions in
+    // https://github.com/getsentry/sentry-conventions/pull/256 but is still
+    // used in Relay.
+    pub const PROFILE_ID: &str = "sentry.profile_id";
 }
 pub use self::not_yet_defined::*;

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -95,18 +95,18 @@ mod tests {
     fn test_http_response_content_length() {
         let info = attribute_info("http.response_content_length").unwrap();
 
-        insta::assert_debug_snapshot!(info, @r###"
+        insta::assert_debug_snapshot!(info, @r#"
         AttributeInfo {
             write_behavior: BothNames(
                 "http.response.body.size",
             ),
-            pii: False,
+            pii: Maybe,
             aliases: [
                 "http.response.body.size",
                 "http.response.header.content-length",
             ],
         }
-        "###);
+        "#);
     }
 
     #[test]


### PR DESCRIPTION
Updates the sentry-conventions submodule to its latest commit (https://github.com/getsentry/sentry-conventions/commit/0db15becb4b06b592d53bd18aa9f945d7b065a71) in order to get the definition of `resource.deploument.environment` (https://github.com/getsentry/sentry-conventions/pull/266), which is used to turn incoming OTLP `deployment.environment` resource attributes into `sentry.environment`, which the product uses everywhere for its environment dropdowns.