### PR TITLE
ci: Stop publishing to docker hub

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -29,19 +29,10 @@ targets:
     name: docker
     source: ghcr.io/getsentry/relay
     target: ghcr.io/getsentry/relay
-  - id: release-dockerhub
-    name: docker
-    source: ghcr.io/getsentry/relay
-    target: getsentry/relay
   - id: latest
     name: docker
     source: ghcr.io/getsentry/relay
     target: ghcr.io/getsentry/relay
-    targetFormat: "{{{target}}}:latest"
-  - id: latest
-    name: docker
-    source: ghcr.io/getsentry/relay
-    target: getsentry/relay
     targetFormat: "{{{target}}}:latest"
 
 requireNames:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Breaking Changes**:
+
+- Stop publishing to Docker Hub. ([#5845](https://github.com/getsentry/relay/pull/5845))
+
 **Features**:
 
 - Add `ModelMetadata` config with context size and utilization. ([#5814](https://github.com/getsentry/relay/pull/5814))
@@ -10,7 +14,6 @@
 
 - Move unreal crash report expansion from processing into endpoint. ([#5825](https://github.com/getsentry/relay/pull/5825))
 - Retry failing objectstore requests. ([#5836](https://github.com/getsentry/relay/pull/5836))
-- Stop publishing to Docker Hub. ([#5845](https://github.com/getsentry/relay/pull/5845))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Move unreal crash report expansion from processing into endpoint. ([#5825](https://github.com/getsentry/relay/pull/5825))
 - Retry failing objectstore requests. ([#5836](https://github.com/getsentry/relay/pull/5836))
+- Stop publishing to Docker Hub. ([#5845](https://github.com/getsentry/relay/pull/5845))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Breaking Changes**:
 
-- Stop publishing to Docker Hub. ([#5845](https://github.com/getsentry/relay/pull/5845))
+- Docker images are no longer published to Docker Hub, use the Github Container Registry instead ([see documentation](https://github.com/getsentry/relay/pkgs/container/relay)). ([#5845](https://github.com/getsentry/relay/pull/5845))
 
 **Features**:
 


### PR DESCRIPTION
Ref [RELAY-133](https://linear.app/getsentry/issue/RELAY-133/stop-publishing-releases-to-dockerhub)