### PR TITLE
feat(tracemetrics): Allow similar size to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Set `sentry.segment.id` and `sentry.segment.name` attributes on OTLP segment spans. ([#5748](https://github.com/getsentry/relay/pull/5748))
 - Envelope buffer: Add option to disable flush-to-disk on shutdown. ([#5751](https://github.com/getsentry/relay/pull/5751))
 - Allow configuring Objectstore client auth parameters. ([#5720](https://github.com/getsentry/relay/pull/5720))
+- Metric size limit per metric default changed to 1mib. ([#5779](https://github.com/getsentry/relay/pull/5779))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -716,7 +716,7 @@ impl Default for Limits {
             max_api_file_upload_size: ByteSize::mebibytes(40),
             max_api_chunk_upload_size: ByteSize::mebibytes(100),
             max_profile_size: ByteSize::mebibytes(50),
-            max_trace_metric_size: ByteSize::kibibytes(2),
+            max_trace_metric_size: ByteSize::mebibytes(1),
             max_log_size: ByteSize::mebibytes(1),
             max_span_size: ByteSize::mebibytes(1),
             max_container_size: ByteSize::mebibytes(12),


### PR DESCRIPTION
Moving metrics over to byte based outcomes means we no longer need / want to enforce a limit on size, so they should match logs.

Other:
- Was looking at outcome breakdowns for datacategory 37 (metric bytes) via `streams_aggregates.aggregate_outcomes` and this appears to have very little additional data being added w.r.t. this change.
- Project limit is at 50k metrics per project (logs is 20k), we've safely tested logs to > then that number so it shouldn't have load impact. 

Closes LOGS-645


