### PR TITLE
ref(cells): Inject advertised upstream into project config

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -486,12 +486,21 @@ pub enum ReadinessCondition {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 pub struct Relay {
-    /// The operation mode of this relay.
+    /// The operation mode of this Relay.
     pub mode: RelayMode,
-    /// The instance type of this relay.
+    /// The instance type of this Relay.
     pub instance: RelayInstance,
-    /// The upstream relay or sentry instance.
+    /// The upstream Relay or Sentry instance.
     pub upstream: UpstreamDescriptor<'static>,
+    /// The upstream advertised to downstream Relay instances.
+    ///
+    /// This value will be advertised to downstream Relays as the upstream to use when forwarding
+    /// data. It can be used for traffic routing and balancing, it must not redirect to a different
+    /// Sentry instance.
+    ///
+    /// Downstream Relays will treat the advertised upstream as the same logical component as this instance
+    /// and re-use already established authentication keys.
+    pub advertised_upstream: Option<UpstreamDescriptor<'static>>,
     /// The host the relay should bind to (network interface).
     pub host: IpAddr,
     /// The port to bind for the unencrypted relay HTTP server.
@@ -537,6 +546,7 @@ impl Default for Relay {
             mode: RelayMode::Managed,
             instance: RelayInstance::Default,
             upstream: "https://sentry.io/".parse().unwrap(),
+            advertised_upstream: None,
             host: default_host(),
             port: 3000,
             internal_host: None,
@@ -2050,6 +2060,11 @@ impl Config {
     /// Returns the upstream target as descriptor.
     pub fn upstream_descriptor(&self) -> &UpstreamDescriptor<'_> {
         &self.values.relay.upstream
+    }
+
+    /// Returns the advertised upstream for downstream instances as descriptor.
+    pub fn advertised_upstream_descriptor(&self) -> Option<&UpstreamDescriptor<'_>> {
+        self.values.relay.advertised_upstream.as_ref()
     }
 
     /// Returns the custom HTTP "Host" header.

--- a/relay-config/src/upstream.rs
+++ b/relay-config/src/upstream.rs
@@ -107,6 +107,15 @@ impl<'a> UpstreamDescriptor<'a> {
             scheme: self.scheme,
         }
     }
+
+    /// Converts from `&UpstreamDescriptor<'_>` to `UpstreamDescriptor<'_>`.
+    pub fn as_ref(&self) -> UpstreamDescriptor<'_> {
+        UpstreamDescriptor {
+            host: Cow::Borrowed(&self.host),
+            port: self.port,
+            scheme: self.scheme,
+        }
+    }
 }
 
 impl Default for UpstreamDescriptor<'static> {

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -16,7 +16,7 @@ use crate::extractors::SignedJson;
 use crate::service::ServiceState;
 use crate::services::global_config::{self, StatusResponse};
 use crate::services::projects::project::{
-    LimitedParsedProjectState, ParsedProjectState, ProjectState, Revision,
+    LimitedSerializeProjectState, ProjectState, Revision, SerializeProjectState,
 };
 use crate::utils::ApiErrorResponse;
 
