### PR TITLE
feat(event-normalization): Use `gen_ai.function_id` as a fallback for `gen_ai.agent.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Set `sentry.segment.id` and `sentry.segment.name` attributes on OTLP segment spans. ([#5748](https://github.com/getsentry/relay/pull/5748))
 - Envelope buffer: Add option to disable flush-to-disk on shutdown. ([#5751](https://github.com/getsentry/relay/pull/5751))
 - Allow configuring Objectstore client auth parameters. ([#5720](https://github.com/getsentry/relay/pull/5720))
+- Use `gen_ai.function_id` as a fallback for `gen_ai.agent.name`. ([#5776](https://github.com/getsentry/relay/pull/5776))
 
 **Internal**:
 

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -330,6 +330,13 @@ fn enrich_ai_span_data(
         data.gen_ai_response_model.set_value(Some(request_model));
     }
 
+    // Default agent name to function_id if not set.
+    if data.gen_ai_agent_name.value().is_none()
+        && let Some(function_id) = data.gen_ai_function_id.value().cloned()
+    {
+        data.gen_ai_agent_name.set_value(Some(function_id));
+    }
+
     if let Some(model_costs) = model_costs {
         extract_ai_data(data, duration, model_costs, origin, platform);
     } else {
@@ -711,6 +718,43 @@ mod tests {
           "gen_ai.response.model": "gpt-4-abcd",
           "gen_ai.request.model": "gpt-4",
           "gen_ai.operation.type": "ai_client"
+        }
+        "#);
+    }
+
+    /// Test that gen_ai.agent.name is defaulted from gen_ai.function_id.
+    #[test]
+    fn test_default_agent_name_from_function_id() {
+        let mut span = ai_span_with_data(json!({
+            "gen_ai.function_id": "my-agent",
+        }));
+
+        enrich_ai_span(&mut span, None);
+
+        assert_annotated_snapshot!(&span.data, @r#"
+        {
+          "gen_ai.operation.type": "ai_client",
+          "gen_ai.agent.name": "my-agent",
+          "gen_ai.function_id": "my-agent"
+        }
+        "#);
+    }
+
+    /// Test that gen_ai.agent.name is not overridden when already set.
+    #[test]
+    fn test_default_agent_name_not_overridden() {
+        let mut span = ai_span_with_data(json!({
+            "gen_ai.function_id": "my-function",
+            "gen_ai.agent.name": "my-agent",
+        }));
+
+        enrich_ai_span(&mut span, None);
+
+        assert_annotated_snapshot!(&span.data, @r#"
+        {
+          "gen_ai.operation.type": "ai_client",
+          "gen_ai.agent.name": "my-agent",
+          "gen_ai.function_id": "my-function"
         }
         "#);
     }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -692,6 +692,14 @@ pub struct SpanData {
     #[metastructure(field = "gen_ai.operation.type", pii = "maybe")]
     pub gen_ai_operation_type: Annotated<String>,
 
+    /// The name of the AI agent.
+    #[metastructure(field = "gen_ai.agent.name", pii = "maybe")]
+    pub gen_ai_agent_name: Annotated<String>,
+
+    /// The function ID of the AI agent.
+    #[metastructure(field = "gen_ai.function_id", pii = "maybe")]
+    pub gen_ai_function_id: Annotated<String>,
+
     /// The result of the MCP prompt.
     #[metastructure(field = "mcp.prompt.result", pii = "maybe")]
     pub mcp_prompt_result: Annotated<Value>,
@@ -1519,6 +1527,8 @@ mod tests {
             gen_ai_tool_name: ~,
             gen_ai_operation_name: ~,
             gen_ai_operation_type: ~,
+            gen_ai_agent_name: ~,
+            gen_ai_function_id: ~,
             mcp_prompt_result: ~,
             mcp_tool_result_content: ~,
             browser_name: ~,

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -195,6 +195,8 @@ mod tests {
                 gen_ai_tool_name: ~,
                 gen_ai_operation_name: ~,
                 gen_ai_operation_type: ~,
+                gen_ai_agent_name: ~,
+                gen_ai_function_id: ~,
                 mcp_prompt_result: ~,
                 mcp_tool_result_content: ~,
                 browser_name: "Chrome",

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -390,6 +390,7 @@ def test_ai_spans_example_transaction(
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.45},
                 "gen_ai.cost.output_tokens": {"type": "double", "value": 1.3},
                 "gen_ai.cost.total_tokens": {"type": "double", "value": 3.75},
+                "gen_ai.agent.name": {"type": "string", "value": "weather-chat"},
                 "gen_ai.function_id": {"type": "string", "value": "weather-chat"},
                 "gen_ai.operation.type": {"type": "string", "value": "agent"},
                 "gen_ai.prompt": {"type": "string", "value": "Weather Prompt"},
@@ -478,6 +479,7 @@ def test_ai_spans_example_transaction(
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 0.37},
                 "gen_ai.cost.output_tokens": {"type": "double", "value": 0.92},
                 "gen_ai.cost.total_tokens": {"type": "double", "value": 1.29},
+                "gen_ai.agent.name": {"type": "string", "value": "weather-chat"},
                 "gen_ai.function_id": {"type": "string", "value": "weather-chat"},
                 "gen_ai.operation.type": {"type": "string", "value": "ai_client"},
                 "gen_ai.request.available_tools": {
@@ -966,6 +968,7 @@ def test_ai_spans_example_transaction(
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.08},
                 "gen_ai.cost.output_tokens": {"type": "double", "value": 0.38},
                 "gen_ai.cost.total_tokens": {"type": "double", "value": 2.46},
+                "gen_ai.agent.name": {"type": "string", "value": "weather-chat"},
                 "gen_ai.function_id": {"type": "string", "value": "weather-chat"},
                 "gen_ai.operation.type": {"type": "string", "value": "ai_client"},
                 "gen_ai.request.available_tools": {


### PR DESCRIPTION
Currently, the Vercel AI integration does not set `gen_ai.agent.name`, but instead the `gen_ai.function_name`, which basically fulfills the same purpose.

This PR adds the mapping.

Closes https://linear.app/getsentry/issue/TET-2148/map-vercels-function-id-to-gen-aiagentname