### PR TITLE
fix(upload): Make independent of general `http.timeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 - Use new processor architecture to process client reports. ([#5686](https://github.com/getsentry/relay/pull/5686))
 - Prevent timeouts on the `/upload` endpoint. ([#5692](https://github.com/getsentry/relay/pull/5692))
 
-
 ## 26.2.1
 
 **Bug Fixes**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
 - Populate gen_ai.response.model from gen_ai.request.model if not already set. ([#5654](https://github.com/getsentry/relay/pull/5654))
 - Add support for Unix domain sockets for statsd metrics. ([#5668](https://github.com/getsentry/relay/pull/5668))
 
-**Internal**
+**Internal**:
 
 - Allow deferred lengths to the `/upload` endpoint when the sender is trusted. ([#5658](https://github.com/getsentry/relay/pull/5658))
 - Use new processor architecture to process client reports. ([#5686](https://github.com/getsentry/relay/pull/5686))
+- Prevent timeouts on the `/upload` endpoint. ([#5692](https://github.com/getsentry/relay/pull/5692))
+
 
 ## 26.2.1
 

--- a/relay-server/src/http.rs
+++ b/relay-server/src/http.rs
@@ -9,6 +9,7 @@
 //! objects and common request objects, it's just that nobody bothers to implement the conversion
 //! logic.
 use std::io;
+use std::time::Duration;
 
 use relay_config::HttpEncoding;
 pub use reqwest::StatusCode;
@@ -93,6 +94,13 @@ impl RequestBuilder {
 
     pub fn content_encoding(&mut self, encoding: HttpEncoding) -> &mut Self {
         self.header_opt("content-encoding", encoding.name())
+    }
+
+    /// Enables a total request timeout.
+    ///
+    /// See [`reqwest::RequestBuilder::timeout`].
+    pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.build(|builder| builder.timeout(timeout))
     }
 
     pub fn body(&mut self, body: impl Into<reqwest::Body>) -> &mut Self {

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -272,7 +272,7 @@ impl SignedLocation {
 /// An upstream request made to the `/upload` endpoint.
 struct UploadRequest {
     scoping: Scoping,
-    timeout: Duration,
+    timeout: Option<Duration>,
     body: Option<BoundedStream<BoxStream<'static, std::io::Result<Bytes>>>>,
     sender: oneshot::Sender<Result<Response, UpstreamRequestError>>,
 }
@@ -290,7 +290,7 @@ impl UploadRequest {
         (
             Self {
                 scoping,
-                timeout: Duration::MAX, // will be set by `configure()`
+                timeout: None, // will be set by `configure()`
                 body: Some(stream),
                 sender,
             },
@@ -322,7 +322,7 @@ impl UpstreamRequest for UploadRequest {
     }
 
     fn configure(&mut self, config: &Config) {
-        self.timeout = Duration::from_secs(config.upload().timeout);
+        self.timeout = Some(Duration::from_secs(config.upload().timeout));
     }
 
     fn respond(
@@ -360,7 +360,13 @@ impl UpstreamRequest for UploadRequest {
             builder.header(key, value);
         }
 
-        builder.timeout(self.timeout);
+        debug_assert!(
+            self.timeout.is_some(),
+            "timeout should be set by UpstreamRequest::configure()"
+        );
+        if let Some(timeout) = self.timeout {
+            builder.timeout(timeout);
+        }
 
         builder.body(reqwest::Body::wrap_stream(body));
 

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -113,7 +113,6 @@ fn create_service_inner(
     }
     Service::Upstream {
         addr: upstream.clone(),
-        timeout: Duration::from_secs(config.upload().timeout),
     }
 }
 
@@ -124,7 +123,6 @@ fn create_service_inner(
 pub enum Service {
     Upstream {
         addr: Addr<UpstreamRelay>,
-        timeout: Duration,
     },
     #[cfg(feature = "processing")]
     Objectstore {
@@ -136,10 +134,10 @@ pub enum Service {
 impl Service {
     async fn upload(&self, stream: Stream) -> Result<SignedLocation, Error> {
         match self {
-            Service::Upstream { addr, timeout } => {
+            Service::Upstream { addr } => {
                 let (request, rx) = UploadRequest::create(stream);
                 addr.send(SendRequest(request));
-                let response = tokio::time::timeout(*timeout, rx).await???;
+                let response = rx.await??;
                 SignedLocation::try_from_response(response)
             }
             #[cfg(feature = "processing")]
@@ -270,6 +268,7 @@ impl SignedLocation {
 /// An upstream request made to the `/upload` endpoint.
 struct UploadRequest {
     scoping: Scoping,
+    timeout: Duration,
     body: Option<BoundedStream<BoxStream<'static, std::io::Result<Bytes>>>>,
     sender: oneshot::Sender<Result<Response, UpstreamRequestError>>,
 }
@@ -287,6 +286,7 @@ impl UploadRequest {
         (
             Self {
                 scoping,
+                timeout: Duration::MAX, // will be set by `configure()`
                 body: Some(stream),
                 sender,
             },
@@ -315,6 +315,10 @@ impl UpstreamRequest for UploadRequest {
 
     fn route(&self) -> &'static str {
         "upload"
+    }
+
+    fn configure(&mut self, config: &Config) {
+        self.timeout = Duration::from_secs(config.upload().timeout);
     }
 
     fn respond(
@@ -351,6 +355,8 @@ impl UpstreamRequest for UploadRequest {
             let Some(key) = key else { continue };
             builder.header(key, value);
         }
+
+        builder.timeout(self.timeout);
 
         builder.body(reqwest::Body::wrap_stream(body));
 

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -113,6 +113,7 @@ fn create_service_inner(
     }
     Service::Upstream {
         addr: upstream.clone(),
+        timeout: Duration::from_secs(config.upload().timeout),
     }
 }
 
@@ -123,6 +124,7 @@ fn create_service_inner(
 pub enum Service {
     Upstream {
         addr: Addr<UpstreamRelay>,
+        timeout: Duration,
     },
     #[cfg(feature = "processing")]
     Objectstore {
@@ -134,10 +136,12 @@ pub enum Service {
 impl Service {
     async fn upload(&self, stream: Stream) -> Result<SignedLocation, Error> {
         match self {
-            Service::Upstream { addr } => {
+            Service::Upstream { addr, timeout } => {
                 let (request, rx) = UploadRequest::create(stream);
                 addr.send(SendRequest(request));
-                let response = rx.await??;
+                // We're already passing `timeout` to the reqwest library, but we also want to
+                // limit the time spent waiting for the upstream service:
+                let response = tokio::time::timeout(*timeout, rx).await???;
                 SignedLocation::try_from_response(response)
             }
             #[cfg(feature = "processing")]

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -2,6 +2,7 @@
 Tests for the TUS upload endpoint (/api/{project_id}/upload/).
 """
 
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Event
@@ -191,6 +192,53 @@ def test_upload_rate_limited(
         )
 
     assert request().status_code == 429
+
+
+@pytest.mark.parametrize(
+    "http_timeout, upload_timeout, expected_status_code",
+    [
+        pytest.param(1, 60, 201, id="http"),
+        pytest.param(60, 1, 504, id="upload"),
+    ],
+)
+def test_timeout(
+    mini_sentry,
+    relay,
+    project_config,
+    http_timeout,
+    upload_timeout,
+    expected_status_code,
+):
+    """Ensure that the general HTTP timeout does not affect the upload endpoint"""
+    mini_sentry.allow_chunked = True
+
+    @mini_sentry.app.route("/api/<project>/upload/", methods=["POST"])
+    def slow_upload(**opts):
+        time.sleep(2)
+        return Response("", status=201, headers={"Location": "dummy"})
+
+    project_id = 42
+    relay = relay(
+        mini_sentry,
+        options={
+            "http": {"timeout": http_timeout},
+            "upload": {"timeout": upload_timeout},
+        },
+    )
+
+    data = b"hello world"
+    response = relay.post(
+        "/api/%s/upload/?sentry_key=%s"
+        % (project_id, mini_sentry.get_dsn_public_key(project_id)),
+        headers={
+            "Tus-Resumable": "1.0.0",
+            "Upload-Length": str(len(data)),
+            "Content-Type": "application/offset+octet-stream",
+        },
+        data=data,
+    )
+
+    assert response.status_code == expected_status_code, response.text
 
 
 PROCESSING_OPTIONS = {


### PR DESCRIPTION
The upload endpoint was implicitly constrained by the default request timeout of the upstream service, which is too low for large requests.

This PR overrides the general timeout with a timeout specific to the upload service.

ref: INGEST-784

fixes INGEST-776