### PR TITLE
fix(tests): Fix flaky test_graceful_shutdown timing

### DIFF
--- a/tests/integration/test_shutdown.py
+++ b/tests/integration/test_shutdown.py
@@ -58,7 +58,19 @@ def test_graceful_shutdown(mini_sentry, relay, storage):
 
         # Trigger graceful shutdown while the request is in-flight.
         relay.process.send_signal(signal.SIGTERM)
-        time.sleep(0.05)
+
+        # Wait until relay has actually entered shutdown by trying to open new
+        # TCP connections.  The first thing graceful shutdown does is close the
+        # TCP listener, so `create_connection` will raise "connection refused"
+        # once shutdown has started — no arbitrary sleep needed.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                probe = socket.create_connection((host, port), timeout=1)
+                probe.close()
+            except OSError:
+                break  # Connection refused — listener is closed, shutdown started
+            time.sleep(0.01)  # throttle probes to avoid hot-spinning on CI
 
         # Complete the request — relay will respond with Service Unavailable.
         sock.sendall(request[-1:])


### PR DESCRIPTION
This has been flaky in the last couple of PRs I opened.

Replace the brittle `time.sleep(0.05)` after SIGTERM with a deterministic
check that probes for TCP listener closure.

The original 50ms sleep was a race condition: on slow/loaded CI machines,
relay might not have processed the SIGTERM signal yet, so the test would
complete the in-flight request before shutdown started — causing the
permanent-storage variant to get `200` instead of the expected `503`.

The new approach tries to open new TCP connections in a tight loop. The
first thing relay's graceful shutdown does is close the TCP listener, so
`create_connection` raises `ConnectionRefusedError` once shutdown has
actually started. This is a direct observation of the state transition
rather than a guess about timing.