### PR TITLE
feat(objectstore): Enable objectstore auth if key is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Set `sentry.segment.id` and `sentry.segment.name` attributes on OTLP segment spans. ([#5748](https://github.com/getsentry/relay/pull/5748))
 - Envelope buffer: Add option to disable flush-to-disk on shutdown. ([#5751](https://github.com/getsentry/relay/pull/5751))
+- Allow configuring Objectstore client auth parameters. ([#5720](https://github.com/getsentry/relay/pull/5720))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1290,6 +1290,26 @@ impl Default for OutcomeAggregatorConfig {
     }
 }
 
+/// Configuration options for objectstore's auth scheme.
+#[derive(Serialize, Deserialize)]
+pub struct ObjectstoreAuthConfig {
+    /// Identifier for the private key used to sign objectstore's tokens. Must correspond to a
+    /// public key configured in objectstore.
+    pub key_id: String,
+
+    /// EdDSA private key used to sign Objectstore's tokens, in PEM format.
+    pub signing_key: String,
+}
+
+impl fmt::Debug for ObjectstoreAuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObjectstoreAuthConfig")
+            .field("key_id", &self.key_id)
+            .field("signing_key", &"[redacted]")
+            .finish()
+    }
+}
+
 /// Configuration values for the objectstore service.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
@@ -1310,6 +1330,9 @@ pub struct ObjectstoreServiceConfig {
 
     /// Maximum duration of an attachment upload in seconds. Uploads that take longer are discarded.
     pub timeout: u64,
+
+    /// Configuration values for objectstore's auth scheme.
+    pub auth: Option<ObjectstoreAuthConfig>,
 }
 
 impl Default for ObjectstoreServiceConfig {
@@ -1319,6 +1342,7 @@ impl Default for ObjectstoreServiceConfig {
             max_concurrent_requests: 10,
             max_backlog: 20,
             timeout: 60,
+            auth: None,
         }
     }
 }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use objectstore_client::{Client, ExpirationPolicy, PutBuilder, Session, Usecase};
+use objectstore_client::{
+    Client, ExpirationPolicy, PutBuilder, SecretKey as SigningKey, Session, TokenGenerator, Usecase,
+};
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
 use relay_config::ObjectstoreServiceConfig;
@@ -182,14 +184,37 @@ impl ObjectstoreService {
             max_concurrent_requests: _,
             max_backlog: _,
             timeout,
+            auth,
         } = config;
         let Some(objectstore_url) = objectstore_url else {
             return Ok(None);
         };
 
-        let objectstore_client = Client::builder(objectstore_url)
-            .configure_reqwest(|builder| builder.timeout(Duration::from_secs(*timeout)))
-            .build()?;
+        let objectstore_client = {
+            let mut builder = Client::builder(objectstore_url)
+                .configure_reqwest(|builder| builder.timeout(Duration::from_secs(*timeout)));
+
+            if let Some(auth) = auth {
+                // TODO(FS-313): when Objectstore starts enforcing auth, propagate error with ?
+                let token_generator = TokenGenerator::new(SigningKey {
+                    kid: auth.key_id.clone(),
+                    secret_key: auth.signing_key.clone(),
+                });
+
+                builder = match token_generator {
+                    Ok(token_generator) => builder.token(token_generator),
+                    Err(error) => {
+                        relay_log::error!(
+                            error = &error as &dyn std::error::Error,
+                            "failed to configure objectstore auth"
+                        );
+                        builder
+                    }
+                };
+            }
+
+            builder.build()?
+        };
         let event_attachments = Usecase::new("attachments")
             .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
         let trace_attachments = Usecase::new("trace_attachments")


### PR DESCRIPTION
reissue of https://github.com/getsentry/relay/pull/5525

- creates `ObjectstoreAuthConfig` config struct for configuring the key id and key material
- wires the key id and key material up to the objectstore client if it's provided

in production deployments the signing key lives in GCP Secret Manager and is mounted as a file at some path. it is expected that the signing key is given to relay by setting `signing_key: ${file:/path/to/key.pem}` which (thanks to https://github.com/getsentry/relay/pull/5531) will read the content of the file into that field. i'm working on the k8s PR for that

**Question**: is there a preferred way to include secret fields in Relay config structs so they aren't accidentally logged or dumped? `relay_auth::SecretKey` appears to also be an EdDSA key but not PEM format which is what our JWT dependency expects

Closes FS-229.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
