### PR TITLE
test: Configure objectstore in all processing tests

### DIFF
--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -78,6 +78,9 @@ def processing_config(get_topic_name):
                 f"relay-test-relayconfig-{uuid.uuid4()}"
             )
 
+        if processing.get("objectstore") is None:
+            processing["objectstore"] = {"objectstore_url": "http://127.0.0.1:8888/"}
+
         return options
 
     return inner

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -135,7 +135,6 @@ def test_attachments_with_objectstore(
     options = {
         "processing": {
             "attachment_chunk_size": "100KB",
-            "upload": {"objectstore_url": "http://127.0.0.1:8888/"},
         }
     }
     relay = relay_with_processing(options)
@@ -636,9 +635,7 @@ def test_event_with_attachment(
             "relay.objectstore-attachments.sample-rate"
         ] = 1.0
 
-    relay = relay_with_processing(
-        {"processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}}}
-    )
+    relay = relay_with_processing()
     attachments_consumer = attachments_consumer()
     transactions_consumer = transactions_consumer()
     objectstore = objectstore("attachments", project_id)

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -114,9 +114,7 @@ def test_standalone_attachment_store(
         "projects:span-v2-attachment-processing",
         "projects:trace-attachment-processing",
     ]
-    relay = relay_with_processing(
-        {"processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}}}
-    )
+    relay = relay_with_processing()
 
     attachment_metadata = create_attachment_metadata()
     attachment_body = b"This is some mock attachment content"
@@ -362,9 +360,7 @@ def test_attachment_with_matching_span_store(
         "projects:span-v2-experimental-processing",
         "projects:span-v2-attachment-processing",
     ]
-    relay = relay_with_processing(
-        {"processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}}}
-    )
+    relay = relay_with_processing()
 
     ts = datetime.now(timezone.utc)
     span_id = "eee19b7ec3c1b174"

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -405,11 +405,13 @@ def test_minidump_with_processing(
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"]["eventRetention"] = 50000
 
-    options = (
-        {"processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}}}
-        if use_objectstore
-        else None
-    )
+    options = {
+        "processing": {
+            "objectstore": {
+                "objectstore_url": "http://127.0.0.1:8888/" if use_objectstore else None
+            }
+        }
+    }
     relay = relay_with_processing(options)
 
     # Disable scurbbing, the basic and full project configs from the mini_sentry fixture

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -405,7 +405,6 @@ def test_playstation_large_attachments(
     credentials = relay_credentials()
     relay = relay_processing_with_playstation(
         {
-            "processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}},
             # 1 MiB extra for minidump etc.
             "limits": {
                 "max_attachment_size": len(playstation_dump) + 1 * 1024 * 1024,

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -308,11 +308,6 @@ def test_timeout(
         }
 
 
-PROCESSING_OPTIONS = {
-    "processing": {"upload": {"objectstore_url": "http://127.0.0.1:8888/"}}
-}
-
-
 @pytest.mark.parametrize(
     "chain", [pytest.param(False, id="processing_only"), pytest.param(True, id="chain")]
 )
@@ -321,7 +316,7 @@ def test_create_with_upload_processing(
 ):
     """Upload via processing relay stores the blob in objectstore."""
     project_id = 42
-    processing_relay = relay_with_processing(PROCESSING_OPTIONS)
+    processing_relay = relay_with_processing()
     if chain:
         relay = relay(processing_relay)
     else:
@@ -371,7 +366,7 @@ def test_create_processing(
     project_id = 42
     project_key = mini_sentry.get_dsn_public_key(project_id)
 
-    processing_relay = relay_with_processing(PROCESSING_OPTIONS)
+    processing_relay = relay_with_processing()
     if chain:
         relay = relay(processing_relay)
     else:
@@ -417,7 +412,7 @@ def test_processing_invalid_length(
     project_id = 42
     project_key = mini_sentry.get_dsn_public_key(project_id)
 
-    relay = relay_with_processing(PROCESSING_OPTIONS)
+    relay = relay_with_processing()
 
     response = relay.post(
         f"/api/{project_id}/upload/?sentry_key={project_key}",
@@ -453,7 +448,7 @@ def test_upload_with_deferred_length(
     mini_sentry, relay, relay_with_processing, project_config, defer_length_value
 ):
     project_id = 42
-    processing_relay = relay_with_processing(PROCESSING_OPTIONS)
+    processing_relay = relay_with_processing()
     relay = relay(processing_relay)
 
     data = b"hello world"


### PR DESCRIPTION
- Remove config snippets from tests that require objectstore, and add it everywhere.
- Rename the `upload` section to `objectstore` (the former is an alias).