### PR TITLE
fix(objectstore): Propagate attachment retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Store segment name in `sentry.transaction` in addition to `sentry.segment.name` on OTLP spans. ([#5765](https://github.com/getsentry/relay/pull/5765))
 - Explicitly handle in-flight requests during shutdown. ([#5746](https://github.com/getsentry/relay/pull/5746), [#5769](https://github.com/getsentry/relay/pull/5769))
 - Emit outcomes in both `log_byte` and `log_item` categories when logs are dropped. ([#5766](https://github.com/getsentry/relay/pull/5766))
+- Propagate an event's retention policy to its attachments ([#5774](https://github.com/getsentry/relay/pull/5774))
 
 **Features**:
 

--- a/relay-server/src/processing/attachments/forward.rs
+++ b/relay-server/src/processing/attachments/forward.rs
@@ -41,6 +41,7 @@ impl Forward for AttachmentsOutput {
                     event_id,
                     attachment,
                     quantities,
+                    retention: ctx.event_retention().standard,
                 }
             });
             if use_objectstore {

--- a/relay-server/src/processing/trace_attachments/store.rs
+++ b/relay-server/src/processing/trace_attachments/store.rs
@@ -42,7 +42,11 @@ pub fn convert(
         let trace_item = attachment_to_trace_item(meta, quantities, ctx)
             .ok_or(Outcome::Invalid(DiscardReason::InvalidTraceAttachment))?;
 
-        Ok::<_, Outcome>(StoreTraceAttachment { trace_item, body })
+        Ok::<_, Outcome>(StoreTraceAttachment {
+            trace_item,
+            body,
+            retention: retention.standard,
+        })
     })
 }
 

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -302,6 +302,7 @@ impl ObjectstoreServiceInner {
             .event_attachments
             .for_project(scoping.organization_id.value(), scoping.project_id.value())
             .session(&self.objectstore_client);
+        let retention = envelope.envelope().retention();
 
         let attachments = envelope
             .envelope_mut()
@@ -324,7 +325,13 @@ impl ObjectstoreServiceInner {
                         continue;
                     }
                     let result = self
-                        .upload_bytes("envelope", &session, attachment.payload(), None)
+                        .upload_bytes(
+                            "envelope",
+                            &session,
+                            attachment.payload(),
+                            Some(retention),
+                            None,
+                        )
                         .await;
 
                     relay_statsd::metric!(
@@ -378,6 +385,7 @@ impl ObjectstoreServiceInner {
                         "attachment",
                         &session,
                         attachment.attachment.payload(),
+                        Some(attachment.retention),
                         None,
                     )
                     .await;
@@ -453,7 +461,13 @@ impl ObjectstoreServiceInner {
             let original_key = key.clone();
 
             let _stored_key = self
-                .upload_bytes("attachment_v2", &session, body, Some(key))
+                .upload_bytes(
+                    "attachment_v2",
+                    &session,
+                    body,
+                    None, /* retention */
+                    Some(key),
+                )
                 .await
                 .reject(&trace_item)?;
 
@@ -511,9 +525,15 @@ impl ObjectstoreServiceInner {
         ty: &str,
         session: &Session,
         payload: Bytes,
+        retention: Option<u16>,
         key: Option<String>,
     ) -> Result<ObjectstoreKey, Error> {
         let mut request = session.put(payload);
+        if let Some(retention_hours) = retention.and_then(|retention| retention.checked_mul(24)) {
+            request = request.expiration_policy(ExpirationPolicy::TimeToLive(
+                Duration::from_hours(retention_hours.into()),
+            ));
+        }
         if let Some(key) = key {
             request = request.key(key);
         }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -325,13 +325,7 @@ impl ObjectstoreServiceInner {
                         continue;
                     }
                     let result = self
-                        .upload_bytes(
-                            "envelope",
-                            &session,
-                            attachment.payload(),
-                            Some(retention),
-                            None,
-                        )
+                        .upload_bytes("envelope", &session, attachment.payload(), retention, None)
                         .await;
 
                     relay_statsd::metric!(
@@ -385,7 +379,7 @@ impl ObjectstoreServiceInner {
                         "attachment",
                         &session,
                         attachment.attachment.payload(),
-                        Some(attachment.retention),
+                        attachment.retention,
                         None,
                     )
                     .await;
@@ -465,7 +459,8 @@ impl ObjectstoreServiceInner {
                     "attachment_v2",
                     &session,
                     body,
-                    None, /* retention */
+                    // Use the retention of the trace item so there are no dangling references.
+                    trace_item.trace_item.retention_days as u16,
                     Some(key),
                 )
                 .await
@@ -525,11 +520,12 @@ impl ObjectstoreServiceInner {
         ty: &str,
         session: &Session,
         payload: Bytes,
-        retention: Option<u16>,
+        retention: u16,
         key: Option<String>,
     ) -> Result<ObjectstoreKey, Error> {
         let mut request = session.put(payload);
-        if let Some(retention_hours) = retention.and_then(|retention| retention.checked_mul(24)) {
+
+        if let Some(retention_hours) = retention.checked_mul(24) {
             request = request.expiration_policy(ExpirationPolicy::TimeToLive(
                 Duration::from_hours(retention_hours.into()),
             ));

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -111,6 +111,8 @@ pub struct StoreTraceAttachment {
     pub body: Bytes,
     /// The trace item to be published via Kafka.
     pub trace_item: TraceItem,
+    /// Data retention in days for this attachment.
+    pub retention: u16,
 }
 
 impl Counted for StoreTraceAttachment {
@@ -432,12 +434,14 @@ impl ObjectstoreServiceInner {
             .reject(&managed)?;
 
         let body = Bytes::clone(&managed.body);
+        let retention = managed.retention;
 
         // Make sure that the attachment can be converted into a trace item:
         let trace_item = managed.try_map(|attachment, _record_keeper| {
             let StoreTraceAttachment {
                 trace_item,
                 body: _,
+                retention: _,
             } = attachment;
             Ok::<_, Error>(StoreTraceItem { trace_item })
         })?;
@@ -455,14 +459,7 @@ impl ObjectstoreServiceInner {
             let original_key = key.clone();
 
             let _stored_key = self
-                .upload_bytes(
-                    "attachment_v2",
-                    &session,
-                    body,
-                    // Use the retention of the trace item so there are no dangling references.
-                    trace_item.trace_item.retention_days as u16,
-                    Some(key),
-                )
+                .upload_bytes("attachment_v2", &session, body, retention, Some(key))
                 .await
                 .reject(&trace_item)?;
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -189,6 +189,8 @@ pub struct StoreAttachment {
     pub attachment: Item,
     /// Outcome quantities associated with this attachment.
     pub quantities: Quantities,
+    /// Data retention in days for this attachment.
+    pub retention: u16,
 }
 
 impl Counted for StoreAttachment {


### PR DESCRIPTION
objectstore clients in Relay and Sentry are hardcoded to use 30d TTL retention for all attachments. we need to instead inherit the correct retention policy from the event/envelope/project/whatever.

questions:
- are `ctx.event_retention().standard` and `envelope.envelope().retention()` the correct places to inherit the retention policy from?
- what are trace attachments? usage of the type is not clear to me

Ref INGEST-837