### PR TITLE
feat(server): Accept inflight requests during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 **Bug Fixes**:
 
 - Store segment name in `sentry.transaction` in addition to `sentry.segment.name` on OTLP spans. ([#5765](https://github.com/getsentry/relay/pull/5765))
-- Explicitly reject in-flight requests during shutdown. ([#5746](https://github.com/getsentry/relay/pull/5746))
+- Explicitly handle in-flight requests during shutdown. ([#5746](https://github.com/getsentry/relay/pull/5746), [#5769](https://github.com/getsentry/relay/pull/5769))
 - Emit outcomes in both `log_byte` and `log_item` categories when logs are dropped. ([#5766](https://github.com/getsentry/relay/pull/5766))
 
 **Features**:

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -11,11 +11,11 @@ use ahash::RandomState;
 use chrono::DateTime;
 use chrono::Utc;
 use relay_config::Config;
+use relay_system::Receiver;
 use relay_system::ServiceSpawn;
 use relay_system::ServiceSpawnExt as _;
 use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
 use relay_system::{Controller, Shutdown};
-use relay_system::{Receiver, ShutdownHandle};
 use tokio::sync::watch;
 use tokio::time::{Instant, timeout};
 
@@ -175,8 +175,6 @@ pub struct EnvelopeBufferMetrics {
 pub enum PushError {
     #[error("relay is running out of memory")]
     OutOfMemory,
-    #[error("relay is shutting down")]
-    Shutdown,
     #[error("envelope buffer channel is closed")]
     ChannelClosed,
     #[error("envelope buffer does not have capacity")]
@@ -201,7 +199,6 @@ impl OutcomeError for PushError {
 pub struct ObservableEnvelopeBuffer {
     addr: Addr<EnvelopeBuffer>,
     metrics: Arc<EnvelopeBufferMetrics>,
-    shutdown_handle: ShutdownHandle,
 }
 
 impl ObservableEnvelopeBuffer {
@@ -215,14 +212,9 @@ impl ObservableEnvelopeBuffer {
     /// Returns `false`, if the envelope buffer does not have enough capacity,
     /// or if the process is shutting down.
     pub fn try_push(&self, envelope: Managed<Box<Envelope>>) -> Result<(), Rejected<PushError>> {
-        if self.shutdown_handle.shutting_down() {
-            relay_log::trace!("Shutting down, envelope rejected");
-            return Err(envelope.reject_err(PushError::Shutdown));
-        }
-
         if self.addr.is_closed() {
-            // This should not happen as it should be covered by the branch above.
-            relay_log::error!("Pushing envelope after envelope buffer dropped");
+            // This happens for inflight requests when `ephemeral: false`.
+            relay_log::warn!("Pushing envelope after envelope buffer shutdown");
             return Err(envelope.reject_err(PushError::ChannelClosed));
         }
 
@@ -304,13 +296,8 @@ impl EnvelopeBufferService {
     pub fn start_in(self, services: &dyn ServiceSpawn) -> ObservableEnvelopeBuffer {
         let metrics = self.metrics.clone();
         let addr = services.start(self);
-        let shutdown_handle = Controller::shutdown_handle();
 
-        ObservableEnvelopeBuffer {
-            addr,
-            metrics,
-            shutdown_handle,
-        }
+        ObservableEnvelopeBuffer { addr, metrics }
     }
 
     /// Wait for the configured amount of time and make sure the project cache is ready to receive.

--- a/tests/integration/test_shutdown.py
+++ b/tests/integration/test_shutdown.py
@@ -5,8 +5,11 @@ import socket
 import time
 import tempfile
 
+import pytest
 
-def test_graceful_shutdown(mini_sentry, relay):
+
+@pytest.mark.parametrize("storage", ["ephemeral", "permanent"])
+def test_graceful_shutdown(mini_sentry, relay, storage):
     """
     On SIGTERM, relay completes any in-flight HTTP requests before shutting down.
     New connections are rejected once the TCP listener closes.
@@ -15,6 +18,7 @@ def test_graceful_shutdown(mini_sentry, relay):
     headers and the first byte of the body, then send SIGTERM, then send the rest
     of the body.  Relay must process and respond to the request before it exits.
     """
+    is_ephemeral = storage == "ephemeral"
     project_id = 42
     mini_sentry.add_basic_project_config(project_id)
 
@@ -25,7 +29,9 @@ def test_graceful_shutdown(mini_sentry, relay):
             mini_sentry,
             options={
                 "limits": {"shutdown_timeout": 5},
-                "spool": {"envelopes": {"path": db_file_path}},
+                "spool": {
+                    "envelopes": {"path": db_file_path, "ephemeral": is_ephemeral}
+                },
             },
         )
 
@@ -63,12 +69,12 @@ def test_graceful_shutdown(mini_sentry, relay):
             response += chunk
         sock.close()
 
-        assert b"HTTP/1.1 503" in response
+        expected_status_code = b"HTTP/1.1 200" if is_ephemeral else b"HTTP/1.1 503"
+        assert expected_status_code in response
 
-        # After relay exits, new connections are refused.
-        relay.wait_for_exit(timeout=10)
-        try:
-            socket.create_connection((host, port))
-            assert False, "Expected connection to be refused after relay exited"
-        except ConnectionRefusedError:
-            pass
+        if is_ephemeral:
+            envelope = mini_sentry.get_captured_envelope()
+            assert (
+                envelope.get_event()["logentry"]["formatted"]
+                == "in-flight during shutdown"
+            )

--- a/tests/integration/test_shutdown.py
+++ b/tests/integration/test_shutdown.py
@@ -78,3 +78,5 @@ def test_graceful_shutdown(mini_sentry, relay, storage):
                 envelope.get_event()["logentry"]["formatted"]
                 == "in-flight during shutdown"
             )
+        else:
+            assert mini_sentry.captured_envelopes.empty()


### PR DESCRIPTION
With https://github.com/getsentry/relay/pull/5746 and https://github.com/getsentry/relay/pull/5751, we should be able to process all inflight requests even during shutdown.

Previous behavior:

1. Relay receives SIGTERM
2. All inflight requests (i.e. requests that have not been written into the buffer) are rejected with 503

New behavior:

1. Relay receives SIGTERM
1. Depending on `spool.envelopes.ephemeral`:
    1. if `true` (which it is in SaaS), the envelope buffer service will keep accepting & processing envelopes until the process is killed. Inflight requests are accepted with 200 because the `Addr` of the envelope buffer service is still open.
    2. if `false`, the envelope buffer will flush its in-memory state to disk and stop accepting envelopes. Inflight requests are rejected with 503 like before.

Note that the axum server rejects all requests once the shutdown signal has been received, so this only affects requests that are already being handled while the envelope buffer shuts down.

Fixes INGEST-510