### PR TITLE
fix(upload): Respond with 400 on incorrect file length

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -94,6 +94,9 @@ impl IntoResponse for Error {
                         objectstore_client::Error::Reqwest(error) => match error.status() {
                             _ if error.is_timeout() => StatusCode::GATEWAY_TIMEOUT,
                             Some(status) => status,
+                            None if find_error_source(&error, is_hyper_user_error).is_some() => {
+                                StatusCode::BAD_REQUEST
+                            }
                             None => StatusCode::INTERNAL_SERVER_ERROR,
                         },
                         _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/relay-server/src/utils/error.rs
+++ b/relay-server/src/utils/error.rs
@@ -10,11 +10,11 @@ where
     P: Fn(&(dyn Error + 'static)) -> bool,
 {
     let mut source = error.source();
-    while let Some(s) = source {
-        if predicate(s) {
-            return Some(s);
+    while let Some(error) = source {
+        if predicate(error) {
+            return Some(error);
         }
-        source = s.source();
+        source = error.source();
     }
     None
 }

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -361,7 +361,7 @@ def test_create_processing(
 def test_processing_invalid_length(
     mini_sentry, relay, relay_with_processing, project_config, length
 ):
-    """Create and separate upload via processing relay stores the blob in objectstore."""
+    mini_sentry.fail_on_relay_error = False
     project_id = 42
     project_key = mini_sentry.get_dsn_public_key(project_id)
 

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -357,6 +357,45 @@ def test_create_processing(
     assert response.headers["Upload-Offset"] == str(len(data)), response.headers
 
 
+@pytest.mark.parametrize("length", [9, 11])
+def test_processing_invalid_length(
+    mini_sentry, relay, relay_with_processing, project_config, length
+):
+    """Create and separate upload via processing relay stores the blob in objectstore."""
+    project_id = 42
+    project_key = mini_sentry.get_dsn_public_key(project_id)
+
+    relay = relay_with_processing(PROCESSING_OPTIONS)
+
+    response = relay.post(
+        f"/api/{project_id}/upload/?sentry_key={project_key}",
+        headers={
+            "Content-Length": "0",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Length": "10",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.headers["Tus-Resumable"] == "1.0.0"
+    assert "Upload-Offset" not in response.headers
+
+    # Use the location to send a PATCH request that is too long // too short
+    data = length * b"X"
+    response = relay.patch(
+        f"{response.headers['Location']}&sentry_key={project_key}",
+        headers={
+            "Content-Length": str(len(data)),
+            "Content-Type": "application/offset+octet-stream",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Offset": "0",
+        },
+        data=data,
+    )
+
+    assert response.status_code == 400
+
+
 @pytest.mark.parametrize("defer_length_value", ["1", "2"])
 def test_upload_with_deferred_length(
     mini_sentry, relay, relay_with_processing, project_config, defer_length_value


### PR DESCRIPTION
Respond with 400 instead of 500 if the signed length does not match the actual length.

ref: INGEST-779