### PR TITLE
fix(devservices): Increase local Relay's message.max.bytes

### DIFF
--- a/devservices/config/relay.yml
+++ b/devservices/config/relay.yml
@@ -12,7 +12,6 @@ processing:
   enabled: true
   kafka_config:
     - { name: "bootstrap.servers", value: "kafka:9093" }
-    # The maximum attachment chunk size is 1MB. Together with some meta data,
-    # messages will never get larger than 2MB in total.
-    - { name: "message.max.bytes", value: 2097176 }
+    # Align with Relay's default `max_envelope_size` size (200 MiB -> 209,715,200 bytes).
+    - { name: "message.max.bytes", value: 209715200 }
   redis: redis://redis:6379


### PR DESCRIPTION
Trying to run profiling on my local environment, profile chunks frequently failed with `MessageSizeTooLarge` errors. Increasing Relay's `message.max.bytes` fixed the issue. Profiles and profile chunks [cap out at 50 MiB](https://github.com/getsentry/relay/blob/2571b0e5745eda50a933b8c911f450d776717f96/relay-config/src/config.rs#L718), but this should probably align with the [maximum envelope size of 200 MiB](https://github.com/getsentry/relay/blob/2571b0e5745eda50a933b8c911f450d776717f96/relay-config/src/config.rs#L713).