### PR TITLE
fix: Mix kafka partition key with org id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - TUS: Disallow creation with upload. ([#5734](https://github.com/getsentry/relay/pull/5734))
 - Remove continuous-profiling-beta feature flags. ([#5762](https://github.com/getsentry/relay/pull/5762))
 - Add payload byte size to trace metrics. ([#5764](https://github.com/getsentry/relay/pull/5764))
+- Mix kafka partition key with org id. ([#5772](https://github.com/getsentry/relay/pull/5772))
 
 ## 26.3.1
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -454,6 +454,7 @@ impl StoreService {
                     if let Some(attachment) = self.produce_attachment(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
+                        scoping.organization_id,
                         item,
                         send_individual_attachments,
                     )? {
@@ -465,6 +466,7 @@ impl StoreService {
                     self.produce_user_report(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
+                        scoping.organization_id,
                         received_at,
                         item,
                     )?;
@@ -474,6 +476,7 @@ impl StoreService {
                     self.produce_user_report_v2(
                         event_id.ok_or(StoreError::NoEventId)?,
                         scoping.project_id,
+                        scoping.organization_id,
                         received_at,
                         item,
                         remote_addr,
@@ -489,7 +492,14 @@ impl StoreService {
                 )?,
                 ItemType::CheckIn => {
                     let client = envelope.meta().client();
-                    self.produce_check_in(scoping.project_id, received_at, client, retention, item)?
+                    self.produce_check_in(
+                        scoping.project_id,
+                        scoping.organization_id,
+                        received_at,
+                        client,
+                        retention,
+                        item,
+                    )?
                 }
                 ItemType::Span if content_type == Some(ContentType::Json) => self.produce_span(
                     scoping,
@@ -563,6 +573,7 @@ impl StoreService {
                     project_id,
                     remote_addr,
                     attachments,
+                    org_id: scoping.organization_id,
                 }),
             )?;
         } else {
@@ -747,6 +758,7 @@ impl StoreService {
                     meta,
                     span: SerializableAnnotated(&item),
                 },
+                org_id: scoping.organization_id,
             };
 
             self.produce(KafkaTopic::Spans, message)
@@ -825,6 +837,7 @@ impl StoreService {
             let result = self.produce_attachment(
                 attachment.event_id,
                 scoping.project_id,
+                scoping.organization_id,
                 &attachment.attachment,
                 // Hardcoded to `true` since standalone attachments are 'individual attachments'.
                 true,
@@ -846,6 +859,7 @@ impl StoreService {
                 event_id: report.event_id,
                 start_time: safe_timestamp(received_at),
                 payload: report.report.payload(),
+                org_id: scoping.organization_id,
             });
             self.produce(KafkaTopic::Attachments, kafka_msg)
         });
@@ -973,6 +987,7 @@ impl StoreService {
         &self,
         event_id: EventId,
         project_id: ProjectId,
+        org_id: OrganizationId,
         item: &Item,
         send_individual_attachments: bool,
     ) -> Result<Option<ChunkedAttachment>, StoreError> {
@@ -1004,6 +1019,7 @@ impl StoreService {
                     project_id,
                     id: id.clone(),
                     chunk_index,
+                    org_id,
                 };
 
                 self.produce(
@@ -1037,6 +1053,7 @@ impl StoreService {
                 event_id,
                 project_id,
                 attachment,
+                org_id,
             });
             self.produce(KafkaTopic::Attachments, message)?;
             Ok(None)
@@ -1049,6 +1066,7 @@ impl StoreService {
         &self,
         event_id: EventId,
         project_id: ProjectId,
+        org_id: OrganizationId,
         received_at: DateTime<Utc>,
         item: &Item,
     ) -> Result<(), StoreError> {
@@ -1057,6 +1075,7 @@ impl StoreService {
             event_id,
             start_time: safe_timestamp(received_at),
             payload: item.payload(),
+            org_id,
         });
 
         self.produce(KafkaTopic::Attachments, message)
@@ -1066,6 +1085,7 @@ impl StoreService {
         &self,
         event_id: EventId,
         project_id: ProjectId,
+        org_id: OrganizationId,
         received_at: DateTime<Utc>,
         item: &Item,
         remote_addr: Option<String>,
@@ -1077,6 +1097,7 @@ impl StoreService {
             start_time: safe_timestamp(received_at),
             remote_addr,
             attachments: vec![],
+            org_id,
         });
         self.produce(KafkaTopic::Feedback, message)
     }
@@ -1134,6 +1155,7 @@ impl StoreService {
     fn produce_check_in(
         &self,
         project_id: ProjectId,
+        org_id: OrganizationId,
         received_at: DateTime<Utc>,
         client: Option<&str>,
         retention_days: u16,
@@ -1147,6 +1169,7 @@ impl StoreService {
             sdk: client.map(str::to_owned),
             payload: item.payload(),
             routing_key_hint: item.routing_hint(),
+            org_id,
         });
 
         self.produce(KafkaTopic::Monitors, message)?;
@@ -1214,6 +1237,7 @@ impl StoreService {
                     scoping.project_id.to_string(),
                 )]),
                 message,
+                org_id: organization_id,
             },
         )?;
 
@@ -1340,6 +1364,10 @@ struct EventKafkaMessage {
     remote_addr: Option<String>,
     /// Attachments that are potentially relevant for processing.
     attachments: Vec<ChunkedAttachment>,
+
+    /// Used for [`KafkaMessage::key`]
+    #[serde(skip)]
+    org_id: OrganizationId,
 }
 
 /// Container payload for chunks of attachments.
@@ -1357,6 +1385,10 @@ struct AttachmentChunkKafkaMessage {
     id: String,
     /// Sequence number of chunk. Starts at 0 and ends at `AttachmentKafkaMessage.num_chunks - 1`.
     chunk_index: usize,
+
+    /// Used for [`KafkaMessage::key`]
+    #[serde(skip)]
+    org_id: OrganizationId,
 }
 
 /// A "standalone" attachment.
@@ -1371,6 +1403,10 @@ struct AttachmentKafkaMessage {
     project_id: ProjectId,
     /// The attachment.
     attachment: ChunkedAttachment,
+
+    /// Used for [`KafkaMessage::key`]
+    #[serde(skip)]
+    org_id: OrganizationId,
 }
 
 #[derive(Debug, Serialize)]
@@ -1400,9 +1436,12 @@ struct UserReportKafkaMessage {
     start_time: u64,
     payload: Bytes,
 
-    // Used for KafkaMessage::key
+    /// Used for [`KafkaMessage::key`]
     #[serde(skip)]
     event_id: EventId,
+    /// Used for [`KafkaMessage::key`]
+    #[serde(skip)]
+    org_id: OrganizationId,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1478,9 +1517,6 @@ enum CheckInMessageType {
 
 #[derive(Debug, Serialize)]
 struct CheckInKafkaMessage {
-    #[serde(skip)]
-    routing_key_hint: Option<Uuid>,
-
     /// Used by the consumer to discrinminate the message.
     message_type: CheckInMessageType,
     /// Raw event payload.
@@ -1493,6 +1529,13 @@ struct CheckInKafkaMessage {
     project_id: ProjectId,
     /// Number of days to retain.
     retention_days: u16,
+
+    /// Used for [`KafkaMessage::key`]
+    #[serde(skip)]
+    routing_key_hint: Option<Uuid>,
+    /// Used for [`KafkaMessage::key`]
+    #[serde(skip)]
+    org_id: OrganizationId,
 }
 
 #[derive(Debug, Serialize)]
@@ -1570,6 +1613,10 @@ enum KafkaMessage<'a> {
         headers: BTreeMap<String, String>,
         #[serde(flatten)]
         message: SpanKafkaMessageRaw<'a>,
+
+        /// Used for [`KafkaMessage::key`]
+        #[serde(skip)]
+        org_id: OrganizationId,
     },
     SpanV2 {
         #[serde(skip)]
@@ -1578,6 +1625,10 @@ enum KafkaMessage<'a> {
         headers: BTreeMap<String, String>,
         #[serde(flatten)]
         message: SpanKafkaMessage<'a>,
+
+        /// Used for [`KafkaMessage::key`]
+        #[serde(skip)]
+        org_id: OrganizationId,
     },
 
     Attachment(AttachmentKafkaMessage),
@@ -1633,18 +1684,27 @@ impl Message for KafkaMessage<'_> {
     /// Returns the partitioning key for this Kafka message determining.
     fn key(&self) -> Option<relay_kafka::Key> {
         match self {
-            Self::Event(message) => Some(message.event_id.0),
-            Self::UserReport(message) => Some(message.event_id.0),
-            Self::SpanRaw { routing_key, .. } | Self::SpanV2 { routing_key, .. } => *routing_key,
+            Self::Event(message) => Some((message.event_id.0, message.org_id)),
+            Self::UserReport(message) => Some((message.event_id.0, message.org_id)),
+            Self::SpanRaw {
+                routing_key,
+                org_id,
+                ..
+            }
+            | Self::SpanV2 {
+                routing_key,
+                org_id,
+                ..
+            } => routing_key.map(|r| (r, *org_id)),
 
             // Monitor check-ins use the hinted UUID passed through from the Envelope.
             //
             // XXX(epurkhiser): In the future it would be better if all KafkaMessage's would
             // recieve the routing_key_hint form their envelopes.
-            Self::CheckIn(message) => message.routing_key_hint,
+            Self::CheckIn(message) => message.routing_key_hint.map(|r| (r, message.org_id)),
 
-            Self::Attachment(message) => Some(message.event_id.0),
-            Self::AttachmentChunk(message) => Some(message.event_id.0),
+            Self::Attachment(message) => Some((message.event_id.0, message.org_id)),
+            Self::AttachmentChunk(message) => Some((message.event_id.0, message.org_id)),
 
             // Random partitioning
             Self::Metric { .. }
@@ -1653,8 +1713,16 @@ impl Message for KafkaMessage<'_> {
             | Self::ProfileChunk(_)
             | Self::ReplayRecordingNotChunked(_) => None,
         }
-        .filter(|uuid| !uuid.is_nil())
-        .map(|uuid| uuid.as_u128())
+        .filter(|(uuid, _)| !uuid.is_nil())
+        .map(|(uuid, org_id)| {
+            // mix key with org id for better paritioning in case of incidents where messages
+            // across orgs get the same id
+            let mut res = uuid.into_bytes();
+            for (i, &b) in org_id.value().to_be_bytes().iter().enumerate() {
+                res[i] ^= b;
+            }
+            u128::from_be_bytes(res)
+        })
     }
 
     fn headers(&self) -> Option<&BTreeMap<String, String>> {

--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -585,13 +585,22 @@ class MonitorsConsumer(ConsumerBase):
 
 
 class SpansConsumer(ConsumerBase):
+    @staticmethod
+    def _expected_key(span):
+        trace_id_bytes = bytearray.fromhex(span["trace_id"])
+        org_id = span.get("organization_id", 0)
+        org_id_bytes = org_id.to_bytes(8, byteorder="big")
+        for i, b in enumerate(org_id_bytes):
+            trace_id_bytes[i] ^= b
+        return bytes(trace_id_bytes)
+
     def get_span(self):
         message = self.poll()
         assert message is not None
         assert message.error() is None
 
         span = json.loads(message.value())
-        assert message.key() == bytes.fromhex(span["trace_id"])
+        assert message.key() == self._expected_key(span)
         return span
 
     def get_spans(self, *, timeout=None, n=None):
@@ -600,7 +609,7 @@ class SpansConsumer(ConsumerBase):
         for message in self.poll_many(timeout=timeout, n=n):
             assert message.error() is None
             span = json.loads(message.value())
-            assert message.key() == bytes.fromhex(span["trace_id"])
+            assert message.key() == self._expected_key(span)
             spans.append(span)
 
         return spans


### PR DESCRIPTION
Mix the kafka message partition key with the organization id in order to provide better partitioning in potential incidents where multiple messages across organizations have the same id (e.g. an SDK starts using a fixed event id for all events).

Fixes https://linear.app/getsentry/issue/RELAY-76/include-org-id-in-kafka-partition-key