### PR TITLE
fix(server): Fix deserialization errors on unknown item headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug Fixes**:
 
 - Prevent minidump compression bomb. ([#5613](https://github.com/getsentry/relay/pull/5613))
+- Relay Temporarily rejected unknown headers on envelope items. ([#5709](https://github.com/getsentry/relay/pull/5709))
 
 **Features**:
 

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -66,7 +66,7 @@ impl Item {
         let payload_start = std::cmp::min(headers_end + 1, bytes.len());
 
         let length = headers
-            .try_get::<usize>(&ItemHeaderKey::Length)
+            .try_get::<usize>(ItemHeaderKey::Length)
             .map_err(EnvelopeError::InvalidItemHeader)?;
         let payload_end = match length {
             Some(len) => {
@@ -207,7 +207,7 @@ impl Item {
     /// This method can be safely used to generate outcomes.
     pub fn item_count(&self) -> Option<u32> {
         match self.ty().can_support_container() {
-            true => self.headers.get(&ItemHeaderKey::ItemCount),
+            true => self.headers.get(ItemHeaderKey::ItemCount),
             false => None,
         }
     }
@@ -221,7 +221,7 @@ impl Item {
     ///
     /// This number does *not* count the transaction itself.
     pub fn span_count(&self) -> u32 {
-        self.headers.get(&ItemHeaderKey::SpanCount).unwrap_or(0)
+        self.headers.get(ItemHeaderKey::SpanCount).unwrap_or(0)
     }
 
     /// Sets the number of spans in the transaction payload.
@@ -240,7 +240,7 @@ impl Item {
 
     /// Returns the `span_count`` header, and computes it if it has not yet been set.
     pub fn ensure_span_count(&mut self) -> usize {
-        match self.headers.get(&ItemHeaderKey::SpanCount) {
+        match self.headers.get(ItemHeaderKey::SpanCount) {
             Some(count) => count,
             None => self.refresh_span_count(),
         }
@@ -249,17 +249,17 @@ impl Item {
     /// Returns the content type of this item's payload.
     #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn content_type(&self) -> Option<ContentType> {
-        self.headers.get(&ItemHeaderKey::ContentType)
+        self.headers.get(ItemHeaderKey::ContentType)
     }
 
     /// Returns the raw (unparsed) content type, as specified by the SDK.
     pub fn raw_content_type(&self) -> Option<&str> {
-        self.headers.get(&ItemHeaderKey::ContentType)
+        self.headers.get(ItemHeaderKey::ContentType)
     }
 
     /// Sets the content type if there isn't already one set.
     pub fn set_default_content_type(&mut self, content_type: ContentType) {
-        if !self.headers.contains(&ItemHeaderKey::ContentType) {
+        if !self.headers.contains(ItemHeaderKey::ContentType) {
             self.headers.set(ItemHeaderKey::ContentType, content_type);
         }
     }
@@ -283,7 +283,7 @@ impl Item {
     /// Returns the attachment type if this item is an attachment.
     pub fn attachment_type(&self) -> Option<AttachmentType> {
         // TODO: consider to replace this with an ItemType?
-        if let Some(ty) = self.headers.get(&ItemHeaderKey::AttachmentType) {
+        if let Some(ty) = self.headers.get(ItemHeaderKey::AttachmentType) {
             return Some(ty);
         }
 
@@ -358,7 +358,7 @@ impl Item {
     /// Returns the file name of this item, if it is an attachment.
     #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn filename(&self) -> Option<&str> {
-        self.headers.get(&ItemHeaderKey::Filename)
+        self.headers.get(ItemHeaderKey::Filename)
     }
 
     /// Sets the file name of this item.
@@ -412,7 +412,7 @@ impl Item {
     /// Returns the metrics extracted flag.
     pub fn metrics_extracted(&self) -> bool {
         self.headers
-            .get(&ItemHeaderKey::MetricsExtracted)
+            .get(ItemHeaderKey::MetricsExtracted)
             .unwrap_or_default()
     }
 
@@ -425,7 +425,7 @@ impl Item {
     /// Returns the spans extracted flag.
     pub fn spans_extracted(&self) -> bool {
         self.headers
-            .get(&ItemHeaderKey::SpansExtracted)
+            .get(ItemHeaderKey::SpansExtracted)
             .unwrap_or_default()
     }
 
@@ -438,7 +438,7 @@ impl Item {
     /// Returns the fully normalized flag.
     pub fn fully_normalized(&self) -> bool {
         self.headers
-            .get(&ItemHeaderKey::FullyNormalized)
+            .get(ItemHeaderKey::FullyNormalized)
             .unwrap_or_default()
     }
 
@@ -452,7 +452,7 @@ impl Item {
     ///
     /// Note: this is currently only used for [`ItemType::ProfileChunk`].
     pub fn platform(&self) -> Option<&str> {
-        self.headers.get(&ItemHeaderKey::Platform)
+        self.headers.get(ItemHeaderKey::Platform)
     }
 
     /// Set the associated platform.
@@ -471,7 +471,7 @@ impl Item {
 
     /// Gets the `sampled` flag.
     pub fn sampled(&self) -> bool {
-        self.headers.get(&ItemHeaderKey::Sampled).unwrap_or(true)
+        self.headers.get(ItemHeaderKey::Sampled).unwrap_or(true)
     }
 
     /// Sets the `sampled` flag.
@@ -481,7 +481,7 @@ impl Item {
 
     /// Returns the length of the item.
     pub fn meta_length(&self) -> Option<u32> {
-        self.headers.get(&ItemHeaderKey::MetaLength)
+        self.headers.get(ItemHeaderKey::MetaLength)
     }
 
     /// Sets the length of the optional meta segment.
@@ -502,7 +502,7 @@ impl Item {
 
     /// Retrieves the sentry release from an item header.
     pub fn sentry_release(&self) -> Option<&str> {
-        self.headers.get(&ItemHeaderKey::SentryRelease)
+        self.headers.get(ItemHeaderKey::SentryRelease)
     }
 
     /// Sets the sentry release on an item header.
@@ -512,7 +512,7 @@ impl Item {
 
     /// Retrieves the sentry environment from an item header.
     pub fn sentry_environment(&self) -> Option<&str> {
-        self.headers.get(&ItemHeaderKey::SentryEnvironment)
+        self.headers.get(ItemHeaderKey::SentryEnvironment)
     }
 
     /// Sets the sentry environment on an item header.
@@ -526,7 +526,7 @@ impl Item {
     /// Only applicable if the item is an attachment.
     pub fn parent_id(&self) -> Option<ParentId> {
         // Currently only `span_id` supported in `ParentId`.
-        let span_id = self.headers.get(&ItemHeaderKey::SpanId)?;
+        let span_id = self.headers.get(ItemHeaderKey::SpanId)?;
         Some(ParentId::SpanId(span_id))
     }
 
@@ -595,7 +595,7 @@ impl Item {
                 .saturating_sub(self.meta_length().unwrap_or(0) as usize)
         } else if self.is_attachment_ref() {
             self.headers
-                .get(&ItemHeaderKey::AttachmentLength)
+                .get(ItemHeaderKey::AttachmentLength)
                 .unwrap_or(0)
         } else {
             self.len()
@@ -610,7 +610,7 @@ impl Item {
         }
         if self
             .headers
-            .try_get::<AttachmentType>(&ItemHeaderKey::AttachmentType)
+            .try_get::<AttachmentType>(ItemHeaderKey::AttachmentType)
             .is_err()
         {
             return true;
@@ -984,7 +984,7 @@ impl std::str::FromStr for ItemType {
 relay_common::impl_str_serde!(ItemType, "an envelope item type (see sentry develop docs)");
 
 /// AN item header stored in [`ItemHeaders`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ItemHeaderKey {
     /// Content length of the item.
@@ -1068,8 +1068,6 @@ pub enum ItemHeaderKey {
     SentryRelease,
     /// The Sentry environment stored in a header.
     SentryEnvironment,
-    /// An unknown item header.
-    Other(String),
 }
 
 /// The value of an item header.
@@ -1116,27 +1114,29 @@ pub struct ItemHeaders {
 
     /// Other attributes for forward compatibility.
     #[serde(flatten)]
-    inner: BTreeMap<ItemHeaderKey, ItemHeaderValue>,
+    inner: BTreeMap<MaybeKnown<ItemHeaderKey>, ItemHeaderValue>,
 }
 
 impl ItemHeaders {
-    fn contains(&self, key: &ItemHeaderKey) -> bool {
-        self.inner.contains_key(key)
+    fn contains(&self, key: ItemHeaderKey) -> bool {
+        self.inner.contains_key(&MaybeKnown::Known(key))
     }
 
-    fn get<'a, T>(&'a self, key: &ItemHeaderKey) -> Option<T>
-    where
-        T: Deserialize<'a>,
-    {
-        self.inner.get(key).and_then(|v| T::deserialize(&v.0).ok())
-    }
-
-    fn try_get<'a, T>(&'a self, key: &ItemHeaderKey) -> Result<Option<T>, serde_json::Error>
+    fn get<'a, T>(&'a self, key: ItemHeaderKey) -> Option<T>
     where
         T: Deserialize<'a>,
     {
         self.inner
-            .get(key)
+            .get(&MaybeKnown::Known(key))
+            .and_then(|v| T::deserialize(&v.0).ok())
+    }
+
+    fn try_get<'a, T>(&'a self, key: ItemHeaderKey) -> Result<Option<T>, serde_json::Error>
+    where
+        T: Deserialize<'a>,
+    {
+        self.inner
+            .get(&MaybeKnown::Known(key))
             .map(|v| T::deserialize(&v.0))
             .transpose()
     }
@@ -1146,7 +1146,8 @@ impl ItemHeaders {
         T: Serialize,
     {
         let value = serde_json::to_value(value).expect("header value must be json serializable");
-        self.inner.insert(key, ItemHeaderValue(value));
+        self.inner
+            .insert(MaybeKnown::Known(key), ItemHeaderValue(value));
         self
     }
 
@@ -1157,10 +1158,22 @@ impl ItemHeaders {
         if let Some(value) = value {
             self.set(key, value);
         } else {
-            self.inner.remove(&key);
+            self.inner.remove(&MaybeKnown::Known(key));
         }
         self
     }
+}
+
+/// An item key which is potentially known to Relay.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MaybeKnown<T> {
+    /// An item known to this Relay.
+    Known(T),
+    /// An unknown item.
+    ///
+    /// Kept for forward compatibility.
+    Unknown(String),
 }
 
 /// Container for item quantities that the item was derived from.
@@ -1312,5 +1325,49 @@ mod tests {
         assert_eq!(ItemType::Unknown("test".to_owned()).as_str(), "test");
         assert_eq!(&ItemType::Span.to_string(), "span");
         assert_eq!(&ItemType::Unknown("test".to_owned()).to_string(), "test");
+    }
+
+    #[test]
+    fn test_item_headers_unknown() {
+        let (item, _) = Item::parse(Bytes::from_static(
+            concat!(
+                r#"{"type":"attachment","unknown1":"foo","unknown2":"bar","length":5}"#,
+                "\n",
+                "12345"
+            )
+            .as_bytes(),
+        ))
+        .unwrap();
+
+        insta::assert_debug_snapshot!(&item.headers, @r#"
+        ItemHeaders {
+            ty: Attachment,
+            stored_key: None,
+            routing_hint: None,
+            rate_limited: false,
+            source_quantities: None,
+            inner: {
+                Known(
+                    Length,
+                ): ItemHeaderValue(
+                    Number(5),
+                ),
+                Unknown(
+                    "unknown1",
+                ): ItemHeaderValue(
+                    String("foo"),
+                ),
+                Unknown(
+                    "unknown2",
+                ): ItemHeaderValue(
+                    String("bar"),
+                ),
+            },
+        }
+        "#);
+
+        // Round trip -> serializes the headers again.
+        let json = serde_json::to_string(&item.headers).unwrap();
+        insta::assert_snapshot!(json, @r#"{"type":"attachment","length":5,"unknown1":"foo","unknown2":"bar"}"#);
     }
 }

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -1328,6 +1328,36 @@ mod tests {
     }
 
     #[test]
+    fn test_item_headers() {
+        let mut headers: ItemHeaders = serde_json::from_str(
+            r#"{
+            "type":"attachment",
+            "length":42,
+            "content_type": "application/json",
+            "filename":"test.txt"
+        }"#,
+        )
+        .unwrap();
+
+        assert_eq!(headers.ty, ItemType::Attachment);
+        assert!(headers.contains(ItemHeaderKey::Length));
+        assert_eq!(headers.get(ItemHeaderKey::Length), Some(42u32));
+        assert_eq!(headers.get(ItemHeaderKey::Filename), Some("test.txt"));
+        assert_eq!(
+            headers.get(ItemHeaderKey::ContentType),
+            Some("application/json")
+        );
+
+        headers.set_or_remove(ItemHeaderKey::Length, Some(1337u32));
+        assert_eq!(headers.get(ItemHeaderKey::Length), Some(1337));
+        headers.set_or_remove(ItemHeaderKey::Length, None::<u32>);
+        assert!(!headers.contains(ItemHeaderKey::Length));
+
+        let s = serde_json::to_string(&headers).unwrap();
+        insta::assert_snapshot!(s, @r#"{"type":"attachment","content_type":"application/json","filename":"test.txt"}"#);
+    }
+
+    #[test]
     fn test_item_headers_unknown() {
         let (item, _) = Item::parse(Bytes::from_static(
             concat!(
@@ -1367,7 +1397,7 @@ mod tests {
         "#);
 
         // Round trip -> serializes the headers again.
-        let json = serde_json::to_string(&item.headers).unwrap();
-        insta::assert_snapshot!(json, @r#"{"type":"attachment","length":5,"unknown1":"foo","unknown2":"bar"}"#);
+        let s = serde_json::to_string(&item.headers).unwrap();
+        insta::assert_snapshot!(s, @r#"{"type":"attachment","length":5,"unknown1":"foo","unknown2":"bar"}"#);
     }
 }


### PR DESCRIPTION
I broke it in #5671, not realizing the `Unknown` doesn't work.

Relay needs to accept unknown item headers, because of old SDKs, but also future SDKs.