### PR TITLE
feat(server): Verbose error on QueueFailed

### DIFF
--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
 use crate::managed::{Managed, Rejected};
 use crate::service::ServiceState;
-use crate::services::buffer::ProjectKeyPair;
+use crate::services::buffer::{ProjectKeyPair, PushError};
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome};
 use crate::services::processor::{BucketSource, MetricData, ProcessMetrics};
 use crate::statsd::{RelayCounters, RelayDistributions};
@@ -82,7 +82,7 @@ pub enum BadStoreRequest {
     InvalidEventId,
 
     #[error("failed to queue envelope")]
-    QueueFailed,
+    QueueFailed(#[source] PushError),
 
     #[error(
         "envelope exceeded size limits for type '{0}' (https://develop.sentry.dev/sdk/envelopes/#size-limits)"
@@ -121,7 +121,7 @@ impl IntoResponse for BadStoreRequest {
 
                 (StatusCode::TOO_MANY_REQUESTS, headers, body).into_response()
             }
-            BadStoreRequest::QueueFailed => {
+            BadStoreRequest::QueueFailed(_) => {
                 // These errors indicate that something's wrong with our service system, most likely
                 // mailbox congestion or a faulty shutdown. Indicate an unavailable service to the
                 // client. It might retry event submission at a later time.
@@ -304,14 +304,10 @@ fn queue_envelope(
     }
 
     let pkp = ProjectKeyPair::from_envelope(&envelope);
-    if let Err(envelope) = state.envelope_buffer(pkp).try_push(envelope) {
-        return Err(envelope.reject_err((
-            Outcome::Invalid(DiscardReason::Internal),
-            BadStoreRequest::QueueFailed,
-        )));
-    }
-
-    Ok(())
+    state
+        .envelope_buffer(pkp)
+        .try_push(envelope)
+        .map_err(|e| e.map(BadStoreRequest::QueueFailed))
 }
 
 /// Handles an envelope store request.
@@ -333,7 +329,7 @@ pub async fn handle_envelope(
     if state.memory_checker().check_memory().is_exceeded() {
         return Err(envelope.reject_err((
             Outcome::Invalid(DiscardReason::Internal),
-            BadStoreRequest::QueueFailed,
+            BadStoreRequest::QueueFailed(PushError::OutOfMemory),
         )));
     };
 

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -31,7 +31,7 @@ use crate::statsd::RelayCounters;
 
 use crate::MemoryChecker;
 use crate::MemoryStat;
-use crate::managed::{Managed, ManagedEnvelope};
+use crate::managed::{Managed, ManagedEnvelope, OutcomeError, Rejected};
 
 // pub for benchmarks
 pub use envelope_buffer::EnvelopeBufferError;
@@ -171,6 +171,26 @@ pub struct EnvelopeBufferMetrics {
     storage_size: AtomicU64,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum PushError {
+    #[error("relay is running out of memory")]
+    OutOfMemory,
+    #[error("relay is shutting down")]
+    Shutdown,
+    #[error("envelope buffer channel is closed")]
+    ChannelClosed,
+    #[error("envelope buffer does not have capacity")]
+    Capacity,
+}
+
+impl OutcomeError for PushError {
+    type Error = Self;
+
+    fn consume(self) -> (Option<Outcome>, Self::Error) {
+        (Some(Outcome::Invalid(DiscardReason::Internal)), self)
+    }
+}
+
 /// Contains the services [`Addr`] and a watch channel to observe its state.
 ///
 /// This allows outside observers to check the capacity without having to send a message.
@@ -194,20 +214,20 @@ impl ObservableEnvelopeBuffer {
     ///
     /// Returns `false`, if the envelope buffer does not have enough capacity,
     /// or if the process is shutting down.
-    pub fn try_push(&self, envelope: Managed<Box<Envelope>>) -> Result<(), Managed<Box<Envelope>>> {
+    pub fn try_push(&self, envelope: Managed<Box<Envelope>>) -> Result<(), Rejected<PushError>> {
         if self.shutdown_handle.shutting_down() {
             relay_log::trace!("Shutting down, envelope rejected");
-            return Err(envelope);
+            return Err(envelope.reject_err(PushError::Shutdown));
         }
 
         if self.addr.is_closed() {
             // This should not happen as it should be covered by the branch above.
             relay_log::error!("Pushing envelope after envelope buffer dropped");
-            return Err(envelope);
+            return Err(envelope.reject_err(PushError::ChannelClosed));
         }
 
         if !self.has_capacity() {
-            return Err(envelope);
+            return Err(envelope.reject_err(PushError::Capacity));
         }
 
         self.addr.send(EnvelopeBuffer::Push(envelope.into()));


### PR DESCRIPTION
Get a bit more information out of the `QueueFailed` sentry error, so we can verify that we only reject envelopes during shutdown.