### PR TITLE
Revert "ref(crash): Switch to sentry native's native crash backend"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 - Graduate standalone span ingestion feature flag. ([#5786](https://github.com/getsentry/relay/pull/5786))
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))
 - TUS: Disallow creation with upload. ([#5734](https://github.com/getsentry/relay/pull/5734))
-- Use sentry native's native crash reporting backend instead of breakpad. ([#5789](https://github.com/getsentry/relay/pull/5789))
 - Add logic to verify attachment placeholders and correctly store them. ([#5747](https://github.com/getsentry/relay/pull/5747))
 - Remove continuous-profiling-beta feature flags. ([#5762](https://github.com/getsentry/relay/pull/5762))
 - Playstation: Do not upload attachments if quota is 0. ([#5770](https://github.com/getsentry/relay/pull/5770))

--- a/relay-crash/build.rs
+++ b/relay-crash/build.rs
@@ -2,6 +2,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    // sentry-native dependencies
+    match std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
+        "macos" => println!("cargo:rustc-link-lib=dylib=c++"),
+        "linux" => println!("cargo:rustc-link-lib=dylib=stdc++"),
+        _ => return, // allow building with --all-features, fail during runtime
+    }
+
     if !Path::new("sentry-native/.git").exists() {
         let _ = Command::new("git")
             .args(["submodule", "update", "--init", "--recursive"])
@@ -11,8 +18,8 @@ fn main() {
     let destination = cmake::Config::new("sentry-native")
         // we never need a debug build of sentry-native
         .profile("RelWithDebInfo")
-        // use the sentry native crash reporting backend
-        .define("SENTRY_BACKEND", "native")
+        // always build breakpad regardless of platform defaults
+        .define("SENTRY_BACKEND", "breakpad")
         // inject a custom transport instead of curl
         .define("SENTRY_TRANSPORT", "none")
         // build a static library
@@ -29,9 +36,7 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         destination.join("lib").display()
     );
-    if std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() == "linux" {
-        println!("cargo:rustc-link-lib=static=unwind");
-    }
+    println!("cargo:rustc-link-lib=static=breakpad_client");
     println!("cargo:rustc-link-lib=static=sentry");
 
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
Reverts getsentry/relay#5789

This backends needs a secondary binary available `sentry-crash`. 