### PR TITLE
feat(config): Opt-out of DNS cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Populate gen_ai.response.model from gen_ai.request.model if not already set. ([#5654](https://github.com/getsentry/relay/pull/5654))
 - Add support for Unix domain sockets for statsd metrics. ([#5668](https://github.com/getsentry/relay/pull/5668))
 - Support `deployment.environment` OTLP resource attribute for setting the Sentry environment. ([#5691](https://github.com/getsentry/relay/pull/5691))
+- Allow users to opt-out of DNS caching. ([#5700](https://github.com/getsentry/relay/pull/5700))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -883,6 +883,10 @@ pub struct Http {
     ///
     /// The forward endpoint forwards unknown API requests to the upstream.
     pub forward: bool,
+    /// Enables an async DNS resolver through the `hickory-dns` crate, which uses an LRU cache for
+    /// the resolved entries. This helps to limit the amount of requests made to the upstream DNS
+    /// server (important for K8s infrastructure).
+    pub dns_cache: bool,
 }
 
 impl Default for Http {
@@ -899,6 +903,7 @@ impl Default for Http {
             encoding: HttpEncoding::Zstd,
             global_metrics: false,
             forward: true,
+            dns_cache: true,
         }
     }
 }
@@ -2224,6 +2229,11 @@ impl Config {
     /// Returns the failed upstream request retry interval.
     pub fn http_max_retry_interval(&self) -> Duration {
         Duration::from_secs(self.values.http.max_retry_interval.into())
+    }
+
+    /// Returns `true` if relay should use an in-process cache for DNS lookups.
+    pub fn http_dns_cache(&self) -> bool {
+        self.values.http.dns_cache
     }
 
     /// Returns the expiry timeout for cached projects.

--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -862,10 +862,7 @@ impl SharedClient {
             // In the forward endpoint, this means that content negotiation is done twice, and the
             // response body is first decompressed by the client, then re-compressed by the server.
             .gzip(true)
-            // Enables async resolver through the `hickory-dns` crate, which uses an LRU cache for
-            // the resolved entries. This helps to limit the amount of requests made to upstream DNS
-            // server (important for K8s infrastructure).
-            .hickory_dns(true)
+            .hickory_dns(config.http_dns_cache())
             .build()
             .unwrap();
 


### PR DESCRIPTION
Add a config option to disable DNS caching.

DNS caching is "important for K8s infrastructure" (see https://github.com/getsentry/relay/pull/2164/), but in self-hosted it could have the side effect of caching a negative lookup result when the `web` container is removed while the `relay` container keeps running.

ref: https://github.com/getsentry/sentry/issues/109002