### PR TITLE
ref(crash): Switch to sentry native's native crash backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Calculate and track accepted bytes per individual trace metric item via `TraceMetricByte` data category. ([#5744](https://github.com/getsentry/relay/pull/5744), [#5767](https://github.com/getsentry/relay/pull/5767))
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 - TUS: Disallow creation with upload. ([#5734](https://github.com/getsentry/relay/pull/5734))
+- Use sentry native's native crash reporting backend instead of breakpad. ([#5789](https://github.com/getsentry/relay/pull/5789))
 - Add logic to verify attachment placeholders and correctly store them. ([#5747](https://github.com/getsentry/relay/pull/5747))
 - Remove continuous-profiling-beta feature flags. ([#5762](https://github.com/getsentry/relay/pull/5762))
 - Playstation: Do not upload attachments if quota is 0. ([#5770](https://github.com/getsentry/relay/pull/5770))

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .profile("RelWithDebInfo")
         // use the sentry native crash reporting backend
         .define("SENTRY_BACKEND", "native")
+        .define("SENTRY_WITH_LIBUNWIND", "ON")
         // inject a custom transport instead of curl
         .define("SENTRY_TRANSPORT", "none")
         // build a static library

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -13,7 +13,6 @@ fn main() {
         .profile("RelWithDebInfo")
         // use the sentry native crash reporting backend
         .define("SENTRY_BACKEND", "native")
-        .define("SENTRY_WITH_LIBUNWIND", "ON")
         // inject a custom transport instead of curl
         .define("SENTRY_TRANSPORT", "none")
         // build a static library

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 fn main() {
     if !Path::new("sentry-native/.git").exists() {
         let _ = Command::new("git")
-            .args(["submodule", "update", "--init"])
+            .args(["submodule", "update", "--init", "--recursive"])
             .status();
     }
 

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -29,10 +29,10 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         destination.join("lib").display()
     );
-    println!("cargo:rustc-link-lib=static=sentry");
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() == "linux" {
         println!("cargo:rustc-link-lib=static=unwind");
     }
+    println!("cargo:rustc-link-lib=static=sentry");
 
     let bindings = bindgen::Builder::default()
         .header("sentry-native/include/sentry.h")

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -30,6 +30,9 @@ fn main() {
         destination.join("lib").display()
     );
     println!("cargo:rustc-link-lib=static=sentry");
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() == "linux" {
+        println!("cargo:rustc-link-lib=static=unwind");
+    }
 
     let bindings = bindgen::Builder::default()
         .header("sentry-native/include/sentry.h")

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -2,24 +2,17 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    // sentry-native dependencies
-    match std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
-        "macos" => println!("cargo:rustc-link-lib=dylib=c++"),
-        "linux" => println!("cargo:rustc-link-lib=dylib=stdc++"),
-        _ => return, // allow building with --all-features, fail during runtime
-    }
-
     if !Path::new("sentry-native/.git").exists() {
         let _ = Command::new("git")
-            .args(["submodule", "update", "--init", "--recursive"])
+            .args(["submodule", "update", "--init"])
             .status();
     }
 
     let destination = cmake::Config::new("sentry-native")
         // we never need a debug build of sentry-native
         .profile("RelWithDebInfo")
-        // always build breakpad regardless of platform defaults
-        .define("SENTRY_BACKEND", "breakpad")
+        // use the sentry native crash reporting backend
+        .define("SENTRY_BACKEND", "native")
         // inject a custom transport instead of curl
         .define("SENTRY_TRANSPORT", "none")
         // build a static library
@@ -36,7 +29,6 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         destination.join("lib").display()
     );
-    println!("cargo:rustc-link-lib=static=breakpad_client");
     println!("cargo:rustc-link-lib=static=sentry");
 
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
This means we no longer rely on breakpad, but use sentry native's capabilities instead. 