### PR TITLE
ref(unreal): Remove unused argument to `process_apple_crash_report`

### DIFF
--- a/relay-server/src/processing/errors/errors/apple_crash_report.rs
+++ b/relay-server/src/processing/errors/errors/apple_crash_report.rs
@@ -26,10 +26,7 @@ impl SentryError for AppleCrashReport {
         let mut event = utils::take_event_from_crash_items(items, &mut metrics, ctx)?;
 
         utils::if_processing!(ctx, {
-            crate::utils::process_apple_crash_report(
-                event.get_or_insert_with(Default::default),
-                &apple_crash_report.payload(),
-            );
+            crate::utils::process_apple_crash_report(event.get_or_insert_with(Default::default));
             metrics.bytes_ingested_event_applecrashreport =
                 (apple_crash_report.len() as u64).into();
         });

--- a/relay-server/src/processing/errors/errors/unreal.rs
+++ b/relay-server/src/processing/errors/errors/unreal.rs
@@ -94,8 +94,7 @@ impl SentryError for Unreal {
             }
             if let Some(acr) = &apple_crash_report {
                 crate::utils::process_apple_crash_report(
-                    event.get_or_insert_with(Default::default),
-                    &acr.payload(),
+                    event.get_or_insert_with(Default::default)
                 );
                 metrics.bytes_ingested_event_applecrashreport = (acr.len() as u64).into();
             }

--- a/relay-server/src/services/processor/attachment.rs
+++ b/relay-server/src/services/processor/attachment.rs
@@ -37,7 +37,7 @@ pub fn create_placeholders(
     } else if let Some(item) = apple_crash_report_attachment {
         let event = event.get_or_insert_with(Event::default);
         metrics.bytes_ingested_event_applecrashreport = Annotated::new(item.len() as u64);
-        utils::process_apple_crash_report(event, &item.payload());
+        utils::process_apple_crash_report(event);
         return Some(EventFullyNormalized(false));
     }
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -251,7 +251,7 @@ pub fn process_minidump(event: &mut Event, data: &[u8]) {
 
 /// Writes minimal information into the event to indicate it is associated with an Apple Crash
 /// Report.
-pub fn process_apple_crash_report(event: &mut Event, _data: &[u8]) {
+pub fn process_apple_crash_report(event: &mut Event) {
     let placeholder = NativePlaceholder {
         exception_type: "AppleCrashReport",
         exception_value: "Invalid Apple Crash Report",


### PR DESCRIPTION
While looking at the unreal crash processing code in the lead up to working on https://linear.app/getsentry/issue/INGEST-735/implement-streaming-unreal-endpoint noticed that `process_apple_crash_report` takes an argument that it does nothing with. This now removes this unused argument.