### PR TITLE
feat(standalone): Add Content-Type to attachment metric

### DIFF
--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -109,6 +109,7 @@ impl processing::Processor for AttachmentProcessor {
                 distribution(RelayDistributions::StandaloneAttachmentSize) = item.len() as u64,
                 sdk = client_name,
                 attachment_type = attachment_type_tag,
+                content_type = item.content_type().map_or("", |ct| ct.as_str()),
             );
         }
 


### PR DESCRIPTION
Figure out what these attachments are.

The tag is low-cardinality since it's defined by an enum.