### PR TITLE
fix(ourlogs): Emit outcomes in both categories when logs are dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Store segment name in `sentry.transaction` in addition to `sentry.segment.name` on OTLP spans. ([#5765](https://github.com/getsentry/relay/pull/5765))
 - Explicitly reject in-flight requests during shutdown. ([#5746](https://github.com/getsentry/relay/pull/5746))
+- Emit outcomes in both `log_byte` and `log_item` categories when logs are dropped. ([#5766](https://github.com/getsentry/relay/pull/5766))
 
 **Features**:
 

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1073,20 +1073,25 @@ where
         }
 
         // Handle logs.
+        let mut log_limits = RateLimits::new();
         if summary.log_item_quantity > 0 {
             let item_scoping = scoping.item(DataCategory::LogItem);
-            let log_limits = self
+            log_limits = self
                 .check
                 .apply(item_scoping, summary.log_item_quantity)
                 .await?;
+            enforcement.log_bytes = CategoryLimit::new(
+                DataCategory::LogByte,
+                summary.log_byte_quantity,
+                log_limits.longest(),
+            );
             enforcement.log_items = CategoryLimit::new(
                 DataCategory::LogItem,
                 summary.log_item_quantity,
                 log_limits.longest(),
             );
-            rate_limits.merge(log_limits);
         }
-        if summary.log_byte_quantity > 0 {
+        if !log_limits.is_limited() && summary.log_byte_quantity > 0 {
             let item_scoping = scoping.item(DataCategory::LogByte);
             let log_limits = self
                 .check
@@ -1097,8 +1102,13 @@ where
                 summary.log_byte_quantity,
                 log_limits.longest(),
             );
-            rate_limits.merge(log_limits);
+            enforcement.log_items = CategoryLimit::new(
+                DataCategory::LogItem,
+                summary.log_item_quantity,
+                log_limits.longest(),
+            );
         }
+        rate_limits.merge(log_limits);
 
         // Handle profiles.
         if enforcement.is_event_active() {

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -1093,7 +1093,7 @@ where
         }
         if !log_limits.is_limited() && summary.log_byte_quantity > 0 {
             let item_scoping = scoping.item(DataCategory::LogByte);
-            let log_limits = self
+            log_limits = self
                 .check
                 .apply(item_scoping, summary.log_byte_quantity)
                 .await?;
@@ -2251,9 +2251,11 @@ mod tests {
         assert!(limits.is_limited());
         assert_eq!(envelope.envelope().len(), 0);
         mock.lock().await.assert_call(DataCategory::LogItem, 2);
-        mock.lock().await.assert_call(DataCategory::LogByte, 20);
 
-        assert_eq!(get_outcomes(enforcement), vec![(DataCategory::LogItem, 2)]);
+        assert_eq!(
+            get_outcomes(enforcement),
+            vec![(DataCategory::LogItem, 2), (DataCategory::LogByte, 20)]
+        );
     }
 
     #[tokio::test]
@@ -2268,7 +2270,10 @@ mod tests {
         mock.lock().await.assert_call(DataCategory::LogItem, 2);
         mock.lock().await.assert_call(DataCategory::LogByte, 20);
 
-        assert_eq!(get_outcomes(enforcement), vec![(DataCategory::LogByte, 20)]);
+        assert_eq!(
+            get_outcomes(enforcement),
+            vec![(DataCategory::LogItem, 2), (DataCategory::LogByte, 20)]
+        );
     }
 
     #[tokio::test]

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone, timedelta
 from unittest import mock
 import uuid
 
+from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
@@ -127,8 +128,8 @@ def test_ourlog_multiple_containers_not_allowed(
     "categories",
     [
         pytest.param(["log_item"], id="item"),
-        pytest.param(["log_byte"], id="bytes"),
-        pytest.param(["log_item", "log_bytes"], id="both"),
+        pytest.param(["log_byte"], id="byte"),
+        pytest.param(["log_item", "log_byte"], id="both"),
     ],
 )
 def test_fast_path_rate_limits(mini_sentry, relay, categories):
@@ -147,7 +148,7 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
         for category in categories
     ]
 
-    relay = relay(mini_sentry)
+    relay = relay(mini_sentry, TEST_CONFIG)
     start = datetime.now(timezone.utc)
 
     envelope = envelope_with_sentry_logs(
@@ -162,12 +163,52 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
     response = relay.send_envelope(project_id, envelope)
     assert response.status_code == 200  # project config not yet loaded
 
-    # assert mini_sentry.get_aggregated_outcomes() == ["TODO"]
+    assert mini_sentry.get_aggregated_outcomes() == [
+        {
+            "category": 23,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,
+            "project_id": 42,
+            "reason": "no_more_quota",
+            "quantity": 1,
+        },
+        {
+            "category": 24,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,
+            "project_id": 42,
+            "reason": "no_more_quota",
+            "quantity": 162,
+        },
+    ]
 
-    response = relay.send_envelope(project_id, envelope)
-    assert response.status_code == 429  # project config loaded
+    with pytest.raises(HTTPError, match="429 Client Error"):
+        response = relay.send_envelope(project_id, envelope)
 
-    # assert mini_sentry.get_aggregated_outcomes() == ["TODO"]
+    assert mini_sentry.get_aggregated_outcomes() == [
+        {
+            "category": 23,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,
+            "project_id": 42,
+            "reason": "no_more_quota",
+            "quantity": 1,
+        },
+        {
+            "category": 24,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,
+            "project_id": 42,
+            "reason": "no_more_quota",
+            "quantity": 162,
+        },
+    ]
+
+    # TODO: copy this test to metrics
 
 
 @pytest.mark.parametrize("eap_emits_outcomes", [True, False])

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -149,7 +149,7 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
     ]
 
     relay = relay(mini_sentry, TEST_CONFIG)
-    start = datetime.now(timezone.utc)
+    start = datetime.now(timezone.utc).replace(microsecond=0)
 
     envelope = envelope_with_sentry_logs(
         {
@@ -180,7 +180,7 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
             "outcome": 2,
             "project_id": 42,
             "reason": "no_more_quota",
-            "quantity": 162,
+            "quantity": 157,
         },
     ]
 
@@ -204,7 +204,7 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
             "outcome": 2,
             "project_id": 42,
             "reason": "no_more_quota",
-            "quantity": 162,
+            "quantity": 157,
         },
     ]
 

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -2,6 +2,7 @@ import json
 
 from datetime import datetime, timezone, timedelta
 from unittest import mock
+import uuid
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
@@ -120,6 +121,53 @@ def test_ourlog_multiple_containers_not_allowed(
             "reason": "duplicate_item",
         },
     ]
+
+
+@pytest.mark.parametrize(
+    "categories",
+    [
+        pytest.param(["log_item"], id="item"),
+        pytest.param(["log_byte"], id="bytes"),
+        pytest.param(["log_item", "log_bytes"], id="both"),
+    ],
+)
+def test_fast_path_rate_limits(mini_sentry, relay, categories):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:ourlogs-ingestion",
+    ]
+    project_config["config"]["quotas"] = [
+        {
+            "id": f"test_rate_limiting_{uuid.uuid4().hex}",
+            "categories": [category],
+            "limit": 0,
+            "reasonCode": "no_more_quota",
+        }
+        for category in categories
+    ]
+
+    relay = relay(mini_sentry)
+    start = datetime.now(timezone.utc)
+
+    envelope = envelope_with_sentry_logs(
+        {
+            "timestamp": start.timestamp(),
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b175",
+            "level": "error",
+            "body": "This is really bad",
+        }
+    )
+    response = relay.send_envelope(project_id, envelope)
+    assert response.status_code == 200  # project config not yet loaded
+
+    # assert mini_sentry.get_aggregated_outcomes() == ["TODO"]
+
+    response = relay.send_envelope(project_id, envelope)
+    assert response.status_code == 429  # project config loaded
+
+    # assert mini_sentry.get_aggregated_outcomes() == ["TODO"]
 
 
 @pytest.mark.parametrize("eap_emits_outcomes", [True, False])


### PR DESCRIPTION
Looks like we only emitted outcomes in the category for which the rate limit was defined (`log_item` vs `log_byte`).

Follow-up: Do the same for trace metrics.