### PR TITLE
feat(standalone): Add metric for standalone items

### DIFF
--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -378,6 +378,19 @@ impl ProcessingGroup {
         // will be in the same envelope with all require event items.
         if !envelope.items().any(Item::creates_event) {
             let standalone_items = envelope.take_items_by(Item::requires_event);
+
+            for item in &standalone_items {
+                let attachment_type_tag = match item.attachment_type() {
+                    Some(t) => &t.to_string(),
+                    None => "",
+                };
+                relay_statsd::metric!(
+                    counter(RelayCounters::StandaloneItem) += 1,
+                    item_type = item.ty().name(),
+                    attachment_type = attachment_type_tag,
+                );
+            }
+
             if !standalone_items.is_empty() {
                 grouped_envelopes.push((
                     ProcessingGroup::Standalone,

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -378,19 +378,6 @@ impl ProcessingGroup {
         // will be in the same envelope with all require event items.
         if !envelope.items().any(Item::creates_event) {
             let standalone_items = envelope.take_items_by(Item::requires_event);
-
-            for item in &standalone_items {
-                let attachment_type_tag = match item.attachment_type() {
-                    Some(t) => &t.to_string(),
-                    None => "",
-                };
-                relay_statsd::metric!(
-                    counter(RelayCounters::StandaloneItem) += 1,
-                    item_type = item.ty().name(),
-                    attachment_type = attachment_type_tag,
-                );
-            }
-
             if !standalone_items.is_empty() {
                 grouped_envelopes.push((
                     ProcessingGroup::Standalone,
@@ -1436,6 +1423,18 @@ impl EnvelopeProcessorService {
         managed_envelope: &mut TypedEnvelope<StandaloneGroup>,
         ctx: processing::Context<'_>,
     ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
+        for item in managed_envelope.envelope().items() {
+            let attachment_type_tag = match item.attachment_type() {
+                Some(t) => &t.to_string(),
+                None => "",
+            };
+            relay_statsd::metric!(
+                counter(RelayCounters::StandaloneItem) += 1,
+                item_type = item.ty().name(),
+                attachment_type = attachment_type_tag,
+            );
+        }
+
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
         standalone::process(managed_envelope);

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -964,6 +964,12 @@ pub enum RelayCounters {
     /// The metric is emitted when processing profile chunks, profile chunks which are fast path
     /// rate limited are not counted in this metric.
     ProfileChunksWithoutPlatform,
+    /// Number of 'standalone' items.
+    ///
+    /// This metric is tagged with:
+    /// - `item_type`: The type of the item.
+    /// - `attachment_type`: The attachment type of the item, if any.
+    StandaloneItem,
 }
 
 impl CounterMetric for RelayCounters {
@@ -1023,6 +1029,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::AttachmentUpload => "attachment.upload",
             RelayCounters::EnvelopeWithLogs => "logs.envelope",
             RelayCounters::ProfileChunksWithoutPlatform => "profile_chunk.no_platform",
+            RelayCounters::StandaloneItem => "processing.standalone_item",
         }
     }
 }


### PR DESCRIPTION
Add a metric so we can see which items still end up in the standalone processor. This should eventually drop to 0 after we migrating the logic item-type per item-type to the new processor architecture.