### PR TITLE
fix(spans): Add missing Getter arms for gen_ai span name attributes

### DIFF
--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -1031,6 +1031,9 @@ impl Getter for SpanData {
             "gen_ai\\.cost\\.total_tokens" => self.gen_ai_cost_total_tokens.value()?.into(),
             "gen_ai\\.cost\\.input_tokens" => self.gen_ai_cost_input_tokens.value()?.into(),
             "gen_ai\\.cost\\.output_tokens" => self.gen_ai_cost_output_tokens.value()?.into(),
+            "gen_ai\\.operation\\.name" => self.gen_ai_operation_name.as_str()?.into(),
+            "gen_ai\\.agent\\.name" => self.gen_ai_agent_name.as_str()?.into(),
+            "gen_ai\\.request\\.model" => self.gen_ai_request_model.value()?.into(),
             "http\\.decoded_response_content_length" => {
                 self.http_decoded_response_content_length.value()?.into()
             }

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -1205,7 +1205,7 @@ def test_ai_spans_example_transaction(
             "event_id": mock.ANY,
             "is_segment": True,
             "key_id": 123,
-            "name": "Generative AI agent operation",
+            "name": "gen_ai.invoke_agent",
             "organization_id": 1,
             "project_id": 42,
             "received": time_within_delta(),


### PR DESCRIPTION
The `SpanData` `Getter` implementation was missing match arms for `gen_ai.operation.name`, `gen_ai.agent.name`, and `gen_ai.request.model`. These attributes are deserialized into typed struct fields on `SpanData` (not the `other` map), but the `Getter` had no arms for them, so lookups fell through to the `_` fallback which searched `other` — where the values no longer exist.

This caused the span name template inference in `sentry-conventions` to always skip all templates and produce the hardcoded fallback: `"Generative AI model operation"` or `"Generative AI agent operation"`, regardless of what attributes the SDK sent.

Fixes [TET-2106: Fix relay span.name mapping](https://linear.app/getsentry/issue/TET-2106/fix-relay-spanname-mapping)