### PR TITLE
fix(upload): Enforce timeout in upload service instead of objectstore service

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1676,7 +1676,6 @@ pub struct Upload {
     /// Additional uploads will be rejected.
     pub max_concurrent_requests: usize,
     /// Maximum time spent trying to upload, in seconds.
-    /// Currently only used by non-processing relays, as the objectstore service has its own timeout.
     pub timeout: u64,
     /// The maximum time between creating the upload and uploading the data / the attachment placeholder.
     ///

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1330,8 +1330,8 @@ pub struct ObjectstoreServiceConfig {
 
     /// Maximum duration of an attachment upload in seconds. Uploads that take longer are discarded.
     ///
-    /// NOTE: This timeout applies to attachment uploads, not to streaming uploads
-    /// that might take longer, and are restricted independently by [`Upload::timeout`].
+    /// NOTE: This timeout applies to attachments that are already in-memory. Streaming uploads
+    /// might take longer and are restricted independently by [`Upload::timeout`].
     pub timeout: u64,
 
     /// Configuration values for objectstore's auth scheme.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1329,6 +1329,9 @@ pub struct ObjectstoreServiceConfig {
     pub max_backlog: usize,
 
     /// Maximum duration of an attachment upload in seconds. Uploads that take longer are discarded.
+    ///
+    /// NOTE: This timeout applies to attachment uploads, not to streaming uploads
+    /// that might take longer, and are restricted independently by [`Upload::timeout`].
     pub timeout: u64,
 
     /// Configuration values for objectstore's auth scheme.

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -98,6 +98,7 @@ impl IntoResponse for Error {
                 upload::Error::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
                 #[cfg(feature = "processing")]
                 upload::Error::Objectstore(service_error) => match service_error {
+                    objectstore::Error::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
                     objectstore::Error::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
                     objectstore::Error::UploadFailed(error) => match error {
                         objectstore_client::Error::Reqwest(error) => match error.status() {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -122,6 +122,8 @@ impl Counted for StoreTraceAttachment {
 /// Errors that can occur when trying to upload an attachment.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("timeout: {0}")]
+    Timeout(#[from] tokio::time::error::Elapsed),
     #[error("load shed")]
     LoadShed,
     #[error("upload failed: {0}")]
@@ -133,6 +135,7 @@ pub enum Error {
 impl Error {
     fn as_str(&self) -> &'static str {
         match self {
+            Error::Timeout(_) => "timeout",
             Error::LoadShed => "load-shed",
             Error::UploadFailed(_) => "upload_failed",
             Error::Uuid(_) => "uuid",
@@ -191,8 +194,7 @@ impl ObjectstoreService {
         };
 
         let objectstore_client = {
-            let mut builder = Client::builder(objectstore_url)
-                .configure_reqwest(|builder| builder.timeout(Duration::from_secs(*timeout)));
+            let mut builder = Client::builder(objectstore_url);
 
             if let Some(auth) = auth {
                 // TODO(FS-313): when Objectstore starts enforcing auth, propagate error with ?
@@ -225,6 +227,7 @@ impl ObjectstoreService {
             objectstore_client,
             event_attachments,
             trace_attachments,
+            timeout: Duration::from_secs(*timeout),
         };
 
         Ok(Some(Self {
@@ -274,6 +277,7 @@ struct ObjectstoreServiceInner {
     objectstore_client: Client,
     event_attachments: Usecase,
     trace_attachments: Usecase,
+    timeout: Duration,
 }
 
 impl ObjectstoreServiceInner {
@@ -517,7 +521,8 @@ impl ObjectstoreServiceInner {
         if let Some(key) = key {
             request = request.key(key);
         }
-        self.upload(ty, request).await
+
+        Ok(tokio::time::timeout(self.timeout, self.upload(ty, request)).await??)
     }
 
     async fn upload(&self, ty: &str, request: PutBuilder) -> Result<ObjectstoreKey, Error> {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -522,7 +522,7 @@ impl ObjectstoreServiceInner {
             request = request.key(key);
         }
 
-        Ok(tokio::time::timeout(self.timeout, self.upload(ty, request)).await??)
+        tokio::time::timeout(self.timeout, self.upload(ty, request)).await?
     }
 
     async fn upload(&self, ty: &str, request: PutBuilder) -> Result<ObjectstoreKey, Error> {

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -256,7 +256,7 @@ impl Service {
         &self,
         future: F,
     ) -> Result<SignedLocation, Error> {
-        Ok(tokio::time::timeout(self.timeout, future).await??)
+        tokio::time::timeout(self.timeout, future).await?
     }
 }
 

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -144,7 +144,7 @@ pub fn create_service(
 }
 
 fn create_backend(
-    config: &Arc<Config>,
+    #[allow(unused)] config: &Arc<Config>,
     upstream: &Addr<UpstreamRelay>,
     #[cfg(feature = "processing")] objectstore: &Option<Addr<Objectstore>>,
 ) -> Backend {

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -201,8 +201,6 @@ impl Service {
             Service::Upstream { addr, timeout } => {
                 let (request, rx) = UploadRequest::upload(stream);
                 addr.send(SendRequest(request));
-                // We're already passing `timeout` to the reqwest library, but we also want to
-                // limit the time spent waiting for the upstream service:
                 let response = tokio::time::timeout(*timeout, rx).await???;
                 SignedLocation::try_from_response(response)
             }

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -128,32 +128,35 @@ pub fn create_service(
     upstream: &Addr<UpstreamRelay>,
     #[cfg(feature = "processing")] objectstore: &Option<Addr<Objectstore>>,
 ) -> ConcurrentService<Service> {
-    let service = create_service_inner(
+    let backend = create_backend(
         config,
         upstream,
         #[cfg(feature = "processing")]
         objectstore,
     );
+    let service = Service {
+        timeout: Duration::from_secs(config.upload().timeout),
+        backend,
+    };
     ConcurrentService::new(service)
         .with_backlog_limit(0)
         .with_concurrency_limit(config.upload().max_concurrent_requests)
 }
 
-fn create_service_inner(
+fn create_backend(
     config: &Arc<Config>,
     upstream: &Addr<UpstreamRelay>,
     #[cfg(feature = "processing")] objectstore: &Option<Addr<Objectstore>>,
-) -> Service {
+) -> Backend {
     #[cfg(feature = "processing")]
     if let Some(addr) = objectstore.as_ref() {
-        return Service::Objectstore {
+        return Backend::Objectstore {
             addr: addr.clone(),
             config: config.clone(),
         };
     }
-    Service::Upstream {
+    Backend::Upstream {
         addr: upstream.clone(),
-        timeout: Duration::from_secs(config.upload().timeout),
     }
 }
 
@@ -161,10 +164,15 @@ fn create_service_inner(
 ///
 /// Uploads go to either the upstream relay or objectstore.
 #[derive(Debug, Clone)]
-pub enum Service {
+pub struct Service {
+    timeout: Duration,
+    backend: Backend,
+}
+
+#[derive(Debug, Clone)]
+enum Backend {
     Upstream {
         addr: Addr<UpstreamRelay>,
-        timeout: Duration,
     },
     #[cfg(feature = "processing")]
     Objectstore {
@@ -175,15 +183,15 @@ pub enum Service {
 
 impl Service {
     async fn create(&self, Create { scoping, length }: Create) -> Result<SignedLocation, Error> {
-        match self {
-            Self::Upstream { addr, timeout } => {
+        match &self.backend {
+            Backend::Upstream { addr } => {
                 let (request, rx) = UploadRequest::create(scoping, length);
                 addr.send(SendRequest(request));
-                let response = tokio::time::timeout(*timeout, rx).await???;
+                let response = rx.await??;
                 SignedLocation::try_from_response(response)
             }
             #[cfg(feature = "processing")]
-            Self::Objectstore { addr: _, config } => {
+            Backend::Objectstore { addr: _, config } => {
                 // We can create & sign a location right here, no need to query the objectstore service.
                 let key = Uuid::now_v7().as_simple().to_string();
                 Location {
@@ -197,15 +205,15 @@ impl Service {
     }
 
     async fn upload(&self, stream: Stream) -> Result<SignedLocation, Error> {
-        match self {
-            Service::Upstream { addr, timeout } => {
+        match &self.backend {
+            Backend::Upstream { addr } => {
                 let (request, rx) = UploadRequest::upload(stream);
                 addr.send(SendRequest(request));
-                let response = tokio::time::timeout(*timeout, rx).await???;
+                let response = rx.await??;
                 SignedLocation::try_from_response(response)
             }
             #[cfg(feature = "processing")]
-            Service::Objectstore { addr, config } => {
+            Backend::Objectstore { addr, config } => {
                 let Stream {
                     received,
                     scoping,
@@ -243,6 +251,13 @@ impl Service {
             }
         }
     }
+
+    async fn timeout<F: IntoFuture<Output = Result<SignedLocation, Error>>>(
+        &self,
+        future: F,
+    ) -> Result<SignedLocation, Error> {
+        Ok(tokio::time::timeout(self.timeout, future).await??)
+    }
 }
 
 impl SimpleService for Service {
@@ -251,10 +266,10 @@ impl SimpleService for Service {
     async fn handle_message(&self, message: Upload) {
         match message {
             Upload::Create(create, sender) => {
-                sender.send(self.create(create).await);
+                sender.send(self.timeout(self.create(create)).await);
             }
             Upload::Upload(stream, sender) => {
-                sender.send(self.upload(stream).await);
+                sender.send(self.timeout(self.upload(stream)).await);
             }
         }
     }


### PR DESCRIPTION
Because streams need a larger upload timeout than `Bytes`,  we should enforce a timeout only in the upload service, not the objectstore service.

This reverts https://github.com/getsentry/relay/pull/5690.