### PR TITLE
fix(rate limits): Don't err on rate limits in `handle_envelope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Propagate an event's retention policy to its attachments ([#5774](https://github.com/getsentry/relay/pull/5774))
 - Prevent panic in span description normalization. ([#5781](https://github.com/getsentry/relay/pull/5781))
 - Limit overall stream size in playstation multiparts. ([#5795](https://github.com/getsentry/relay/pull/5795))
-- Respect rate limit ignoration even when all items are rate limited ([#5840](https://github.com/getsentry/relay/pull/5840))
+- Respect rate limit silencing also when all items are rate limited ([#5840](https://github.com/getsentry/relay/pull/5840))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug Fixes**:
 
 - Respond with 429 if otlp logs are rate limited, as per spec. ([#5841](https://github.com/getsentry/relay/pull/5841))
+- Respect rate limit silencing also when all items are rate limited. ([#5840](https://github.com/getsentry/relay/pull/5840))
 
 ## 26.4.0
 
@@ -26,7 +27,6 @@
 - Propagate an event's retention policy to its attachments ([#5774](https://github.com/getsentry/relay/pull/5774))
 - Prevent panic in span description normalization. ([#5781](https://github.com/getsentry/relay/pull/5781))
 - Limit overall stream size in playstation multiparts. ([#5795](https://github.com/getsentry/relay/pull/5795))
-- Respect rate limit silencing also when all items are rate limited ([#5840](https://github.com/getsentry/relay/pull/5840))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Propagate an event's retention policy to its attachments ([#5774](https://github.com/getsentry/relay/pull/5774))
 - Prevent panic in span description normalization. ([#5781](https://github.com/getsentry/relay/pull/5781))
 - Limit overall stream size in playstation multiparts. ([#5795](https://github.com/getsentry/relay/pull/5795))
+- Respect rate limit ignoration even when all items are rate limited ([#5840](https://github.com/getsentry/relay/pull/5840))
 
 **Features**:
 

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -60,6 +60,6 @@ pub async fn handle(
     let envelope = extract_envelope(meta, path, multipart, state.config()).await?;
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .check_rate_limits()?;
     Ok(StatusCode::CREATED)
 }

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -60,6 +60,6 @@ pub async fn handle(
     let envelope = extract_envelope(meta, path, multipart, state.config()).await?;
     common::handle_envelope(&state, envelope)
         .await?
-        .ignore_rate_limits();
+        .silence_rate_limits();
     Ok(StatusCode::CREATED)
 }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -362,7 +362,10 @@ pub async fn handle_envelope(
         .map_err(|err| err.map(BadStoreRequest::EventRejected))?;
 
     if envelope.is_empty() {
-        return Err(envelope.reject_err((None, BadStoreRequest::RateLimited(rate_limits))));
+        return Ok(HandledEnvelope {
+            event_id,
+            rate_limits,
+        });
     }
 
     if let Err(offender) = utils::check_envelope_size_limits(state.config(), &envelope) {
@@ -412,14 +415,12 @@ impl HandledEnvelope {
         Ok(self.event_id)
     }
 
-    /// Explicitly ignores contained active rate limits.
+    /// Explicitly ignore all rate limits.
     ///
     /// Endpoints which choose to not propagate active rate limits, should use this method to
     /// explicitly state the fact they do not propagate the rate limits.
     ///
     /// Most endpoints ignore active rate limits, they are mostly used in envelope based endpoints.
-    ///
-    /// Note: enforced rate limits are still returned as an error from [`handle_envelope`].
     pub fn ignore_rate_limits(self) -> Option<EventId> {
         self.event_id
     }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -409,11 +409,11 @@ impl HandledEnvelope {
         Ok(self.event_id)
     }
 
-    /// Ignore rate limits, even if they caused items to be dropped from the envelope.
+    /// Silence rate limits, even if they caused items to be dropped from the envelope.
     ///
     /// Endpoints which choose to not propagate rate limits should use this method to explicitly
-    /// state the fact that they do not propagate rate limits.
-    pub fn ignore_rate_limits(self) -> Option<EventId> {
+    /// state the fact that they do so.
+    pub fn silence_rate_limits(self) -> Option<EventId> {
         self.event_id
     }
 }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -413,7 +413,7 @@ impl HandledEnvelope {
     ///
     /// Endpoints which choose to not propagate rate limits should use this method to explicitly
     /// state the fact that they do so.
-    pub fn silence_rate_limits(self) -> Option<EventId> {
+    pub fn ignore_rate_limits(self) -> Option<EventId> {
         self.event_id
     }
 }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -400,14 +400,8 @@ pub struct HandledEnvelope {
 }
 
 impl HandledEnvelope {
-    /// Ensures all active rate limits are handled as an error.
-    ///
-    /// This is legacy behaviour where active rate limits are returned as an error, instead of
-    /// being added to the usual response.
-    /// The event id in this legacy behaviour is only returned when there are no active rate
-    /// limits.
-    ///
-    /// The functions simplifies this legacy handling by turning rate limits into an error again.
+    /// Check if any rate limits were enforced (i.e. led to one or more items being dropped) and
+    /// return an error if so.
     pub fn check_rate_limits(self) -> Result<Option<EventId>, BadStoreRequest> {
         if self.rate_limits.is_limited() {
             return Err(BadStoreRequest::RateLimited(self.rate_limits));
@@ -415,12 +409,10 @@ impl HandledEnvelope {
         Ok(self.event_id)
     }
 
-    /// Explicitly ignore all rate limits.
+    /// Ignore rate limits, even if they caused items to be dropped from the envelope.
     ///
-    /// Endpoints which choose to not propagate active rate limits, should use this method to
-    /// explicitly state the fact they do not propagate the rate limits.
-    ///
-    /// Most endpoints ignore active rate limits, they are mostly used in envelope based endpoints.
+    /// Endpoints which choose to not propagate rate limits should use this method to explicitly
+    /// state the fact that they do not propagate rate limits.
     pub fn ignore_rate_limits(self) -> Option<EventId> {
         self.event_id
     }

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -268,13 +268,9 @@ async fn handle(
     let id = envelope.event_id();
 
     // Never respond with a 429 since clients often retry these
-    match common::handle_envelope(&state, envelope)
-        .await
-        .map_err(|err| err.into_inner())
-    {
-        Ok(_) | Err(BadStoreRequest::RateLimited(_)) => (),
-        Err(error) => return Err(error.into()),
-    };
+    common::handle_envelope(&state, envelope)
+        .await?
+        .silence_rate_limits();
 
     // The return here is only useful for consistency because the UE4 crash reporter doesn't
     // care about it.

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -270,7 +270,7 @@ async fn handle(
     // Never respond with a 429 since clients often retry these
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .ignore_rate_limits();
 
     // The return here is only useful for consistency because the UE4 crash reporter doesn't
     // care about it.

--- a/relay-server/src/endpoints/monitor.rs
+++ b/relay-server/src/endpoints/monitor.rs
@@ -66,13 +66,9 @@ async fn handle(
     envelope.add_item(item);
 
     // Never respond with a 429
-    match common::handle_envelope(&state, envelope)
-        .await
-        .map_err(|err| err.into_inner())
-    {
-        Ok(_) | Err(BadStoreRequest::RateLimited(_)) => (),
-        Err(error) => return Err(error.into()),
-    };
+    common::handle_envelope(&state, envelope)
+        .await?
+        .silence_rate_limits();
 
     // Event will be processed by Sentry, respond with a 202
     Ok(StatusCode::ACCEPTED)

--- a/relay-server/src/endpoints/monitor.rs
+++ b/relay-server/src/endpoints/monitor.rs
@@ -68,7 +68,7 @@ async fn handle(
     // Never respond with a 429
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .ignore_rate_limits();
 
     // Event will be processed by Sentry, respond with a 202
     Ok(StatusCode::ACCEPTED)

--- a/relay-server/src/endpoints/nel.rs
+++ b/relay-server/src/endpoints/nel.rs
@@ -57,7 +57,7 @@ async fn handle(
 
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .ignore_rate_limits();
 
     Ok(().into_response())
 }

--- a/relay-server/src/endpoints/nel.rs
+++ b/relay-server/src/endpoints/nel.rs
@@ -57,7 +57,7 @@ async fn handle(
 
     common::handle_envelope(&state, envelope)
         .await?
-        .ignore_rate_limits();
+        .silence_rate_limits();
 
     Ok(().into_response())
 }

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -232,7 +232,7 @@ async fn handle(
     // Never respond with a 429 since clients often retry these
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .ignore_rate_limits();
 
     // Return here needs to be a 200 with arbitrary text to make the sender happy.
     Ok(TextResponse(id).into_response())

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -230,13 +230,9 @@ async fn handle(
     let id = envelope.event_id();
 
     // Never respond with a 429 since clients often retry these
-    match common::handle_envelope(&state, envelope)
-        .await
-        .map_err(|err| err.into_inner())
-    {
-        Ok(_) | Err(BadStoreRequest::RateLimited(_)) => (),
-        Err(error) => return Err(error.into()),
-    };
+    common::handle_envelope(&state, envelope)
+        .await?
+        .silence_rate_limits();
 
     // Return here needs to be a 200 with arbitrary text to make the sender happy.
     Ok(TextResponse(id).into_response())

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -103,7 +103,7 @@ async fn handle(
     let envelope = params.extract_envelope()?;
     common::handle_envelope(&state, envelope)
         .await?
-        .ignore_rate_limits();
+        .silence_rate_limits();
 
     Ok(().into_response())
 }

--- a/relay-server/src/endpoints/security_report.rs
+++ b/relay-server/src/endpoints/security_report.rs
@@ -103,7 +103,7 @@ async fn handle(
     let envelope = params.extract_envelope()?;
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .check_rate_limits()?;
 
     Ok(().into_response())
 }

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -105,7 +105,7 @@ async fn handle(
     // Never respond with a 429 since clients often retry these
     common::handle_envelope(&state, envelope)
         .await?
-        .silence_rate_limits();
+        .ignore_rate_limits();
 
     // The return here is only useful for consistency because the UE4 crash reporter doesn't
     // care about it.

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -98,18 +98,14 @@ impl UnrealParams {
 async fn handle(
     state: ServiceState,
     params: UnrealParams,
-) -> Result<impl IntoResponse, BadStoreRequest> {
+) -> axum::response::Result<impl IntoResponse> {
     let envelope = params.extract_envelope(&state).await?;
     let id = envelope.event_id();
 
     // Never respond with a 429 since clients often retry these
-    match common::handle_envelope(&state, envelope)
-        .await
-        .map_err(|err| err.into_inner())
-    {
-        Ok(_) | Err(BadStoreRequest::RateLimited(_)) => (),
-        Err(error) => return Err(error),
-    };
+    common::handle_envelope(&state, envelope)
+        .await?
+        .silence_rate_limits();
 
     // The return here is only useful for consistency because the UE4 crash reporter doesn't
     // care about it.

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
+from time import sleep
 from unittest import mock
 
 from .asserts import time_within_delta
@@ -78,3 +79,18 @@ def test_nel_converted_to_logs(mini_sentry, relay):
         ],
     }
     assert mini_sentry.captured_envelopes.empty()
+
+
+def test_nel_rate_limited(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = ["organizations:ourlogs-ingestion"]
+    project_config["config"]["quotas"] = [
+        {"categories": [], "limit": 0, "reasonCode": "static_disabled_quota"}
+    ]
+    relay = relay(mini_sentry)
+
+    # Nel never returns 429
+    relay.send_nel_event(project_id)
+    sleep(1)
+    relay.send_nel_event(project_id)

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from time import sleep
 from unittest import mock
 import pytest
 import os
@@ -798,3 +799,31 @@ def test_event_merging(
     assert sorted(event["attachments"], key=lambda x: x["name"]) == attachments(
         158008, 60446, 210174
     )
+
+
+@pytest.mark.parametrize("rate_limits", [[], ["error"], ["error", "attachment"]])
+@pytest.mark.parametrize("use_pop_relay", [True, False])
+def test_playstation_rate_limited(
+    mini_sentry,
+    relay_with_playstation,
+    relay_processing_with_playstation,
+    relay_credentials,
+    use_pop_relay,
+    rate_limits,
+):
+    PROJECT_ID = 42
+    playstation_dump = load_dump_file("playstation.prosperodmp")
+    config = playstation_project_config()
+    config["config"]["quotas"] = [
+        {"categories": rate_limits, "limit": 0, "reasonCode": "static_disabled_quota"}
+    ]
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=config)
+    credentials = relay_credentials()
+    relay = relay_processing_with_playstation(static_credentials=credentials)
+    if use_pop_relay:
+        relay = relay_with_playstation(relay, credentials=credentials)
+
+    # Playstation never returns 429
+    relay.send_playstation_request(PROJECT_ID, playstation_dump)
+    sleep(1)
+    relay.send_playstation_request(PROJECT_ID, playstation_dump)

--- a/tests/integration/test_security_report.py
+++ b/tests/integration/test_security_report.py
@@ -1,5 +1,8 @@
 import json
+from time import sleep
+
 import pytest
+from requests.exceptions import HTTPError
 
 CSP_IGNORED_FIELDS = (
     "event_id",
@@ -368,3 +371,34 @@ def test_adds_origin_header(mini_sentry, relay, json_fixture_provider):
     event = get_security_report(envelope)
 
     assert ["Origin", "http://valid.com/"] in event["request"]["headers"]
+
+
+def test_security_report_rate_limited(mini_sentry, relay, json_fixture_provider):
+    proj_id = 42
+    project_config = mini_sentry.add_full_project_config(proj_id)
+    project_config["config"]["quotas"] = [
+        {"categories": ["security"], "limit": 0, "reasonCode": "static_disabled_quota"}
+    ]
+    relay = relay(mini_sentry)
+    report = json_fixture_provider(__file__).load("csp", ".input")
+
+    relay.send_security_report(
+        project_id=proj_id,
+        content_type="application/json",
+        payload=report,
+        release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
+        environment="production",
+    )
+
+    sleep(1)
+
+    with pytest.raises(HTTPError) as exc_info:
+        relay.send_security_report(
+            project_id=proj_id,
+            content_type="application/json",
+            payload=report,
+            release="01d5c3165d9fbc5c8bdcf9550a1d6793a80fc02b",
+            environment="production",
+        )
+
+    assert exc_info.value.response.status_code == 429


### PR DESCRIPTION
Return `Ok` from `handle_envelope` even when rate limits cause all envelope items to be dropped. This is a prerequisite for having the ability to silence rate limits, as intended with `HandledEnvelope::ignore_rate_limits()`.

Fixes https://linear.app/getsentry/issue/INGEST-858/fix-rate-limits-not-being-ignored