### PR TITLE
ref(upload): Subtract request age from upstream timeout

### DIFF
--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -3,12 +3,12 @@
 //! Crashes are received as multipart uploads in this [format](https://game.develop.playstation.net/resources/documents/SDK/12.000/Core_Dump_System-Overview/ps5-core-dump-file-set-sending-format.html).
 use std::io;
 use std::str::FromStr;
+use std::time::Instant;
 
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
-use chrono::Utc;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
 use http::StatusCode;
@@ -113,7 +113,7 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
         };
         let result = upload
             .send(Stream {
-                received: Utc::now(),
+                received: Instant::now(),
                 scoping: self.scoping,
                 location,
                 stream,

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -6,6 +6,7 @@
 //! Reference: <https://tus.io/protocols/resumable-upload#creation-with-upload>
 
 use std::io;
+use std::time::Instant;
 
 use axum::body::Body;
 use axum::extract::{Path, Query};
@@ -13,7 +14,6 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, NoContent, Response};
 use axum::routing::{MethodRouter, patch, post};
 use bytes::Bytes;
-use chrono::Utc;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use http::header;
@@ -268,7 +268,7 @@ async fn upload(
     let location = state
         .upload()
         .send(upload::Stream {
-            received: Utc::now(),
+            received: Instant::now(),
             scoping,
             location,
             stream,

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use bytes::Bytes;
 use chrono::DateTime;
@@ -93,7 +94,7 @@ pub struct Create {
 /// A stream of bytes to be uploaded to objectstore or the upstream.
 pub struct Stream {
     /// Time of arrival of the request.
-    pub received: DateTime<Utc>,
+    pub received: Instant,
     /// The organization & project that the stream belongs to.
     pub scoping: Scoping,
     /// The location to upload to.
@@ -214,7 +215,7 @@ impl Service {
                     project_id,
                     key,
                     length,
-                } = location.verify(received, config)?;
+                } = location.verify(Utc::now() - received.elapsed(), config)?;
 
                 debug_assert_eq!(scoping.project_id, project_id);
                 debug_assert!(stream.length().is_none_or(|l| Some(l) == length));
@@ -439,6 +440,7 @@ enum RequestKind {
         length: Option<usize>,
     },
     Upload {
+        received: Instant,
         location: SignedLocation,
         stream: Option<BoundedStream<BoxStream<'static, std::io::Result<Bytes>>>>,
     },
@@ -482,7 +484,7 @@ impl UploadRequest {
         let (sender, rx) = oneshot::channel();
         let Stream {
             scoping,
-            received: _,
+            received,
             location,
             stream,
         } = stream;
@@ -492,6 +494,7 @@ impl UploadRequest {
                 scoping,
                 timeout: None, // will be set by `configure()`
                 kind: RequestKind::Upload {
+                    received,
                     location,
                     stream: Some(stream),
                 },
@@ -588,6 +591,10 @@ impl UpstreamRequest for UploadRequest {
             "timeout should be set by UpstreamRequest::configure()"
         );
         if let Some(timeout) = self.timeout {
+            let timeout = match self.kind {
+                RequestKind::Upload { received, .. } => timeout.saturating_sub(received.elapsed()),
+                RequestKind::Create { .. } => timeout,
+            };
             builder.timeout(timeout);
         }
 


### PR DESCRIPTION
Pass `received` into the `Upload` variant of `RequestKind` and use the elapsed time since arrival to reduce the upstream request timeout, avoiding the case where the total time exceeds the configured timeout.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
