### PR TITLE
ref(upstream): Internally reference count the upstream descriptor

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -491,7 +491,7 @@ pub struct Relay {
     /// The instance type of this Relay.
     pub instance: RelayInstance,
     /// The upstream Relay or Sentry instance.
-    pub upstream: UpstreamDescriptor<'static>,
+    pub upstream: UpstreamDescriptor,
     /// The upstream advertised to downstream Relay instances.
     ///
     /// This value will be advertised to downstream Relays as the upstream to use when forwarding
@@ -500,7 +500,7 @@ pub struct Relay {
     ///
     /// Downstream Relays will treat the advertised upstream as the same logical component as this instance
     /// and re-use already established authentication keys.
-    pub advertised_upstream: Option<UpstreamDescriptor<'static>>,
+    pub advertised_upstream: Option<UpstreamDescriptor>,
     /// The host the relay should bind to (network interface).
     pub host: IpAddr,
     /// The port to bind for the unencrypted relay HTTP server.
@@ -1854,7 +1854,7 @@ impl Config {
         } else if let Some(upstream_dsn) = overrides.upstream_dsn {
             relay.upstream = upstream_dsn
                 .parse::<Dsn>()
-                .map(|dsn| UpstreamDescriptor::from_dsn(&dsn).into_owned())
+                .map(|dsn| UpstreamDescriptor::from_dsn(&dsn))
                 .with_context(|| ConfigError::field("upstream_dsn"))?;
         }
 
@@ -2066,12 +2066,12 @@ impl Config {
     }
 
     /// Returns the upstream target as descriptor.
-    pub fn upstream_descriptor(&self) -> &UpstreamDescriptor<'_> {
+    pub fn upstream_descriptor(&self) -> &UpstreamDescriptor {
         &self.values.relay.upstream
     }
 
     /// Returns the advertised upstream for downstream instances as descriptor.
-    pub fn advertised_upstream_descriptor(&self) -> Option<&UpstreamDescriptor<'_>> {
+    pub fn advertised_upstream_descriptor(&self) -> Option<&UpstreamDescriptor> {
         self.values.relay.advertised_upstream.as_ref()
     }
 

--- a/relay-config/src/upstream.rs
+++ b/relay-config/src/upstream.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
+use std::sync::Arc;
 use std::{fmt, io};
 
 use relay_common::{Dsn, Scheme};
@@ -38,17 +38,20 @@ pub enum UpstreamParseError {
 /// The upstream target is a type that holds all the information
 /// to uniquely identify an upstream target.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub struct UpstreamDescriptor<'a> {
-    host: Cow<'a, str>,
+pub struct UpstreamDescriptor {
+    host: Arc<str>,
     port: u16,
     scheme: Scheme,
 }
 
-impl<'a> UpstreamDescriptor<'a> {
+impl UpstreamDescriptor {
     /// Manually constructs an upstream descriptor.
-    pub fn new(host: &'a str, port: u16, scheme: Scheme) -> UpstreamDescriptor<'a> {
+    pub fn new<T>(host: T, port: u16, scheme: Scheme) -> Self
+    where
+        T: Into<Arc<str>>,
+    {
         UpstreamDescriptor {
-            host: Cow::Borrowed(host),
+            host: host.into(),
             port,
             scheme,
         }
@@ -56,12 +59,8 @@ impl<'a> UpstreamDescriptor<'a> {
 
     /// Given a DSN this returns an upstream descriptor that
     /// describes it.
-    pub fn from_dsn(dsn: &'a Dsn) -> UpstreamDescriptor<'a> {
-        UpstreamDescriptor {
-            host: Cow::Borrowed(dsn.host()),
-            port: dsn.port(),
-            scheme: dsn.scheme(),
-        }
+    pub fn from_dsn(dsn: &Dsn) -> Self {
+        Self::new(dsn.host(), dsn.port(), dsn.scheme())
     }
 
     /// Returns the host as a string.
@@ -98,37 +97,15 @@ impl<'a> UpstreamDescriptor<'a> {
     pub fn scheme(&self) -> Scheme {
         self.scheme
     }
+}
 
-    /// Returns a version of the upstream descriptor that is static.
-    pub fn into_owned(self) -> UpstreamDescriptor<'static> {
-        UpstreamDescriptor {
-            host: Cow::Owned(self.host.into_owned()),
-            port: self.port,
-            scheme: self.scheme,
-        }
-    }
-
-    /// Converts from `&UpstreamDescriptor<'_>` to `UpstreamDescriptor<'_>`.
-    pub fn as_ref(&self) -> UpstreamDescriptor<'_> {
-        UpstreamDescriptor {
-            host: Cow::Borrowed(&self.host),
-            port: self.port,
-            scheme: self.scheme,
-        }
+impl Default for UpstreamDescriptor {
+    fn default() -> Self {
+        Self::new("sentry.io", 443, Scheme::Https)
     }
 }
 
-impl Default for UpstreamDescriptor<'static> {
-    fn default() -> UpstreamDescriptor<'static> {
-        UpstreamDescriptor {
-            host: Cow::Borrowed("sentry.io"),
-            port: 443,
-            scheme: Scheme::Https,
-        }
-    }
-}
-
-impl fmt::Display for UpstreamDescriptor<'_> {
+impl fmt::Display for UpstreamDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}://{}", &self.scheme, &self.host)?;
         if self.port() != self.scheme.default_port() {
@@ -138,10 +115,10 @@ impl fmt::Display for UpstreamDescriptor<'_> {
     }
 }
 
-impl FromStr for UpstreamDescriptor<'static> {
+impl FromStr for UpstreamDescriptor {
     type Err = UpstreamParseError;
 
-    fn from_str(s: &str) -> Result<UpstreamDescriptor<'static>, UpstreamParseError> {
+    fn from_str(s: &str) -> Result<Self, UpstreamParseError> {
         let url = Url::parse(s).map_err(|_| UpstreamParseError::BadUrl)?;
         if url.path() != "/" || !(url.query().is_none() || url.query() == Some("")) {
             return Err(UpstreamParseError::NonOriginUrl);
@@ -155,7 +132,7 @@ impl FromStr for UpstreamDescriptor<'static> {
 
         Ok(UpstreamDescriptor {
             host: match url.host_str() {
-                Some(host) => Cow::Owned(host.to_owned()),
+                Some(host) => host.into(),
                 None => return Err(UpstreamParseError::NoHost),
             },
             port: url.port().unwrap_or_else(|| scheme.default_port()),
@@ -164,7 +141,7 @@ impl FromStr for UpstreamDescriptor<'static> {
     }
 }
 
-relay_common::impl_str_serde!(UpstreamDescriptor<'static>, "a sentry upstream URL");
+relay_common::impl_str_serde!(UpstreamDescriptor, "a sentry upstream URL");
 
 #[cfg(test)]
 mod tests {
@@ -172,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_basic_parsing() {
-        let desc: UpstreamDescriptor<'_> = "https://sentry.io/".parse().unwrap();
+        let desc: UpstreamDescriptor = "https://sentry.io/".parse().unwrap();
         assert_eq!(desc.host(), "sentry.io");
         assert_eq!(desc.port(), 443);
         assert_eq!(desc.scheme(), Scheme::Https);

--- a/relay-server/src/endpoints/project_configs.rs
+++ b/relay-server/src/endpoints/project_configs.rs
@@ -200,10 +200,7 @@ async fn inner(
                 OutgoingProjectState {
                     disabled: false,
                     info: Arc::clone(project_info),
-                    upstream: state
-                        .config()
-                        .advertised_upstream_descriptor()
-                        .map(|u| u.as_ref().into_owned()),
+                    upstream: state.config().advertised_upstream_descriptor().cloned(),
                 },
                 full,
             );

--- a/relay-server/src/extractors/request_meta.rs
+++ b/relay-server/src/extractors/request_meta.rs
@@ -121,7 +121,7 @@ impl PartialDsn {
     }
 
     /// Creates a new [`PartialDsn`] for a Relay outbound request.
-    pub fn outbound(scoping: &Scoping, upstream: &UpstreamDescriptor<'_>) -> Self {
+    pub fn outbound(scoping: &Scoping, upstream: &UpstreamDescriptor) -> Self {
         Self {
             scheme: upstream.scheme(),
             public_key: scoping.project_key,

--- a/relay-server/src/services/projects/project/info.rs
+++ b/relay-server/src/services/projects/project/info.rs
@@ -72,7 +72,7 @@ pub struct ProjectInfo {
     /// As this is purely a mechanism to route and shape traffic authentication credentials will
     /// be re-used.
     #[serde(skip_serializing)]
-    pub upstream: Option<UpstreamDescriptor<'static>>,
+    pub upstream: Option<UpstreamDescriptor>,
 }
 
 /// Controls how we serialize a ProjectState for an external Relay

--- a/relay-server/src/services/projects/project/serialize.rs
+++ b/relay-server/src/services/projects/project/serialize.rs
@@ -37,7 +37,7 @@ pub struct OutgoingProjectState {
     ///
     /// See also: [`ProjectInfo::upstream`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upstream: Option<UpstreamDescriptor<'static>>,
+    pub upstream: Option<UpstreamDescriptor>,
 }
 
 /// Limited project state for external Relays.
@@ -56,7 +56,7 @@ pub struct LimitedOutgoingProjectState {
     ///
     /// See also: [`ProjectInfo::upstream`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upstream: Option<UpstreamDescriptor<'static>>,
+    pub upstream: Option<UpstreamDescriptor>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Internally reference counts the `UpstreamDescriptor` host.

- The `host` itself never needs to be mutated
- Relay never actually uses a borrowed variant of the descriptor, it's always owned
- We're going to need to clone the upstream descriptor a bunch very soon. Each upstream request will need to hold on to a copy of the upstream.

Overall this also improves ergonomics a tiny bit, from `&UpstreamDescriptor<'_>` to `&UpstreamDescriptor`. Also reducing the API surface.

Tried the generic variant and just `Arc<str>` internally, the generic variant did not seem worth it. We never use a referenced borrowed and it's just another generic you need to specify. 

The variant where the generic defaults to UpstreamDescriptor<T = Arc<str>> was basically equivalent to just using `Arc<str>` except it needed a bit more API surface to support converting between different T's