### PR TITLE
fix(store): Add retention_days to chunked attachment messages

### DIFF
--- a/relay-server/src/processing/attachments/forward.rs
+++ b/relay-server/src/processing/attachments/forward.rs
@@ -33,8 +33,6 @@ impl Forward for AttachmentsOutput {
             crate::utils::sample(options.objectstore_attachments_sample_rate).is_keep()
         };
 
-        let retention_days = ctx.event_retention().standard;
-
         for attachment in attachments.split(|attachment| attachment.attachments) {
             let store_attachment = attachment.map(|attachment, _| {
                 use crate::services::store::StoreAttachment;
@@ -42,7 +40,6 @@ impl Forward for AttachmentsOutput {
                 StoreAttachment {
                     event_id,
                     attachment,
-                    retention_days,
                     quantities,
                     retention: ctx.event_retention().standard,
                 }

--- a/relay-server/src/processing/attachments/forward.rs
+++ b/relay-server/src/processing/attachments/forward.rs
@@ -33,6 +33,8 @@ impl Forward for AttachmentsOutput {
             crate::utils::sample(options.objectstore_attachments_sample_rate).is_keep()
         };
 
+        let retention_days = ctx.event_retention().standard;
+
         for attachment in attachments.split(|attachment| attachment.attachments) {
             let store_attachment = attachment.map(|attachment, _| {
                 use crate::services::store::StoreAttachment;
@@ -40,6 +42,7 @@ impl Forward for AttachmentsOutput {
                 StoreAttachment {
                     event_id,
                     attachment,
+                    retention_days,
                     quantities,
                 }
             });

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -198,10 +198,10 @@ pub struct StoreAttachment {
     pub event_id: EventId,
     /// That attachment item.
     pub attachment: Item,
-    /// Data retention in days for this attachment.
-    pub retention: u16,
     /// Outcome quantities associated with this attachment.
     pub quantities: Quantities,
+    /// Data retention in days for this attachment.
+    pub retention: u16,
 }
 
 impl Counted for StoreAttachment {
@@ -1401,6 +1401,7 @@ struct ChunkedAttachment {
     /// The size of the attachment in bytes.
     size: usize,
 
+    /// The retention in days for this attachment.
     retention_days: u16,
 
     /// The attachment payload, chunked, inlined, or already stored.

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -198,12 +198,10 @@ pub struct StoreAttachment {
     pub event_id: EventId,
     /// That attachment item.
     pub attachment: Item,
-    /// Number of days to retain.
-    pub retention_days: u16,
-    /// Outcome quantities associated with this attachment.
-    pub quantities: Quantities,
     /// Data retention in days for this attachment.
     pub retention: u16,
+    /// Outcome quantities associated with this attachment.
+    pub quantities: Quantities,
 }
 
 impl Counted for StoreAttachment {
@@ -857,7 +855,7 @@ impl StoreService {
                 &attachment.attachment,
                 // Hardcoded to `true` since standalone attachments are 'individual attachments'.
                 true,
-                attachment.retention_days,
+                attachment.retention,
             );
             // Since we are sending an 'individual attachment' this function should never return a
             // `ChunkedAttachment`.

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -187,6 +187,8 @@ pub struct StoreAttachment {
     pub event_id: EventId,
     /// That attachment item.
     pub attachment: Item,
+    /// Number of days to retain.
+    pub retention_days: u16,
     /// Outcome quantities associated with this attachment.
     pub quantities: Quantities,
 }
@@ -457,6 +459,7 @@ impl StoreService {
                         scoping.organization_id,
                         item,
                         send_individual_attachments,
+                        retention,
                     )? {
                         attachments.push(attachment);
                     }
@@ -841,6 +844,7 @@ impl StoreService {
                 &attachment.attachment,
                 // Hardcoded to `true` since standalone attachments are 'individual attachments'.
                 true,
+                attachment.retention_days,
             );
             // Since we are sending an 'individual attachment' this function should never return a
             // `ChunkedAttachment`.
@@ -990,6 +994,7 @@ impl StoreService {
         org_id: OrganizationId,
         item: &Item,
         send_individual_attachments: bool,
+        retention_days: u16,
     ) -> Result<Option<ChunkedAttachment>, StoreError> {
         let id = Uuid::new_v4().to_string();
 
@@ -1045,6 +1050,7 @@ impl StoreService {
             content_type: item.raw_content_type().map(|s| s.to_ascii_lowercase()),
             attachment_type: item.attachment_type().unwrap_or_default(),
             size,
+            retention_days,
             payload,
         };
 
@@ -1328,6 +1334,8 @@ struct ChunkedAttachment {
 
     /// The size of the attachment in bytes.
     size: usize,
+
+    retention_days: u16,
 
     /// The attachment payload, chunked, inlined, or already stored.
     #[serde(flatten)]

--- a/tests/integration/test_attachment_ref.py
+++ b/tests/integration/test_attachment_ref.py
@@ -206,6 +206,7 @@ def test_attachment_ref(
         "size": len(attachment_data),
         "rate_limited": False,
         "stored_id": mock.ANY,
+        "retention_days": mock.ANY,
     }
 
     if event_type == "event":

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -70,6 +70,7 @@ def test_mixed_attachments_with_processing(
             "rate_limited": False,
             "attachment_type": "event.attachment",
             "size": len(chunked_contents),
+            "retention_days": 90,
             "chunks": attachment_num_chunks[id1],
         },
         "event_id": event_id,
@@ -89,6 +90,7 @@ def test_mixed_attachments_with_processing(
             "rate_limited": False,
             "attachment_type": "event.attachment",
             "size": len(b"hell yeah"),
+            "retention_days": 90,
             "data": b"hell yeah",
         },
         "event_id": event_id,
@@ -110,6 +112,7 @@ def test_mixed_attachments_with_processing(
             "rate_limited": False,
             "attachment_type": "event.attachment",
             "size": 0,
+            "retention_days": 90,
             "chunks": 0,
         },
         "event_id": event_id,
@@ -166,6 +169,7 @@ def test_attachments_with_objectstore(
             "rate_limited": False,
             "attachment_type": "event.attachment",
             "size": len(chunked_contents),
+            "retention_days": 90,
         },
         "event_id": event_id,
         "project_id": project_id,
@@ -182,6 +186,7 @@ def test_attachments_with_objectstore(
             "rate_limited": False,
             "attachment_type": "event.attachment",
             "size": 0,
+            "retention_days": 90,
             "chunks": 0,
         },
         "event_id": event_id,
@@ -607,6 +612,7 @@ def test_view_hierarchy_processing(
             "content_type": "application/json",
             "attachment_type": "event.view_hierarchy",
             "size": len(expected_payload),
+            "retention_days": 90,
             "data": expected_payload,
         },
         "event_id": event_id,
@@ -666,6 +672,7 @@ def test_event_with_attachment(
             "content_type": "application/octet-stream",
             "attachment_type": "event.attachment",
             "size": len(b"event attachment"),
+            "retention_days": 90,
             **({"stored_id": mock.ANY} if use_objectstore else {"chunks": 1}),
         }
     ]
@@ -693,6 +700,7 @@ def test_event_with_attachment(
         "content_type": "application/octet-stream",
         "attachment_type": "event.attachment",
         "size": len(b"transaction attachment"),
+        "retention_days": 90,
         **(
             {"stored_id": mock.ANY}
             if use_objectstore
@@ -749,6 +757,7 @@ def test_form_data_is_rejected(
             "rate_limited": False,
             "attachment_type": "event.attachment",
             "size": len(b"file content"),
+            "retention_days": 90,
             "data": b"file content",
         },
         "event_id": event_id,

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -480,6 +480,7 @@ def test_minidump_with_processing(
                 "attachment_type": "event.minidump",
                 "content_type": "application/x-dmp",
                 "size": len(content),
+                "retention_days": 50000,
                 "chunks": num_chunks,
             }
         ]
@@ -497,6 +498,7 @@ def test_minidump_with_processing(
             "attachment_type": "event.minidump",
             "content_type": "application/x-dmp",
             "size": len(content),
+            "retention_days": 50000,
         }
 
     assert "errors" not in event
@@ -563,6 +565,7 @@ def test_minidump_with_processing_invalid(
             "content_type": "application/x-dmp",
             "attachment_type": "event.minidump",
             "size": len(content),
+            "retention_days": 90,
             "chunks": num_chunks,
         }
     ]

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -184,6 +184,7 @@ def attachments(
             "content_type": "text/plain",
             "attachment_type": "event.attachment",
             "size": log_size,
+            "retention_days": 36500,
             "chunks": 1,
         },
         {
@@ -193,6 +194,7 @@ def attachments(
             "content_type": "application/x-dmp",
             "attachment_type": "event.minidump",
             "size": generated_dump_size,
+            "retention_days": 36500,
             "chunks": 1,
         },
         {
@@ -202,6 +204,7 @@ def attachments(
             "content_type": "application/octet-stream",
             "attachment_type": "playstation.prosperodump",
             "size": playstation_dump_size,
+            "retention_days": 36500,
             "chunks": 1,
         },
     ]
@@ -573,6 +576,7 @@ def test_playstation_attachment_no_feature_flag(
             "content_type": "application/octet-stream",
             "attachment_type": "playstation.prosperodump",
             "size": 209385,
+            "retention_days": 90,
             "chunks": 1,
         },
     )


### PR DESCRIPTION
Injects `retention_days` into the attachments kafka message, so that readers in Sentry codebase (ingest-consumer, save-events task) have access to the same value that is applied to objectstore.

See also https://github.com/getsentry/sentry/pull/111879
Ref FS-328