### PR TITLE
fix(tracemetrics): Update pii scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 **Internal**:
 
+- Update trace metric PII scrubbing to use `relay_pii::eap::scrub`. ([#5815](https://github.com/getsentry/relay/pull/5815))
 - Calculate and track accepted bytes per individual trace metric item via `TraceMetricByte` data category. ([#5744](https://github.com/getsentry/relay/pull/5744), [#5767](https://github.com/getsentry/relay/pull/5767))
 - Graduate standalone span ingestion feature flag. ([#5786](https://github.com/getsentry/relay/pull/5786))
 - Use new processor architecture to process standalone profiles. ([#5741](https://github.com/getsentry/relay/pull/5741))

--- a/relay-pii/src/eap.rs
+++ b/relay-pii/src/eap.rs
@@ -38,7 +38,7 @@ pub fn scrub<T: ProcessValue>(
 #[cfg(test)]
 mod tests {
     use relay_event_schema::processor::ValueType;
-    use relay_event_schema::protocol::{Attributes, OurLog, SpanV2};
+    use relay_event_schema::protocol::{Attributes, OurLog, SpanV2, TraceMetric};
     use relay_protocol::{Annotated, SerializableAnnotated};
 
     use crate::{DataScrubbingConfig, PiiConfig, eap};
@@ -858,6 +858,32 @@ mod tests {
                 eap::scrub(ValueType::OurLog, &mut log, Some(&config), scrubbing_config.as_ref()).unwrap();
 
                 insta::allow_duplicates!(insta::assert_json_snapshot!(SerializableAnnotated(&log.value().unwrap().attributes), @$snapshot));
+
+                let metric_json = format!(r#"{{
+                    "timestamp": 1544719860.0,
+                    "trace_id": "5b8efff798038103d269b633813fc60c",
+                    "name": "test.metric",
+                    "type": "counter",
+                    "value": 1.0,
+                    "attributes": {{
+                        "{rule_type}|{value}": {{
+                            "type": "string",
+                            "value": "{value}"
+                        }}
+                    }}
+                }}"#,
+                rule_type = $rule_type,
+                value = $test_value
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n")
+                );
+
+                let mut metric = Annotated::<TraceMetric>::from_json(&metric_json).unwrap();
+
+                eap::scrub(ValueType::TraceMetric, &mut metric, Some(&config), scrubbing_config.as_ref()).unwrap();
+
+                insta::allow_duplicates!(insta::assert_json_snapshot!(SerializableAnnotated(&metric.value().unwrap().attributes), @$snapshot));
             }
         };
     }

--- a/relay-server/src/processing/trace_metrics/process.rs
+++ b/relay-server/src/processing/trace_metrics/process.rs
@@ -1,7 +1,6 @@
 use relay_event_normalization::{RequiredMode, SchemaProcessor, eap};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
 use relay_event_schema::protocol::{TraceMetric, TraceMetricHeader};
-use relay_pii::{AttributeMode, PiiProcessor};
 use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 
@@ -93,21 +92,12 @@ fn expand_trace_metric_container(
 fn scrub_trace_metric(metric: &mut Annotated<TraceMetric>, ctx: Context<'_>) -> Result<()> {
     let pii_config_from_scrubbing = ctx.project_info.config.datascrubbing_settings.pii_config();
 
-    let state = ProcessingState::root().enter_borrowed("", None, [ValueType::TraceMetric]);
-
-    if let Some(ref config) = ctx.project_info.config.pii_config {
-        let mut processor = PiiProcessor::new(config.compiled())
-            // For advanced rules we want to treat attributes as objects.
-            .attribute_mode(AttributeMode::Object);
-        process_value(metric, &mut processor, &state)?;
-    }
-
-    if let Some(config) = pii_config_from_scrubbing {
-        let mut processor = PiiProcessor::new(config.compiled())
-            // For "legacy" rules we want to identify attributes with their values.
-            .attribute_mode(AttributeMode::ValueOnly);
-        process_value(metric, &mut processor, &state)?;
-    }
+    relay_pii::eap::scrub(
+        ValueType::TraceMetric,
+        metric,
+        ctx.project_info.config.pii_config.as_ref(),
+        pii_config_from_scrubbing.as_ref(),
+    )?;
 
     Ok(())
 }
@@ -154,4 +144,305 @@ fn normalize_trace_metric(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_pii::PiiConfig;
+    use relay_protocol::assert_annotated_snapshot;
+
+    use crate::services::projects::project::ProjectInfo;
+
+    use super::*;
+
+    #[test]
+    fn test_scrub_trace_metric_base_fields() {
+        let json = r#"
+        {
+            "timestamp": 1544719860.0,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "test.metric",
+            "type": "counter",
+            "value": 1.0,
+            "attributes": {
+                "secret": {
+                    "type": "string",
+                    "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                }
+            }
+        }
+        "#;
+
+        let mut data = Annotated::<TraceMetric>::from_json(json).unwrap();
+
+        let mut datascrubbing_settings = relay_pii::DataScrubbingConfig::default();
+        datascrubbing_settings.scrub_data = true;
+        datascrubbing_settings.scrub_defaults = true;
+
+        let ctx = Context {
+            project_info: &ProjectInfo {
+                config: relay_dynamic_config::ProjectConfig {
+                    datascrubbing_settings,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Context::for_test()
+        };
+
+        scrub_trace_metric(&mut data, ctx).unwrap();
+
+        assert_annotated_snapshot!(data, @r#"
+        {
+          "timestamp": 1544719860.0,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "name": "test.metric",
+          "type": "counter",
+          "value": 1.0,
+          "attributes": {
+            "secret": {
+              "type": "string",
+              "value": "[Filtered]"
+            }
+          },
+          "_meta": {
+            "attributes": {
+              "secret": {
+                "value": {
+                  "": {
+                    "rem": [
+                      [
+                        "@bearer:filter",
+                        "s",
+                        0,
+                        10
+                      ]
+                    ],
+                    "len": 43
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_scrub_trace_metric_deep_wild_cards() {
+        let json = r#"
+        {
+            "timestamp": 1544719860.0,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "test.metric",
+            "type": "counter",
+            "value": 1.0,
+            "attributes": {
+                "normal_field": {
+                    "type": "string",
+                    "value": "normal_value"
+                }
+            }
+        }
+        "#;
+
+        let mut data = Annotated::<TraceMetric>::from_json(json).unwrap();
+
+        let deep_wildcard_config = serde_json::from_value::<PiiConfig>(serde_json::json!({
+            "rules": {
+                "remove_normal_field": {
+                    "type": "pattern",
+                    "pattern": "normal_value",
+                    "redaction": {
+                        "method": "replace",
+                        "text": "[REDACTED]"
+                    }
+                }
+            },
+            "applications": {
+                "**": ["remove_normal_field"]
+            }
+        }))
+        .unwrap();
+
+        let ctx = Context {
+            project_info: &ProjectInfo {
+                config: relay_dynamic_config::ProjectConfig {
+                    pii_config: Some(deep_wildcard_config),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Context::for_test()
+        };
+
+        scrub_trace_metric(&mut data, ctx).unwrap();
+
+        assert_annotated_snapshot!(data, @r#"
+        {
+          "timestamp": 1544719860.0,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "name": "test.metric",
+          "type": "counter",
+          "value": 1.0,
+          "attributes": {
+            "normal_field": {
+              "type": "string",
+              "value": "[REDACTED]"
+            }
+          },
+          "_meta": {
+            "attributes": {
+              "normal_field": {
+                "value": {
+                  "": {
+                    "rem": [
+                      [
+                        "remove_normal_field",
+                        "s",
+                        0,
+                        10
+                      ]
+                    ],
+                    "len": 12
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#);
+
+        data = Annotated::<TraceMetric>::from_json(json).unwrap();
+        let config = serde_json::from_value::<PiiConfig>(serde_json::json!({
+            "rules": {
+                "should_not_remove_normal_field": {
+                    "type": "pattern",
+                    "pattern": "normal_value",
+                    "redaction": {
+                        "method": "replace",
+                        "text": "[REDACTED]"
+                    }
+                }
+            },
+            "applications": {
+                "** && !$trace_metric.**": ["should_not_remove_normal_field"]
+            }
+        }))
+        .unwrap();
+
+        let ctx = Context {
+            project_info: &ProjectInfo {
+                config: relay_dynamic_config::ProjectConfig {
+                    pii_config: Some(config),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Context::for_test()
+        };
+
+        scrub_trace_metric(&mut data, ctx).unwrap();
+
+        assert_annotated_snapshot!(data, @r###"
+        {
+          "timestamp": 1544719860.0,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "name": "test.metric",
+          "type": "counter",
+          "value": 1.0,
+          "attributes": {
+            "normal_field": {
+              "type": "string",
+              "value": "normal_value"
+            }
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_scrub_trace_metric_deep_wild_cards_anything() {
+        let json = r#"
+        {
+            "timestamp": 1544719860.0,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "test.metric",
+            "type": "counter",
+            "value": 1.0,
+            "attributes": {
+                "normal_field": {
+                    "type": "string",
+                    "value": "normal_value"
+                }
+            }
+        }
+        "#;
+
+        let mut data = Annotated::<TraceMetric>::from_json(json).unwrap();
+
+        let config = serde_json::from_value::<PiiConfig>(serde_json::json!({
+            "rules": {
+                "remove_normal_field": {
+                    "type": "anything",
+                    "redaction": {
+                        "method": "replace",
+                        "text": "[REDACTED]"
+                    }
+                }
+            },
+            "applications": {
+                "**": ["remove_normal_field"]
+            }
+        }))
+        .unwrap();
+
+        let ctx = Context {
+            project_info: &ProjectInfo {
+                config: relay_dynamic_config::ProjectConfig {
+                    pii_config: Some(config),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Context::for_test()
+        };
+
+        scrub_trace_metric(&mut data, ctx).unwrap();
+
+        assert_annotated_snapshot!(data, @r#"
+        {
+          "timestamp": 1544719860.0,
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "name": "test.metric",
+          "type": "counter",
+          "value": 1.0,
+          "attributes": {
+            "normal_field": {
+              "type": "string",
+              "value": "[REDACTED]"
+            }
+          },
+          "_meta": {
+            "attributes": {
+              "normal_field": {
+                "value": {
+                  "": {
+                    "rem": [
+                      [
+                        "remove_normal_field",
+                        "s",
+                        0,
+                        10
+                      ]
+                    ],
+                    "len": 12
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#);
+    }
 }

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -394,6 +394,164 @@ def test_trace_metric_pii_scrubbing(
     ]
 
 
+def test_trace_metric_string_pii_scrubbing(
+    mini_sentry,
+    relay,
+    scrubbing_rule,
+):
+    rule_type, test_value, expected_scrubbed = scrubbing_rule
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:tracemetrics-ingestion",
+    ]
+
+    project_config["config"]["piiConfig"]["applications"] = {"$string": [rule_type]}
+
+    relay_instance = relay(mini_sentry, options=TEST_CONFIG)
+    start = datetime.now(timezone.utc)
+
+    envelope = envelope_with_trace_metrics(
+        {
+            "timestamp": start.timestamp(),
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "test.metric",
+            "type": "counter",
+            "value": 1.0,
+            "attributes": {
+                "test_pii": {"value": test_value, "type": "string"},
+            },
+        }
+    )
+
+    relay_instance.send_envelope(project_id, envelope)
+
+    envelope = mini_sentry.get_captured_envelope()
+    item_payload = json.loads(envelope.items[0].payload.bytes.decode())
+    item = item_payload["items"][0]
+
+    assert item["attributes"]["test_pii"] == {
+        "type": "string",
+        "value": expected_scrubbed,
+    }
+    assert "_meta" in item
+    meta = item["_meta"]["attributes"]["test_pii"]["value"][""]
+    assert "rem" in meta
+    assert meta["rem"][0][0] == rule_type
+
+
+def test_trace_metric_default_pii_scrubbing_attributes(
+    mini_sentry,
+    relay,
+    secret_attribute,
+):
+    attribute_key, attribute_value, expected_value, rule_type = secret_attribute
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:tracemetrics-ingestion",
+    ]
+
+    project_config["config"].setdefault(
+        "datascrubbingSettings",
+        {
+            "scrubData": True,
+            "scrubDefaults": True,
+            "scrubIpAddresses": True,
+        },
+    )
+
+    relay_instance = relay(mini_sentry, options=TEST_CONFIG)
+    start = datetime.now(timezone.utc)
+
+    envelope = envelope_with_trace_metrics(
+        {
+            "timestamp": start.timestamp(),
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "test.metric",
+            "type": "counter",
+            "value": 1.0,
+            "attributes": {
+                attribute_key: {"value": attribute_value, "type": "string"},
+            },
+        }
+    )
+
+    relay_instance.send_envelope(project_id, envelope)
+
+    envelope = mini_sentry.get_captured_envelope()
+    item_payload = json.loads(envelope.items[0].payload.bytes.decode())
+    item = item_payload["items"][0]
+    attributes = item["attributes"]
+
+    assert attribute_key in attributes
+    assert attributes[attribute_key]["value"] == expected_value
+    assert "_meta" in item
+    meta = item["_meta"]["attributes"][attribute_key]["value"][""]
+    assert "rem" in meta
+    rem_info = meta["rem"]
+    assert len(rem_info) == 1
+    assert rem_info[0][0] == rule_type
+
+
+def test_trace_metric_default_pii_scrubbing_does_not_scrub_default_attributes(
+    mini_sentry,
+    relay,
+):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:tracemetrics-ingestion",
+    ]
+    project_config["config"].setdefault(
+        "datascrubbingSettings",
+        {
+            "scrubData": True,
+            "scrubDefaults": True,
+            "scrubIpAddresses": True,
+        },
+    )
+
+    project_config["config"]["piiConfig"] = {
+        "rules": {
+            "remove_custom_field": {
+                "type": "anything",
+                "redaction": {"method": "replace", "text": "[REDACTED]"},
+            }
+        },
+        "applications": {"**": ["remove_custom_field"]},
+    }
+
+    relay_instance = relay(mini_sentry, options=TEST_CONFIG)
+    start = datetime.now(timezone.utc)
+
+    envelope = envelope_with_trace_metrics(
+        {
+            "timestamp": start.timestamp(),
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "name": "test.metric",
+            "type": "counter",
+            "value": 1.0,
+            "attributes": {
+                "custom_field": {"value": "custom_value", "type": "string"},
+            },
+        }
+    )
+
+    relay_instance.send_envelope(project_id, envelope)
+
+    envelope = mini_sentry.get_captured_envelope()
+    item_payload = json.loads(envelope.items[0].payload.bytes.decode())
+    item = item_payload["items"][0]
+
+    assert item["attributes"]["custom_field"] == {
+        "type": "string",
+        "value": "[REDACTED]",
+    }
+    assert "_meta" in item
+    assert "custom_field" in item["_meta"]["attributes"]
+
+
 def test_trace_metric_size_limits(
     mini_sentry,
     relay,

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -11,7 +11,6 @@ from .asserts import time_within_delta, time_within, only_items
 import pytest
 import json
 
-
 TEST_CONFIG = {
     "outcomes": {
         "emit_outcomes": True,

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -6,7 +6,7 @@ from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, only_items
+from .asserts import time_within_delta, time_within, only_items
 
 import pytest
 import json
@@ -430,14 +430,35 @@ def test_trace_metric_string_pii_scrubbing(
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
 
-    assert item["attributes"]["test_pii"] == {
-        "type": "string",
-        "value": expected_scrubbed,
+    assert item == {
+        "timestamp": time_within(start),
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "name": "test.metric",
+        "type": "counter",
+        "value": 1.0,
+        "attributes": {
+            "test_pii": {"type": "string", "value": expected_scrubbed},
+            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
+            "sentry.browser.version": {"type": "string", "value": "2.32"},
+            "sentry.observed_timestamp_nanos": {
+                "type": "string",
+                "value": time_within(start, expect_resolution="ns"),
+            },
+        },
+        "__header": {"byte_size": mock.ANY},
+        "_meta": {
+            "attributes": {
+                "test_pii": {
+                    "value": {
+                        "": {
+                            "len": mock.ANY,
+                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                        }
+                    }
+                }
+            },
+        },
     }
-    assert "_meta" in item
-    meta = item["_meta"]["attributes"]["test_pii"]["value"][""]
-    assert "rem" in meta
-    assert meta["rem"][0][0] == rule_type
 
 
 def test_trace_metric_default_pii_scrubbing_attributes(
@@ -482,16 +503,35 @@ def test_trace_metric_default_pii_scrubbing_attributes(
     envelope = mini_sentry.get_captured_envelope()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
-    attributes = item["attributes"]
-
-    assert attribute_key in attributes
-    assert attributes[attribute_key]["value"] == expected_value
-    assert "_meta" in item
-    meta = item["_meta"]["attributes"][attribute_key]["value"][""]
-    assert "rem" in meta
-    rem_info = meta["rem"]
-    assert len(rem_info) == 1
-    assert rem_info[0][0] == rule_type
+    assert item == {
+        "timestamp": time_within(start),
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "name": "test.metric",
+        "type": "counter",
+        "value": 1.0,
+        "attributes": {
+            attribute_key: {"type": "string", "value": expected_value},
+            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
+            "sentry.browser.version": {"type": "string", "value": "2.32"},
+            "sentry.observed_timestamp_nanos": {
+                "type": "string",
+                "value": time_within(start, expect_resolution="ns"),
+            },
+        },
+        "__header": {"byte_size": mock.ANY},
+        "_meta": {
+            "attributes": {
+                attribute_key: {
+                    "value": {
+                        "": {
+                            "len": mock.ANY,
+                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                        }
+                    }
+                }
+            },
+        },
+    }
 
 
 def test_trace_metric_default_pii_scrubbing_does_not_scrub_default_attributes(
@@ -544,12 +584,37 @@ def test_trace_metric_default_pii_scrubbing_does_not_scrub_default_attributes(
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     item = item_payload["items"][0]
 
-    assert item["attributes"]["custom_field"] == {
-        "type": "string",
-        "value": "[REDACTED]",
+    assert item == {
+        "timestamp": time_within(start),
+        "trace_id": "5b8efff798038103d269b633813fc60c",
+        "name": "test.metric",
+        "type": "counter",
+        "value": 1.0,
+        "attributes": {
+            "custom_field": {"type": "string", "value": "[REDACTED]"},
+            "sentry.browser.name": {"type": "string", "value": "Python Requests"},
+            "sentry.browser.version": {"type": "string", "value": "2.32"},
+            "sentry.observed_timestamp_nanos": {
+                "type": "string",
+                "value": time_within(start, expect_resolution="ns"),
+            },
+        },
+        "__header": {"byte_size": mock.ANY},
+        "_meta": {
+            "attributes": {
+                "custom_field": {
+                    "value": {
+                        "": {
+                            "len": mock.ANY,
+                            "rem": [
+                                ["remove_custom_field", mock.ANY, mock.ANY, mock.ANY]
+                            ],
+                        }
+                    }
+                }
+            },
+        },
     }
-    assert "_meta" in item
-    assert "custom_field" in item["_meta"]["attributes"]
 
 
 def test_trace_metric_size_limits(


### PR DESCRIPTION
This updates pii scrubbing to use the eap pii scrub package just like scrub_log does now, and adds some more tests to ensure pii scrubbing is happening properly before we add UI.

