### PR TITLE
chore(features): Remove `organizations:device-class-synthesis` feature

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -261,7 +261,6 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         is_renormalize,
         remove_other: config.remove_other.unwrap_or(!is_renormalize),
         emit_event_errors: !is_renormalize,
-        device_class_synthesis_config: false, // only supported in relay
         enrich_spans: false,
         max_tag_value_length: usize::MAX,
         span_description_rules: None,

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -29,13 +29,6 @@ pub enum Feature {
     /// Serialized as `organizations:session-replay-video-disabled`.
     #[serde(rename = "organizations:session-replay-video-disabled")]
     SessionReplayVideoDisabled,
-    /// Enables device.class synthesis
-    ///
-    /// Enables device.class tag synthesis on mobile events.
-    ///
-    /// Serialized as `organizations:device-class-synthesis`.
-    #[serde(rename = "organizations:device-class-synthesis")]
-    DeviceClassSynthesis,
     /// Allow ingestion of metrics in the "custom" namespace.
     ///
     /// Serialized as `organizations:custom-metrics`.

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -120,9 +120,6 @@ pub struct NormalizationConfig<'a> {
     /// When enabled, adds errors in the meta to the event's errors.
     pub emit_event_errors: bool,
 
-    /// When `true`, infers the device class from CPU and model.
-    pub device_class_synthesis_config: bool,
-
     /// When `true`, extracts tags from event and spans and materializes them into `span.data`.
     pub enrich_spans: bool,
 
@@ -190,7 +187,6 @@ impl Default for NormalizationConfig<'_> {
             is_renormalize: Default::default(),
             remove_other: Default::default(),
             emit_event_errors: Default::default(),
-            device_class_synthesis_config: Default::default(),
             enrich_spans: Default::default(),
             max_tag_value_length: usize::MAX,
             span_description_rules: Default::default(),
@@ -309,9 +305,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_event_tags(event); // Tags are added to every metric
 
     // TODO: Consider moving to store normalization
-    if config.device_class_synthesis_config {
-        normalize_device_class(event);
-    }
+    normalize_device_class(event);
     normalize_stacktraces(event);
     normalize_exceptions(event); // Browser extension filters look at the stacktrace
     normalize_user_agent(event, config.normalize_user_agent); // Legacy browsers filter

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -278,7 +278,6 @@ pub fn normalize(
             transaction_name_config: TransactionNameConfig {
                 rules: &project_info.config.tx_name_rules,
             },
-            device_class_synthesis_config: project_info.has_feature(Feature::DeviceClassSynthesis),
             enrich_spans: true,
             max_tag_value_length: ctx
                 .config

--- a/relay-server/tests/snapshots/test_fixtures__cocoa__pii_stripping.snap
+++ b/relay-server/tests/snapshots/test_fixtures__cocoa__pii_stripping.snap
@@ -810,6 +810,10 @@ expression: SerializableAnnotated(& event)
     [
       "a",
       "b"
+    ],
+    [
+      "device.class",
+      "2"
     ]
   ],
   "extra": {


### PR DESCRIPTION
This feature has been released for many years. Removing the feature check here so that we can remove the feature from sentry.

My only concern here is that cabi path that defaulted it to false. If that might be a problem, we could always keep the variable around and just stop relying on the feature flag.

Also wanted to check that this is fine to release in self-hosted.