### PR TITLE
ref(kafka): Deduplicate kafka error logging

### DIFF
--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -69,25 +69,6 @@ impl KafkaTopic {
         ];
         TOPICS.iter()
     }
-
-    /// Returns a name for the topic for instrumentation.
-    pub fn as_str(&self) -> &str {
-        match self {
-            KafkaTopic::Events => "events",
-            KafkaTopic::Attachments => "attachments",
-            KafkaTopic::Transactions => "transactions",
-            KafkaTopic::Outcomes => "outcomes",
-            KafkaTopic::OutcomesBilling => "outcomes_billing",
-            KafkaTopic::MetricsSessions => "metrics_sessions",
-            KafkaTopic::MetricsGeneric => "metrics_generic",
-            KafkaTopic::Profiles => "profiles",
-            KafkaTopic::ReplayRecordings => "replay_recordings",
-            KafkaTopic::Monitors => "monitors",
-            KafkaTopic::Spans => "spans",
-            KafkaTopic::Feedback => "feedback",
-            KafkaTopic::Items => "items",
-        }
-    }
 }
 
 macro_rules! define_topic_assignments {

--- a/relay-kafka/src/config.rs
+++ b/relay-kafka/src/config.rs
@@ -69,6 +69,25 @@ impl KafkaTopic {
         ];
         TOPICS.iter()
     }
