### PR TITLE
fix(nswitch): Fix typo in max de-compressed size

### DIFF
--- a/relay-server/src/processing/errors/errors/nswitch.rs
+++ b/relay-server/src/processing/errors/errors/nswitch.rs
@@ -19,7 +19,7 @@ use crate::services::outcome::DiscardItemType;
 use crate::services::processor::ProcessingError;
 
 /// Limit the size of the decompressed data to prevent an invalid frame blowing up memory usage.
-const MAX_DECOMPRESSED_SIZE: usize = 100_1024;
+const MAX_DECOMPRESSED_SIZE: usize = 100 * 1024;
 
 #[derive(Debug)]
 pub enum Nswitch {

--- a/relay-server/src/services/processor/nnswitch.rs
+++ b/relay-server/src/services/processor/nnswitch.rs
@@ -16,7 +16,7 @@ use crate::utils;
 pub use crate::processing::errors::SwitchProcessingError;
 
 /// Limit the size of the decompressed data to prevent an invalid frame blowing up memory usage.
-const MAX_DECOMPRESSED_SIZE: usize = 100_1024;
+const MAX_DECOMPRESSED_SIZE: usize = 100 * 1024;
 
 type Result<T> = std::result::Result<T, SwitchProcessingError>;
 


### PR DESCRIPTION
10x too much then what it should've been.