### PR TITLE
fix: Don't drop attachment placerholder content type

### DIFF
--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -2,7 +2,6 @@
 //!
 //! Crashes are received as multipart uploads in this [format](https://game.develop.playstation.net/resources/documents/SDK/12.000/Core_Dump_System-Overview/ps5-core-dump-file-set-sending-format.html).
 use std::io;
-use std::str::FromStr;
 
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
@@ -12,6 +11,7 @@ use chrono::Utc;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
 use http::StatusCode;
+use mime::Mime;
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_dynamic_config::Feature;
@@ -128,7 +128,7 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
             && let Ok(location) = location.to_str()
             && let Ok(payload) = serde_json::to_vec(&AttachmentPlaceholder {
                 location,
-                content_type: content_type.and_then(|ct| ContentType::from_str(ct.as_ref()).ok()),
+                content_type: content_type.as_ref().map(Mime::to_string),
             })
         {
             item.set_payload(ContentType::AttachmentRef, payload);

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -11,7 +11,6 @@ use chrono::Utc;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
 use http::StatusCode;
-use mime::Mime;
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_dynamic_config::Feature;
@@ -128,7 +127,7 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
             && let Ok(location) = location.to_str()
             && let Ok(payload) = serde_json::to_vec(&AttachmentPlaceholder {
                 location,
-                content_type: content_type.as_ref().map(Mime::to_string),
+                content_type: content_type.as_ref().map(|c| c.to_string()),
             })
         {
             item.set_payload(ContentType::AttachmentRef, payload);

--- a/relay-server/src/envelope/attachment.rs
+++ b/relay-server/src/envelope/attachment.rs
@@ -79,7 +79,7 @@ pub struct AttachmentPlaceholder<'a> {
     #[serde(borrow)]
     pub location: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content_type: Option<crate::envelope::ContentType>,
+    pub content_type: Option<String>,
 }
 
 #[derive(Debug)]

--- a/relay-server/src/envelope/content_type.rs
+++ b/relay-server/src/envelope/content_type.rs
@@ -6,8 +6,8 @@ pub const CONTENT_TYPE: &str = "application/x-sentry-envelope";
 
 /// Payload content types.
 ///
-/// This is an optimized enum intended to reduce allocations for common content types.
-/// Do not use this enum for arbitrary content types.
+/// This is an optimized enum intended to reduce allocations for common content types used by Relay.
+/// When dealing with generic/user provided content types, use a different type instead, e.g. `String`.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ContentType {
     /// `text/plain`

--- a/relay-server/src/envelope/content_type.rs
+++ b/relay-server/src/envelope/content_type.rs
@@ -7,6 +7,7 @@ pub const CONTENT_TYPE: &str = "application/x-sentry-envelope";
 /// Payload content types.
 ///
 /// This is an optimized enum intended to reduce allocations for common content types.
+/// Do not use this enum for arbitrary content types.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ContentType {
     /// `text/plain`

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1011,7 +1011,7 @@ impl StoreService {
             id: Uuid::new_v4().to_string(),
             name: item.filename().unwrap_or(UNNAMED_ATTACHMENT).to_owned(),
             rate_limited: item.rate_limited(),
-            content_type: placeholder.content_type.map(|c| c.as_str().to_owned()),
+            content_type: placeholder.content_type,
             attachment_type: item.attachment_type().unwrap_or_default(),
             size: item.attachment_body_size(),
             retention_days,


### PR DESCRIPTION
Arbitrary content types not defined in the `ContentType` enum would get silently dropped. Better to just pass the string along then rather than using `ContentType`.

Fixes https://linear.app/getsentry/issue/INGEST-833/arbitrary-content-types-are-erased