@@ -55,17 +55,16 @@ struct VersionQuery {
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 enum ProjectStateWrapper {
-    Full(ParsedProjectState),
-    Limited(#[serde(with = "LimitedParsedProjectState")] ParsedProjectState),
+    Full(SerializeProjectState),
+    Limited(#[serde(with = "LimitedSerializeProjectState")] SerializeProjectState),
 }
 
 impl ProjectStateWrapper {
-    /// Create a wrapper which forces serialization into external or internal format
-    pub fn new(state: ParsedProjectState, full: bool) -> Self {
-        if full {
-            Self::Full(state)
-        } else {
-            Self::Limited(state)
+    /// Create a wrapper which forces serialization into external or internal format.
+    pub fn new(state: SerializeProjectState, full: bool) -> Self {
+        match full {
+            true => Self::Full(state),
+            false => Self::Limited(state),
         }
     }
 }
@@ -198,9 +197,13 @@ async fn inner(
         if has_access {
             let full = relay.internal && inner.full_config;
             let wrapper = ProjectStateWrapper::new(
-                ParsedProjectState {
+                SerializeProjectState {
                     disabled: false,
                     info: Arc::clone(project_info),
+                    upstream: state
+                        .config()
+                        .advertised_upstream_descriptor()
+                        .map(|u| u.as_ref().into_owned()),
                 },
                 full,
             );

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -16,7 +16,7 @@ use crate::extractors::SignedJson;
 use crate::service::ServiceState;
 use crate::services::global_config::{self, StatusResponse};
 use crate::services::projects::project::{
-    LimitedSerializeProjectState, ProjectState, Revision, SerializeProjectState,
+    LimitedOutgoingProjectState, OutgoingProjectState, ProjectState, Revision,
 };
 use crate::utils::ApiErrorResponse;
 
@@ -55,13 +55,13 @@ struct VersionQuery {
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 enum ProjectStateWrapper {
-    Full(SerializeProjectState),
-    Limited(#[serde(with = "LimitedSerializeProjectState")] SerializeProjectState),
+    Full(OutgoingProjectState),
+    Limited(#[serde(with = "LimitedOutgoingProjectState")] OutgoingProjectState),
 }
 
 impl ProjectStateWrapper {
     /// Create a wrapper which forces serialization into external or internal format.
-    pub fn new(state: SerializeProjectState, full: bool) -> Self {
+    pub fn new(state: OutgoingProjectState, full: bool) -> Self {
         match full {
             true => Self::Full(state),
             false => Self::Limited(state),
@@ -197,7 +197,7 @@ async fn inner(
         if has_access {
             let full = relay.internal && inner.full_config;
             let wrapper = ProjectStateWrapper::new(
-                SerializeProjectState {
+                OutgoingProjectState {
                     disabled: false,
                     info: Arc::clone(project_info),
                     upstream: state

--- a/relay-server/src/services/projects/project/info.rs
+++ b/relay-server/src/services/projects/project/info.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Duration, Utc};
 
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::{ProjectId, ProjectKey};
-use relay_config::Config;
+use relay_config::{Config, UpstreamDescriptor};
 use relay_dynamic_config::{Feature, LimitedProjectConfig, ProjectConfig, SignatureVerification};
 use relay_filter::matches_any_origin;
 use relay_quotas::{Quota, Scoping};
@@ -39,14 +39,40 @@ pub struct ProjectInfo {
     #[serde(default)]
     pub public_keys: SmallVec<[PublicKeyConfig; 1]>,
     /// The project's slug if available.
-    #[serde(default)]
     pub slug: Option<String>,
     /// The project's current config.
     #[serde(default)]
     pub config: ProjectConfig,
     /// The organization id.
-    #[serde(default)]
     pub organization_id: Option<OrganizationId>,
+
+    /// The upstream this Relay should use to forward/send data to.
+    ///
+    /// A Relay can advertise an upstream override per project to Relays which request
+    /// a project config.
+    ///
+    /// The upstream specified here acts as a, per project, override for the locally configured
+    /// (default) upstream.
+    ///
+    /// An upstream received with a project config must never be forwarded to a downstream Relay,
+    /// instead each Relay instance must (optionally) inject an upstream value to be used by the next
+    /// downstream Relay in the chain.
+    ///
+    /// ```text
+    /// /-----------\     /-----------\     /-----------\
+    /// |  Relay 3  |---->|  Relay 2  |---->|  Relay 1  |
+    /// \-----------?     \-----------/     \-----------?
+    ///        ^               | ^               |
+    ///        \---------------/ \---------------/
+    ///           r2.upstream       r1.upstream
+    /// ```
+    ///
+    /// Every upstream communicated must be reachable from the Relay receiving the upstream, and
+    /// every upstream must be part of the same Sentry installation.
+    /// As this is purely a mechanism to route and shape traffic authentication credentials will
+    /// be re-used.
+    #[serde(skip_serializing)]
+    pub upstream: Option<UpstreamDescriptor<'static>>,
 }
 
 /// Controls how we serialize a ProjectState for an external Relay

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -1,14 +1,14 @@
 //! Types that represent the current project state.
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
 use relay_base_schema::project::ProjectKey;
 use relay_quotas::Scoping;
 
 mod info;
+mod serialize;
 
 pub use self::info::*;
+pub use self::serialize::*;
 
 /// Representation of a project's current state.
 #[derive(Clone, Debug, Default)]
@@ -40,6 +40,7 @@ impl ProjectState {
             slug: None,
             config: Default::default(),
             organization_id: None,
+            upstream: None,
         }))
     }
 
@@ -97,31 +98,4 @@ impl From<ParsedProjectState> for ProjectState {
             false => Self::Enabled(info),
         }
     }
-}
-
-/// Project state as used in serialization / deserialization.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ParsedProjectState {
-    /// Whether the project state is disabled.
-    #[serde(default)]
-    pub disabled: bool,
-    /// Project info.
-    ///
-    /// This contains no information when `disabled` is `true`.
-    #[serde(flatten)]
-    pub info: Arc<ProjectInfo>,
-}
-
-/// Limited project state for external Relays.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase", remote = "ParsedProjectState")]
-pub struct LimitedParsedProjectState {
-    /// Whether the project state is disabled.
-    pub disabled: bool,
-    /// Limited project info for external Relays.
-    ///
-    /// This contains no information when `disabled` is `true`.
-    #[serde(with = "LimitedProjectInfo")]
-    #[serde(flatten)]
-    pub info: Arc<ProjectInfo>,
 }

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -90,9 +90,9 @@ impl ProjectState {
     }
 }
 
-impl From<ParsedProjectState> for ProjectState {
-    fn from(value: ParsedProjectState) -> Self {
-        let ParsedProjectState { disabled, info } = value;
+impl From<IncomingProjectState> for ProjectState {
+    fn from(value: IncomingProjectState) -> Self {
+        let IncomingProjectState { disabled, info } = value;
         match disabled {
             true => Self::Disabled,
             false => Self::Enabled(info),

--- a/relay-server/src/services/projects/project/serialize.rs
+++ b/relay-server/src/services/projects/project/serialize.rs
@@ -120,10 +120,10 @@ mod tests {
     fn test_serialize_full_project_info_upstream_ignored() {
         let s = SerializeProjectState {
             disabled: false,
-            info: ProjectInfo {
+            info: Arc::new(ProjectInfo {
                 upstream: Some("https://sentry.io".parse().unwrap()),
                 ..Default::default()
-            },
+            }),
             upstream: None,
         };
 
@@ -170,10 +170,10 @@ mod tests {
     fn test_serialize_full_correct_upstream_used() {
         let s = SerializeProjectState {
             disabled: false,
-            info: ProjectInfo {
+            info: Arc::new(ProjectInfo {
                 upstream: Some("https://sentry.io".parse().unwrap()),
                 ..Default::default()
-            },
+            }),
             upstream: Some("https://us.sentry.io".parse().unwrap()),
         };
 

--- a/relay-server/src/services/projects/project/serialize.rs
+++ b/relay-server/src/services/projects/project/serialize.rs
@@ -1,0 +1,269 @@
+use std::sync::Arc;
+
+use relay_config::UpstreamDescriptor;
+use serde::{Deserialize, Serialize};
+
+use crate::services::projects::project::{LimitedProjectInfo, ProjectInfo};
+
+/// Project state as used in de-serialization.
+///
+/// Use [`SerializeProjectState`] to serialize a project state.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParsedProjectState {
+    /// Whether the project state is disabled.
+    #[serde(default)]
+    pub disabled: bool,
+    /// Project info.
+    ///
+    /// This contains no information when `disabled` is `true`.
+    #[serde(flatten)]
+    pub info: Arc<ProjectInfo>,
+}
+
+/// Project state as used in serialization.
+///
+/// Use [`ParsedProjectState`] to de-serialize a project state.
+#[derive(Debug, Clone, Serialize)]
+pub struct SerializeProjectState {
+    /// Whether the project state is disabled.
+    #[serde(default)]
+    pub disabled: bool,
+    /// Project info.
+    ///
+    /// This contains no information when `disabled` is `true`.
+    #[serde(flatten)]
+    pub info: Arc<ProjectInfo>,
+    /// Upstream override to use by the downstream Relay receiving the project state.
+    ///
+    /// See also: [`ProjectInfo::upstream`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<UpstreamDescriptor<'static>>,
+}
+
+/// Limited project state for external Relays.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", remote = "SerializeProjectState")]
+pub struct LimitedSerializeProjectState {
+    /// Whether the project state is disabled.
+    pub disabled: bool,
+    /// Limited project info for external Relays.
+    ///
+    /// This contains no information when `disabled` is `true`.
+    #[serde(with = "LimitedProjectInfo")]
+    #[serde(flatten)]
+    pub info: Arc<ProjectInfo>,
+    /// Upstream override to use by the downstream Relay receiving the project state.
+    ///
+    /// See also: [`ProjectInfo::upstream`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<UpstreamDescriptor<'static>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_json_snapshot;
+
+    use super::*;
+
+    #[derive(Debug, Serialize)]
+    #[serde(transparent)]
+    struct Limited(#[serde(with = "LimitedSerializeProjectState")] SerializeProjectState);
+
+    #[test]
+    fn test_serialize_full_no_upstream() {
+        let s = SerializeProjectState {
+            disabled: false,
+            info: Default::default(),
+            upstream: None,
+        };
+
+        assert_json_snapshot!(s, @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null
+        }
+        "#);
+
+        assert_json_snapshot!(Limited(s), @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_serialize_full_project_info_upstream_ignored() {
+        let s = SerializeProjectState {
+            disabled: false,
+            info: ProjectInfo {
+                upstream: Some("https://sentry.io".parse().unwrap()),
+                ..Default::default()
+            },
+            upstream: None,
+        };
+
+        assert_json_snapshot!(s, @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null
+        }
+        "#);
+
+        assert_json_snapshot!(Limited(s), @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_serialize_full_correct_upstream_used() {
+        let s = SerializeProjectState {
+            disabled: false,
+            info: ProjectInfo {
+                upstream: Some("https://sentry.io".parse().unwrap()),
+                ..Default::default()
+            },
+            upstream: Some("https://us.sentry.io".parse().unwrap()),
+        };
+
+        assert_json_snapshot!(s, @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null,
+          "upstream": "https://us.sentry.io/"
+        }
+        "#);
+
+        assert_json_snapshot!(Limited(s), @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null,
+          "upstream": "https://us.sentry.io/"
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_serialize_full_upstream_used() {
+        let s = SerializeProjectState {
+            disabled: false,
+            info: Default::default(),
+            upstream: Some("https://us.sentry.io".parse().unwrap()),
+        };
+
+        assert_json_snapshot!(s, @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null,
+          "upstream": "https://us.sentry.io/"
+        }
+        "#);
+
+        assert_json_snapshot!(Limited(s), @r#"
+        {
+          "disabled": false,
+          "projectId": null,
+          "lastChange": null,
+          "rev": null,
+          "publicKeys": [],
+          "slug": null,
+          "config": {
+            "allowedDomains": [
+              "*"
+            ],
+            "trustedRelays": [],
+            "piiConfig": null
+          },
+          "organizationId": null,
+          "upstream": "https://us.sentry.io/"
+        }
+        "#);
+    }
+}

--- a/relay-server/src/services/projects/project/serialize.rs
+++ b/relay-server/src/services/projects/project/serialize.rs
@@ -7,9 +7,9 @@ use crate::services::projects::project::{LimitedProjectInfo, ProjectInfo};
 
 /// Project state as used in de-serialization.
 ///
-/// Use [`SerializeProjectState`] to serialize a project state.
+/// Use [`OutgoingProjectState`] to serialize a project state.
 #[derive(Debug, Clone, Deserialize)]
-pub struct ParsedProjectState {
+pub struct IncomingProjectState {
     /// Whether the project state is disabled.
     #[serde(default)]
     pub disabled: bool,
@@ -22,9 +22,9 @@ pub struct ParsedProjectState {
 
 /// Project state as used in serialization.
 ///
-/// Use [`ParsedProjectState`] to de-serialize a project state.
+/// Use [`IncomingProjectState`] to de-serialize a project state.
 #[derive(Debug, Clone, Serialize)]
-pub struct SerializeProjectState {
+pub struct OutgoingProjectState {
     /// Whether the project state is disabled.
     #[serde(default)]
     pub disabled: bool,
@@ -42,8 +42,8 @@ pub struct SerializeProjectState {
 
 /// Limited project state for external Relays.
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase", remote = "SerializeProjectState")]
-pub struct LimitedSerializeProjectState {
+#[serde(rename_all = "camelCase", remote = "OutgoingProjectState")]
+pub struct LimitedOutgoingProjectState {
     /// Whether the project state is disabled.
     pub disabled: bool,
     /// Limited project info for external Relays.
@@ -67,11 +67,11 @@ mod tests {
 
     #[derive(Debug, Serialize)]
     #[serde(transparent)]
-    struct Limited(#[serde(with = "LimitedSerializeProjectState")] SerializeProjectState);
+    struct Limited(#[serde(with = "LimitedOutgoingProjectState")] OutgoingProjectState);
 
     #[test]
     fn test_serialize_full_no_upstream() {
-        let s = SerializeProjectState {
+        let s = OutgoingProjectState {
             disabled: false,
             info: Default::default(),
             upstream: None,
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_serialize_full_project_info_upstream_ignored() {
-        let s = SerializeProjectState {
+        let s = OutgoingProjectState {
             disabled: false,
             info: Arc::new(ProjectInfo {
                 upstream: Some("https://sentry.io".parse().unwrap()),
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_serialize_full_correct_upstream_used() {
-        let s = SerializeProjectState {
+        let s = OutgoingProjectState {
             disabled: false,
             info: Arc::new(ProjectInfo {
                 upstream: Some("https://sentry.io".parse().unwrap()),
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_serialize_full_upstream_used() {
-        let s = SerializeProjectState {
+        let s = OutgoingProjectState {
             disabled: false,
             info: Default::default(),
             upstream: Some("https://us.sentry.io".parse().unwrap()),

--- a/relay-server/src/services/projects/source/redis.rs
+++ b/relay-server/src/services/projects/source/redis.rs
@@ -5,7 +5,7 @@ use relay_statsd::metric;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::services::projects::project::{ParsedProjectState, ProjectState, Revision};
+use crate::services::projects::project::{IncomingProjectState, ProjectState, Revision};
 use crate::services::projects::source::SourceProjectState;
 use crate::statsd::{RelayCounters, RelayDistributions, RelayTimers};
 use relay_redis::redis::cmd;
@@ -25,7 +25,7 @@ pub enum RedisProjectError {
     Redis(#[from] RedisError),
 }
 
-fn parse_redis_response(raw_response: &[u8]) -> Result<ParsedProjectState, RedisProjectError> {
+fn parse_redis_response(raw_response: &[u8]) -> Result<IncomingProjectState, RedisProjectError> {
     let decompression_result = metric!(timer(RelayTimers::ProjectStateDecompression), {
         zstd::decode_all(raw_response)
     });

--- a/relay-server/src/services/projects/source/upstream.rs
+++ b/relay-server/src/services/projects/source/upstream.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::services::projects::project::Revision;
-use crate::services::projects::project::{ParsedProjectState, ProjectState};
+use crate::services::projects::project::{IncomingProjectState, ProjectState};
 use crate::services::projects::source::{FetchProjectState, SourceProjectState};
 use crate::services::upstream::{
     Method, RequestPriority, SendQuery, UpstreamQuery, UpstreamRelay, UpstreamRequestError,
@@ -56,9 +56,9 @@ pub struct GetProjectStates {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetProjectStatesResponse {
-    /// Map of [`ProjectKey`] to [`ParsedProjectState`] that was fetched from the upstream.
+    /// Map of [`ProjectKey`] to [`IncomingProjectState`] that was fetched from the upstream.
     #[serde(default)]
-    configs: HashMap<ProjectKey, ErrorBoundary<Option<ParsedProjectState>>>,
+    configs: HashMap<ProjectKey, ErrorBoundary<Option<IncomingProjectState>>>,
     /// The [`ProjectKey`]'s that couldn't be immediately retrieved from the upstream.
     #[serde(default)]
     pending: HashSet<ProjectKey>,
@@ -208,7 +208,7 @@ type Message = Result<SourceProjectState, Error>;
 
 /// This is the [`UpstreamProjectSourceService`] interface.
 ///
-/// The service is responsible for fetching the [`ParsedProjectState`] from the upstream.
+/// The service is responsible for fetching the [`IncomingProjectState`] from the upstream.
 /// Internally it maintains the buffer queue of the incoming requests, which got scheduled to fetch the
 /// state and takes care of the backoff in case there is a problem with the requests.
 #[derive(Debug)]
@@ -236,7 +236,7 @@ struct UpstreamResponse {
     response: Result<GetProjectStatesResponse, UpstreamRequestError>,
 }
 
-/// The service which handles the fetching of the [`ParsedProjectState`] from upstream.
+/// The service which handles the fetching of the [`IncomingProjectState`] from upstream.
 #[derive(Debug)]
 pub struct UpstreamProjectSourceService {
     backoff: RetryBackoff,

--- a/relay-server/src/services/projects/source/upstream.rs
+++ b/relay-server/src/services/projects/source/upstream.rs
@@ -53,7 +53,7 @@ pub struct GetProjectStates {
 ///
 /// A [`ProjectKey`] is either pending or has a result, it can not appear in both and doing
 /// so is undefined.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetProjectStatesResponse {
     /// Map of [`ProjectKey`] to [`ParsedProjectState`] that was fetched from the upstream.

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -334,3 +334,42 @@ def test_unchanged_projects(mini_sentry, relay):
     assert public_key in data["unchanged"]
     assert public_key not in data["configs"]
     assert data.get("pending") is None
+
+
+def test_project_config_advertised_upstream_added(mini_sentry, relay):
+    """
+    The configured advertised upstream should be injected in the project config.
+    """
+    relay = relay(
+        mini_sentry,
+        {
+            "relay": {
+                "advertised_upstream": "https://relay.example/",
+            }
+        },
+    )
+    mini_sentry.add_basic_project_config(42)
+    public_key = mini_sentry.get_dsn_public_key(42)
+
+    body = {"publicKeys": [public_key]}
+    packed, signature = SecretKey.parse(relay.secret_key).pack(body)
+
+    data, _ = get_response(relay, packed, signature)
+    assert data["configs"][public_key]["upstream"] == "https://relay.example/"
+
+
+def test_project_config_upstream_not_forwarded(mini_sentry, relay):
+    """
+    The from upstream provided upstream, should not be forwarded to downstream consumers
+    of the project config.
+    """
+    relay = relay(mini_sentry)
+    project_config = mini_sentry.add_basic_project_config(42)
+    project_config["upstream"] = "https://relay.example"
+    public_key = mini_sentry.get_dsn_public_key(42)
+
+    body = {"publicKeys": [public_key]}
+    packed, signature = SecretKey.parse(relay.secret_key).pack(body)
+
+    data, _ = get_response(relay, packed, signature)
+    assert data["configs"][public_key].get("upstream") is None

--- a/tests/integration/test_projectconfigs.py
+++ b/tests/integration/test_projectconfigs.py
@@ -336,11 +336,13 @@ def test_unchanged_projects(mini_sentry, relay):
     assert data.get("pending") is None
 
 
-def test_project_config_advertised_upstream_added(mini_sentry, relay):
+def test_project_config_advertised_upstream_added_not_forwarded(mini_sentry, relay):
     """
     The configured advertised upstream should be injected in the project config.
+
+    A Relay receiving an advertised upstream most not forward it further.
     """
-    relay = relay(
+    relay1 = relay(
         mini_sentry,
         {
             "relay": {
@@ -352,24 +354,15 @@ def test_project_config_advertised_upstream_added(mini_sentry, relay):
     public_key = mini_sentry.get_dsn_public_key(42)
 
     body = {"publicKeys": [public_key]}
-    packed, signature = SecretKey.parse(relay.secret_key).pack(body)
+    packed, signature = SecretKey.parse(relay1.secret_key).pack(body)
 
-    data, _ = get_response(relay, packed, signature)
+    data, _ = get_response(relay1, packed, signature)
     assert data["configs"][public_key]["upstream"] == "https://relay.example/"
 
-
-def test_project_config_upstream_not_forwarded(mini_sentry, relay):
-    """
-    The from upstream provided upstream, should not be forwarded to downstream consumers
-    of the project config.
-    """
-    relay = relay(mini_sentry)
-    project_config = mini_sentry.add_basic_project_config(42)
-    project_config["upstream"] = "https://relay.example"
-    public_key = mini_sentry.get_dsn_public_key(42)
+    relay2 = relay(relay1)
 
     body = {"publicKeys": [public_key]}
-    packed, signature = SecretKey.parse(relay.secret_key).pack(body)
+    packed, signature = SecretKey.parse(relay2.secret_key).pack(body)
 
-    data, _ = get_response(relay, packed, signature)
+    data, _ = get_response(relay2, packed, signature)
     assert data["configs"][public_key].get("upstream") is None


### PR DESCRIPTION
Refs: INGEST-700

Injects a statically configured "advertised upstream" into each project config returned from the local Relay instance. Downstream Relays will (in the future) use that injected upstream as the upstream target for envelopes and other payloads which are scoped to a project.