### PR TITLE
fix(otlp): Store segment name in `sentry.transaction` too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**:
 
+- Store segment name in `sentry.transaction` in addition to `sentry.segment.name` on OTLP spans. ([#5765](https://github.com/getsentry/relay/pull/5765))
 - Explicitly reject in-flight requests during shutdown. ([#5746](https://github.com/getsentry/relay/pull/5746))
 
 **Features**:

--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -75,6 +75,7 @@ convention_attributes!(
     SENTRY_GROUP => "sentry.group",
     SENTRY_NORMALIZED_DESCRIPTION => "sentry.normalized_description",
     SENTRY_STATUS_CODE => "sentry.status_code",
+    SENTRY_TRANSACTION => "sentry.transaction",
     SERVER_ADDRESS => "server.address",
     SPAN_KIND => "sentry.kind",
     STATUS_MESSAGE => "sentry.status.message",

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -8,6 +8,7 @@ use relay_conventions::ORIGIN;
 use relay_conventions::PLATFORM;
 use relay_conventions::SEGMENT_ID;
 use relay_conventions::SEGMENT_NAME;
+use relay_conventions::SENTRY_TRANSACTION;
 use relay_conventions::SPAN_KIND;
 use relay_conventions::STATUS_MESSAGE;
 use relay_event_schema::protocol::{Attributes, SpanKind};
@@ -133,6 +134,7 @@ pub fn otel_to_sentry_span(
         }
         if let Some(ref segment_name) = name {
             sentry_attributes.insert(SEGMENT_NAME, segment_name.clone());
+            sentry_attributes.insert(SENTRY_TRANSACTION, segment_name.clone());
         }
     }
 
@@ -987,6 +989,10 @@ mod tests {
               "value": "e342abb1214ca181"
             },
             "sentry.segment.name": {
+              "type": "string",
+              "value": "my segment span"
+            },
+            "sentry.transaction": {
               "type": "string",
               "value": "my segment span"
             }

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -123,6 +123,7 @@ def test_span_ingestion(
             "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
             "sentry.segment.id": {"type": "string", "value": "f0b809703e783d00"},
             "sentry.segment.name": {"type": "string", "value": "A Proto Span"},
+            "sentry.transaction": {"type": "string", "value": "A Proto Span"},
             "sentry.kind": {"type": "string", "value": "server"},
             "ui.component_name": {"type": "string", "value": "MyComponent"},
         },


### PR DESCRIPTION
It turns out that the product [currently uses `sentry.transaction` rather than `sentry.segment.name` to back the `transaction` field in search](https://github.com/getsentry/sentry/blob/4e55c5d71621f6204463fc152959ab02e3de2e0f/src/sentry/search/eap/spans/attributes.py#L145-L149). Really we should deprecate one or the other and backfill, but the odds of breaking something are high if we do that directly. By double-writing just for OTel we can experiment and confirm our approach before moving to a deprecation in [sentry-conventions](https://github.com/getsentry/sentry-conventions) (at which point we will remove one of the two `segment_name` writes here).