### PR TITLE
ref(project): Measure initial fetch duration

### DIFF
--- a/relay-server/src/services/projects/cache/state.rs
+++ b/relay-server/src/services/projects/cache/state.rs
@@ -736,6 +736,11 @@ struct PrivateProjectState {
     ///
     /// A refresh of the project, will not push the expiration time.
     expiry: Option<Instant>,
+
+    /// The time that this state entry was created.
+    ///
+    /// This field is made `None` as soon as the initial metric has been emitted.
+    pending_since: Option<Instant>,
 }
 
 impl PrivateProjectState {
@@ -749,6 +754,7 @@ impl PrivateProjectState {
             backoff: RetryBackoff::new(config.max_retry_backoff),
             last_fetch: None,
             expiry: None,
+            pending_since: Some(Instant::now()),
         }
     }
 
@@ -868,6 +874,12 @@ impl PrivateProjectState {
                 Some(_) | None => when.expiry_time(config),
             };
             self.expiry = Some(expiry.0);
+
+            if let Some(created) = self.pending_since.take() {
+                relay_statsd::metric!(
+                    timer(RelayTimers::ProjectCacheInitialFetchDuration) = now - created,
+                )
+            };
 
             self.state = FetchState::Complete { when };
             FetchResult::Done { expiry, refresh }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -440,6 +440,9 @@ pub enum RelayTimers {
     ProjectCacheUpdateLatency,
     /// Total time spent from starting to fetch a project config update to completing the fetch.
     ProjectCacheFetchDuration,
+    /// Total time spent from creating a "pending" project state the the first non-pending state
+    /// is loaded.
+    ProjectCacheInitialFetchDuration,
     /// Total time in milliseconds spent fetching queued project configuration updates requests to
     /// resolve.
     ///
@@ -636,6 +639,7 @@ impl TimerMetric for RelayTimers {
             RelayTimers::ProjectStateDecompression => "project_state.decompression",
             RelayTimers::ProjectCacheUpdateLatency => "project_cache.latency",
             RelayTimers::ProjectCacheFetchDuration => "project_cache.fetch.duration",
+            RelayTimers::ProjectCacheInitialFetchDuration => "project_cache.fetch.initial.duration",
             RelayTimers::RequestsDuration => "requests.duration",
             RelayTimers::MinidumpScrubbing => "scrubbing.minidumps.duration",
             RelayTimers::ViewHierarchyScrubbing => "scrubbing.view_hierarchy_scrubbing.duration",


### PR DESCRIPTION
Measure the time between the first time a project state is requested, and actually resolving. This will inform what timeouts we need on the `/upload` endpoint.

ref: INGEST-782