+
+    /// Returns a name for the topic for instrumentation.
+    pub fn as_str(&self) -> &str {
+        match self {
+            KafkaTopic::Events => "events",
+            KafkaTopic::Attachments => "attachments",
+            KafkaTopic::Transactions => "transactions",
+            KafkaTopic::Outcomes => "outcomes",
+            KafkaTopic::OutcomesBilling => "outcomes_billing",
+            KafkaTopic::MetricsSessions => "metrics_sessions",
+            KafkaTopic::MetricsGeneric => "metrics_generic",
+            KafkaTopic::Profiles => "profiles",
+            KafkaTopic::ReplayRecordings => "replay_recordings",
+            KafkaTopic::Monitors => "monitors",
+            KafkaTopic::Spans => "spans",
+            KafkaTopic::Feedback => "feedback",
+            KafkaTopic::Items => "items",
+        }
+    }
 }
 
 macro_rules! define_topic_assignments {

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -214,6 +214,8 @@ impl Producer {
             return Err(ClientError::MissingTopic);
         };
 
+        relay_log::configure_scope(|s| s.set_tag("topic", topic_name));
+
         let producer_name = producer.context().producer_name();
 
         metric!(
@@ -272,12 +274,6 @@ impl Producer {
         });
 
         producer.send(record).map_err(|(error, _message)| {
-            relay_log::error!(
-                error = &error as &dyn std::error::Error,
-                tags.variant = variant,
-                tags.topic = topic_name,
-                "error sending kafka message",
-            );
             metric!(
                 counter(KafkaCounters::ProducerEnqueueError) += 1,
                 variant = variant,
@@ -342,6 +338,22 @@ impl KafkaClient {
         topic: KafkaTopic,
         message: &impl Message,
     ) -> Result<&str, ClientError> {
+        self.send_message_inner(topic, message)
+            .inspect_err(|error| {
+                relay_log::error!(
+                    error = error as &dyn std::error::Error,
+                    tags.variant = message.variant(),
+                    tags.abstract_topic = topic.as_str(),
+                    "error sending kafka message",
+                );
+            })
+    }
+
+    fn send_message_inner(
+        &self,
+        topic: KafkaTopic,
+        message: &impl Message,
+    ) -> Result<&str, ClientError> {
         let serialized = message.serialize()?;
 
         #[cfg(debug_assertions)]
@@ -370,12 +382,10 @@ impl KafkaClient {
         variant: &str,
         payload: &[u8],
     ) -> Result<&str, ClientError> {
-        let producer = self.producers.get(&topic).ok_or_else(|| {
-            relay_log::error!(
-                "attempted to send message to {topic:?} using an unconfigured kafka producer",
-            );
-            ClientError::InvalidTopicName
-        })?;
+        let producer = self
+            .producers
+            .get(&topic)
+            .ok_or_else(|| ClientError::InvalidTopicName)?;
 
         producer.send(key, headers, variant, payload)
     }

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -338,22 +338,6 @@ impl KafkaClient {
         topic: KafkaTopic,
         message: &impl Message,
     ) -> Result<&str, ClientError> {
-        self.send_message_inner(topic, message)
-            .inspect_err(|error| {
-                relay_log::error!(
-                    error = error as &dyn std::error::Error,
-                    tags.variant = message.variant(),
-                    tags.abstract_topic = topic.as_str(),
-                    "error sending kafka message",
-                );
-            })
-    }
-
-    fn send_message_inner(
-        &self,
-        topic: KafkaTopic,
-        message: &impl Message,
-    ) -> Result<&str, ClientError> {
         let serialized = message.serialize()?;
 
         #[cfg(debug_assertions)]

--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -53,7 +53,7 @@ pub enum ClientError {
 
     /// Failed to serialize the json message using serde.
     #[error("failed to serialize json message")]
-    InvalidJson(#[source] serde_json::Error),
+    InvalidJson(#[from] serde_json::Error),
 
     /// Failed to run schema validation on message.
     #[cfg(debug_assertions)]
@@ -362,7 +362,7 @@ impl KafkaClient {
     /// Sends the payload to the correct producer for the current topic.
     ///
     /// Returns the name of the Kafka topic to which the message was produced.
-    pub fn send(
+    fn send(
         &self,
         topic: KafkaTopic,
         key: Option<Key>,

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -27,9 +27,8 @@ use relay_config::{Config, EmitOutcomes};
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::{ClientReport, DiscardedEvent, EventId};
 use relay_filter::FilterStatKey;
-use relay_kafka::SerializationOutput;
 #[cfg(feature = "processing")]
-use relay_kafka::{ClientError, KafkaClient, KafkaTopic};
+use relay_kafka::{ClientError, KafkaClient, KafkaTopic, SerializationOutput};
 use relay_quotas::{DataCategory, ReasonCode, Scoping};
 use relay_sampling::config::RuleId;
 use relay_sampling::evaluation::MatchedRuleIds;
@@ -1260,6 +1259,7 @@ impl OutcomeBroker {
     }
 }
 
+#[cfg(feature = "processing")]
 impl relay_kafka::Message for TrackRawOutcome {
     fn key(&self) -> Option<relay_kafka::Key> {
         // At the moment, we support outcomes with optional EventId.

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -904,14 +904,6 @@ impl FromMessage<Self> for TrackRawOutcome {
     }
 }
 
-#[derive(Debug)]
-#[cfg(feature = "processing")]
-#[cfg_attr(feature = "processing", derive(thiserror::Error))]
-pub enum OutcomeError {
-    #[error("failed to send kafka message")]
-    SendFailed(ClientError),
-}
-
 /// Outcome producer backend via HTTP as [`TrackRawOutcome`].
 #[derive(Debug)]
 struct HttpOutcomeProducer {
@@ -1196,11 +1188,7 @@ impl OutcomeBroker {
     }
 
     #[cfg(feature = "processing")]
-    fn send_kafka_message(
-        &self,
-        producer: &KafkaOutcomesProducer,
-        message: TrackRawOutcome,
-    ) -> Result<(), OutcomeError> {
+    fn send_kafka_message(&self, producer: &KafkaOutcomesProducer, message: TrackRawOutcome) {
         relay_log::trace!("Tracking kafka outcome: {message:?}");
 
         // Dispatch to the correct topic and cluster based on the kind of outcome.
@@ -1210,12 +1198,7 @@ impl OutcomeBroker {
             KafkaTopic::Outcomes
         };
 
-        let result = producer.client.send_message(topic, &message);
-
-        match result {
-            Ok(_) => Ok(()),
-            Err(kafka_error) => Err(OutcomeError::SendFailed(kafka_error)),
-        }
+        let _ = producer.client.send_message(topic, &message); // logs error internally
     }
 
     fn handle_track_outcome(&self, message: TrackOutcome, config: &Config) {
@@ -1224,9 +1207,7 @@ impl OutcomeBroker {
             Self::Kafka(kafka_producer) => {
                 send_outcome_metric(&message, "kafka");
                 let raw_message = TrackRawOutcome::from_outcome(message, config);
-                if let Err(error) = self.send_kafka_message(kafka_producer, raw_message) {
-                    relay_log::error!(error = &error as &dyn Error, "failed to produce outcome");
-                }
+                self.send_kafka_message(kafka_producer, raw_message);
             }
             Self::ClientReport(producer) => {
                 send_outcome_metric(&message, "client_report");
@@ -1245,9 +1226,7 @@ impl OutcomeBroker {
             #[cfg(feature = "processing")]
             Self::Kafka(kafka_producer) => {
                 send_outcome_metric(&message, "kafka");
-                if let Err(error) = self.send_kafka_message(kafka_producer, message) {
-                    relay_log::error!(error = &error as &dyn Error, "failed to produce outcome");
-                }
+                self.send_kafka_message(kafka_producer, message);
             }
             Self::Http(producer) => {
                 send_outcome_metric(&message, "http");

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -1198,7 +1198,9 @@ impl OutcomeBroker {
             KafkaTopic::Outcomes
         };
 
-        let _ = producer.client.send_message(topic, &message); // logs error internally
+        if let Err(error) = producer.client.send_message(topic, &message) {
+            relay_log::error!(error = &error as &dyn Error, "failed to produce outcome");
+        }
     }
 
     fn handle_track_outcome(&self, message: TrackOutcome, config: &Config) {

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -1181,10 +1181,13 @@ enum OutcomeBroker {
 
 impl OutcomeBroker {
     fn handle_message(&self, message: OutcomeProducer, config: &Config) {
-        match message {
-            OutcomeProducer::TrackOutcome(msg) => self.handle_track_outcome(msg, config),
-            OutcomeProducer::TrackRawOutcome(msg) => self.handle_track_raw_outcome(msg),
-        }
+        relay_log::with_scope(
+            |_| {},
+            || match message {
+                OutcomeProducer::TrackOutcome(msg) => self.handle_track_outcome(msg, config),
+                OutcomeProducer::TrackRawOutcome(msg) => self.handle_track_raw_outcome(msg),
+            },
+        )
     }
 
     #[cfg(feature = "processing")]

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -1262,6 +1262,10 @@ impl OutcomeBroker {
 
 impl relay_kafka::Message for TrackRawOutcome {
     fn key(&self) -> Option<relay_kafka::Key> {
+        // At the moment, we support outcomes with optional EventId.
+        // Here we create a fake EventId, when we don't have the real one, so that we can
+        // create a kafka message key that spreads the events nicely over all the
+        // kafka consumer groups.
         let key = self.event_id.unwrap_or_default().0;
         Some(key.as_u128())
     }

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -27,6 +27,7 @@ use relay_config::{Config, EmitOutcomes};
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::{ClientReport, DiscardedEvent, EventId};
 use relay_filter::FilterStatKey;
+use relay_kafka::SerializationOutput;
 #[cfg(feature = "processing")]
 use relay_kafka::{ClientError, KafkaClient, KafkaTopic};
 use relay_quotas::{DataCategory, ReasonCode, Scoping};
@@ -910,8 +911,6 @@ impl FromMessage<Self> for TrackRawOutcome {
 pub enum OutcomeError {
     #[error("failed to send kafka message")]
     SendFailed(ClientError),
-    #[error("json serialization error")]
-    SerializationError(serde_json::Error),
 }
 
 /// Outcome producer backend via HTTP as [`TrackRawOutcome`].
@@ -1205,14 +1204,6 @@ impl OutcomeBroker {
     ) -> Result<(), OutcomeError> {
         relay_log::trace!("Tracking kafka outcome: {message:?}");
 
-        let payload = serde_json::to_string(&message).map_err(OutcomeError::SerializationError)?;
-
-        // At the moment, we support outcomes with optional EventId.
-        // Here we create a fake EventId, when we don't have the real one, so that we can
-        // create a kafka message key that spreads the events nicely over all the
-        // kafka consumer groups.
-        let key = message.event_id.unwrap_or_default().0;
-
         // Dispatch to the correct topic and cluster based on the kind of outcome.
         let topic = if message.is_billing() {
             KafkaTopic::OutcomesBilling
@@ -1220,13 +1211,7 @@ impl OutcomeBroker {
             KafkaTopic::Outcomes
         };
 
-        let result = producer.client.send(
-            topic,
-            Some(key.as_u128()),
-            None,
-            "outcome",
-            payload.as_bytes(),
-        );
+        let result = producer.client.send_message(topic, &message);
 
         match result {
             Ok(_) => Ok(()),
@@ -1272,6 +1257,26 @@ impl OutcomeBroker {
             Self::ClientReport(_) => (),
             Self::Disabled => (),
         }
+    }
+}
+
+impl relay_kafka::Message for TrackRawOutcome {
+    fn key(&self) -> Option<relay_kafka::Key> {
+        let key = self.event_id.unwrap_or_default().0;
+        Some(key.as_u128())
+    }
+
+    fn variant(&self) -> &'static str {
+        "outcome"
+    }
+
+    fn headers(&self) -> Option<&BTreeMap<String, String>> {
+        None
+    }
+
+    fn serialize(&self) -> Result<SerializationOutput<'_>, ClientError> {
+        let serialized = serde_json::to_vec(self)?;
+        Ok(SerializationOutput::Json(Cow::Owned(serialized)))
     }
 }
 

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -399,7 +399,7 @@ impl StoreService {
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {
                 Store::Envelope(message) => self.handle_store_envelope(message),
-                Store::Metrics(message) => self.handle_store_metrics(message),
+                Store::Metrics(message) => return self.handle_store_metrics(message),
                 Store::TraceItem(message) => self.handle_store_trace_item(message),
                 Store::Span(message) => self.handle_store_span(message),
                 Store::ProfileChunk(message) => self.handle_store_profile_chunk(message),
@@ -429,7 +429,7 @@ impl StoreService {
             Err(error) => {
                 // The envelope is now empty. `ManagedEnvelope` still counts items correctly
                 // through `EnvelopeSummary`, but `Managed<Box<Envelope>>` does not.
-                // -> reject the old way and return a dummy item.
+                // -> Reject the old way and return a dummy item.
                 envelope.reject(Outcome::Invalid(DiscardReason::Internal));
                 Err(Managed::with_meta_from(&envelope, ()).reject_err(error))
             }
@@ -605,7 +605,7 @@ impl StoreService {
         Ok(())
     }
 
-    fn handle_store_metrics(&self, message: StoreMetrics) -> Result<(), Rejected<StoreError>> {
+    fn handle_store_metrics(&self, message: StoreMetrics) {
         let StoreMetrics {
             buckets,
             scoping,
@@ -706,8 +706,6 @@ impl StoreService {
                 namespace = namespace.as_str()
             );
         }
-
-        Ok(())
     }
 
     fn handle_store_trace_item(

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -404,7 +404,10 @@ impl StoreService {
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {
                 Store::Envelope(message) => self.handle_store_envelope(message),
-                Store::Metrics(message) => return self.handle_store_metrics(message),
+                Store::Metrics(message) => {
+                    self.handle_store_metrics(message);
+                    Ok(())
+                }
                 Store::TraceItem(message) => self.handle_store_trace_item(message),
                 Store::Span(message) => self.handle_store_span(message),
                 Store::ProfileChunk(message) => self.handle_store_profile_chunk(message),

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -940,18 +940,7 @@ impl StoreService {
     ) -> Result<(), StoreError> {
         relay_log::trace!("Sending kafka message of type {}", message.variant());
 
-        let topic_name = self
-            .producer
-            .client
-            .send_message(topic, &message)
-            .inspect_err(|err| {
-                relay_log::error!(
-                    error = err as &dyn Error,
-                    tags.topic = ?topic,
-                    tags.message = message.variant(),
-                    "failed to produce to Kafka"
-                )
-            })?;
+        let topic_name = self.producer.client.send_message(topic, &message)?;
 
         match &message {
             KafkaMessage::Metric {

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -395,6 +395,11 @@ impl StoreService {
     }
 
     fn handle_message(&self, message: Store) {
+        // relay_kafka configures the scope
+        relay_log::with_scope(|_| {}, || self.handle_message_inner(message))
+    }
+
+    fn handle_message_inner(&self, message: Store) {
         let ty = message.variant();
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -398,14 +398,8 @@ impl StoreService {
         let ty = message.variant();
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {
-                Store::Envelope(message) => {
-                    self.handle_store_envelope(message);
-                    Ok(())
-                }
-                Store::Metrics(message) => {
-                    self.handle_store_metrics(message);
-                    Ok(())
-                }
+                Store::Envelope(message) => self.handle_store_envelope(message),
+                Store::Metrics(message) => self.handle_store_metrics(message),
                 Store::TraceItem(message) => self.handle_store_trace_item(message),
                 Store::Span(message) => self.handle_store_span(message),
                 Store::ProfileChunk(message) => self.handle_store_profile_chunk(message),
@@ -418,25 +412,26 @@ impl StoreService {
                 relay_log::error!(
                     error = &error as &dyn Error,
                     tags.message = ty,
-                    "failed to store kafka message"
+                    "failed to store message"
                 );
             }
         })
     }
 
-    fn handle_store_envelope(&self, message: StoreEnvelope) {
+    fn handle_store_envelope(&self, message: StoreEnvelope) -> Result<(), Rejected<StoreError>> {
         let StoreEnvelope { mut envelope } = message;
 
-        let scoping = envelope.scoping();
         match self.store_envelope(&mut envelope) {
-            Ok(()) => envelope.accept(),
+            Ok(()) => {
+                envelope.accept();
+                Ok(())
+            }
             Err(error) => {
-                envelope.reject(Outcome::Invalid(DiscardReason::Internal));
-                relay_log::error!(
-                    error = &error as &dyn Error,
-                    tags.project_key = %scoping.project_key,
-                    "failed to store envelope"
-                );
+                let envelope = envelope.into_envelope();
+                Err(
+                    Managed::from_envelope(envelope, self.outcome_aggregator.clone())
+                        .reject_err(error),
+                )
             }
         }
     }
@@ -610,7 +605,7 @@ impl StoreService {
         Ok(())
     }
 
-    fn handle_store_metrics(&self, message: StoreMetrics) {
+    fn handle_store_metrics(&self, message: StoreMetrics) -> Result<(), Rejected<StoreError>> {
         let StoreMetrics {
             buckets,
             scoping,
@@ -677,7 +672,13 @@ impl StoreService {
                 && let Some(trace_item) = sessions::to_trace_item(scoping, bucket, retention)
             {
                 let message = KafkaMessage::for_item(scoping, trace_item);
-                let _ = self.produce(KafkaTopic::Items, message);
+                let res = self.produce(KafkaTopic::Items, message);
+                if let Err(error) = res {
+                    relay_log::error!(
+                        error = &error as &dyn std::error::Error,
+                        "failed to produce session metrics to EAP"
+                    )
+                }
             }
         }
 
@@ -705,6 +706,8 @@ impl StoreService {
                 namespace = namespace.as_str()
             );
         }
+
+        Ok(())
     }
 
     fn handle_store_trace_item(

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -427,11 +427,11 @@ impl StoreService {
                 Ok(())
             }
             Err(error) => {
-                let envelope = envelope.into_envelope();
-                Err(
-                    Managed::from_envelope(envelope, self.outcome_aggregator.clone())
-                        .reject_err(error),
-                )
+                // The envelope is now empty. `ManagedEnvelope` still counts items correctly
+                // through `EnvelopeSummary`, but `Managed<Box<Envelope>>` does not.
+                // -> reject the old way and return a dummy item.
+                envelope.reject(Outcome::Invalid(DiscardReason::Internal));
+                Err(Managed::with_meta_from(&envelope, ()).reject_err(error))
             }
         }
     }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1885,13 +1885,32 @@ mod tests {
 
     #[test]
     fn disallow_outcomes() {
+        struct TestMessage;
+        impl relay_kafka::Message for TestMessage {
+            fn key(&self) -> Option<relay_kafka::Key> {
+                None
+            }
+
+            fn variant(&self) -> &'static str {
+                "test"
+            }
+
+            fn headers(&self) -> Option<&BTreeMap<String, String>> {
+                None
+            }
+
+            fn serialize(&self) -> Result<SerializationOutput<'_>, ClientError> {
+                Ok(SerializationOutput::Json(Cow::Borrowed(
+                    br#"{"timestamp": "foo", "outcome": 1}"#,
+                )))
+            }
+        }
+
         let config = Config::default();
         let producer = Producer::create(&config).unwrap();
 
         for topic in [KafkaTopic::Outcomes, KafkaTopic::OutcomesBilling] {
-            let res = producer
-                .client
-                .send(topic, Some(0x0123456789abcdef), None, "foo", b"");
+            let res = producer.client.send_message(topic, &TestMessage);
 
             assert!(matches!(res, Err(ClientError::InvalidTopicName)));
         }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -34,7 +34,7 @@ use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
 use relay_threading::AsyncPool;
 
 use crate::envelope::{AttachmentPlaceholder, AttachmentType, ContentType, Item, ItemType};
-use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities};
+use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities, Rejected};
 use crate::metrics::{ArrayEncoding, BucketEncoder, MetricOutcomes};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
@@ -397,9 +397,15 @@ impl StoreService {
     fn handle_message(&self, message: Store) {
         let ty = message.variant();
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
-            match message {
-                Store::Envelope(message) => self.handle_store_envelope(message),
-                Store::Metrics(message) => self.handle_store_metrics(message),
+            let result = match message {
+                Store::Envelope(message) => {
+                    self.handle_store_envelope(message);
+                    Ok(())
+                }
+                Store::Metrics(message) => {
+                    self.handle_store_metrics(message);
+                    Ok(())
+                }
                 Store::TraceItem(message) => self.handle_store_trace_item(message),
                 Store::Span(message) => self.handle_store_span(message),
                 Store::ProfileChunk(message) => self.handle_store_profile_chunk(message),
@@ -407,6 +413,13 @@ impl StoreService {
                 Store::Attachment(message) => self.handle_store_attachment(message),
                 Store::UserReport(message) => self.handle_user_report(message),
                 Store::Profile(message) => self.handle_profile(message),
+            };
+            if let Err(error) = result {
+                relay_log::error!(
+                    error = &error as &dyn Error,
+                    tags.message = ty,
+                    "failed to store kafka message"
+                );
             }
         })
     }
@@ -694,7 +707,10 @@ impl StoreService {
         }
     }
 
-    fn handle_store_trace_item(&self, message: Managed<StoreTraceItem>) {
+    fn handle_store_trace_item(
+        &self,
+        message: Managed<StoreTraceItem>,
+    ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
         let received_at = message.received_at();
 
@@ -715,13 +731,13 @@ impl StoreService {
 
             let message = KafkaMessage::for_item(scoping, item.trace_item);
             self.produce(KafkaTopic::Items, message).map(|()| outcomes)
-        });
+        })?;
 
         // Accepted outcomes when items have been successfully produced to rdkafka.
         //
         // This is only a temporary measure, long term these outcomes will be part of the trace
         // item and emitted by Snuba to guarantee a delivery to storage.
-        if let Ok(Some(outcomes)) = outcomes {
+        if let Some(outcomes) = outcomes {
             for (category, quantity) in outcomes.quantities() {
                 self.outcome_aggregator.send(TrackOutcome {
                     category,
@@ -734,9 +750,14 @@ impl StoreService {
                 });
             }
         }
+
+        Ok(())
     }
 
-    fn handle_store_span(&self, message: Managed<Box<StoreSpanV2>>) {
+    fn handle_store_span(
+        &self,
+        message: Managed<Box<StoreSpanV2>>,
+    ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
         let received_at = message.received_at();
 
@@ -760,7 +781,7 @@ impl StoreService {
             accepted_outcome_emitted: relay_emits_accepted_outcome,
         };
 
-        let result = message.try_accept(|span| {
+        message.try_accept(|span| {
             let item = Annotated::new(span.item);
             let message = KafkaMessage::SpanV2 {
                 routing_key: span.routing_key,
@@ -776,35 +797,38 @@ impl StoreService {
             };
 
             self.produce(KafkaTopic::Spans, message)
-        });
+        })?;
 
-        if result.is_ok() {
-            relay_statsd::metric!(
-                counter(RelayCounters::SpanV2Produced) += 1,
-                via = "processing"
-            );
+        relay_statsd::metric!(
+            counter(RelayCounters::SpanV2Produced) += 1,
+            via = "processing"
+        );
 
-            if relay_emits_accepted_outcome {
-                // XXX: Temporarily produce span outcomes. Keep in sync with either EAP
-                // or the segments consumer, depending on which will produce outcomes later.
-                self.outcome_aggregator.send(TrackOutcome {
-                    category: DataCategory::SpanIndexed,
-                    event_id: None,
-                    outcome: Outcome::Accepted,
-                    quantity: 1,
-                    remote_addr: None,
-                    scoping,
-                    timestamp: received_at,
-                });
-            }
+        if relay_emits_accepted_outcome {
+            // XXX: Temporarily produce span outcomes. Keep in sync with either EAP
+            // or the segments consumer, depending on which will produce outcomes later.
+            self.outcome_aggregator.send(TrackOutcome {
+                category: DataCategory::SpanIndexed,
+                event_id: None,
+                outcome: Outcome::Accepted,
+                quantity: 1,
+                remote_addr: None,
+                scoping,
+                timestamp: received_at,
+            });
         }
+
+        Ok(())
     }
 
-    fn handle_store_profile_chunk(&self, message: Managed<StoreProfileChunk>) {
+    fn handle_store_profile_chunk(
+        &self,
+        message: Managed<StoreProfileChunk>,
+    ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
         let received_at = message.received_at();
 
-        let _ = message.try_accept(|message| {
+        message.try_accept(|message| {
             let message = ProfileChunkKafkaMessage {
                 organization_id: scoping.organization_id,
                 project_id: scoping.project_id,
@@ -818,14 +842,17 @@ impl StoreService {
             };
 
             self.produce(KafkaTopic::Profiles, KafkaMessage::ProfileChunk(message))
-        });
+        })
     }
 
-    fn handle_store_replay(&self, message: Managed<StoreReplay>) {
+    fn handle_store_replay(
+        &self,
+        message: Managed<StoreReplay>,
+    ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
         let received_at = message.received_at();
 
-        let _ = message.try_accept(|replay| {
+        message.try_accept(|replay| {
             let kafka_msg =
                 KafkaMessage::ReplayRecordingNotChunked(ReplayRecordingNotChunkedKafkaMessage {
                     replay_id: replay.event_id,
@@ -842,12 +869,15 @@ impl StoreService {
                     relay_snuba_publish_disabled: true,
                 });
             self.produce(KafkaTopic::ReplayRecordings, kafka_msg)
-        });
+        })
     }
 
-    fn handle_store_attachment(&self, message: Managed<StoreAttachment>) {
+    fn handle_store_attachment(
+        &self,
+        message: Managed<StoreAttachment>,
+    ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
-        let _ = message.try_accept(|attachment| {
+        message.try_accept(|attachment| {
             let result = self.produce_attachment(
                 attachment.event_id,
                 scoping.project_id,
@@ -860,15 +890,18 @@ impl StoreService {
             // Since we are sending an 'individual attachment' this function should never return a
             // `ChunkedAttachment`.
             debug_assert!(!matches!(result, Ok(Some(_))));
-            result
-        });
+            result.map(|_| ())
+        })
     }
 
-    fn handle_user_report(&self, message: Managed<StoreUserReport>) {
+    fn handle_user_report(
+        &self,
+        message: Managed<StoreUserReport>,
+    ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
         let received_at = message.received_at();
 
-        let _ = message.try_accept(|report| {
+        message.try_accept(|report| {
             let kafka_msg = KafkaMessage::UserReport(UserReportKafkaMessage {
                 project_id: scoping.project_id,
                 event_id: report.event_id,
@@ -877,14 +910,14 @@ impl StoreService {
                 org_id: scoping.organization_id,
             });
             self.produce(KafkaTopic::Attachments, kafka_msg)
-        });
+        })
     }
 
-    fn handle_profile(&self, message: Managed<StoreProfile>) {
+    fn handle_profile(&self, message: Managed<StoreProfile>) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
         let received_at = message.received_at();
 
-        let _ = message.try_accept(|profile| {
+        message.try_accept(|profile| {
             self.produce_profile(
                 scoping.organization_id,
                 scoping.project_id,
@@ -893,7 +926,7 @@ impl StoreService {
                 profile.retention_days,
                 &profile.profile,
             )
-        });
+        })
     }
 
     fn create_metric_message<'a>(


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/relay/pull/5607:

We are currently getting two sentry errors for producer failures:

1. "failed to produce to Kafka" - This is specific to the store service and also catches configuration errors such as missing topics.
2. "error sending kafka message" - This is generic in `relay_kafka`, but does not report config errors.

This PR removes the public `send` function on the `KafkaClient` so there is only one entry point `send_kafka_message`, and logs all errors there. For this, the outcome producer also needs to implement `relay_kafka::Message`.