### PR TITLE
feat(tracemetric): Add tracemetric bytes as outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Calculate and track accepted bytes per individual trace metric item via `TraceMetricByte` data category.
+- Calculate and track accepted bytes per individual trace metric item via `TraceMetricByte` data category. ([#5744](https://github.com/getsentry/relay/pull/5744))
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 
 ## 26.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Internal**:
 
+- Calculate and track accepted bytes per individual trace metric item via `TraceMetricByte` data category.
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 
 ## 26.3.1

--- a/relay-event-schema/src/protocol/trace_metric.rs
+++ b/relay-event-schema/src/protocol/trace_metric.rs
@@ -1,10 +1,11 @@
 use relay_protocol::{
     Annotated, Empty, FromValue, Getter, IntoValue, Object, SkipSerialization, Value,
 };
+use std::collections::BTreeMap;
 use std::fmt::{self, Display};
 
 use relay_base_schema::metrics::MetricUnit;
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::processor::ProcessValue;
 use crate::protocol::{Attributes, SpanId, Timestamp, TraceId};
@@ -49,6 +50,23 @@ pub struct TraceMetric {
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, retain = false)]
     pub other: Object<Value>,
+}
+
+/// Relay specific metadata embedded into the trace metric item.
+///
+/// This metadata is purely an internal protocol extension used by Relay,
+/// no one except Relay should be sending this data, nor should anyone except Relay rely on it.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TraceMetricHeader {
+    /// Original (calculated) size of the trace metric item when it was first received by a Relay.
+    ///
+    /// If this value exists, Relay uses it as quantity for all outcomes emitted to the
+    /// trace metric byte data category.
+    pub byte_size: Option<u64>,
+
+    /// Forward compatibility for additional headers.
+    #[serde(flatten)]
+    pub other: BTreeMap<String, Value>,
 }
 
 impl Getter for TraceMetric {

--- a/relay-server/src/envelope/container.rs
+++ b/relay-server/src/envelope/container.rs
@@ -300,7 +300,7 @@ impl ContainerItem for relay_event_schema::protocol::TraceMetric {
     const ITEM_TYPE: ItemType = ItemType::TraceMetric;
     const CONTENT_TYPE: ContentType = ContentType::TraceMetricContainer;
 
-    type Header = NoHeader;
+    type Header = relay_event_schema::protocol::TraceMetricHeader;
 }
 
 #[cfg(test)]

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -133,7 +133,10 @@ impl Item {
                 (DataCategory::LogByte, self.len().max(1)),
                 (DataCategory::LogItem, item_count)
             ],
-            ItemType::TraceMetric => smallvec![(DataCategory::TraceMetric, item_count)],
+            ItemType::TraceMetric => smallvec![
+                (DataCategory::TraceMetricByte, self.len().max(1)),
+                (DataCategory::TraceMetric, item_count)
+            ],
             ItemType::FormData => smallvec![],
             ItemType::UserReport => smallvec![(DataCategory::UserReportV2, item_count)],
             ItemType::UserReportV2 => smallvec![(DataCategory::UserReportV2, item_count)],

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -111,7 +111,10 @@ impl Counted for EnvelopeSummary {
             (DataCategory::ProfileChunkUi, self.profile_chunk_ui_quantity),
             (DataCategory::UserReportV2, self.user_report_quantity),
             (DataCategory::TraceMetric, self.trace_metric_quantity),
-            (DataCategory::TraceMetricByte, self.trace_metric_byte_quantity),
+            (
+                DataCategory::TraceMetricByte,
+                self.trace_metric_byte_quantity,
+            ),
             (DataCategory::LogItem, self.log_item_quantity),
             (DataCategory::LogByte, self.log_byte_quantity),
             (DataCategory::Monitor, self.monitor_quantity),

--- a/relay-server/src/managed/counted.rs
+++ b/relay-server/src/managed/counted.rs
@@ -111,6 +111,7 @@ impl Counted for EnvelopeSummary {
             (DataCategory::ProfileChunkUi, self.profile_chunk_ui_quantity),
             (DataCategory::UserReportV2, self.user_report_quantity),
             (DataCategory::TraceMetric, self.trace_metric_quantity),
+            (DataCategory::TraceMetricByte, self.trace_metric_byte_quantity),
             (DataCategory::LogItem, self.log_item_quantity),
             (DataCategory::LogByte, self.log_byte_quantity),
             (DataCategory::Monitor, self.monitor_quantity),
@@ -141,7 +142,13 @@ impl Counted for WithHeader<OurLog> {
 
 impl Counted for WithHeader<TraceMetric> {
     fn quantities(&self) -> Quantities {
-        smallvec::smallvec![(DataCategory::TraceMetric, 1)]
+        smallvec::smallvec![
+            (DataCategory::TraceMetric, 1),
+            (
+                DataCategory::TraceMetricByte,
+                processing::trace_metrics::get_calculated_byte_size(self)
+            )
+        ]
     }
 }
 

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -186,7 +186,10 @@ impl Forward for TraceMetricOutput {
         };
 
         for metric in metrics.split(|metrics| metrics.metrics) {
-            if let Ok(metric) = metric.try_map(|metric, _| store::convert(metric, &ctx)) {
+            if let Ok(metric) = metric.try_map(|metric, r| {
+                r.lenient(DataCategory::TraceMetricByte);
+                store::convert(metric, &ctx)
+            }) {
                 s.send_to_store(metric);
             }
         }

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -17,7 +17,10 @@ mod filter;
 mod process;
 #[cfg(feature = "processing")]
 mod store;
+mod utils;
 mod validate;
+
+pub use self::utils::get_calculated_byte_size;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, thiserror::Error)]
@@ -154,7 +157,8 @@ impl Forward for TraceMetricOutput {
         self,
         _: processing::ForwardContext<'_>,
     ) -> Result<Managed<Box<crate::Envelope>>, Rejected<()>> {
-        self.0.try_map(|metrics, _| {
+        self.0.try_map(|metrics, r| {
+            r.lenient(DataCategory::TraceMetricByte);
             metrics
                 .serialize_envelope()
                 .map_err(|error| {
@@ -211,7 +215,12 @@ impl Counted for SerializedTraceMetrics {
             .map(|item| item.item_count().unwrap_or(1) as usize)
             .sum();
 
-        smallvec![(DataCategory::TraceMetric, count)]
+        let bytes = self.metrics.iter().map(|item| item.len()).sum();
+
+        smallvec![
+            (DataCategory::TraceMetric, count),
+            (DataCategory::TraceMetricByte, bytes)
+        ]
     }
 }
 
@@ -234,7 +243,17 @@ pub struct ExpandedTraceMetrics {
 
 impl Counted for ExpandedTraceMetrics {
     fn quantities(&self) -> Quantities {
-        smallvec![(DataCategory::TraceMetric, self.metrics.len())]
+        let count = self.metrics.len();
+        let bytes = self
+            .metrics
+            .iter()
+            .map(get_calculated_byte_size)
+            .sum();
+
+        smallvec![
+            (DataCategory::TraceMetric, count),
+            (DataCategory::TraceMetricByte, bytes)
+        ]
     }
 }
 

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -247,11 +247,7 @@ pub struct ExpandedTraceMetrics {
 impl Counted for ExpandedTraceMetrics {
     fn quantities(&self) -> Quantities {
         let count = self.metrics.len();
-        let bytes = self
-            .metrics
-            .iter()
-            .map(get_calculated_byte_size)
-            .sum();
+        let bytes = self.metrics.iter().map(get_calculated_byte_size).sum();
 
         smallvec![
             (DataCategory::TraceMetric, count),

--- a/relay-server/src/processing/trace_metrics/process.rs
+++ b/relay-server/src/processing/trace_metrics/process.rs
@@ -1,12 +1,14 @@
 use relay_event_normalization::{RequiredMode, SchemaProcessor, eap};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
-use relay_event_schema::protocol::TraceMetric;
+use relay_event_schema::protocol::{TraceMetric, TraceMetricHeader};
 use relay_pii::{AttributeMode, PiiProcessor};
 use relay_protocol::Annotated;
+use relay_quotas::DataCategory;
 
 use crate::envelope::{ContainerItems, EnvelopeHeaders, Item, ItemContainer};
+use crate::extractors::RequestTrust;
 use crate::processing::Managed;
-use crate::processing::trace_metrics::{Error, Result};
+use crate::processing::trace_metrics::{Error, Result, utils::calculate_size};
 use crate::processing::trace_metrics::{ExpandedTraceMetrics, SerializedTraceMetrics};
 use crate::processing::{Context, utils};
 use crate::services::outcome::DiscardReason;
@@ -15,10 +17,14 @@ use crate::services::outcome::DiscardReason;
 ///
 /// Individual, invalid trace metrics will be discarded.
 pub fn expand(metrics: Managed<SerializedTraceMetrics>) -> Managed<ExpandedTraceMetrics> {
+    let trust = metrics.headers.meta().request_trust();
+
     metrics.map(|metrics, records| {
+        records.lenient(DataCategory::TraceMetricByte);
+
         let mut all_metrics = Vec::new();
         for item in metrics.metrics {
-            let expanded = expand_trace_metric_container(&item);
+            let expanded = expand_trace_metric_container(&item, trust);
             let expanded = records.or_default(expanded, item);
             all_metrics.extend(expanded);
         }
@@ -58,13 +64,27 @@ pub fn scrub(metrics: &mut Managed<ExpandedTraceMetrics>, ctx: Context<'_>) {
 }
 
 /// Parses a trace metric container into its [`ContainerItems<TraceMetric>`] representation.
-fn expand_trace_metric_container(item: &Item) -> Result<ContainerItems<TraceMetric>> {
-    let metrics = ItemContainer::parse(item)
+fn expand_trace_metric_container(
+    item: &Item,
+    trust: RequestTrust,
+) -> Result<ContainerItems<TraceMetric>> {
+    let mut metrics = ItemContainer::parse(item)
         .map_err(|err| {
             relay_log::debug!("failed to parse trace metrics container: {err}");
             Error::Invalid(DiscardReason::InvalidJson)
         })?
         .into_items();
+
+    for metric in &mut metrics {
+        let byte_size = metric
+            .header
+            .as_ref()
+            .and_then(|h: &TraceMetricHeader| h.byte_size);
+        if trust.is_untrusted() || matches!(byte_size, None | Some(0)) {
+            let byte_size = metric.value().map(calculate_size).unwrap_or(1);
+            metric.header.get_or_insert_default().byte_size = Some(byte_size);
+        }
+    }
 
     Ok(metrics)
 }

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -220,7 +220,10 @@ mod tests {
     macro_rules! trace_metric {
         ($($tt:tt)*) => {{
            WithHeader {
-               header: None,
+               header: Some(relay_event_schema::protocol::TraceMetricHeader {
+                   byte_size: Some(420),
+                   other: Default::default(),
+               }),
                value: TraceMetric::from_value(serde_json::json!($($tt)*).into())
            }
         }};

--- a/relay-server/src/processing/trace_metrics/utils.rs
+++ b/relay-server/src/processing/trace_metrics/utils.rs
@@ -4,7 +4,7 @@ use crate::envelope::WithHeader;
 
 /// Returns the calculated size of a trace metric.
 ///
-/// Unlike [`validate::calculate_size`], this accesses the already materialized byte size
+/// Unlike [`calculate_size`], this accesses the already materialized byte size
 /// from the header, instead of calculating it.
 ///
 /// When compiled with debug assertions the function asserts the presence of a materialized byte size.

--- a/relay-server/src/processing/trace_metrics/utils.rs
+++ b/relay-server/src/processing/trace_metrics/utils.rs
@@ -28,6 +28,7 @@ pub fn calculate_size(metric: &TraceMetric) -> u64 {
     let mut total_size = 0;
 
     total_size += metric.name.value().map_or(0, |s| s.len());
+    // Currently always a number (8 bytes), but could be a string for sets in the future.
     total_size += relay_event_normalization::eap::value_size(&metric.value);
 
     if let Some(attributes) = metric.attributes.value() {

--- a/relay-server/src/processing/trace_metrics/utils.rs
+++ b/relay-server/src/processing/trace_metrics/utils.rs
@@ -1,0 +1,38 @@
+use relay_event_schema::protocol::TraceMetric;
+
+use crate::envelope::WithHeader;
+
+/// Returns the calculated size of a trace metric.
+///
+/// Unlike [`validate::calculate_size`], this accesses the already materialized byte size
+/// from the header, instead of calculating it.
+///
+/// When compiled with debug assertions the function asserts the presence of a materialized byte size.
+pub fn get_calculated_byte_size(metric: &WithHeader<TraceMetric>) -> usize {
+    let bytes = metric.header.as_ref().and_then(|header| header.byte_size);
+
+    debug_assert!(
+        bytes.is_some(),
+        "processed trace metrics should always have a byte size assigned"
+    );
+
+    let bytes = bytes.unwrap_or_else(|| metric.value().map_or(1, calculate_size));
+
+    usize::try_from(bytes).unwrap_or(usize::MAX)
+}
+
+/// Calculates the byte size for a trace metric.
+///
+/// Similar to [`relay_ourlogs::calculate_size`].
+pub fn calculate_size(metric: &TraceMetric) -> u64 {
+    let mut total_size = 0;
+
+    total_size += metric.name.value().map_or(0, |s| s.len());
+    total_size += relay_event_normalization::eap::value_size(&metric.value);
+
+    if let Some(attributes) = metric.attributes.value() {
+        total_size += relay_event_normalization::eap::attributes_size(attributes);
+    }
+
+    u64::try_from(total_size).unwrap_or(u64::MAX).max(1)
+}

--- a/relay-server/src/processing/trace_metrics/validate.rs
+++ b/relay-server/src/processing/trace_metrics/validate.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn test_calculate_size_string_attribute() {
         assert_calculated_size_of!(
-            43,
+            55,
             r#"{
             "name": "test.metric",
             "value": 1.0,
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn test_calculate_size_full_metric() {
         assert_calculated_size_of!(
-            82,
+            66,
             r#"{
             "timestamp": 946684800.0,
             "trace_id": "5b8efff798038103d269b633813fc60c",

--- a/relay-server/src/processing/trace_metrics/validate.rs
+++ b/relay-server/src/processing/trace_metrics/validate.rs
@@ -1,11 +1,10 @@
 use relay_event_schema::protocol::{MetricType, TraceMetric};
 use relay_protocol::Annotated;
 
-use crate::envelope::WithHeader;
 use crate::managed::{Managed, Rejected};
 use crate::processing::Context;
 use crate::processing::trace_metrics::{
-    Error, ExpandedTraceMetrics, Result, SerializedTraceMetrics,
+    Error, ExpandedTraceMetrics, Result, SerializedTraceMetrics, get_calculated_byte_size,
 };
 use crate::services::outcome::DiscardReason;
 use crate::statsd::RelayDistributions;
@@ -44,7 +43,7 @@ pub fn size(metrics: &mut Managed<ExpandedTraceMetrics>, ctx: Context<'_>) {
     metrics.retain(
         |metrics| &mut metrics.metrics,
         |metric, _| {
-            let size = calculate_size(metric);
+            let size = get_calculated_byte_size(metric);
             let is_too_large = size > max_size_bytes;
 
             relay_statsd::metric!(
@@ -59,27 +58,6 @@ pub fn size(metrics: &mut Managed<ExpandedTraceMetrics>, ctx: Context<'_>) {
             }
         },
     );
-}
-
-/// Calculates the byte size for a trace metric.
-///
-/// Similar to [`relay_ourlogs::calculate_size`].
-fn calculate_size(metric: &WithHeader<TraceMetric>) -> usize {
-    let Some(metric) = metric.value() else {
-        // Same logic we use for logs.
-        return 1;
-    };
-
-    let mut size = 0;
-
-    size += metric.name.value().map_or(0, |s| s.len());
-    size += relay_event_normalization::eap::value_size(&metric.value);
-
-    if let Some(attributes) = metric.attributes.value() {
-        size += relay_event_normalization::eap::attributes_size(attributes);
-    }
-
-    size.max(1)
 }
 
 /// Validates the semantic validity of a trace metric.

--- a/relay-server/src/processing/trace_metrics/validate.rs
+++ b/relay-server/src/processing/trace_metrics/validate.rs
@@ -81,3 +81,165 @@ fn validate_trace_metric(metric: &Annotated<TraceMetric>) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::processing::trace_metrics::utils::calculate_size;
+
+    macro_rules! assert_calculated_size_of {
+        ($expected:expr, $json:expr) => {{
+            let json = $json;
+
+            let metric = Annotated::<TraceMetric>::from_json(json)
+                .unwrap()
+                .into_value()
+                .unwrap();
+
+            let size = calculate_size(&metric);
+            assert_eq!(size, $expected, "metric: {json}");
+        }};
+    }
+
+    #[test]
+    fn test_calculate_size_empty_metric_is_1byte() {
+        assert_calculated_size_of!(1, r#"{}"#);
+    }
+
+    #[test]
+    fn test_calculate_size_name_only() {
+        assert_calculated_size_of!(
+            11,
+            r#"{
+            "name": "test.metric"
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_name_and_value() {
+        assert_calculated_size_of!(
+            19,
+            r#"{
+            "name": "test.metric",
+            "value": 123.45
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_string_attribute() {
+        assert_calculated_size_of!(
+            43,
+            r#"{
+            "name": "test.metric",
+            "value": 1.0,
+            "attributes": {
+                "foo": {
+                    "value": "ඞ and some more equals 33 bytes",
+                    "type": "string"
+                }
+            }
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_integer_attribute() {
+        assert_calculated_size_of!(
+            30,
+            r#"{
+            "name": "test.metric",
+            "value": 1.0,
+            "attributes": {
+                "foo": {
+                    "value": 12,
+                    "type": "integer"
+                }
+            }
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_bool_attribute() {
+        assert_calculated_size_of!(
+            23,
+            r#"{
+            "name": "test.metric",
+            "value": 1.0,
+            "attributes": {
+                "foo": {
+                    "value": true,
+                    "type": "boolean"
+                }
+            }
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_null_attribute() {
+        assert_calculated_size_of!(
+            22,
+            r#"{
+            "name": "test.metric",
+            "value": 1.0,
+            "attributes": {
+                "foo": {
+                    "value": null,
+                    "type": "double"
+                }
+            }
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_full_metric() {
+        assert_calculated_size_of!(
+            82,
+            r#"{
+            "timestamp": 946684800.0,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "http.request.duration",
+            "type": "distribution",
+            "value": 123.45,
+            "attributes": {
+                "k1": {
+                    "value": "string value",
+                    "type": "string"
+                },
+                "k2": {
+                    "value": 18446744073709551615,
+                    "type": "integer"
+                },
+                "k3": {
+                    "value": 42.0,
+                    "type": "double"
+                },
+                "k4": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            }
+        }"#
+        );
+    }
+
+    #[test]
+    fn test_calculate_size_ignores_non_counted_fields() {
+        assert_calculated_size_of!(
+            19,
+            r#"{
+            "timestamp": 946684800.0,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b174",
+            "name": "test.metric",
+            "type": "distribution",
+            "unit": "millisecond",
+            "value": 123.45
+        }"#
+        );
+    }
+}

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -264,6 +264,9 @@ pub struct EnvelopeSummary {
 
     /// The number of trace metrics in this envelope.
     pub trace_metric_quantity: usize,
+
+    /// The number of trace metric bytes in this envelope.
+    pub trace_metric_byte_quantity: usize,
 }
 
 impl EnvelopeSummary {
@@ -345,6 +348,7 @@ impl EnvelopeSummary {
                 DataCategory::Monitor => &mut self.monitor_quantity,
                 DataCategory::Span => &mut self.span_quantity,
                 DataCategory::TraceMetric => &mut self.trace_metric_quantity,
+                DataCategory::TraceMetricByte => &mut self.trace_metric_byte_quantity,
                 DataCategory::LogItem => &mut self.log_item_quantity,
                 DataCategory::LogByte => &mut self.log_byte_quantity,
                 DataCategory::ProfileChunk => &mut self.profile_chunk_quantity,

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -123,7 +123,7 @@ def test_trace_metric_extraction(
         "traceId": "5b8efff798038103d269b633813fc60c",
     }
 
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=1)
+    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
     assert outcomes == [
         {
             "category": DataCategory.TRACE_METRIC.value,
@@ -132,7 +132,17 @@ def test_trace_metric_extraction(
             "outcome": 0,
             "project_id": 42,
             "quantity": 1,
-        }
+        },
+        {
+            "category": DataCategory.TRACE_METRIC_BYTE.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            # Calculated byte size: name + value + attribute keys/values.
+            # This is a billing relevant number, do not just adjust this because it changed.
+            "quantity": 241,
+        },
     ]
 
 
@@ -165,7 +175,7 @@ def test_trace_metric_validation(
     envelope = envelope_with_trace_metrics(invalid_payload)
     relay.send_envelope(project_id, envelope)
 
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=1)
+    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
     assert outcomes == [
         {
             "category": DataCategory.TRACE_METRIC.value,
@@ -175,7 +185,16 @@ def test_trace_metric_validation(
             "project_id": 42,
             "quantity": 1,
             "reason": "invalid_trace_metric",
-        }
+        },
+        {
+            "category": DataCategory.TRACE_METRIC_BYTE.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,  # Invalid
+            "project_id": 42,
+            "quantity": 19,
+            "reason": "invalid_trace_metric",
+        },
     ]
 
 
@@ -261,7 +280,7 @@ def test_trace_metric_pii_scrubbing(
         "traceId": "5b8efff798038103d269b633813fc60c",
     }
 
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=1)
+    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
     assert outcomes == [
         {
             "category": DataCategory.TRACE_METRIC.value,
@@ -270,7 +289,15 @@ def test_trace_metric_pii_scrubbing(
             "outcome": 0,
             "project_id": 42,
             "quantity": 1,
-        }
+        },
+        {
+            "category": DataCategory.TRACE_METRIC_BYTE.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 0,
+            "project_id": 42,
+            "quantity": 159,
+        },
     ]
 
 
@@ -323,6 +350,15 @@ def test_trace_metric_size_limits(
             "quantity": 1,
             "reason": "too_large:trace_metric",
         },
+        {
+            "category": 37,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 608,
+            "reason": "too_large:trace_metric",
+        },
     ]
 
 
@@ -362,6 +398,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
     envelope = mini_sentry.get_captured_envelope()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     assert item_payload["items"][0] == {
+        "__header": mock.ANY,
         "_meta": {
             "timestamp": {
                 "": {


### PR DESCRIPTION
Following from https://github.com/getsentry/relay/pull/5719, this behaves identically to log size calculations (or at least it should).
