### PR TITLE
ref(upload): Clean up objectstore error handling

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -101,10 +101,10 @@ impl IntoResponse for Error {
                 upload::Error::InvalidSignature => StatusCode::BAD_REQUEST,
                 upload::Error::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
                 #[cfg(feature = "processing")]
-                upload::Error::Objectstore(service_error) => match service_error {
-                    objectstore::Error::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
-                    objectstore::Error::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
-                    objectstore::Error::UploadFailed(error) => match error {
+                upload::Error::Objectstore(service_error) => match service_error.kind {
+                    objectstore::ErrorKind::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
+                    objectstore::ErrorKind::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
+                    objectstore::ErrorKind::UploadFailed(error) => match error {
                         objectstore_client::Error::Reqwest(error) => match error.status() {
                             _ if error.is_timeout() => StatusCode::GATEWAY_TIMEOUT,
                             Some(status) => status,
@@ -115,7 +115,7 @@ impl IntoResponse for Error {
                         },
                         _ => StatusCode::INTERNAL_SERVER_ERROR,
                     },
-                    objectstore::Error::Uuid(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                    objectstore::ErrorKind::Uuid(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 },
                 upload::Error::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
                 upload::Error::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -50,6 +50,19 @@ impl Objectstore {
             Self::Stream { .. } => MessageKind::Stream,
         }
     }
+
+    fn attachment_count(&self) -> usize {
+        match self {
+            Self::Envelope(StoreEnvelope { envelope }) => envelope
+                .envelope()
+                .items()
+                .filter(|item| *item.ty() == ItemType::Attachment)
+                .count(),
+            Self::TraceAttachment(_) => 1,
+            Self::EventAttachment(_) => 1,
+            Self::Stream { .. } => 1,
+        }
+    }
 }
 
 impl Interface for Objectstore {}
@@ -201,7 +214,7 @@ impl ErrorKind {
     fn as_str(&self) -> &'static str {
         match self {
             Self::Timeout(_) => "timeout",
-            Self::LoadShed => "load-shed",
+            Self::LoadShed => "load_shed",
             Self::UploadFailed(_) => "upload_failed",
             Self::Uuid(_) => "uuid",
         }
@@ -315,7 +328,7 @@ impl SimpleService for ObjectstoreService {
 
 impl LoadShed<Objectstore> for ObjectstoreService {
     fn handle_loadshed(&self, message: Objectstore) {
-        let error = Error::from(ErrorKind::LoadShed);
+        let error = Error::from(ErrorKind::LoadShed).with_amount(message.attachment_count());
         error.log(message.kind());
         match message {
             Objectstore::Envelope(envelope) => {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -327,10 +327,10 @@ impl LoadShed<Objectstore> for ObjectstoreService {
                 self.inner.store.send(message);
             }
             Objectstore::TraceAttachment(managed) => {
-                let _ = managed.reject_err(Error::from(ErrorKind::LoadShed));
+                let _ = managed.reject_err(error);
             }
             Objectstore::Stream(_, sender) => {
-                sender.send(Err(Error::from(ErrorKind::LoadShed)));
+                sender.send(Err(error));
             }
         }
     }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -42,12 +42,12 @@ pub enum Objectstore {
 }
 
 impl Objectstore {
-    fn ty(&self) -> &str {
+    fn kind(&self) -> MessageKind {
         match self {
-            Objectstore::Envelope(_) => "envelope",
-            Objectstore::TraceAttachment(_) => "attachment_v2",
-            Objectstore::EventAttachment(_) => "attachment",
-            Objectstore::Stream { .. } => "stream",
+            Self::Envelope(_) => MessageKind::Envelope,
+            Self::TraceAttachment(_) => MessageKind::TraceAttachment,
+            Self::EventAttachment(_) => MessageKind::EventAttachment,
+            Self::Stream { .. } => MessageKind::Stream,
         }
     }
 
@@ -88,6 +88,26 @@ impl FromMessage<Managed<StoreAttachment>> for Objectstore {
 
     fn from_message(message: Managed<StoreAttachment>, _sender: ()) -> Self {
         Self::EventAttachment(message)
+    }
+}
+
+/// A type tag used for logging.
+#[derive(Debug, Clone, Copy)]
+enum MessageKind {
+    Envelope,
+    EventAttachment,
+    TraceAttachment,
+    Stream,
+}
+
+impl MessageKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Envelope => "envelope",
+            Self::EventAttachment => "attachment",
+            Self::TraceAttachment => "attachment_v2",
+            Self::Stream => "stream",
+        }
     }
 }
 
@@ -283,7 +303,7 @@ impl LoadShed<Objectstore> for ObjectstoreService {
         relay_statsd::metric!(
             counter(RelayCounters::AttachmentUpload) += message.attachment_count() as u64,
             result = "load_shed",
-            type = message.ty(),
+            type = message.kind().as_str(),
         );
         match message {
             Objectstore::Envelope(envelope) => {
@@ -323,10 +343,10 @@ impl ObjectstoreServiceInner {
                 self.handle_envelope(envelope).await;
             }
             Objectstore::TraceAttachment(attachment) => {
-                self.handle_trace_attachment(attachment).await
+                self.handle_trace_attachment(attachment).await // TODO
             }
             Objectstore::EventAttachment(attachment) => {
-                self.handle_event_attachment(attachment).await
+                self.handle_event_attachment(attachment).await // TODO
             }
             Objectstore::Stream(message, sender) => self.handle_stream(message, sender).await,
         }
@@ -364,11 +384,28 @@ impl ObjectstoreServiceInner {
                         continue;
                     }
                     let result = self
-                        .upload_bytes("envelope", &session, attachment.payload(), retention, None)
+                        .upload_bytes(
+                            MessageKind::Envelope,
+                            &session,
+                            attachment.payload(),
+                            retention,
+                            None,
+                        )
                         .await;
 
-                    if let Ok(stored_key) = result {
-                        attachment.set_stored_key(stored_key.into_inner());
+                    match result {
+                        Ok(stored_key) => {
+                            attachment.set_stored_key(stored_key.into_inner());
+                        }
+                        Err(Error { kind, attempts }) => {
+                            relay_log::error!(
+                                error = &kind as &dyn std::error::Error,
+                                attempts = attempts,
+                                type = MessageKind::Envelope.as_str(),
+                                "objectstore upload failed in {} attempt(s)",
+                                attempts
+                            )
+                        }
                     }
                 }
             }
@@ -400,13 +437,13 @@ impl ObjectstoreServiceInner {
                 relay_statsd::metric!(
                     counter(RelayCounters::AttachmentUpload) += 1,
                     result = error.to_string().as_str(),
-                    type = "attachment",
+                    type = MessageKind::EventAttachment.as_str(),
                 );
             }
             Ok(session) => {
                 let result = self
                     .upload_bytes(
-                        "attachment",
+                        MessageKind::EventAttachment,
                         &session,
                         attachment.attachment.payload(),
                         attachment.retention,
@@ -484,7 +521,13 @@ impl ObjectstoreServiceInner {
             let original_key = key.clone();
 
             let _stored_key = self
-                .upload_bytes("attachment_v2", &session, body, retention, Some(key))
+                .upload_bytes(
+                    MessageKind::TraceAttachment,
+                    &session,
+                    body,
+                    retention,
+                    Some(key),
+                )
                 .await
                 .reject(&trace_item)?;
 
@@ -524,7 +567,7 @@ impl ObjectstoreServiceInner {
 
         let result = self
             .upload(
-                "stream",
+                MessageKind::Stream,
                 &session,
                 Some(key),
                 Body::Stream(TakeOnce::new(stream)),
@@ -537,20 +580,20 @@ impl ObjectstoreServiceInner {
 
     async fn upload_bytes(
         &self,
-        ty: &str,
+        kind: MessageKind,
         session: &Session,
         payload: Bytes,
         retention: u16,
         key: Option<String>,
     ) -> Result<ObjectstoreKey, Error> {
         let retention_hours = retention.checked_mul(24);
-        self.upload(ty, session, key, Body::Bytes(payload), retention_hours)
+        self.upload(kind, session, key, Body::Bytes(payload), retention_hours)
             .await
     }
 
     async fn upload(
         &self,
-        ty: &str,
+        kind: MessageKind,
         session: &Session,
         key: Option<String>,
         body: Body,
@@ -565,7 +608,7 @@ impl ObjectstoreServiceInner {
                 };
                 attempts += 1;
                 result.replace(
-                    self.attempt_upload(ty, session, key.clone(), body, retention_hours)
+                    self.attempt_upload(kind, session, key.clone(), body, retention_hours)
                         .await,
                 );
 
@@ -586,23 +629,13 @@ impl ObjectstoreServiceInner {
         .map_err(Error::from)
         .flatten();
 
-        if let Err(e) = &result {
-            relay_log::error!(
-                error = e as &dyn std::error::Error,
-                attempts = attempts,
-                type = ty,
-                "objectstore upload failed in {} attempt(s)",
-                attempts
-            )
-        }
-
         relay_statsd::metric!(
             counter(RelayCounters::AttachmentUpload) += 1,
             result = match &result {
                 Ok(_) => "success",
                 Err(e) => e.kind.as_str(),
             },
-            type = ty,
+            type = kind.as_str(),
             attempts = attempts.to_string()
         );
 
@@ -611,7 +644,7 @@ impl ObjectstoreServiceInner {
 
     async fn attempt_upload(
         &self,
-        ty: &str,
+        kind: MessageKind,
         session: &Session,
         key: Option<String>,
         body: BodyAttempt,
@@ -633,7 +666,7 @@ impl ObjectstoreServiceInner {
 
         let response = relay_statsd::metric!(
             timer(RelayTimers::AttachmentUploadDuration),
-            type = ty,
+            type = kind.as_str(),
             {
                 request.send().await
             }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -50,19 +50,6 @@ impl Objectstore {
             Self::Stream { .. } => MessageKind::Stream,
         }
     }
-
-    fn attachment_count(&self) -> usize {
-        match self {
-            Self::Envelope(StoreEnvelope { envelope }) => envelope
-                .envelope()
-                .items()
-                .filter(|item| *item.ty() == ItemType::Attachment)
-                .count(),
-            Self::TraceAttachment(_) => 1,
-            Self::EventAttachment(_) => 1,
-            Self::Stream { .. } => 1,
-        }
-    }
 }
 
 impl Interface for Objectstore {}
@@ -150,7 +137,11 @@ pub struct Error {
     #[source]
     pub kind: ErrorKind,
     /// The number of upload attempts.
+    ///
+    /// Zero for errors that occur before the first upload attempt.
     pub attempts: u16,
+    /// The amount of attachments that failed.
+    pub amount: u64,
 }
 
 impl Error {
@@ -159,12 +150,25 @@ impl Error {
         self
     }
 
+    fn with_amount(mut self, amount: usize) -> Self {
+        self.amount = amount as u64;
+        self
+    }
+
     fn log(&self, kind: MessageKind) {
+        relay_statsd::metric!(
+            counter(RelayCounters::AttachmentUpload) += self.amount,
+            result = self.kind.as_str(),
+            type = kind.as_str(),
+            attempts = self.attempts.to_string(),
+        );
         relay_log::error!(
             error = &self.kind as &dyn std::error::Error,
+            amount = self.amount,
             attempts = self.attempts,
             type = kind.as_str(),
-            "objectstore upload failed in {} attempt(s)",
+            "failed to upload {} attachment(s) to objectstore in {} attempt(s)",
+            self.amount,
             self.attempts
         )
     }
@@ -175,6 +179,7 @@ impl<E: Into<ErrorKind>> From<E> for Error {
         Self {
             kind: value.into(),
             attempts: 0,
+            amount: 1,
         }
     }
 }
@@ -310,15 +315,11 @@ impl SimpleService for ObjectstoreService {
 
 impl LoadShed<Objectstore> for ObjectstoreService {
     fn handle_loadshed(&self, message: Objectstore) {
-        relay_statsd::metric!(
-            counter(RelayCounters::AttachmentUpload) += message.attachment_count() as u64,
-            result = "load_shed",
-            type = message.kind().as_str(),
-        );
+        let error = Error::from(ErrorKind::LoadShed);
+        error.log(message.kind());
         match message {
             Objectstore::Envelope(envelope) => {
                 // Event attachments can still go the old route.
-
                 self.inner.store.send(envelope);
             }
             Objectstore::EventAttachment(message) => {
@@ -392,14 +393,9 @@ impl ObjectstoreServiceInner {
             .filter(|item| *item.ty() == ItemType::Attachment);
 
         match session {
-            Err(error) => {
-                relay_log::error!(error = &error as &dyn std::error::Error, "session error");
-                relay_statsd::metric!(
-                    counter(RelayCounters::AttachmentUpload) += attachments.count() as u64,
-                    result = error.to_string().as_str(),
-                    type = "envelope",
-                );
-            }
+            Err(error) => Error::from(error)
+                .with_amount(attachments.count())
+                .log(MessageKind::Envelope),
             Ok(session) => {
                 for attachment in attachments {
                     if Self::should_skip_upload(attachment) {
@@ -448,14 +444,7 @@ impl ObjectstoreServiceInner {
             .session(&self.objectstore_client);
 
         match session {
-            Err(error) => {
-                relay_log::error!(error = &error as &dyn std::error::Error, "session error");
-                relay_statsd::metric!(
-                    counter(RelayCounters::AttachmentUpload) += 1,
-                    result = error.to_string().as_str(),
-                    type = MessageKind::EventAttachment.as_str(),
-                );
-            }
+            Err(error) => Error::from(error).log(MessageKind::EventAttachment),
             Ok(session) => {
                 let result = self
                     .upload_bytes(
@@ -551,14 +540,7 @@ impl ObjectstoreServiceInner {
         let session = self
             .event_attachments
             .for_project(organization_id.value(), project_id.value())
-            .session(&self.objectstore_client)
-            .inspect_err(|error| {
-                relay_statsd::metric!(
-                    counter(RelayCounters::AttachmentUpload) += 1,
-                    result = error.to_string().as_str(),
-                    type = "stream",
-                );
-            })?;
+            .session(&self.objectstore_client)?;
 
         self.upload(
             MessageKind::Stream,
@@ -621,15 +603,14 @@ impl ObjectstoreServiceInner {
         .map_err(Error::from)
         .flatten();
 
-        relay_statsd::metric!(
-            counter(RelayCounters::AttachmentUpload) += 1,
-            result = match &result {
-                Ok(_) => "success",
-                Err(e) => e.kind.as_str(),
-            },
-            type = kind.as_str(),
-            attempts = attempts.to_string()
-        );
+        if result.is_ok() {
+            relay_statsd::metric!(
+                counter(RelayCounters::AttachmentUpload) += 1,
+                result = "success",
+                type = kind.as_str(),
+                attempts = attempts.to_string()
+            );
+        }
 
         result.map_err(|e| e.with_attempts(attempts))
     }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -158,6 +158,16 @@ impl Error {
         self.attempts = attempts;
         self
     }
+
+    fn log(&self, kind: MessageKind) {
+        relay_log::error!(
+            error = &self.kind as &dyn std::error::Error,
+            attempts = self.attempts,
+            type = kind.as_str(),
+            "objectstore upload failed in {} attempt(s)",
+            self.attempts
+        )
+    }
 }
 
 impl<E: Into<ErrorKind>> From<E> for Error {
@@ -343,20 +353,32 @@ impl ObjectstoreServiceInner {
                 self.handle_envelope(envelope).await;
             }
             Objectstore::TraceAttachment(attachment) => {
-                self.handle_trace_attachment(attachment).await // TODO
+                let result = self
+                    .handle_trace_attachment(attachment)
+                    .await
+                    .map_err(Rejected::into_inner);
+                if let Err(error) = result {
+                    error.log(MessageKind::TraceAttachment);
+                }
             }
             Objectstore::EventAttachment(attachment) => {
-                self.handle_event_attachment(attachment).await // TODO
+                self.handle_event_attachment(attachment).await;
             }
-            Objectstore::Stream(message, sender) => self.handle_stream(message, sender).await,
-        }
+            Objectstore::Stream(stream, sender) => {
+                let result = self.handle_stream(stream).await;
+                if let Err(error) = &result {
+                    error.log(MessageKind::Stream);
+                }
+                sender.send(result);
+            }
+        };
     }
 
     /// Uploads all attachments belonging to the given envelope.
     ///
     /// This mutates the attachment items in-place, setting their `stored_key` field to the key
     /// in objectstore.
-    async fn handle_envelope(&self, mut envelope: ManagedEnvelope) -> () {
+    async fn handle_envelope(&self, mut envelope: ManagedEnvelope) {
         let scoping = envelope.scoping();
         let session = self
             .event_attachments
@@ -397,14 +419,8 @@ impl ObjectstoreServiceInner {
                         Ok(stored_key) => {
                             attachment.set_stored_key(stored_key.into_inner());
                         }
-                        Err(Error { kind, attempts }) => {
-                            relay_log::error!(
-                                error = &kind as &dyn std::error::Error,
-                                attempts = attempts,
-                                type = MessageKind::Envelope.as_str(),
-                                "objectstore upload failed in {} attempt(s)",
-                                attempts
-                            )
+                        Err(error) => {
+                            error.log(MessageKind::Envelope);
                         }
                     }
                 }
@@ -451,12 +467,15 @@ impl ObjectstoreServiceInner {
                     )
                     .await;
 
-                if let Ok(stored_key) = result {
-                    attachment.modify(|attachment, _| {
-                        attachment
-                            .attachment
-                            .set_stored_key(stored_key.into_inner());
-                    });
+                match result {
+                    Ok(stored_key) => {
+                        attachment.modify(|attachment, _| {
+                            attachment
+                                .attachment
+                                .set_stored_key(stored_key.into_inner());
+                        });
+                    }
+                    Err(e) => e.log(MessageKind::EventAttachment),
                 }
             }
         }
@@ -464,26 +483,7 @@ impl ObjectstoreServiceInner {
         self.store.send(attachment)
     }
 
-    async fn handle_trace_attachment(&self, managed: Managed<StoreTraceAttachment>) {
-        let result = self.do_handle_trace_attachment(managed).await;
-
-        match result.map_err(Rejected::into_inner) {
-            Ok(_) => (), // all good
-            Err(error) => match error.kind {
-                ErrorKind::UploadFailed(_) | ErrorKind::Timeout(_) => (), // logged in upload()
-                other => {
-                    // TODO(follow-up): clean up error handling so we do not need to log in multiple places.
-                    relay_statsd::metric!(
-                        counter(RelayCounters::AttachmentUpload) += 1,
-                        result = other.as_str(),
-                        type = "attachment_v2",
-                    );
-                }
-            },
-        }
-    }
-
-    async fn do_handle_trace_attachment(
+    async fn handle_trace_attachment(
         &self,
         managed: Managed<StoreTraceAttachment>,
     ) -> Result<(), Rejected<Error>> {
@@ -541,41 +541,33 @@ impl ObjectstoreServiceInner {
         Ok(())
     }
 
-    async fn handle_stream(&self, stream: Stream, sender: Sender<Result<ObjectstoreKey, Error>>) {
+    async fn handle_stream(&self, stream: Stream) -> Result<ObjectstoreKey, Error> {
         let Stream {
             organization_id,
             project_id,
             key,
             stream,
         } = stream;
-        let session = match self
+        let session = self
             .event_attachments
             .for_project(organization_id.value(), project_id.value())
             .session(&self.objectstore_client)
-        {
-            Ok(session) => session,
-            Err(error) => {
+            .inspect_err(|error| {
                 relay_statsd::metric!(
                     counter(RelayCounters::AttachmentUpload) += 1,
                     result = error.to_string().as_str(),
                     type = "stream",
                 );
-                sender.send(Err(ErrorKind::UploadFailed(error).into()));
-                return;
-            }
-        };
+            })?;
 
-        let result = self
-            .upload(
-                MessageKind::Stream,
-                &session,
-                Some(key),
-                Body::Stream(TakeOnce::new(stream)),
-                None,
-            )
-            .await;
-
-        sender.send(result);
+        self.upload(
+            MessageKind::Stream,
+            &session,
+            Some(key),
+            Body::Stream(TakeOnce::new(stream)),
+            None,
+        )
+        .await
     }
 
     async fn upload_bytes(

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -123,9 +123,35 @@ impl Counted for StoreTraceAttachment {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("objectstore upload failed")]
+pub struct Error {
+    /// The source of the error.
+    #[source]
+    pub kind: ErrorKind,
+    /// The number of upload attempts.
+    pub attempts: u16,
+}
+
+impl Error {
+    fn with_attempts(mut self, attempts: u16) -> Self {
+        self.attempts = attempts;
+        self
+    }
+}
+
+impl<E: Into<ErrorKind>> From<E> for Error {
+    fn from(value: E) -> Self {
+        Self {
+            kind: value.into(),
+            attempts: 0,
+        }
+    }
+}
+
 /// Errors that can occur when trying to upload an attachment.
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum ErrorKind {
     #[error("timeout: {0}")]
     Timeout(#[from] tokio::time::error::Elapsed),
     #[error("load shed")]
@@ -136,13 +162,13 @@ pub enum Error {
     Uuid(#[from] TryFromSliceError),
 }
 
-impl Error {
+impl ErrorKind {
     fn as_str(&self) -> &'static str {
         match self {
-            Error::Timeout(_) => "timeout",
-            Error::LoadShed => "load-shed",
-            Error::UploadFailed(_) => "upload_failed",
-            Error::Uuid(_) => "uuid",
+            Self::Timeout(_) => "timeout",
+            Self::LoadShed => "load-shed",
+            Self::UploadFailed(_) => "upload_failed",
+            Self::Uuid(_) => "uuid",
         }
     }
 }
@@ -270,10 +296,10 @@ impl LoadShed<Objectstore> for ObjectstoreService {
                 self.inner.store.send(message);
             }
             Objectstore::TraceAttachment(managed) => {
-                let _ = managed.reject_err(Error::LoadShed);
+                let _ = managed.reject_err(Error::from(ErrorKind::LoadShed));
             }
             Objectstore::Stream(_, sender) => {
-                sender.send(Err(Error::LoadShed));
+                sender.send(Err(Error::from(ErrorKind::LoadShed)));
             }
         }
     }
@@ -405,16 +431,18 @@ impl ObjectstoreServiceInner {
         let result = self.do_handle_trace_attachment(managed).await;
 
         match result.map_err(Rejected::into_inner) {
-            Ok(_) => (),                                           //all good
-            Err(Error::UploadFailed(_) | Error::Timeout(_)) => (), // logged in upload()
-            Err(e) => {
-                // TODO(follow-up): clean up error handling so we do not need to log in multiple places.
-                relay_statsd::metric!(
-                    counter(RelayCounters::AttachmentUpload) += 1,
-                    result = e.as_str(),
-                    type = "attachment_v2",
-                );
-            }
+            Ok(_) => (), // all good
+            Err(error) => match error.kind {
+                ErrorKind::UploadFailed(_) | ErrorKind::Timeout(_) => (), // logged in upload()
+                other => {
+                    // TODO(follow-up): clean up error handling so we do not need to log in multiple places.
+                    relay_statsd::metric!(
+                        counter(RelayCounters::AttachmentUpload) += 1,
+                        result = other.as_str(),
+                        type = "attachment_v2",
+                    );
+                }
+            },
         }
     }
 
@@ -427,7 +455,7 @@ impl ObjectstoreServiceInner {
             .trace_attachments
             .for_project(scoping.organization_id.value(), scoping.project_id.value())
             .session(&self.objectstore_client)
-            .map_err(Error::UploadFailed)
+            .map_err(|e| Error::from(ErrorKind::UploadFailed(e)))
             .reject(&managed)?;
 
         let body = Bytes::clone(&managed.body);
@@ -489,7 +517,7 @@ impl ObjectstoreServiceInner {
                     result = error.to_string().as_str(),
                     type = "stream",
                 );
-                sender.send(Err(Error::UploadFailed(error)));
+                sender.send(Err(ErrorKind::UploadFailed(error).into()));
                 return;
             }
         };
@@ -528,21 +556,20 @@ impl ObjectstoreServiceInner {
         body: Body,
         retention_hours: Option<u16>,
     ) -> Result<ObjectstoreKey, Error> {
-        let mut attempt = 0;
-
+        let mut attempts = 0;
         let result = tokio::time::timeout(self.timeout, async {
             let mut result = None;
             loop {
                 let Some(body) = body.try_clone() else {
                     break;
                 };
-                attempt += 1;
+                attempts += 1;
                 result.replace(
                     self.attempt_upload(ty, session, key.clone(), body, retention_hours)
                         .await,
                 );
 
-                if attempt < self.max_attempts.get()
+                if attempts < self.max_attempts.get()
                     && matches!(&result, Some(Err(e)) if is_retryable(e))
                 {
                     tokio::time::sleep(self.retry_interval).await;
@@ -562,10 +589,10 @@ impl ObjectstoreServiceInner {
         if let Err(e) = &result {
             relay_log::error!(
                 error = e as &dyn std::error::Error,
-                attempts = attempt,
+                attempts = attempts,
                 type = ty,
                 "objectstore upload failed in {} attempt(s)",
-                attempt
+                attempts
             )
         }
 
@@ -573,13 +600,13 @@ impl ObjectstoreServiceInner {
             counter(RelayCounters::AttachmentUpload) += 1,
             result = match &result {
                 Ok(_) => "success",
-                Err(e) => e.as_str(),
+                Err(e) => e.kind.as_str(),
             },
             type = ty,
-            attempts = attempt.to_string()
+            attempts = attempts.to_string()
         );
 
-        result
+        result.map_err(|e| e.with_attempts(attempts))
     }
 
     async fn attempt_upload(

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -558,6 +558,6 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
         data=data,
     )
 
-    failure = mini_sentry.test_failures.get()
+    failure = mini_sentry.test_failures.get(timeout=10)
     assert "objectstore upload failed in 3 attempt(s)" in str(failure)
     assert response.status_code == 500

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -559,5 +559,7 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
     )
 
     failure = mini_sentry.test_failures.get(timeout=10)
-    assert "objectstore upload failed in 3 attempt(s)" in str(failure)
+    assert "failed to upload 1 attachment(s) to objectstore in 3 attempt(s)" in str(
+        failure
+    )
     assert response.status_code == 500


### PR DESCRIPTION
Follow-up from https://github.com/getsentry/relay/pull/5836#discussion_r3092074634 to prevent under- or over-reporting of metrics and errors:

1. Log success metric in the innermost function as soon as the upload is successful.
2. Log failure metric & error in the function that handles the error.