### PR TITLE
feat(tracemetrics): Add payload size to traceitem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 - TUS: Disallow creation with upload. ([#5734](https://github.com/getsentry/relay/pull/5734))
 - Remove continuous-profiling-beta feature flags. ([#5762](https://github.com/getsentry/relay/pull/5762))
-- Add payload byte size to trace metrics ([#5764](https://github.com/getsentry/relay/pull/5764))
+- Add payload byte size to trace metrics. ([#5764](https://github.com/getsentry/relay/pull/5764))
 
 ## 26.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 - TUS: Disallow creation with upload. ([#5734](https://github.com/getsentry/relay/pull/5734))
 - Remove continuous-profiling-beta feature flags. ([#5762](https://github.com/getsentry/relay/pull/5762))
+- Add payload byte size to trace metrics ([#5764](https://github.com/getsentry/relay/pull/5764))
 
 ## 26.3.1
 

--- a/relay-server/src/processing/trace_metrics/store.rs
+++ b/relay-server/src/processing/trace_metrics/store.rs
@@ -46,6 +46,11 @@ pub struct Context {
 
 pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTraceItem> {
     let quantities = metric.quantities();
+    let payload_size_bytes = metric
+        .header
+        .as_ref()
+        .and_then(|h| h.byte_size)
+        .unwrap_or_default();
 
     let metric = required!(metric.value);
     let timestamp = required!(metric.timestamp);
@@ -59,6 +64,7 @@ pub fn convert(metric: WithHeader<TraceMetric>, ctx: &Context) -> Result<StoreTr
         value: extract_numeric_value(required!(metric.value))?,
         timestamp,
         span_id: metric.span_id.into_value(),
+        payload_size_bytes,
     };
 
     let client_sample_rate = extract_client_sample_rate(&attrs).unwrap_or(1.0);
@@ -96,6 +102,7 @@ struct FieldAttributes {
     value: f64,
     timestamp: relay_event_schema::protocol::Timestamp,
     span_id: Option<SpanId>,
+    payload_size_bytes: u64,
 }
 
 fn extract_numeric_value(value: Value) -> Result<f64> {
@@ -125,6 +132,7 @@ fn attributes(
         value,
         timestamp,
         span_id,
+        payload_size_bytes,
     } = fields;
 
     result.insert(
@@ -198,6 +206,13 @@ fn attributes(
             },
         );
     }
+
+    result.insert(
+        "sentry.payload_size_bytes".to_owned(),
+        AnyValue {
+            value: Some(any_value::Value::IntValue(payload_size_bytes as i64)),
+        },
+    );
 
     result
 }

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -98,6 +98,9 @@ def test_trace_metric_extraction(
                     precision="us",
                 )
             },
+            "sentry.payload_size_bytes": {
+                "intValue": "241",
+            },
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
             "sentry.client_sample_rate": {"doubleValue": 0.25},
             "sentry.browser.name": {"stringValue": mock.ANY},
@@ -256,6 +259,9 @@ def test_trace_metric_pii_scrubbing(
                     expect_resolution="ns",
                     precision="us",
                 )
+            },
+            "sentry.payload_size_bytes": {
+                "intValue": "159",
             },
             "sentry.browser.name": {"stringValue": mock.ANY},
             "sentry.browser.version": {"stringValue": mock.ANY},


### PR DESCRIPTION
Adds payload size so we can catch it in analytics and show it in the UI for debugging large metrics.
