### PR TITLE
WIP: Remove old standalone logic

### DIFF
--- a/relay-server/src/processing/profiles/mod.rs
+++ b/relay-server/src/processing/profiles/mod.rs
@@ -101,12 +101,6 @@ impl Processor for ProfilesProcessor {
         profiles: Managed<Self::Input>,
         ctx: Context<'_>,
     ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
-        relay_statsd::metric!(
-            counter(RelayCounters::StandaloneItem) += profiles.profiles.len() as u64,
-            processor = "new",
-            item_type = "profile",
-        );
-
         filter::feature_flag(ctx).reject(&profiles)?;
 
         let profile = process::expand(profiles)?;

--- a/relay-server/src/processing/user_reports/mod.rs
+++ b/relay-server/src/processing/user_reports/mod.rs
@@ -87,12 +87,6 @@ impl Processor for UserReportsProcessor {
         mut reports: Managed<Self::Input>,
         ctx: Context<'_>,
     ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
-        relay_statsd::metric!(
-            counter(RelayCounters::StandaloneItem) += reports.reports.len() as u64,
-            processor = "new",
-            item_type = "user_report",
-        );
-
         process::process(&mut reports);
 
         let reports = self.limiter.enforce_quotas(reports, ctx).await?;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1499,9 +1499,8 @@ impl EnvelopeProcessorService {
 
         let mut extracted_metrics = ProcessingExtractedMetrics::new();
 
+        // TODO: Not sure where to best move this logic
         standalone::process(managed_envelope);
-
-        profile::filter(managed_envelope, ctx.config, ctx.project_info);
 
         self.enforce_quotas(
             managed_envelope,
@@ -1510,8 +1509,6 @@ impl EnvelopeProcessorService {
             ctx,
         )
         .await?;
-
-        report::process_user_reports(managed_envelope);
 
         Ok(Some(extracted_metrics))
     }

--- a/relay-server/src/services/processor/profile.rs
+++ b/relay-server/src/services/processor/profile.rs
@@ -1,55 +1,9 @@
 //! Profiles related processor code.
 
-use relay_dynamic_config::Feature;
-
-use relay_config::Config;
-use relay_profiling::ProfileError;
-
-use crate::envelope::ItemType;
-use crate::managed::{ItemAction, TypedEnvelope};
-use crate::services::outcome::{DiscardReason, Outcome};
-use crate::services::processor::should_filter;
-use crate::services::projects::project::ProjectInfo;
-
-pub fn filter<Group>(
-    managed_envelope: &mut TypedEnvelope<Group>,
-    config: &Config,
-    project_info: &ProjectInfo,
-) {
-    let profiling_disabled = should_filter(config, project_info, Feature::Profiling);
-
-    let mut saw_profile = false;
-    managed_envelope.retain_items(|item| match item.ty() {
-        ItemType::Profile if profiling_disabled => ItemAction::DropSilently,
-        // First profile found in the envelope, we'll keep it if metadata are valid.
-        ItemType::Profile if !saw_profile => {
-            // Drop profile without a transaction in the same envelope,
-            // except if unsampled profiles are allowed for this project.
-            let profile_allowed = !item.sampled();
-            if !profile_allowed {
-                return ItemAction::DropSilently;
-            }
-
-            match relay_profiling::parse_metadata(&item.payload()) {
-                Ok(_) => {
-                    saw_profile = true;
-                    ItemAction::Keep
-                }
-                Err(err) => ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
-                    relay_profiling::discard_reason(&err),
-                ))),
-            }
-        }
-        // We found another profile, we'll drop it.
-        ItemType::Profile => ItemAction::Drop(Outcome::Invalid(DiscardReason::Profiling(
-            relay_profiling::discard_reason(&ProfileError::TooManyProfiles),
-        ))),
-        _ => ItemAction::Keep,
-    });
-}
-
+// TODO: Not sure what to do with these tests now
 #[cfg(test)]
 mod tests {
+    use crate::envelope::ItemType;
     use crate::envelope::{ContentType, Envelope, Item};
     use crate::extractors::RequestMeta;
     use crate::managed::ManagedEnvelope;
@@ -59,12 +13,11 @@ mod tests {
     use crate::services::projects::project::ProjectInfo;
     use crate::testutils::create_test_processor;
     use insta::assert_debug_snapshot;
+    use relay_config::Config;
     use relay_dynamic_config::{ErrorBoundary, Feature, GlobalConfig, TransactionMetricsConfig};
     use relay_event_schema::protocol::{Event, EventId, ProfileContext};
     use relay_protocol::Annotated;
     use relay_system::Addr;
-
-    use super::*;
 
     async fn process_event(envelope: Box<Envelope>) -> Result<Annotated<Event>, ProcessingError> {
         let config = Config::from_json_value(serde_json::json!({


### PR DESCRIPTION
Cleans up some of the old standalone processing logic.

Open Questions:
- [ ] What to do with standalone form data (only thing that `process_standalone` does now is drop silently).
- [ ] What to do with the profiling tests that are now the only thing in the file.
