### PR TITLE
fix(tracemetrics): Change selector name to $metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 **Internal**:
 
 - Update trace metric PII scrubbing to use `relay_pii::eap::scrub`. ([#5815](https://github.com/getsentry/relay/pull/5815))
+- Update trace metric PII scrubbing to use `metric` as a selector. ([#5842](https://github.com/getsentry/relay/pull/5842))
 - Calculate and track accepted bytes per individual trace metric item via `TraceMetricByte` data category. ([#5744](https://github.com/getsentry/relay/pull/5744), [#5767](https://github.com/getsentry/relay/pull/5767))
 - Graduate standalone span ingestion feature flag. ([#5786](https://github.com/getsentry/relay/pull/5786))
 - Remove cardinality limiter. ([#5809](https://github.com/getsentry/relay/pull/5809))

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -87,7 +87,7 @@ relay_common::derive_fromstr_and_display!(ValueType, UnknownValueTypeError, {
     ValueType::Thread => "thread",
     ValueType::Breadcrumb => "breadcrumb",
     ValueType::OurLog => "log",
-    ValueType::TraceMetric => "trace_metric",
+    ValueType::TraceMetric => "metric",
 
     ValueType::Span => "span",
     ValueType::ClientSdkInfo => "sdk",

--- a/relay-pii/src/selector.rs
+++ b/relay-pii/src/selector.rs
@@ -673,4 +673,15 @@ mod tests {
         assert_matches_pii_true!(body_state, "$log.body",);
         assert_matches_pii_true!(attributes_state, "$log.attributes",);
     }
+
+    #[test]
+    fn test_trace_metric_matching() {
+        let event_state = ProcessingState::new_root(None, None);
+        let metric_state = event_state.enter_borrowed("", None, Some(ValueType::TraceMetric));
+        let attributes_state =
+            metric_state.enter_borrowed("attributes", None, Some(ValueType::Object));
+
+        assert_matches_pii_maybe!(metric_state, "$metric",);
+        assert_matches_pii_true!(attributes_state, "$metric.attributes",);
+    }
 }

--- a/relay-server/src/processing/trace_metrics/process.rs
+++ b/relay-server/src/processing/trace_metrics/process.rs
@@ -326,7 +326,7 @@ mod tests {
                 }
             },
             "applications": {
-                "** && !$trace_metric.**": ["should_not_remove_normal_field"]
+                "** && !$metric.**": ["should_not_remove_normal_field"]
             }
         }))
         .unwrap();


### PR DESCRIPTION
We previously had 'trace_metric' which we don't want to expose in the selector syntax, similar to how `ourlog` becomes `log`.

UI doesn't exist yet for scrubbing so no metric specific rules exist yet.


