### PR TITLE
feat(view-hierarchies): Account for scrubbing view hierarchies size changes

### DIFF
--- a/relay-server/src/processing/errors/process.rs
+++ b/relay-server/src/processing/errors/process.rs
@@ -126,11 +126,19 @@ pub fn normalize(
 }
 
 pub fn scrub(error: &mut Managed<ExpandedError>, ctx: Context<'_>) -> Result<(), Rejected<Error>> {
-    error.try_modify(|error, _| {
+    error.try_modify(|error, records| {
         processing::utils::event::scrub(&mut error.event, ctx.project_info)?;
-        processing::utils::attachments::scrub(error.attachments.iter_mut(), ctx.project_info);
+        processing::utils::attachments::scrub(
+            error.attachments.iter_mut(),
+            ctx.project_info,
+            Some(records),
+        );
         if let Some(minidump) = error.data.minidump_mut() {
-            processing::utils::attachments::scrub(std::iter::once(minidump), ctx.project_info);
+            processing::utils::attachments::scrub(
+                std::iter::once(minidump),
+                ctx.project_info,
+                Some(records),
+            );
         }
 
         Ok::<_, Error>(())

--- a/relay-server/src/processing/transactions/process.rs
+++ b/relay-server/src/processing/transactions/process.rs
@@ -431,9 +431,9 @@ pub fn scrub(
     work: Managed<Box<ExpandedTransaction>>,
     ctx: Context<'_>,
 ) -> Result<Managed<Box<ExpandedTransaction>>, Rejected<Error>> {
-    work.try_map(|mut work, _| {
+    work.try_map(|mut work, records| {
         utils::event::scrub(&mut work.event, ctx.project_info)?;
-        utils::attachments::scrub(work.attachments.iter_mut(), ctx.project_info);
+        utils::attachments::scrub(work.attachments.iter_mut(), ctx.project_info, Some(records));
         Ok::<_, Error>(work)
     })
 }

--- a/relay-server/src/processing/utils/attachments.rs
+++ b/relay-server/src/processing/utils/attachments.rs
@@ -5,6 +5,7 @@ use relay_pii::{PiiAttachmentsProcessor, SelectorPathItem, SelectorSpec};
 use relay_statsd::metric;
 
 use crate::envelope::{AttachmentType, ContentType, Item, ItemType};
+use crate::managed::RecordKeeper;
 use crate::statsd::RelayTimers;
 
 use crate::services::projects::project::ProjectInfo;
@@ -15,8 +16,17 @@ use relay_dynamic_config::Feature;
 /// This only applies the new PII rules that explicitly select `ValueType::Binary` or one of the
 /// attachment types. When special attachments are detected, these are scrubbed with custom
 /// logic; otherwise the entire attachment is treated as a single binary blob.
-pub fn scrub<'a>(attachments: impl Iterator<Item = &'a mut Item>, project_info: &ProjectInfo) {
+///
+/// Requires `record_keeper` since scrubbing a view hierarchy might change the size of it and hence
+/// modifies the attachment quantity.
+pub fn scrub<'a>(
+    attachments: impl Iterator<Item = &'a mut Item>,
+    project_info: &ProjectInfo,
+    mut record_keeper: Option<&mut RecordKeeper>,
+) {
+    let _ = record_keeper;
     if let Some(ref config) = project_info.config.pii_config {
+        let mut already_lenient = false;
         let view_hierarchy_scrubbing_enabled = project_info
             .config
             .features
@@ -26,6 +36,12 @@ pub fn scrub<'a>(attachments: impl Iterator<Item = &'a mut Item>, project_info: 
             if view_hierarchy_scrubbing_enabled
                 && item.attachment_type() == Some(AttachmentType::ViewHierarchy)
             {
+                if let Some(record_keeper) = record_keeper.as_deref_mut()
+                    && !already_lenient
+                {
+                    record_keeper.lenient(relay_quotas::DataCategory::Attachment);
+                    already_lenient = true;
+                }
                 scrub_view_hierarchy(item, config)
             } else if item.attachment_type() == Some(AttachmentType::Minidump) {
                 scrub_minidump(item, config)

--- a/relay-server/src/processing/utils/attachments.rs
+++ b/relay-server/src/processing/utils/attachments.rs
@@ -26,7 +26,6 @@ pub fn scrub<'a>(
 ) {
     let _ = record_keeper;
     if let Some(ref config) = project_info.config.pii_config {
-        let mut already_lenient = false;
         let view_hierarchy_scrubbing_enabled = project_info
             .config
             .features
@@ -36,13 +35,16 @@ pub fn scrub<'a>(
             if view_hierarchy_scrubbing_enabled
                 && item.attachment_type() == Some(AttachmentType::ViewHierarchy)
             {
-                if let Some(record_keeper) = record_keeper.as_deref_mut()
-                    && !already_lenient
-                {
-                    record_keeper.lenient(relay_quotas::DataCategory::Attachment);
-                    already_lenient = true;
+                let old_size = item.payload().len();
+                scrub_view_hierarchy(item, config);
+                let new_size = item.payload().len();
+
+                if let Some(record_keeper) = record_keeper.as_mut() {
+                    record_keeper.modify_by(
+                        relay_quotas::DataCategory::Attachment,
+                        new_size as isize - old_size as isize,
+                    );
                 }
-                scrub_view_hierarchy(item, config)
             } else if item.attachment_type() == Some(AttachmentType::Minidump) {
                 scrub_minidump(item, config)
             } else if item.ty() == &ItemType::Attachment && has_simple_attachment_selector(config) {

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1400,7 +1400,7 @@ impl EnvelopeProcessorService {
             .envelope_mut()
             .items_mut()
             .filter(|i| i.ty() == &ItemType::Attachment);
-        processing::utils::attachments::scrub(attachments, ctx.project_info);
+        processing::utils::attachments::scrub(attachments, ctx.project_info, None);
 
         if self.inner.config.processing_enabled() && !event_fully_normalized.0 {
             relay_log::error!(
@@ -1450,7 +1450,7 @@ impl EnvelopeProcessorService {
             .envelope_mut()
             .items_mut()
             .filter(|i| i.ty() == &ItemType::Attachment);
-        processing::utils::attachments::scrub(attachments, ctx.project_info);
+        processing::utils::attachments::scrub(attachments, ctx.project_info, None);
 
         Ok(Some(extracted_metrics))
     }

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -303,6 +303,55 @@ def test_view_hierarchy_scrubbing(mini_sentry, relay, feature_flags, expected):
         ),
     ],
 )
+def test_attachment_scrubbing_with_event_with_fallback(
+    mini_sentry, relay, feature_flags, expected
+):
+    """
+    Like test_attachment_scrubbing_with_fallback, but goes through the ErrorsProcessor
+    """
+    event_id = "515539018c9b4260a6f999572f1661ee"
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"].setdefault("features", []).extend(feature_flags)
+    project_config["config"]["piiConfig"] = {
+        "rules": {"0": {"type": "password", "redaction": {"method": "remove"}}},
+        "applications": {
+            "$string": ["@password:remove"],
+            "$attachments.'view-hierarchy.json'": ["0"],
+        },
+    }
+    relay = relay(mini_sentry)
+    json_payload = {
+        "rendering_system": "UIKIT",
+        "password": "hunter42",
+    }
+    envelope = Envelope(headers=[["event_id", event_id]])
+    envelope.add_event({"message": "Hello, World!"})
+    envelope.add_item(
+        Item(
+            headers=[["attachment_type", "event.view_hierarchy"]],
+            type="attachment",
+            payload=PayloadRef(json=json_payload),
+            filename="view-hierarchy.json",
+        )
+    )
+    relay.send_envelope(project_id, envelope)
+    envelope = mini_sentry.get_captured_envelope()
+    attachment = next(item for item in envelope.items if item.type == "attachment")
+    payload = attachment.payload.bytes
+    assert payload == expected
+
+
+@pytest.mark.parametrize(
+    "feature_flags, expected",
+    [
+        ([], b"**************************************************"),
+        (
+            ["organizations:view-hierarchy-scrubbing"],
+            b'{"rendering_system":"UIKIT","password":""}',
+        ),
+    ],
+)
 def test_attachment_scrubbing_with_fallback(
     mini_sentry, relay, feature_flags, expected
 ):


### PR DESCRIPTION
While working on this https://github.com/getsentry/relay/pull/5703 noticed that scrubbing a view hierarchy might change its size and hence the Attachment quantity. This adds logic to the scrub function to adjust the quantity so that the book keeping is correct.