### PR TITLE
feat(ai): Add ModelMetadata config with context size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add `gen_ai.input.messages` and `gen_ai.output.messages` as distinct fields for SpanData. ([#5797](https://github.com/getsentry/relay/pull/5797))
 - Merge `gen_ai.request.messages` into `gen_ai.input.messages` and `gen_ai.response.text` into `gen_ai.output.messages`. ([#5813](https://github.com/getsentry/relay/pull/5813))
 - Extract `http.query` and `url.query` attributes from `query_string` in transactions' request context. ([#5784](https://github.com/getsentry/relay/pull/5784))
+- Add `ModelMetadata` config with context size. ([#5831](https://github.com/getsentry/relay/pull/5831))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Add `gen_ai.input.messages` and `gen_ai.output.messages` as distinct fields for SpanData. ([#5797](https://github.com/getsentry/relay/pull/5797))
 - Merge `gen_ai.request.messages` into `gen_ai.input.messages` and `gen_ai.response.text` into `gen_ai.output.messages`. ([#5813](https://github.com/getsentry/relay/pull/5813))
 - Extract `http.query` and `url.query` attributes from `query_string` in transactions' request context. ([#5784](https://github.com/getsentry/relay/pull/5784))
-- Add `ModelMetadata` config with context size. ([#5831](https://github.com/getsentry/relay/pull/5831))
+- Add `ModelMetadata` global config with context size. ([#5831](https://github.com/getsentry/relay/pull/5831))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -4,7 +4,9 @@ use std::io::BufReader;
 use std::path::Path;
 
 use relay_base_schema::metrics::MetricNamespace;
-use relay_event_normalization::{MeasurementsConfig, ModelCosts, SpanOpDefaults};
+use relay_event_normalization::{
+    MeasurementsConfig, ModelCosts, ModelMetadata, ModelMetadataEntry, SpanOpDefaults,
+};
 use relay_filter::GenericFiltersConfig;
 use relay_quotas::Quota;
 use serde::{Deserialize, Serialize, de};
@@ -49,6 +51,10 @@ pub struct GlobalConfig {
     #[serde(skip_serializing_if = "is_model_costs_empty")]
     pub ai_model_costs: ErrorBoundary<ModelCosts>,
 
+    /// Metadata for AI models including costs and context size.
+    #[serde(skip_serializing_if = "is_model_metadata_empty")]
+    pub ai_model_metadata: ErrorBoundary<ModelMetadata>,
+
     /// Configuration to derive the `span.op` from other span fields.
     #[serde(
         deserialize_with = "default_on_error",
@@ -71,6 +77,41 @@ impl GlobalConfig {
         } else {
             Ok(None)
         }
+    }
+
+    /// Returns [`ModelMetadata`], preferring `ai_model_metadata` if present and falling
+    /// back to `ai_model_costs` (adapted to the new format) otherwise.
+    pub fn model_metadata(&self) -> Option<ModelMetadata> {
+        if let Some(metadata) = self
+            .ai_model_metadata
+            .as_ref()
+            .ok()
+            .filter(|m| m.is_enabled())
+        {
+            return Some(metadata.clone());
+        }
+
+        let costs = self
+            .ai_model_costs
+            .as_ref()
+            .ok()
+            .filter(|c| c.is_enabled())?;
+
+        let models = costs
+            .models
+            .iter()
+            .map(|(pattern, cost)| {
+                (
+                    pattern.clone(),
+                    ModelMetadataEntry {
+                        costs: Some(*cost),
+                        context_size: None,
+                    },
+                )
+            })
+            .collect();
+
+        Some(ModelMetadata { version: 1, models })
     }
 
     /// Returns the generic inbound filters.
@@ -298,6 +339,10 @@ fn is_ok_and_empty(value: &ErrorBoundary<MetricExtractionGroups>) -> bool {
 
 fn is_model_costs_empty(value: &ErrorBoundary<ModelCosts>) -> bool {
     matches!(value, ErrorBoundary::Ok(model_costs) if model_costs.is_empty())
+}
+
+fn is_model_metadata_empty(value: &ErrorBoundary<ModelMetadata>) -> bool {
+    matches!(value, ErrorBoundary::Ok(metadata) if metadata.is_empty())
 }
 
 #[cfg(test)]

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -371,6 +371,97 @@ pub struct ModelCostV2 {
     pub input_cache_write_per_token: f64,
 }
 
+/// Metadata for AI models including costs and context size.
+///
+/// Example JSON:
+/// ```json
+/// {
+///   "version": 1,
+///   "models": {
+///     "gpt-4": {
+///       "costs": {
+///         "inputPerToken": 0.0000003,
+///         "outputPerToken": 0.00000165,
+///         "outputReasoningPerToken": 0.0,
+///         "inputCachedPerToken": 0.0000015,
+///         "inputCacheWritePerToken": 0.00001875
+///       },
+///       "contextSize": 1000000
+///     }
+///   }
+/// }
+/// ```
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelMetadata {
+    /// The version of the model metadata struct.
+    pub version: u16,
+
+    /// The mappings of model ID => metadata as a dictionary.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub models: HashMap<Pattern, ModelMetadataEntry>,
+}
+
+impl ModelMetadata {
+    const SUPPORTED_VERSION: u16 = 1;
+
+    /// `true` if the model metadata is empty or the version is unsupported.
+    pub fn is_empty(&self) -> bool {
+        self.models.is_empty() || !self.is_enabled()
+    }
+
+    /// `false` if the version is unsupported.
+    pub fn is_enabled(&self) -> bool {
+        self.version == Self::SUPPORTED_VERSION
+    }
+
+    /// Gets the cost per token for a given model, if defined.
+    pub fn cost_per_token(&self, model_id: &str) -> Option<&ModelCostV2> {
+        self.get(model_id).and_then(|entry| entry.costs.as_ref())
+    }
+
+    /// Gets the context window size for a given model, if defined.
+    pub fn context_size(&self, model_id: &str) -> Option<u64> {
+        self.get(model_id).and_then(|entry| entry.context_size)
+    }
+
+    /// Gets the metadata for a given model, if defined.
+    pub fn get(&self, model_id: &str) -> Option<&ModelMetadataEntry> {
+        if !self.is_enabled() {
+            return None;
+        }
+
+        let normalized_model_id = normalize_ai_model_name(model_id);
+
+        // First try exact match.
+        if let Some(value) = self.models.get(normalized_model_id) {
+            return Some(value);
+        }
+
+        // Fall back to glob matching.
+        self.models.iter().find_map(|(key, value)| {
+            if key.is_match(normalized_model_id) {
+                Some(value)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+/// Metadata for a single AI model.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelMetadataEntry {
+    /// Token costs for this model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub costs: Option<ModelCostV2>,
+
+    /// The context window size in tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_size: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -399,7 +399,7 @@ pub struct ModelMetadata {
 
     /// The mappings of model ID => metadata as a dictionary.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub models: HashMap<Pattern, ModelMetadataEntry>,
+    pub models: BTreeMap<Pattern, ModelMetadataEntry>,
 }
 
 impl ModelMetadata {

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -399,7 +399,7 @@ pub struct ModelMetadata {
 
     /// The mappings of model ID => metadata as a dictionary.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub models: BTreeMap<Pattern, ModelMetadataEntry>,
+    pub models: HashMap<Pattern, ModelMetadataEntry>,
 }
 
 impl ModelMetadata {


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-2220/relay-implement-context-window-usage-per-span

Introduce `ModelMetadata` and `ModelMetadataEntry` types that extend the existing model cost data with context window size. Add `ai_model_metadata` field to `GlobalConfig` with a `model_metadata()` accessor that falls back to `ai_model_costs` (adapted to the new format) when the new config is absent.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
