### PR TITLE
fix(config): Increase default max_span_size from 1 MiB to 10 MiB

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -718,7 +718,7 @@ impl Default for Limits {
             max_profile_size: ByteSize::mebibytes(50),
             max_trace_metric_size: ByteSize::mebibytes(1),
             max_log_size: ByteSize::mebibytes(1),
-            max_span_size: ByteSize::mebibytes(1),
+            max_span_size: ByteSize::mebibytes(10),
             max_container_size: ByteSize::mebibytes(12),
             max_statsd_size: ByteSize::mebibytes(1),
             max_metric_buckets_size: ByteSize::mebibytes(1),


### PR DESCRIPTION
Increases the default `max_span_size` in relay config from 1 MiB to 10 MiB.

With [the new DACI](https://www.notion.so/sentry/DACI-New-1mb-per-span-limit-2b88b10e4b5d8027b8f5f7ef21c895b6?source=copy_link) new limit per span is 1MB (this will be changed in sentry codebase to still come as a config), but that means that we now need to raise `max_span_size` to higher value.

`max_span_size` is used to check if the span will even get to trimming or will immediately get rejected, so if we left it at 1 MiB we'd never trim any larger span the limit, which is not the behavior that we want.

The change is done here, in the code, and not through config to address also the managed relays which do not read our k8s configs.