### PR TITLE
feat(relay): Provide a flag to exit container on healthcheck failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Set `sentry.segment.id` and `sentry.segment.name` attributes on OTLP segment spans. ([#5748](https://github.com/getsentry/relay/pull/5748))
 - Envelope buffer: Add option to disable flush-to-disk on shutdown. ([#5751](https://github.com/getsentry/relay/pull/5751))
+- Healthcheck: Provide a flag to exit container on healthcheck failure. ([#5754](https://github.com/getsentry/relay/pull/5754))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,6 +4168,7 @@ dependencies = [
  "hostname 0.4.1",
  "http",
  "mimalloc",
+ "nix",
  "relay-config",
  "relay-kafka",
  "relay-log",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -32,4 +32,5 @@ relay-statsd = { workspace = true }
 relay-kafka = { workspace = true, optional = true }
 uuid = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "native-tls-vendored"] }
+nix = { version = "0.31.2", features = ["signal"] }
 mimalloc = { workspace = true, features = ["v3", "override", "debug_in_debug"] }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -32,5 +32,5 @@ relay-statsd = { workspace = true }
 relay-kafka = { workspace = true, optional = true }
 uuid = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "native-tls-vendored"] }
-nix = { version = "0.31.2", features = ["signal"] }
+nix = { version = "0.29.0", features = ["signal"] }
 mimalloc = { workspace = true, features = ["v3", "override", "debug_in_debug"] }

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -344,5 +344,11 @@ pub fn make_app() -> Command {
                         .value_parser(clap::value_parser!(SocketAddr))
                         .required(false),
                 )
+                .arg(
+                    Arg::new("kill-on-fail")
+                        .long("kill-on-fail")
+                        .action(ArgAction::SetTrue)
+                        .help("Send SIGTERM to PID 1 if the healthcheck fails."),
+                )
         )
 }

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -348,7 +348,7 @@ pub fn make_app() -> Command {
                     Arg::new("kill-on-fail")
                         .long("kill-on-fail")
                         .action(ArgAction::SetTrue)
-                        .help("Send SIGTERM to PID 1 if the healthcheck fails."),
+                        .help("Send SIGTERM to PID 1 if the healthcheck fails.")
                         .required(false),
                 )
         )

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -349,6 +349,7 @@ pub fn make_app() -> Command {
                         .long("kill-on-fail")
                         .action(ArgAction::SetTrue)
                         .help("Send SIGTERM to PID 1 if the healthcheck fails."),
+                        .required(false),
                 )
         )
 }

--- a/relay/src/healthcheck.rs
+++ b/relay/src/healthcheck.rs
@@ -33,13 +33,17 @@ pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
         .get(format!("http://{addr}/api/relay/healthcheck/{mode}/"))
         .send();
 
+    let kill_on_fail = matches.get_flag("kill-on-fail");
+
     match response {
         Ok(response) => {
             if response.status().is_success() {
                 Ok(())
             } else {
                 relay_log::error!("Relay is unhealthy. Status code: {}", response.status());
-                signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
+                if kill_on_fail {
+                    signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
+                }
                 Err(format_err!(
                     "Relay is unhealthy. Status code: {}",
                     response.status()
@@ -48,7 +52,9 @@ pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
         }
         Err(err) => {
             relay_log::error!("Relay is unhealthy. Error: {err}");
-            signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
+            if kill_on_fail {
+                signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
+            }
             Err(err.into())
         }
     }

--- a/relay/src/healthcheck.rs
+++ b/relay/src/healthcheck.rs
@@ -6,6 +6,9 @@ use clap::ArgMatches;
 use relay_config::Config;
 use reqwest::blocking::Client;
 
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+
 pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
     let mode = matches
         .get_one::<String>("mode")
@@ -36,6 +39,7 @@ pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
                 Ok(())
             } else {
                 relay_log::error!("Relay is unhealthy. Status code: {}", response.status());
+                signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
                 Err(format_err!(
                     "Relay is unhealthy. Status code: {}",
                     response.status()
@@ -44,6 +48,7 @@ pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
         }
         Err(err) => {
             relay_log::error!("Relay is unhealthy. Error: {err}");
+            signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
             Err(err.into())
         }
     }

--- a/relay/src/healthcheck.rs
+++ b/relay/src/healthcheck.rs
@@ -42,7 +42,10 @@ pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
             } else {
                 relay_log::error!("Relay is unhealthy. Status code: {}", response.status());
                 if kill_on_fail {
-                    signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
+                    relay_log::error!("Sending SIGTERM to PID 1 to exit container.");
+                    if let Err(err) = signal::kill(Pid::from_raw(1), Signal::SIGTERM) {
+                        relay_log::error!("Failed to send SIGTERM to PID 1: {err}");
+                    }
                 }
                 Err(format_err!(
                     "Relay is unhealthy. Status code: {}",
@@ -53,7 +56,10 @@ pub fn healthcheck(config: &Config, matches: &ArgMatches) -> Result<()> {
         Err(err) => {
             relay_log::error!("Relay is unhealthy. Error: {err}");
             if kill_on_fail {
-                signal::kill(Pid::from_raw(1), Signal::SIGTERM).ok();
+                relay_log::error!("Sending SIGTERM to PID 1 to exit container.");
+                if let Err(err) = signal::kill(Pid::from_raw(1), Signal::SIGTERM) {
+                    relay_log::error!("Failed to send SIGTERM to PID 1: {err}");
+                }
             }
             Err(err.into())
         }


### PR DESCRIPTION
Another attempt of fixing https://github.com/getsentry/sentry/issues/109002 after https://github.com/getsentry/relay/pull/5750.

`docker-compose` does not restart services if they become unhealthy for any reason whether it's `web` container not accessible and returning `NXDOMAIN` or any another reason, this PR adds a kill signal to PID 1 to healthcheck failures which can be enabled using `kill-on-fail` argument, effectively stopping container, and as `restart_policy` is `unless-stopped` in self-hosted, it should restart itself.

This may rises a problem of getting `relay` in a restart loop if it does not get healthy, which is fine IMO.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
