### PR TITLE
feat(standalone): Emit log message for attachments

### DIFF
--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -99,6 +99,7 @@ impl processing::Processor for AttachmentProcessor {
             sdk = client_name,
         );
 
+        let mut log_emitted = false;
         for item in &attachments.attachments {
             let attachment_type_tag = match item.attachment_type() {
                 Some(t) => &t.to_string(),
@@ -109,8 +110,18 @@ impl processing::Processor for AttachmentProcessor {
                 distribution(RelayDistributions::StandaloneAttachmentSize) = item.len() as u64,
                 sdk = client_name,
                 attachment_type = attachment_type_tag,
-                content_type = item.content_type().map_or("", |ct| ct.as_str()),
             );
+            if !log_emitted {
+                relay_log::info!(
+                    sdk = attachments.headers.meta().client(),
+                    attachment_type = attachment_type_tag,
+                    content_type = item.content_type().map_or("", |ct| ct.as_str()),
+                    size = item.len(),
+                    siblings = attachments.attachments.len(),
+                    "standalone attachment",
+                );
+                log_emitted = true;
+            }
         }
 
         let mut attachments = self.limiter.enforce_quotas(attachments, ctx).await?;

--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -118,6 +118,7 @@ impl processing::Processor for AttachmentProcessor {
                     content_type = item.content_type().map_or("", |ct| ct.as_str()),
                     size = item.len(),
                     siblings = attachments.attachments.len(),
+                    project_id = attachments.headers.meta().project_id().map(|p| p.value()),
                     "standalone attachment",
                 );
                 log_emitted = true;


### PR DESCRIPTION
Emit a log message for the first standalone attachment in every envelope. This should give us more data on where the attachments are coming from.

This PR also removes the content type from the statsd metric to reduce cardinality.