### PR TITLE
ref: Limit request instead of multipart stream

### DIFF
--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -1,10 +1,12 @@
 use axum::extract::{Path, Request};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use axum::routing::{MethodRouter, post};
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_event_schema::protocol::EventId;
 use serde::Deserialize;
+use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{AttachmentType, Envelope, Item};
@@ -56,10 +58,14 @@ pub async fn handle(
     Path(path): Path<AttachmentPath>,
     request: Request,
 ) -> axum::response::Result<impl IntoResponse> {
-    let multipart = utils::multipart_from_request(request, state.config().max_attachments_size())?;
+    let multipart = utils::multipart_from_request(request)?;
     let envelope = extract_envelope(meta, path, multipart, state.config()).await?;
     common::handle_envelope(&state, envelope)
         .await?
         .ignore_rate_limits();
     Ok(StatusCode::CREATED)
+}
+
+pub fn route(config: &Config) -> MethodRouter<ServiceState> {
+    post(handle).route_layer(RequestBodyLimitLayer::new(config.max_attachments_size()))
 }

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Path, Request};
+use axum::extract::{DefaultBodyLimit, Path, Request};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
@@ -67,5 +67,7 @@ pub async fn handle(
 }
 
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-    post(handle).route_layer(RequestBodyLimitLayer::new(config.max_attachments_size()))
+    post(handle)
+        .route_layer(RequestBodyLimitLayer::new(config.max_attachments_size()))
+        .route_layer(DefaultBodyLimit::disable())
 }

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -1,5 +1,5 @@
 use axum::RequestExt;
-use axum::extract::Request;
+use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
@@ -284,6 +284,7 @@ async fn handle(
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
     post(handle)
         .route_layer(RequestBodyLimitLayer::new(config.max_attachments_size()))
+        .route_layer(DefaultBodyLimit::disable())
         .route_layer(axum::middleware::from_fn(middlewares::content_length))
 }
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -1,5 +1,5 @@
 use axum::RequestExt;
-use axum::extract::{DefaultBodyLimit, Request};
+use axum::extract::Request;
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
@@ -13,6 +13,7 @@ use std::convert::Infallible;
 use std::error::Error;
 use std::io::Cursor;
 use std::io::Read;
+use tower_http::limit::RequestBodyLimitLayer;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT};
@@ -260,8 +261,7 @@ async fn handle(
     let envelope = if MINIDUMP_RAW_CONTENT_TYPES.contains(&content_type.as_ref()) {
         extract_raw_minidump(request.extract().await?, meta, config.max_attachment_size())?
     } else {
-        let multipart =
-            utils::multipart_from_request(request, state.config().max_attachments_size())?;
+        let multipart = utils::multipart_from_request(request)?;
         extract_multipart(multipart, meta, config).await?
     };
 
@@ -282,10 +282,8 @@ async fn handle(
 }
 
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-    // Set the single-attachment limit that applies only for raw minidumps. Multipart bypasses the
-    // limited body and applies its own limits.
     post(handle)
-        .route_layer(DefaultBodyLimit::max(config.max_attachment_size()))
+        .route_layer(RequestBodyLimitLayer::new(config.max_attachments_size()))
         .route_layer(axum::middleware::from_fn(middlewares::content_length))
 }
 
