### PR TITLE
ref(pii): Remove unused `Result`

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -328,10 +328,8 @@ pub unsafe extern "C" fn relay_validate_pii_config(value: *const RelayStr) -> Re
 pub unsafe extern "C" fn relay_convert_datascrubbing_config(config: *const RelayStr) -> RelayStr {
     let config: DataScrubbingConfig = serde_json::from_str(unsafe { (*config).as_str() })?;
     match config.pii_config() {
-        Ok(Some(config)) => RelayStr::from_string(serde_json::to_string(config)?),
-        Ok(None) => RelayStr::new("{}"),
-        // NOTE: Callers of this function must be able to handle this error.
-        Err(e) => RelayStr::from_string(e.to_string()),
+        Some(config) => RelayStr::from_string(serde_json::to_string(config)?),
+        None => RelayStr::new("{}"),
     }
 }
 

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -248,7 +248,7 @@ mod tests {
     // has an equivalent testcase in Python.
 
     fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiConfig> {
-        let rv = to_pii_config_impl(datascrubbing_config).unwrap();
+        let rv = to_pii_config_impl(datascrubbing_config);
         if let Some(ref config) = rv {
             let roundtrip: PiiConfig =
                 serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap();

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -5,8 +5,8 @@ use relay_event_schema::processor::ValueType;
 
 use crate::selector::{SelectorPathItem, SelectorSpec};
 use crate::{
-    DataScrubbingConfig, LazyPattern, PiiConfig, PiiConfigError, RedactPairRule, Redaction,
-    RuleSpec, RuleType, Vars,
+    DataScrubbingConfig, LazyPattern, PiiConfig, RedactPairRule, Redaction, RuleSpec, RuleType,
+    Vars,
 };
 
 /// Fields that the legacy data scrubber cannot strip.
@@ -111,9 +111,7 @@ static REPLACE_ONLY_SELECTOR: LazyLock<SelectorSpec> = LazyLock::new(|| {
     .unwrap()
 });
 
-pub fn to_pii_config(
-    datascrubbing_config: &DataScrubbingConfig,
-) -> Result<Option<PiiConfig>, PiiConfigError> {
+pub fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiConfig> {
     let mut custom_rules = BTreeMap::new();
     let mut applied_rules = Vec::new();
     let mut applications = BTreeMap::new();
@@ -187,7 +185,7 @@ pub fn to_pii_config(
     }
 
     if applied_rules.is_empty() && applications.is_empty() {
-        return Ok(None);
+        return None;
     }
 
     let mut conjunctions = vec![
@@ -226,12 +224,12 @@ pub fn to_pii_config(
         applications.insert(applied_selector, applied_rules);
     }
 
-    Ok(Some(PiiConfig {
+    Some(PiiConfig {
         rules: custom_rules,
         vars: Vars::default(),
         applications,
         ..Default::default()
-    }))
+    })
 }
 
 #[cfg(test)]

--- a/relay-pii/src/eap.rs
+++ b/relay-pii/src/eap.rs
@@ -171,7 +171,7 @@ mod tests {
             ..Default::default()
         };
 
-        let scrubbing_config = data_scrubbing_config.pii_config().unwrap();
+        let scrubbing_config = data_scrubbing_config.pii_config();
 
         eap::scrub(ValueType::Span, &mut data, None, scrubbing_config.as_ref()).unwrap();
 
@@ -238,7 +238,7 @@ mod tests {
             ..Default::default()
         };
 
-        let scrubbing_config = scrubbing_config.pii_config().unwrap();
+        let scrubbing_config = scrubbing_config.pii_config();
 
         let config = serde_json::from_value::<PiiConfig>(serde_json::json!(
         {
@@ -529,7 +529,7 @@ mod tests {
             ..Default::default()
         };
 
-        let scrubbing_config = scrubbing_config.pii_config().unwrap();
+        let scrubbing_config = scrubbing_config.pii_config();
 
         eap::scrub(ValueType::Span, &mut data, None, scrubbing_config.as_ref()).unwrap();
 
@@ -628,7 +628,7 @@ mod tests {
             ..Default::default()
         };
 
-        let scrubbing_config = scrubbing_config.pii_config().unwrap();
+        let scrubbing_config = scrubbing_config.pii_config();
 
         eap::scrub(ValueType::Span, &mut data, None, scrubbing_config.as_ref()).unwrap();
 
@@ -718,7 +718,7 @@ mod tests {
             ..Default::default()
         };
 
-        let scrubbing_config = scrubbing_config.pii_config().unwrap();
+        let scrubbing_config = scrubbing_config.pii_config();
 
         eap::scrub(
             ValueType::OurLog,
@@ -805,7 +805,7 @@ mod tests {
                 scrubbing_config.scrub_defaults = false;
                 scrubbing_config.scrub_ip_addresses = false;
 
-                let scrubbing_config = scrubbing_config.pii_config().unwrap();
+                let scrubbing_config = scrubbing_config.pii_config();
 
                 let span_json = format!(r#"{{
                     "start_timestamp": 1544719859.0,
@@ -2171,7 +2171,7 @@ mod tests {
     "###);
 
     attribute_rule_test!(
-        test_scrub_attributes_pii_string_rules_bearer_mask, 
+        test_scrub_attributes_pii_string_rules_bearer_mask,
         "@bearer:mask",
         "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
     @r###"

--- a/relay-pii/src/legacy.rs
+++ b/relay-pii/src/legacy.rs
@@ -7,7 +7,7 @@ use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{PiiConfig, PiiConfigError};
+use crate::config::PiiConfig;
 use crate::convert;
 
 /// Configuration for Sentry's datascrubbing
@@ -36,14 +36,14 @@ pub struct DataScrubbingConfig {
     /// because we want the conversion to run on the processing sync arbiter, so that it does not
     /// slow down or even crash other parts of the system.
     #[serde(skip)]
-    pub(super) pii_config: OnceLock<Result<Option<PiiConfig>, PiiConfigError>>,
+    pub(super) pii_config: OnceLock<Option<PiiConfig>>,
 }
 
 impl DataScrubbingConfig {
     /// Creates a new data scrubbing configuration that does nothing on the event.
     pub fn new_disabled() -> Self {
         let pii_config = OnceLock::new();
-        let _ = pii_config.set(Ok(None));
+        let _ = pii_config.set(None);
 
         DataScrubbingConfig {
             exclude_fields: vec![],
@@ -64,20 +64,13 @@ impl DataScrubbingConfig {
     ///
     /// This can be computationally expensive when called for the first time. The result is cached
     /// internally and reused on the second call.
-    pub fn pii_config(&self) -> Result<&'_ Option<PiiConfig>, &PiiConfigError> {
-        self.pii_config
-            .get_or_init(|| self.pii_config_uncached())
-            .as_ref()
+    pub fn pii_config(&self) -> &'_ Option<PiiConfig> {
+        self.pii_config.get_or_init(|| self.pii_config_uncached())
     }
 
     /// Like [`pii_config`](Self::pii_config) but without internal caching.
     #[inline]
-    pub fn pii_config_uncached(&self) -> Result<Option<PiiConfig>, PiiConfigError> {
-        convert::to_pii_config(self).inspect_err(|e| {
-            relay_log::error!(
-                error = e as &dyn std::error::Error,
-                "failed to convert datascrubbing config"
-            );
-        })
+    pub fn pii_config_uncached(&self) -> Option<PiiConfig> {
+        convert::to_pii_config(self)
     }
 }

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -644,7 +644,7 @@ mod tests {
 
     fn to_pii_config(datascrubbing_config: &DataScrubbingConfig) -> Option<PiiConfig> {
         use crate::convert::to_pii_config as to_pii_config_impl;
-        let rv = to_pii_config_impl(datascrubbing_config).unwrap();
+        let rv = to_pii_config_impl(datascrubbing_config);
         if let Some(ref config) = rv {
             let roundtrip: PiiConfig =
                 serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap();
@@ -1322,7 +1322,6 @@ mod tests {
             scrub_ip_addresses: true,
             ..Default::default()
         })
-        .unwrap()
         .unwrap();
 
         let mut event = Annotated::new(Event {
@@ -1379,7 +1378,6 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         })
-        .unwrap()
         .unwrap();
 
         let mut event = Annotated::new(Event {
@@ -1591,7 +1589,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
         process_value(
@@ -1621,7 +1619,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
         process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
@@ -1647,7 +1645,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
         process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
@@ -1679,7 +1677,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
         process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
@@ -1707,7 +1705,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
         process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
@@ -1730,7 +1728,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
 
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         processor::process_value(&mut span, &mut pii_processor, ProcessingState::root()).unwrap();
@@ -1785,7 +1783,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(breadcrumb);
@@ -1810,7 +1808,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(breadcrumb);
@@ -1841,7 +1839,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
         process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
@@ -1869,7 +1867,7 @@ mod tests {
             scrub_defaults: true,
             ..Default::default()
         };
-        let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+        let pii_config = ds_config.pii_config().as_ref().unwrap();
         let mut pii_processor = PiiProcessor::new(pii_config.compiled());
         process_value(&mut breadcrumb, &mut pii_processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(breadcrumb);

--- a/relay-pii/tests/replay.rs
+++ b/relay-pii/tests/replay.rs
@@ -14,7 +14,7 @@ fn simple_enabled_config() -> DataScrubbingConfig {
 #[test]
 fn test_scrub_pii_from_annotated_replay() {
     let scrub_config = simple_enabled_config();
-    let pii_config = scrub_config.pii_config().unwrap().as_ref().unwrap();
+    let pii_config = scrub_config.pii_config().as_ref().unwrap();
     let mut pii_processor = PiiProcessor::new(pii_config.compiled());
 
     let payload = include_str!("../../tests/fixtures/replay.json");

--- a/relay-replays/benches/benchmarks.rs
+++ b/relay-replays/benches/benchmarks.rs
@@ -19,7 +19,7 @@ fn bench_recording(c: &mut Criterion) {
     scrubbing_config.scrub_data = true;
     scrubbing_config.scrub_defaults = true;
     scrubbing_config.scrub_ip_addresses = true;
-    let pii_config = scrubbing_config.pii_config_uncached().unwrap().unwrap();
+    let pii_config = scrubbing_config.pii_config_uncached().unwrap();
 
     let mut scrubber = RecordingScrubber::new(usize::MAX, Some(&pii_config), None);
 

--- a/relay-replays/src/recording.rs
+++ b/relay-replays/src/recording.rs
@@ -419,7 +419,7 @@ mod tests {
         scrubbing_config.scrub_data = true;
         scrubbing_config.scrub_defaults = true;
         scrubbing_config.scrub_ip_addresses = true;
-        scrubbing_config.pii_config_uncached().unwrap().unwrap()
+        scrubbing_config.pii_config_uncached().unwrap()
     }
 
     fn scrubber(config: &PiiConfig) -> RecordingScrubber<'_> {

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::OurLog;
 use relay_filter::FilterStatKey;
-use relay_pii::PiiConfigError;
 use relay_quotas::{DataCategory, RateLimits};
 
 use crate::Envelope;
@@ -48,9 +47,6 @@ pub enum Error {
     /// The logs are rate limited.
     #[error("rate limited")]
     RateLimited(RateLimits),
-    /// Internal error, Pii config could not be loaded.
-    #[error("Pii configuration error")]
-    PiiConfig(PiiConfigError),
     /// A processor failed to process the logs.
     #[error("envelope processor failed")]
     ProcessingFailed(#[from] ProcessingAction),
@@ -74,7 +70,6 @@ impl OutcomeError for Error {
                 let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
                 Some(Outcome::RateLimited(reason_code))
             }
-            Self::PiiConfig(_) => Some(Outcome::Invalid(DiscardReason::ProjectStatePii)),
             Self::ProcessingFailed(_) => Some(Outcome::Invalid(DiscardReason::Internal)),
             Self::Invalid(reason) => Some(Outcome::Invalid(*reason)),
         };

--- a/relay-server/src/processing/logs/process.rs
+++ b/relay-server/src/processing/logs/process.rs
@@ -90,12 +90,7 @@ fn expand_log_container(item: &Item, trust: RequestTrust) -> Result<ContainerIte
 }
 
 fn scrub_log(log: &mut Annotated<OurLog>, ctx: Context<'_>) -> Result<()> {
-    let pii_config_from_scrubbing = ctx
-        .project_info
-        .config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|e| Error::PiiConfig(e.clone()))?;
+    let pii_config_from_scrubbing = ctx.project_info.config.datascrubbing_settings.pii_config();
 
     relay_pii::eap::scrub(
         ValueType::OurLog,

--- a/relay-server/src/processing/replays/mod.rs
+++ b/relay-server/src/processing/replays/mod.rs
@@ -6,7 +6,6 @@ use relay_event_normalization::GeoIpLookup;
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::Replay;
 use relay_filter::FilterStatKey;
-use relay_pii::PiiConfigError;
 use relay_protocol::Annotated;
 use relay_quotas::{DataCategory, RateLimits};
 use serde::{Deserialize, Serialize};
@@ -63,10 +62,6 @@ pub enum Error {
     #[error("invalid replay")]
     InvalidReplayRecordingEvent,
 
-    /// The PII config could not be loaded.
-    #[error("invalid pii config")]
-    PiiConfig(PiiConfigError),
-
     /// An error occurred during PII scrubbing of the Replay.
     #[error("failed to scrub PII: {0}")]
     CouldNotScrub(#[from] ProcessingAction),
@@ -118,7 +113,6 @@ impl OutcomeError for Error {
             Self::InvalidReplayRecordingEvent => {
                 Some(Outcome::Invalid(DiscardReason::InvalidReplayRecordingEvent))
             }
-            Self::PiiConfig(_) => Some(Outcome::Invalid(DiscardReason::ProjectStatePii)),
             Self::CouldNotScrub(_) => Some(Outcome::Invalid(DiscardReason::InvalidReplayEventPii)),
 
             Self::RateLimited(limits) => {

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -115,12 +115,7 @@ fn scrub_event(event: &mut Annotated<Replay>, ctx: Context<'_>) -> Result<(), Er
         processor::process_value(event, &mut processor, ProcessingState::root())?;
     }
 
-    let pii_config = ctx
-        .project_info
-        .config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|e| Error::PiiConfig(e.clone()))?;
+    let pii_config = ctx.project_info.config.datascrubbing_settings.pii_config();
 
     if let Some(config) = pii_config {
         let mut processor = PiiProcessor::new(config.compiled());
@@ -134,10 +129,12 @@ fn scrub_recordings(
     ctx: Context<'_>,
 ) -> Result<(), Rejected<Error>> {
     let event_id = replay.headers.event_id();
-    let pii_config = match ctx.project_info.config.datascrubbing_settings.pii_config() {
-        Ok(config) => config.as_ref(),
-        Err(e) => return Err(replay.reject_err(Error::PiiConfig(e.clone()))),
-    };
+    let pii_config = ctx
+        .project_info
+        .config
+        .datascrubbing_settings
+        .pii_config()
+        .as_ref();
 
     let mut scrubber = RecordingScrubber::new(
         ctx.config.max_replay_uncompressed_size(),

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -52,9 +52,6 @@ pub enum Error {
     /// A processor failed to process the spans.
     #[error("envelope processor failed")]
     ProcessingFailed(#[from] ProcessingAction),
-    /// Internal error, Pii config could not be loaded.
-    #[error("Pii configuration error")]
-    PiiConfig,
     /// The span is invalid.
     #[error("invalid: {0}")]
     Invalid(DiscardReason),
@@ -78,7 +75,6 @@ impl OutcomeError for Error {
                 let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
                 Some(Outcome::RateLimited(reason_code))
             }
-            Self::PiiConfig => Some(Outcome::Invalid(DiscardReason::ProjectStatePii)),
             Self::ProcessingFailed(_) => Some(Outcome::Invalid(DiscardReason::Internal)),
             Self::Invalid(reason) => Some(Outcome::Invalid(*reason)),
         };
@@ -95,7 +91,6 @@ impl From<RateLimits> for Error {
 impl From<ScrubAttachmentError> for Error {
     fn from(value: ScrubAttachmentError) -> Self {
         match value {
-            ScrubAttachmentError::PiiConfig => Self::PiiConfig,
             ScrubAttachmentError::ProcessingFailed(action) => Self::ProcessingFailed(action),
         }
     }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -266,12 +266,7 @@ pub fn scrub(spans: &mut Managed<ExpandedSpans>, ctx: Context<'_>) {
 }
 
 fn scrub_span(span: &mut Annotated<SpanV2>, ctx: Context<'_>) -> Result<()> {
-    let pii_config_from_scrubbing = ctx
-        .project_info
-        .config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|_| Error::PiiConfig)?;
+    let pii_config_from_scrubbing = ctx.project_info.config.datascrubbing_settings.pii_config();
 
     relay_pii::eap::scrub(
         ValueType::Span,

--- a/relay-server/src/processing/trace_attachments/mod.rs
+++ b/relay-server/src/processing/trace_attachments/mod.rs
@@ -39,10 +39,6 @@ pub enum Error {
     #[error("rate limited")]
     RateLimited(RateLimits),
 
-    /// Internal error, Pii config could not be loaded.
-    #[error("Pii configuration error")]
-    PiiConfig,
-
     /// A processor failed to process the spans.
     #[error("envelope processor failed")]
     ProcessingFailed(#[from] ProcessingAction),
@@ -51,7 +47,6 @@ pub enum Error {
 impl From<ScrubAttachmentError> for Error {
     fn from(value: ScrubAttachmentError) -> Self {
         match value {
-            ScrubAttachmentError::PiiConfig => Self::PiiConfig,
             ScrubAttachmentError::ProcessingFailed(action) => Self::ProcessingFailed(action),
         }
     }
@@ -71,7 +66,6 @@ impl OutcomeError for Error {
             Self::FeatureDisabled(f) => Outcome::Invalid(DiscardReason::FeatureDisabled(*f)),
             Self::SerializeFailed(_) => Outcome::Invalid(DiscardReason::Internal),
             Self::Sampled(outcome) => outcome.clone(),
-            Self::PiiConfig => Outcome::Invalid(DiscardReason::ProjectStatePii),
             Self::RateLimited(rate_limits) => {
                 let reason_code = rate_limits
                     .longest()

--- a/relay-server/src/processing/trace_attachments/process.rs
+++ b/relay-server/src/processing/trace_attachments/process.rs
@@ -112,8 +112,6 @@ pub fn scrub(work: &mut Managed<ExpandedAttachments>, ctx: Context<'_>) {
 /// Errors that can occur during attachment scrubbing.
 #[derive(Debug, thiserror::Error)]
 pub enum ScrubAttachmentError {
-    #[error("pii config")]
-    PiiConfig,
     #[error("processing error: {0}")]
     ProcessingFailed(#[from] ProcessingAction),
 }
@@ -123,12 +121,7 @@ pub fn scrub_attachment<'a>(
     attachment: &mut ExpandedAttachment,
     ctx: Context<'a>,
 ) -> Result<(), ScrubAttachmentError> {
-    let pii_config_from_scrubbing = ctx
-        .project_info
-        .config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|_| ScrubAttachmentError::PiiConfig)?;
+    let pii_config_from_scrubbing = ctx.project_info.config.datascrubbing_settings.pii_config();
 
     let ExpandedAttachment {
         parent_id: _,

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::TraceMetric;
 use relay_filter::FilterStatKey;
-use relay_pii::PiiConfigError;
 use relay_quotas::{DataCategory, RateLimits};
 
 use crate::Envelope;
@@ -23,9 +22,6 @@ mod validate;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Internal error, Pii config could not be loaded.
-    #[error("Pii configuration error")]
-    PiiConfig(PiiConfigError),
     /// Received trace metric exceeds the configured size limit.
     #[error("trace metric exeeds size limit")]
     TooLarge,
@@ -80,7 +76,6 @@ impl crate::managed::OutcomeError for Error {
                 relay_log::error!("internal error: trace metric processing failed");
                 Some(Outcome::Invalid(DiscardReason::Internal))
             }
-            Self::PiiConfig(_) => Some(Outcome::Invalid(DiscardReason::ProjectStatePii)),
             Self::RateLimited(limits) => {
                 let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
                 Some(Outcome::RateLimited(reason_code))

--- a/relay-server/src/processing/trace_metrics/process.rs
+++ b/relay-server/src/processing/trace_metrics/process.rs
@@ -71,12 +71,7 @@ fn expand_trace_metric_container(item: &Item) -> Result<ContainerItems<TraceMetr
 
 /// Applies PII scrubbing to an individual trace metric entry.
 fn scrub_trace_metric(metric: &mut Annotated<TraceMetric>, ctx: Context<'_>) -> Result<()> {
-    let pii_config_from_scrubbing = ctx
-        .project_info
-        .config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|e| Error::PiiConfig(e.clone()))?;
+    let pii_config_from_scrubbing = ctx.project_info.config.datascrubbing_settings.pii_config();
 
     let state = ProcessingState::root().enter_borrowed("", None, [ValueType::TraceMetric]);
 

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -444,10 +444,7 @@ pub fn scrub(
             let mut processor = PiiProcessor::new(config.compiled());
             processor::process_value(event, &mut processor, ProcessingState::root())?;
         }
-        let pii_config = config
-            .datascrubbing_settings
-            .pii_config()
-            .map_err(|e| ProcessingError::PiiConfigError(e.clone()))?;
+        let pii_config = config.datascrubbing_settings.pii_config();
         if let Some(config) = pii_config {
             let mut processor = PiiProcessor::new(config.compiled());
             processor::process_value(event, &mut processor, ProcessingState::root())?;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -28,7 +28,6 @@ use relay_event_schema::protocol::{
 };
 use relay_filter::FilterStatKey;
 use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricNamespace};
-use relay_pii::PiiConfigError;
 use relay_protocol::Annotated;
 use relay_quotas::{DataCategory, Quota, RateLimits, Scoping};
 use relay_sampling::evaluation::{ReservoirCounters, SamplingDecision};
@@ -545,9 +544,6 @@ pub enum ProcessingError {
     #[error("failed to apply quotas")]
     QuotasFailed(#[from] RateLimitingError),
 
-    #[error("invalid pii config")]
-    PiiConfigError(PiiConfigError),
-
     #[error("invalid processing group type")]
     InvalidProcessingGroup(Box<InvalidProcessingGroupType>),
 
@@ -598,7 +594,6 @@ impl ProcessingError {
             }
             #[cfg(feature = "processing")]
             Self::QuotasFailed(_) => Some(Outcome::Invalid(DiscardReason::Internal)),
-            Self::PiiConfigError(_) => Some(Outcome::Invalid(DiscardReason::ProjectStatePii)),
             Self::MissingProjectId => None,
             Self::EventFiltered(_) => None,
             Self::InvalidProcessingGroup(_) => None,

--- a/relay-server/src/services/processor/span/processing.rs
+++ b/relay-server/src/services/processor/span/processing.rs
@@ -523,10 +523,7 @@ fn scrub(
         let mut processor = PiiProcessor::new(config.compiled());
         process_value(annotated_span, &mut processor, ProcessingState::root())?;
     }
-    let pii_config = project_config
-        .datascrubbing_settings
-        .pii_config()
-        .map_err(|e| ProcessingError::PiiConfigError(e.clone()))?;
+    let pii_config = project_config.datascrubbing_settings.pii_config();
     if let Some(config) = pii_config {
         let mut processor = PiiProcessor::new(config.compiled());
         process_value(annotated_span, &mut processor, ProcessingState::root())?;

--- a/relay-server/tests/test_pii.rs
+++ b/relay-server/tests/test_pii.rs
@@ -34,7 +34,7 @@ fn test_reponse_context_pii() {
     ds_config.scrub_ip_addresses = true;
 
     // And also run the PII processort to check if the sensitive data is scrubbed.
-    let pii_config = ds_config.pii_config().unwrap().as_ref().unwrap();
+    let pii_config = ds_config.pii_config().as_ref().unwrap();
     let mut pii_processor = PiiProcessor::new(pii_config.compiled());
     processor::process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
     assert_annotated_snapshot!(data);


### PR DESCRIPTION
While looking at the scrubbing logic, to understand why it can fail, I noticed that `to_pii_config` returns a `Result` but never seems to return an `Err`.
