### PR TITLE
build(conventions): Bump sentry conventions

### DIFF
--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -121,6 +121,19 @@ def test_lcp_span(
 
     (attributes, fields) = lcp_cls_inp_differences(mode)
 
+    lcp_backfill = {}
+    if mode == "v2":
+        lcp_backfill = {
+            "browser.web_vital.lcp.value": {"type": "double", "value": 548.0},
+            "browser.web_vital.lcp.load_time": {"type": "double", "value": 527.5},
+            "browser.web_vital.lcp.render_time": {"type": "integer", "value": 548},
+            "browser.web_vital.lcp.size": {"type": "integer", "value": 8100},
+            "browser.web_vital.lcp.url": {
+                "type": "string",
+                "value": "https://s1.sentry-cdn.com/../sentry-loader.svg",
+            },
+        }
+
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
@@ -155,6 +168,7 @@ def test_lcp_span(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
                 "Safari/537.36",
             },
+            **lcp_backfill,
             **attributes,
         },
         "downsampled_retention_days": 90,
@@ -268,6 +282,16 @@ def test_cls_span(
 
     (attributes, fields) = lcp_cls_inp_differences(mode)
 
+    cls_backfill = {}
+    if mode == "v2":
+        cls_backfill = {
+            "browser.web_vital.cls.value": {"type": "double", "value": 0.1},
+            "browser.web_vital.cls.source.<key>": {
+                "type": "string",
+                "value": "AppContainer > NavContent > MobileTopbar > StyledButton",
+            },
+        }
+
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
@@ -307,6 +331,7 @@ def test_cls_span(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
                 "Safari/537.36",
             },
+            **cls_backfill,
             **attributes,
         },
         "downsampled_retention_days": 90,
@@ -415,6 +440,12 @@ def test_inp_span(
 
     (attributes, fields) = lcp_cls_inp_differences(mode)
 
+    inp_backfill = {}
+    if mode == "v2":
+        inp_backfill = {
+            "browser.web_vital.inp.value": {"type": "double", "value": 104.0},
+        }
+
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
@@ -443,6 +474,7 @@ def test_inp_span(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
                 "Safari/537.36",
             },
+            **inp_backfill,
             **attributes,
         },
         "downsampled_retention_days": 90,

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -119,7 +119,7 @@ def test_lcp_span(
 
     relay.send_envelope(project_id, envelope)
 
-    (attributes, fields) = lcp_cls_inp_differences(mode)
+    attributes, fields = lcp_cls_inp_differences(mode)
 
     lcp_backfill = {}
     if mode == "v2":
@@ -280,7 +280,7 @@ def test_cls_span(
 
     relay.send_envelope(project_id, envelope)
 
-    (attributes, fields) = lcp_cls_inp_differences(mode)
+    attributes, fields = lcp_cls_inp_differences(mode)
 
     cls_backfill = {}
     if mode == "v2":
@@ -438,7 +438,7 @@ def test_inp_span(
 
     relay.send_envelope(project_id, envelope)
 
-    (attributes, fields) = lcp_cls_inp_differences(mode)
+    attributes, fields = lcp_cls_inp_differences(mode)
 
     inp_backfill = {}
     if mode == "v2":


### PR DESCRIPTION
Bumps `sentry-convention` to latest commit https://github.com/getsentry/sentry-conventions/commit/7f94a46bfbf9a0df45e20c96c149a8281a572cb7

This is required for #5824