### PR TITLE
fix(playstation): Do not upload attachments if rate limited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 - TUS: Disallow creation with upload. ([#5734](https://github.com/getsentry/relay/pull/5734))
 - Remove continuous-profiling-beta feature flags. ([#5762](https://github.com/getsentry/relay/pull/5762))
+- Playstation: Do not upload attachments if quota is 0. ([#5770](https://github.com/getsentry/relay/pull/5770))
 
 ## 26.3.1
 

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -170,10 +170,12 @@ async fn extract_multipart(
     let scoping = project_config
         .scoping(meta.public_key())
         .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
-    let attachment_rate_limits = || project.rate_limits().current_limits().check_with_quotas(
-        project_config.get_quotas(),
-        scoping.item(DataCategory::Attachment),
-    );
+    let attachment_rate_limits = || {
+        project.rate_limits().current_limits().check_with_quotas(
+            project_config.get_quotas(),
+            scoping.item(DataCategory::Attachment),
+        )
+    };
     let upload_service = (project_config.has_feature(Feature::PlaystationUploads)
         && !attachment_rate_limits().is_limited())
     .then_some(state.upload());

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -170,12 +170,12 @@ async fn extract_multipart(
     let scoping = project_config
         .scoping(meta.public_key())
         .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
-    let attachment_rate_limits = project.rate_limits().current_limits().check_with_quotas(
+    let attachment_rate_limits = || project.rate_limits().current_limits().check_with_quotas(
         project_config.get_quotas(),
         scoping.item(DataCategory::Attachment),
     );
     let upload_service = (project_config.has_feature(Feature::PlaystationUploads)
-        && !attachment_rate_limits.is_limited())
+        && !attachment_rate_limits().is_limited())
     .then_some(state.upload());
     let attachment_strategy = PlaystationAttachmentStrategy {
         scoping,

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -16,7 +16,7 @@ use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;
-use relay_quotas::Scoping;
+use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use serde::Serialize;
 
@@ -27,7 +27,7 @@ use crate::extractors::{RawContentType, RequestMeta};
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::DiscardReason;
-use crate::services::projects::project::ProjectInfo;
+use crate::services::projects::cache::Project;
 use crate::services::upload::{Create, Stream, Upload};
 use crate::utils;
 use crate::utils::{AttachmentStrategy, BadMultipart, BoundedStream};
@@ -160,14 +160,23 @@ async fn extract_multipart(
     multipart: Multipart<'static>,
     meta: RequestMeta,
     state: &ServiceState,
-    project_config: &ProjectInfo,
+    project: &Project<'_>,
 ) -> Result<Box<Envelope>, BadStoreRequest> {
+    let project_config = project
+        .state()
+        .clone()
+        .enabled()
+        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
     let scoping = project_config
         .scoping(meta.public_key())
         .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
-    let upload_service = project_config
-        .has_feature(Feature::PlaystationUploads)
-        .then_some(state.upload());
+    let attachment_rate_limits = project.rate_limits().current_limits().check_with_quotas(
+        project_config.get_quotas(),
+        scoping.item(DataCategory::Attachment),
+    );
+    let upload_service = (project_config.has_feature(Feature::PlaystationUploads)
+        && !attachment_rate_limits.is_limited())
+    .then_some(state.upload());
     let attachment_strategy = PlaystationAttachmentStrategy {
         scoping,
         upload_service,
@@ -204,19 +213,15 @@ async fn handle(
         return Ok(axum::Json(create_data_request_response()).into_response());
     }
 
-    let project_config = state
+    let project = state
         .project_cache_handle()
         .ready(meta.public_key(), state.config().query_timeout())
         .await
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?
-        .state()
-        .clone()
-        .enabled()
-        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
     let multipart = utils::multipart_from_request(request, multer::Constraints::new())
         .map_err(BadMultipart::Multipart)?;
-    let mut envelope = extract_multipart(multipart, meta, &state, &project_config).await?;
+    let mut envelope = extract_multipart(multipart, meta, &state, &project).await?;
     envelope.require_feature(Feature::PlaystationIngestion);
 
     let id = envelope.event_id();


### PR DESCRIPTION
Do not upload attachments to objectstore if the `attachment` data category is rate limited. This is needed because if the playstation endpoint is hit in a processing relay, attachment uploads go directly to objectstore rather than via the rate-limit-enforcing upload endpoint.

fixes: [INGEST-808](https://linear.app/getsentry/issue/INGEST-808)