### PR TITLE
fix(tests): Remove dead `sessions_consumer` from integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,6 @@ from .fixtures.processing import (  # noqa
     transactions_consumer,
     attachments_consumer,
     replay_recordings_consumer,
-    sessions_consumer,
     metrics_consumer,
     monitors_consumer,
     spans_consumer,

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -393,11 +393,6 @@ def attachments_consumer(consumer_fixture):
 
 
 @pytest.fixture
-def sessions_consumer(consumer_fixture):
-    yield from consumer_fixture(SessionsConsumer, "sessions")
-
-
-@pytest.fixture
 def metrics_consumer(consumer_fixture):
     yield from consumer_fixture(MetricsConsumer, "metrics")
 
@@ -463,15 +458,6 @@ class MetricsConsumer(ConsumerBase):
         metrics.sort(key=_sort)
 
         return metrics
-
-
-class SessionsConsumer(ConsumerBase):
-    def get_session(self):
-        message = self.poll()
-        assert message is not None
-        assert message.error() is None
-
-        return json.loads(message.value())
 
 
 class EventsConsumer(ConsumerBase):

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -81,9 +81,9 @@ def test_sessions(mini_sentry, relay_chain, metric_extraction):
         assert session == session_payload
 
 
-def test_session_age_discard(mini_sentry, relay_with_processing, sessions_consumer):
+def test_session_age_discard(mini_sentry, relay_with_processing, metrics_consumer):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -102,14 +102,14 @@ def test_session_age_discard(mini_sentry, relay_with_processing, sessions_consum
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
 def test_session_age_discard_aggregates(
-    mini_sentry, relay_with_processing, sessions_consumer
+    mini_sentry, relay_with_processing, metrics_consumer
 ):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -136,14 +136,12 @@ def test_session_age_discard_aggregates(
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
-def test_session_release_required(
-    mini_sentry, relay_with_processing, sessions_consumer
-):
+def test_session_release_required(mini_sentry, relay_with_processing, metrics_consumer):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -161,14 +159,14 @@ def test_session_release_required(
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
 def test_session_aggregates_release_required(
-    mini_sentry, relay_with_processing, sessions_consumer
+    mini_sentry, relay_with_processing, metrics_consumer
 ):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -193,12 +191,12 @@ def test_session_aggregates_release_required(
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
-def test_session_disabled(mini_sentry, relay_with_processing, sessions_consumer):
+def test_session_disabled(mini_sentry, relay_with_processing, metrics_consumer):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -226,12 +224,12 @@ def test_session_disabled(mini_sentry, relay_with_processing, sessions_consumer)
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
-def test_session_invalid_release(mini_sentry, relay_with_processing, sessions_consumer):
+def test_session_invalid_release(mini_sentry, relay_with_processing, metrics_consumer):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     PROJECT_ID = 42
     project_config = mini_sentry.add_full_project_config(PROJECT_ID)
@@ -248,14 +246,14 @@ def test_session_invalid_release(mini_sentry, relay_with_processing, sessions_co
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
 def test_session_aggregates_invalid_release(
-    mini_sentry, relay_with_processing, sessions_consumer
+    mini_sentry, relay_with_processing, metrics_consumer
 ):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -277,12 +275,12 @@ def test_session_aggregates_invalid_release(
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()
 
 
-def test_session_filtering(mini_sentry, relay_with_processing, sessions_consumer):
+def test_session_filtering(mini_sentry, relay_with_processing, metrics_consumer):
     relay = relay_with_processing()
-    sessions_consumer = sessions_consumer()
+    metrics_consumer = metrics_consumer()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -403,4 +401,4 @@ def test_session_filtering(mini_sentry, relay_with_processing, sessions_consumer
         },
     )
 
-    sessions_consumer.assert_empty()
+    metrics_consumer.assert_empty()


### PR DESCRIPTION
The `sessions` Kafka topic was removed over a year ago in 5b03bfb107 (feat: Remove sessions (#3271)). Sessions are now converted to metrics and routed through the `metrics_sessions` topic. However, the integration tests still defined a `sessions_consumer` fixture that subscribed to the non-existent `sessions` topic. All 8 tests using it only called `assert_empty()`, which passed trivially since nothing was ever written to that topic — making these assertions meaningless.

Replace `sessions_consumer` with `metrics_consumer` in all affected tests so that `assert_empty()` actually validates that no metrics are produced for invalid/filtered/discarded sessions. Remove the now-unused `SessionsConsumer` class and `sessions_consumer` fixture.

fix: RELAY-135

