### PR TITLE
fix(attachments): Add +json to placeholder content-type

### DIFF
--- a/relay-server/src/envelope/content_type.rs
+++ b/relay-server/src/envelope/content_type.rs
@@ -35,7 +35,7 @@ pub enum ContentType {
     TraceMetricContainer,
     /// `application/vnd.sentry.trace-attachment`
     TraceAttachment,
-    /// `application/vnd.sentry.attachment-ref`
+    /// `application/vnd.sentry.attachment-ref+json`
     AttachmentRef,
     /// All integration content types.
     Integration(Integration),
@@ -58,7 +58,7 @@ impl ContentType {
             Self::SpanV2Container => "application/vnd.sentry.items.span.v2+json",
             Self::TraceMetricContainer => "application/vnd.sentry.items.trace-metric+json",
             Self::TraceAttachment => "application/vnd.sentry.trace-attachment",
-            Self::AttachmentRef => "application/vnd.sentry.attachment-ref",
+            Self::AttachmentRef => "application/vnd.sentry.attachment-ref+json",
             Self::Integration(integration) => integration.as_content_type(),
         }
     }
@@ -104,7 +104,9 @@ impl ContentType {
             || ct.eq_ignore_ascii_case("application/vnd.sentry.attachment.v2")
         {
             Some(Self::TraceAttachment)
-        } else if ct.eq_ignore_ascii_case(Self::AttachmentRef.as_str()) {
+        } else if ct.eq_ignore_ascii_case(Self::AttachmentRef.as_str())
+            || ct.eq_ignore_ascii_case("application/vnd.sentry.attachment-ref")
+        {
             Some(Self::AttachmentRef)
         } else {
             Integration::from_content_type(ct).map(Self::Integration)
@@ -186,3 +188,20 @@ impl serde::Serialize for ContentType {
 }
 
 relay_common::impl_str_de!(ContentType, "a content type string");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attachment_ref_roundtrip() {
+        let canonical_name = "application/vnd.sentry.attachment-ref+json";
+        let ct = ContentType::from_str(canonical_name).unwrap();
+        assert_eq!(ct, ContentType::AttachmentRef);
+        assert_eq!(canonical_name, ct.as_str());
+
+        let legacy_alias = "application/vnd.sentry.attachment-ref";
+        let ct = ContentType::from_str(legacy_alias).unwrap();
+        assert_eq!(ct, ContentType::AttachmentRef);
+    }
+}

--- a/tests/integration/test_attachment_ref.py
+++ b/tests/integration/test_attachment_ref.py
@@ -13,7 +13,7 @@ def make_envelope(event_id):
             payload=PayloadRef(bytes=b""),
             headers={
                 "type": "attachment",
-                "content_type": "application/vnd.sentry.attachment-ref",
+                "content_type": "application/vnd.sentry.attachment-ref+json",
                 "attachment_length": 1,
             },
         )


### PR DESCRIPTION
Add a `+json` suffix to the attachment placeholder content type to signal that it is syntactically JSON. The old value is still parsed correctly for compatibility.

See https://www.rfc-editor.org/rfc/rfc6838#section-4.2.8.