@@ -452,7 +450,7 @@ mod tests {
 
         let config = Config::default();
 
-        let multipart = utils::multipart_from_request(request, multipart_body.len()).unwrap();
+        let multipart = utils::multipart_from_request(request).unwrap();
         let items = utils::multipart_items(multipart, &config, MinidumpAttachmentStrategy)
             .await
             .unwrap();

--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -100,7 +100,7 @@ fn public_routes_raw(config: &Config) -> Router<ServiceState> {
         // No mandatory trailing slash here because people already use it like this.
         .route("/api/{project_id}/minidump", minidump::route(config))
         .route("/api/{project_id}/minidump/", minidump::route(config))
-        .route("/api/{project_id}/events/{event_id}/attachments/", post(attachments::handle))
+        .route("/api/{project_id}/events/{event_id}/attachments/", attachments::route(config))
         .route("/api/{project_id}/unreal/{sentry_key}/", unreal::route(config))
         .route("/api/{project_id}/upload/", upload::route_post(config))
         .route(UPLOAD_PATCH_PATH, upload::route_patch(config));

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -4,7 +4,7 @@
 use std::io;
 use std::str::FromStr;
 
-use axum::extract::{DefaultBodyLimit, Request};
+use axum::extract::Request;
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
@@ -19,6 +19,7 @@ use relay_event_schema::protocol::EventId;
 use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use serde::Serialize;
+use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
 use crate::envelope::ContentType::{self, OctetStream};
@@ -223,8 +224,7 @@ async fn handle(
         .await
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let stream_size_limit = config.max_upload_size() + config.max_attachments_size();
-    let multipart = utils::multipart_from_request(request, stream_size_limit)?;
+    let multipart = utils::multipart_from_request(request)?;
     let mut envelope = extract_multipart(multipart, meta, &state, &project).await?;
     envelope.require_feature(Feature::PlaystationIngestion);
 
@@ -245,6 +245,8 @@ async fn handle(
 
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
     post(handle)
-        .route_layer(DefaultBodyLimit::max(config.max_attachments_size()))
+        .route_layer(RequestBodyLimitLayer::new(
+            config.max_upload_size() + config.max_attachments_size(),
+        ))
         .route_layer(axum::middleware::from_fn(middlewares::content_length))
 }

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -4,7 +4,7 @@
 use std::io;
 use std::str::FromStr;
 
-use axum::extract::Request;
+use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
@@ -248,5 +248,6 @@ pub fn route(config: &Config) -> MethodRouter<ServiceState> {
         .route_layer(RequestBodyLimitLayer::new(
             config.max_upload_size() + config.max_attachments_size(),
         ))
+        .route_layer(DefaultBodyLimit::disable())
         .route_layer(axum::middleware::from_fn(middlewares::content_length))
 }

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -8,7 +8,7 @@
 use std::io;
 
 use axum::body::Body;
-use axum::extract::{Path, Query};
+use axum::extract::{DefaultBodyLimit, Path, Query};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, NoContent, Response};
 use axum::routing::{MethodRouter, patch, post};
@@ -36,11 +36,15 @@ use crate::utils::{ApiErrorResponse, MeteredStream};
 use crate::utils::{BoundedStream, find_error_source, tus};
 
 pub fn route_post(config: &Config) -> MethodRouter<ServiceState> {
-    post(handle_post).route_layer(RequestBodyLimitLayer::new(config.max_upload_size()))
+    post(handle_post)
+        .route_layer(RequestBodyLimitLayer::new(config.max_upload_size()))
+        .route_layer(DefaultBodyLimit::disable())
 }
 
 pub fn route_patch(config: &Config) -> MethodRouter<ServiceState> {
-    patch(handle_patch).route_layer(RequestBodyLimitLayer::new(config.max_upload_size()))
+    patch(handle_patch)
+        .route_layer(RequestBodyLimitLayer::new(config.max_upload_size()))
+        .route_layer(DefaultBodyLimit::disable())
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -4,7 +4,7 @@ use std::io;
 use axum::extract::Request;
 use bytes::Bytes;
 use futures::TryStreamExt;
-use multer::{Constraints, Field, Multipart, SizeLimit};
+use multer::{Field, Multipart};
 use relay_config::Config;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncReadExt;
@@ -266,10 +266,7 @@ pub async fn multipart_items(
     Ok(items)
 }
 
-pub fn multipart_from_request(
-    request: Request,
-    stream_size_limit: usize,
-) -> Result<Multipart<'static>, BadStoreRequest> {
+pub fn multipart_from_request(request: Request) -> Result<Multipart<'static>, BadStoreRequest> {
     let content_type = request
         .headers()
         .get("content-type")
@@ -277,14 +274,9 @@ pub fn multipart_from_request(
         .unwrap_or("");
     let boundary =
         multer::parse_boundary(content_type).map_err(BadStoreRequest::InvalidMultipart)?;
-
-    // Limits the overall stream size, preventing overly long processing times which can cause
-    // incidents like the one described in [#4836](https://github.com/getsentry/relay/pull/4836).
-    let stream_size_limit = SizeLimit::new().whole_stream(stream_size_limit as u64);
-    Ok(Multipart::with_constraints(
+    Ok(Multipart::new(
         request.into_body().into_data_stream(),
         boundary,
-        Constraints::new().size_limit(stream_size_limit),
     ))
 }
 

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -333,7 +333,7 @@ def test_playstation_max_stream_size_exceeded(
 ):
     PROJECT_ID = 42
     playstation_dump = load_dump_file("playstation.prosperodmp")
-    stream_size_limit = len(playstation_dump) - 131
+    stream_size_limit = len(playstation_dump) - 100
     relay = relay_processing_with_playstation(
         {
             "limits": {
@@ -349,11 +349,8 @@ def test_playstation_max_stream_size_exceeded(
         _ = relay.send_playstation_request(PROJECT_ID, playstation_dump)
 
     response = exc_info.value.response
-    assert response.status_code == 400, "Expected a 400 status code"
-    assert (
-        response.content.decode("utf-8")
-        == f'{{"detail":"invalid multipart data","causes":["failed to read stream","stream size exceeded limit: {stream_size_limit} bytes"]}}'
-    )
+    assert response.status_code == 413, "Expected a 413 status code"
+    assert response.content.decode("utf-8") == "length limit exceeded"
     assert len(outcomes_consumer.get_outcomes()) == 0
 
 


### PR DESCRIPTION
Limit the request body using`RequestBodyLimitLayer` instead of  `DefaultBodyLimit` which doesn't support streaming requests. Remove the overall multipart stream size limit as it becomes obsolete with this change.

Fixes https://linear.app/getsentry/issue/INGEST-760/playstation-body-limit-mismatch