### PR TITLE
fix(pii): Scrub API key headers with hyphens (e.g. x-api-key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**:
 
+- Scrub API key headers with hyphens (e.g. `x-api-key`) in default PII scrubbing. ([#5829](https://github.com/getsentry/relay/pull/5829))
 - Store segment name in `sentry.transaction` in addition to `sentry.segment.name` on OTLP spans. ([#5765](https://github.com/getsentry/relay/pull/5765))
 - Explicitly handle in-flight requests during shutdown. ([#5746](https://github.com/getsentry/relay/pull/5746), [#5769](https://github.com/getsentry/relay/pull/5769))
 - Emit outcomes in both `log_byte` and `log_item` categories when logs are dropped. ([#5766](https://github.com/getsentry/relay/pull/5766))

--- a/relay-pii/src/convert.rs
+++ b/relay-pii/src/convert.rs
@@ -1300,6 +1300,34 @@ THd+9FBxiHLGXNKhG/FRSyREXEt+NyYIf/0cyByc9tNksat794ddUqnLOg0vwSkv
     }
 
     #[test]
+    fn test_api_key_header_scrubbing() {
+        // Ensure that API key headers with hyphens (e.g. Anthropic's x-api-key) are scrubbed,
+        // not just underscore variants (api_key).
+        let mut data = Event::from_value(
+            serde_json::json!({
+                "extra": {
+                    "x-api-key": "sk-ant-secret-value",
+                    "api-key": "secret-value",
+                    "api_key": "secret-value",
+                    "apikey": "secret-value",
+                    "X-Api-Key": "secret-value",
+                }
+            })
+            .into(),
+        );
+
+        let pii_config = to_pii_config(&DataScrubbingConfig {
+            sensitive_fields: vec!["".to_owned()],
+            ..simple_enabled_config()
+        });
+
+        let pii_config = pii_config.unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+        assert_annotated_snapshot!(data);
+    }
+
+    #[test]
     fn test_doesnt_scrub_not_scrubbed() {
         let mut data = Event::from_value(
             serde_json::json!({

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -336,7 +336,7 @@ regex!(BEARER_TOKEN_REGEX, r"(?i)\b(Bearer\s+)([^\s]+)");
 
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api_key|apikey|auth|credentials|mysql_pwd|privatekey|private_key|token|^otp$|^two[-_]factor$)"
+    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token|^otp$|^two[-_]factor$)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__api_key_header_scrubbing.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__api_key_header_scrubbing.snap
@@ -1,0 +1,82 @@
+---
+source: relay-pii/src/convert.rs
+expression: data
+---
+{
+  "extra": {
+    "X-Api-Key": "[Filtered]",
+    "api-key": "[Filtered]",
+    "api_key": "[Filtered]",
+    "apikey": "[Filtered]",
+    "x-api-key": "[Filtered]"
+  },
+  "_meta": {
+    "extra": {
+      "X-Api-Key": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 12
+        }
+      },
+      "api-key": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 12
+        }
+      },
+      "api_key": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 12
+        }
+      },
+      "apikey": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 12
+        }
+      },
+      "x-api-key": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 19
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- The `PASSWORD_KEY_REGEX` in `relay-pii` matched `api_key` (underscore) and `apikey` (no separator) but **not** `api-key` (hyphen), meaning HTTP headers like Anthropic's `x-api-key` were not scrubbed by default data scrubbing
- Updated the regex to use `api[-_]key` to cover all separator variants
- Also updated `private_key` → `private[-_]key` for consistency (matches the existing `two[-_]factor` pattern)

## Test plan

- [x] Added `test_api_key_header_scrubbing` test covering `x-api-key`, `api-key`, `api_key`, `apikey`, and `X-Api-Key`
- [x] All 248 existing `relay-pii` tests pass with no regressions
- [x] Snapshot confirms all variants produce `[Filtered]`