### PR TITLE
perf: Move unreal file bytes instead of cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2512,7 +2512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6066,9 +6066,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.12.3"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ba5365997a4e375660bed52f5b42766475d5bc8ceb1bb13fea09c469ea0f49"
+checksum = "6aba7211a1803a826f108af9f4d86d25abe880712f2a6449479279e861b293f8"
 dependencies = [
  "debugid",
  "memmap2",
@@ -6078,20 +6078,19 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unreal"
-version = "12.12.3"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f48772cdfa3ecd14b5417dda997cae619452e0200599e88999189ab8249dae1"
+checksum = "eee96422e1a2b7cec46123cebe7714c1343713e880f6f8f458b89f67ab6df851"
 dependencies = [
  "anylog",
  "bytes",
  "chrono",
  "elementtree",
  "flate2",
- "lazy_static",
  "regex",
  "scroll",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ bytecount = "0.6.9"
 bytes = "1.10.1"
 bzip2 = "0.6.0"
 chrono = { version = "0.4.42", default-features = false, features = [
-  "std",
-  "serde",
+    "std",
+    "serde",
 ] }
 clap = { version = "4.5.48" }
 clap_complete = "4.5.48"
@@ -175,17 +175,17 @@ reqwest = "0.12.23"
 rmp-serde = "1.3.0"
 semver = "1.0.27"
 sentry = { version = "0.41.0", default-features = false, features = [
-  # default features, except `release-health` is disabled
-  "backtrace",
-  "contexts",
-  "debug-images",
-  "panic",
-  "transport",
+    # default features, except `release-health` is disabled
+    "backtrace",
+    "contexts",
+    "debug-images",
+    "panic",
+    "transport",
 ] }
 sentry-core = "0.41.0"
 sentry-kafka-schemas = { version = "2.1.24", default-features = false }
 sentry-release-parser = { version = "1.4.0", default-features = false, features = [
-  "semver-1",
+    "semver-1",
 ] }
 sentry-types = "0.41.0"
 sentry_protos = "0.7.0"
@@ -205,8 +205,8 @@ smallvec = { version = "1.15.1", features = ["serde"] }
 socket2 = "0.6.2"
 sqlparser = { "git" = "https://github.com/apache/datafusion-sqlparser-rs/", "rev" = "6a48f44f99d015a4f7a86275e2521ea2cc45fdae" } # fixes panic, pin to 0.62 once released
 sqlx = { version = "0.8.6", default-features = false }
-symbolic-common = { version = "12.12.3", default-features = false }
-symbolic-unreal = { version = "12.12.3", default-features = false }
+symbolic-common = { version = "12.18.0", default-features = false }
+symbolic-unreal = { version = "12.18.0", default-features = false }
 syn = { version = "2.0.106" }
 sync_wrapper = { version = "1.0.2" }
 synstructure = { version = "0.13.2" }

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -76,7 +76,7 @@ pub fn expand_unreal(
         // TODO: This clones data. Update symbolic to allow moving the bytes out.
         //
         // See: <https://github.com/getsentry/symbolic/issues/959>.
-        item.set_payload(content_type, file.data().to_owned());
+        item.set_payload(content_type, file.into_bytes());
         item.set_attachment_type(attachment_type);
         attachments.push(item);
     }


### PR DESCRIPTION
Fixes https://linear.app/getsentry/issue/SYMBOL-20/expose-bytes-instance-from-unreal4file