### PR TITLE
fix(upload): Increase request timeout

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1648,7 +1648,7 @@ impl Default for Upload {
     fn default() -> Self {
         Self {
             max_concurrent_requests: 10,
-            timeout: 60,
+            timeout: 5 * 60, // five minutes
         }
     }
 }


### PR DESCRIPTION
One minute is not enough for very large payloads. Increase to five minutes for now.

ref: INGEST-784