### PR TITLE
ref(server): Migrate legacy spans pipeline to processing framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Internal**:
 
 - Move unreal crash report expansion from processing into endpoint. ([#5825](https://github.com/getsentry/relay/pull/5825))
+- Ports legacy standalone span processing to the processing framework. ([#5852](https://github.com/getsentry/relay/pull/5852))
 - Retry failing objectstore requests. ([#5836](https://github.com/getsentry/relay/pull/5836))
 
 **Bug Fixes**:

--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -112,6 +112,12 @@ impl From<Uuid> for TraceId {
     }
 }
 
+impl From<TraceId> for Uuid {
+    fn from(trace_id: TraceId) -> Self {
+        trace_id.0
+    }
+}
+
 impl Deref for TraceId {
     type Target = Uuid;
 

--- a/relay-server/src/processing/common.rs
+++ b/relay-server/src/processing/common.rs
@@ -4,6 +4,7 @@ use crate::processing::ForwardContext;
 use crate::processing::attachments::AttachmentProcessor;
 use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::errors::ErrorsProcessor;
+use crate::processing::legacy_spans::LegacySpansProcessor;
 use crate::processing::logs::LogsProcessor;
 use crate::processing::profile_chunks::ProfileChunksProcessor;
 use crate::processing::profiles::ProfilesProcessor;
@@ -68,6 +69,7 @@ outputs!(
     Sessions => SessionsProcessor,
     Transactions => TransactionProcessor,
     Spans => SpansProcessor,
+    LegacySpans => LegacySpansProcessor,
     TraceAttachments => TraceAttachmentsProcessor,
     TraceMetrics => TraceMetricsProcessor,
     Replays => ReplaysProcessor,

--- a/relay-server/src/processing/legacy_spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/legacy_spans/dynamic_sampling.rs
@@ -1,6 +1,4 @@
 use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary};
-use relay_event_schema::protocol::Span;
-use relay_metrics::Bucket;
 use relay_quotas::DataCategory;
 use relay_sampling::evaluation::SamplingDecision;
 
@@ -73,13 +71,14 @@ fn split_indexed_and_total(
 ) {
     let scoping = spans.scoping();
     let transaction_from_dsc = spans.headers.dsc().and_then(|dsc| dsc.transaction.clone());
+    let mec = metrics_extraction_config(ctx);
 
     spans.split_once(|spans, r| {
         r.lenient(DataCategory::MetricBucket);
 
         let mut metrics = ProcessingExtractedMetrics::new();
         for span in spans.spans.iter().filter_map(|s| s.value()) {
-            if let Some(buckets) = extract_generic_metrics(span, ctx) {
+            if let Some(buckets) = mec.map(|config| generic::extract_metrics(span, config)) {
                 metrics.extend_project_metrics(buckets, Some(sampling_decision));
             }
 
@@ -98,15 +97,11 @@ fn split_indexed_and_total(
     })
 }
 
-fn extract_generic_metrics(span: &Span, ctx: Context<'_>) -> Option<Vec<Bucket>> {
-    let config = {
-        let local = match ctx.project_info.config.metric_extraction {
-            ErrorBoundary::Ok(ref config) if config.is_enabled() => config,
-            _ => return None,
-        };
-        let global = ctx.global_config.metric_extraction.as_ref().ok()?;
-        CombinedMetricExtractionConfig::new(global, local)
+fn metrics_extraction_config(ctx: Context<'_>) -> Option<CombinedMetricExtractionConfig<'_>> {
+    let local = match ctx.project_info.config.metric_extraction {
+        ErrorBoundary::Ok(ref config) if config.is_enabled() => config,
+        _ => return None,
     };
-
-    Some(generic::extract_metrics(span, config))
+    let global = ctx.global_config.metric_extraction.as_ref().ok()?;
+    Some(CombinedMetricExtractionConfig::new(global, local))
 }

--- a/relay-server/src/processing/legacy_spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/legacy_spans/dynamic_sampling.rs
@@ -1,0 +1,112 @@
+use relay_dynamic_config::{CombinedMetricExtractionConfig, ErrorBoundary};
+use relay_event_schema::protocol::Span;
+use relay_metrics::Bucket;
+use relay_quotas::DataCategory;
+use relay_sampling::evaluation::SamplingDecision;
+
+use crate::managed::Managed;
+use crate::metrics_extraction::{ExtractedMetrics, event, generic};
+use crate::processing::legacy_spans::{Error, ExpandedLegacySpans, Indexed};
+use crate::processing::{self, Context};
+use crate::services::processor::ProcessingExtractedMetrics;
+use crate::statsd::RelayCounters;
+use crate::utils::SamplingResult;
+
+pub async fn run(
+    spans: Managed<ExpandedLegacySpans>,
+    ctx: Context<'_>,
+) -> (
+    Option<Managed<ExpandedLegacySpans<Indexed>>>,
+    Managed<ExtractedMetrics>,
+) {
+    // If no metrics could be extracted, do not sample anything.
+    let should_sample = matches!(&ctx.project_info.config().metric_extraction, ErrorBoundary::Ok(c) if c.is_supported());
+    let sampling_result = match should_sample {
+        true => {
+            // We only implement trace-based sampling rules for now, which can be computed
+            // once for all spans in the envelope.
+            processing::utils::dynamic_sampling::run(spans.headers.dsc(), None, &ctx, None).await
+        }
+        false => SamplingResult::Pending,
+    };
+
+    relay_statsd::metric!(
+        counter(RelayCounters::SamplingDecision) += 1,
+        decision = sampling_result.decision().as_str(),
+        item = "span"
+    );
+
+    let sampling_decision = sampling_result.decision();
+
+    let (indexed, metrics) = split_indexed_and_total(spans, sampling_decision, ctx);
+
+    match sampling_result.into_dropped_outcome() {
+        Some(outcome) => {
+            let _ = indexed.reject_err(outcome);
+            (None, metrics)
+        }
+        None => (Some(indexed), metrics),
+    }
+}
+
+/// Rejects the indexed portion of the provided sampled spans and returns the total count as metrics.
+///
+/// This is used when the indexed payload is designated to be dropped *after* dynamic sampling (decision is keep),
+/// but metrics have not yet been extracted.
+pub fn reject_indexed_spans(
+    spans: Managed<ExpandedLegacySpans>,
+    ctx: Context<'_>,
+    error: Error,
+) -> Managed<ExtractedMetrics> {
+    let (indexed, total) = split_indexed_and_total(spans, SamplingDecision::Keep, ctx);
+    let _ = indexed.reject_err(error);
+    total
+}
+
+fn split_indexed_and_total(
+    spans: Managed<ExpandedLegacySpans>,
+    sampling_decision: SamplingDecision,
+    ctx: Context<'_>,
+) -> (
+    Managed<ExpandedLegacySpans<Indexed>>,
+    Managed<ExtractedMetrics>,
+) {
+    let scoping = spans.scoping();
+    let transaction_from_dsc = spans.headers.dsc().and_then(|dsc| dsc.transaction.clone());
+
+    spans.split_once(|spans, r| {
+        r.lenient(DataCategory::MetricBucket);
+
+        let mut metrics = ProcessingExtractedMetrics::new();
+        for span in spans.spans.iter().filter_map(|s| s.value()) {
+            if let Some(buckets) = extract_generic_metrics(span, ctx) {
+                metrics.extend_project_metrics(buckets, Some(sampling_decision));
+            }
+
+            let bucket = event::create_span_root_counter(
+                span,
+                transaction_from_dsc.clone(),
+                1,
+                span.is_segment.value().is_some_and(|s| *s),
+                sampling_decision,
+                scoping.project_id,
+            );
+            metrics.extend_sampling_metrics(bucket, Some(sampling_decision));
+        }
+
+        (spans.into_indexed(), metrics.into_inner())
+    })
+}
+
+fn extract_generic_metrics(span: &Span, ctx: Context<'_>) -> Option<Vec<Bucket>> {
+    let config = {
+        let local = match ctx.project_info.config.metric_extraction {
+            ErrorBoundary::Ok(ref config) if config.is_enabled() => config,
+            _ => return None,
+        };
+        let global = ctx.global_config.metric_extraction.as_ref().ok()?;
+        CombinedMetricExtractionConfig::new(global, local)
+    };
+
+    Some(generic::extract_metrics(span, config))
+}

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -180,8 +180,8 @@ impl Forward for LegacySpanOutput {
 
         let retention = ctx.retention(|r| r.span.as_ref());
 
-        for span in spans.split(|spans| spans.spans) {
-            if let Ok(span) = span.try_map(|span, _| store::convert(span, retention)) {
+        for span in spans.split(|spans| spans.spans.into_iter().map(IndexedOnly)) {
+            if let Ok(span) = span.try_map(|span, _| store::convert(span.0, retention)) {
                 s.send_to_store(span)
             };
         }
@@ -308,5 +308,13 @@ impl RateLimited for Managed<ExpandedLegacySpans<TotalAndIndexed>> {
         }
 
         Ok(self.map(|s, _| Either::Left(s)))
+    }
+}
+
+struct IndexedOnly(Annotated<Span>);
+
+impl Counted for IndexedOnly {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::SpanIndexed, 1)]
     }
 }

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -1,0 +1,312 @@
+use std::sync::Arc;
+
+use either::Either;
+use relay_event_normalization::GeoIpLookup;
+use relay_event_schema::processor::ProcessingAction;
+use relay_event_schema::protocol::Span;
+use relay_protocol::Annotated;
+use relay_quotas::{DataCategory, RateLimits};
+
+use crate::Envelope;
+use crate::envelope::{EnvelopeHeaders, Item, ItemType, Items};
+use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities, Rejected};
+use crate::metrics_extraction::ExtractedMetrics;
+use crate::processing::{
+    self, Context, CountRateLimited, Forward, Output, QuotaRateLimiter, RateLimited,
+};
+use crate::services::outcome::{DiscardReason, Outcome};
+
+mod dynamic_sampling;
+mod process;
+#[cfg(feature = "processing")]
+mod store;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("rate limited")]
+    RateLimited(RateLimits),
+    /// Spans filtered due to a filtering rule.
+    #[error("spans filtered")]
+    Filtered(relay_filter::FilterStatKey),
+    /// A processor failed to process the spans.
+    #[error("envelope processor failed")]
+    ProcessingFailed(#[from] ProcessingAction),
+    /// The span is invalid.
+    #[error("invalid: {0}")]
+    Invalid(DiscardReason),
+}
+
+impl OutcomeError for Error {
+    type Error = Self;
+
+    fn consume(self) -> (Option<Outcome>, Self::Error) {
+        let outcome = match &self {
+            Self::Filtered(f) => Some(Outcome::Filtered(f.clone())),
+            Self::RateLimited(limits) => {
+                let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
+                Some(Outcome::RateLimited(reason_code))
+            }
+            Self::ProcessingFailed(_) => Some(Outcome::Invalid(DiscardReason::Internal)),
+            Self::Invalid(reason) => Some(Outcome::Invalid(*reason)),
+        };
+        (outcome, self)
+    }
+}
+
+impl From<RateLimits> for Error {
+    fn from(value: RateLimits) -> Self {
+        Self::RateLimited(value)
+    }
+}
+
+/// A processor for legacy standalone Spans.
+///
+/// This processor will be replaced with the [`SpansProcessor`](super::spans::SpansProcessor), once
+/// it is fully capable to deal with the legacy spans.
+///
+/// This is a port of the old legacy standalone processor, most of the original limitations of the
+/// processor are not addressed with this one, such as only running in processing mode.
+pub struct LegacySpansProcessor {
+    limiter: Arc<QuotaRateLimiter>,
+    geo_lookup: GeoIpLookup,
+}
+
+impl LegacySpansProcessor {
+    /// Creates a new [`Self`].
+    pub fn new(limiter: Arc<QuotaRateLimiter>, geo_lookup: GeoIpLookup) -> Self {
+        Self {
+            limiter,
+            geo_lookup,
+        }
+    }
+}
+
+impl processing::Processor for LegacySpansProcessor {
+    type Input = SerializedLegacySpans;
+    type Output = LegacySpanOutput;
+    type Error = Error;
+
+    fn prepare_envelope(&self, envelope: &mut ManagedEnvelope) -> Option<Managed<Self::Input>> {
+        let headers = envelope.envelope().headers().clone();
+
+        let spans = envelope
+            .envelope_mut()
+            .take_items_by(|item| matches!(item.ty(), ItemType::Span))
+            .into_vec();
+
+        let work = SerializedLegacySpans { headers, spans };
+        Some(Managed::with_meta_from(envelope, work))
+    }
+
+    async fn process(
+        &self,
+        spans: Managed<Self::Input>,
+        ctx: Context<'_>,
+    ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
+        if !ctx.is_processing() {
+            let spans = self.limiter.enforce_quotas(spans, ctx).await?;
+            return Ok(Output::just(LegacySpanOutput::Serialized(spans)));
+        }
+
+        let mut spans = process::expand(spans);
+        process::normalize(&mut spans, ctx, &self.geo_lookup);
+        process::filter(&mut spans, ctx);
+
+        let spans = match self.limiter.enforce_quotas(spans, ctx).await?.transpose() {
+            Either::Left(spans) => spans,
+            Either::Right(metrics) => return Ok(Output::metrics(metrics)),
+        };
+
+        let (mut spans, metrics) = match dynamic_sampling::run(spans, ctx).await {
+            (Some(spans), metrics) => (spans, metrics),
+            (None, metrics) => return Ok(Output::metrics(metrics)),
+        };
+
+        process::scrub(&mut spans, ctx);
+
+        Ok(Output {
+            main: Some(LegacySpanOutput::Indexed(spans)),
+            metrics: Some(metrics),
+        })
+    }
+}
+
+/// Output produced by the [`LegacySpansProcessor`].
+#[derive(Debug)]
+pub enum LegacySpanOutput {
+    Serialized(Managed<SerializedLegacySpans>),
+    Indexed(Managed<ExpandedLegacySpans<Indexed>>),
+}
+
+impl Forward for LegacySpanOutput {
+    fn serialize_envelope(
+        self,
+        _: processing::ForwardContext<'_>,
+    ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
+        let spans = match self {
+            Self::Serialized(spans) => spans,
+            Self::Indexed(spans) => {
+                // If an indexed span is serialized back to an envelope, it loses the information
+                // that metrics have been extracted and the span is ready to be stored.
+                //
+                // On a technical level we can include this as metadata in the envelope or span,
+                // but our ingestion model does (no longer) allow for this.
+                //
+                // Metric extraction must be the last step in the pipeline.
+                return Err(
+                    spans.internal_error("an indexed span must be stored and not forwarded")
+                );
+            }
+        };
+
+        Ok(spans.map(|spans, _| Envelope::from_parts(spans.headers, Items::from_vec(spans.spans))))
+    }
+
+    #[cfg(feature = "processing")]
+    fn forward_store(
+        self,
+        s: processing::forward::StoreHandle<'_>,
+        ctx: processing::ForwardContext<'_>,
+    ) -> Result<(), Rejected<()>> {
+        let spans = match self {
+            Self::Serialized(spans) => {
+                return Err(spans
+                    .internal_error("a span must have metrics extracted in order to be stored"));
+            }
+            Self::Indexed(spans) => spans,
+        };
+
+        let retention = ctx.retention(|r| r.span.as_ref());
+
+        for span in spans.split(|spans| spans.spans) {
+            if let Ok(span) = span.try_map(|span, _| store::convert(span, retention)) {
+                s.send_to_store(span)
+            };
+        }
+
+        Ok(())
+    }
+}
+
+/// Spans in their serialized state, as transported in an envelope.
+#[derive(Debug)]
+pub struct SerializedLegacySpans {
+    /// Original envelope headers.
+    headers: EnvelopeHeaders,
+
+    /// A list of legacy, standalone "span v1" spans.
+    spans: Vec<Item>,
+}
+
+impl Counted for SerializedLegacySpans {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![
+            (DataCategory::Span, self.spans.len()),
+            (DataCategory::SpanIndexed, self.spans.len()),
+        ]
+    }
+}
+
+impl CountRateLimited for Managed<SerializedLegacySpans> {
+    type Error = Error;
+}
+
+/// The total and indexed category.
+///
+/// This category tracks spans in the total and indexed data categories.
+/// Until a span has metrics extracted it owns both categories.
+#[derive(Copy, Clone, Debug)]
+pub struct TotalAndIndexed;
+
+/// The indexed category.
+///
+/// Once metric extraction happened, spans no longer track/represent the total category, this was
+/// transferred over to the metrics.
+///
+/// Every which is stored, must have metrics extracted and transferred this ownership.
+#[derive(Copy, Clone, Debug)]
+pub struct Indexed;
+
+/// Spans in their de-serialized/parsed state.
+#[derive(Debug)]
+pub struct ExpandedLegacySpans<C = TotalAndIndexed> {
+    /// Original envelope headers.
+    headers: EnvelopeHeaders,
+    /// Expanded list of standalone spans.
+    spans: Vec<Annotated<Span>>,
+
+    /// Category of the contained spans.
+    ///
+    /// Either [`TotalAndIndexed`] or [`Indexed`].
+    #[expect(unused, reason = "marker field, only set never read")]
+    category: C,
+}
+
+impl ExpandedLegacySpans<TotalAndIndexed> {
+    /// Logically transforms contained spans into [`Indexed`].
+    ///
+    /// This must only be called during metric extraction.
+    fn into_indexed(self) -> ExpandedLegacySpans<Indexed> {
+        let Self {
+            headers,
+            spans,
+            category: _,
+        } = self;
+
+        ExpandedLegacySpans {
+            headers,
+            spans,
+            category: Indexed,
+        }
+    }
+}
+
+impl Counted for ExpandedLegacySpans<TotalAndIndexed> {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![
+            (DataCategory::Span, self.spans.len()),
+            (DataCategory::SpanIndexed, self.spans.len()),
+        ]
+    }
+}
+
+impl Counted for ExpandedLegacySpans<Indexed> {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::SpanIndexed, self.spans.len())]
+    }
+}
+
+impl RateLimited for Managed<ExpandedLegacySpans<TotalAndIndexed>> {
+    type Output = Managed<Either<ExpandedLegacySpans<TotalAndIndexed>, ExtractedMetrics>>;
+    type Error = Error;
+
+    async fn enforce<R>(
+        self,
+        mut rate_limiter: R,
+        ctx: Context<'_>,
+    ) -> Result<Self::Output, Rejected<Self::Error>>
+    where
+        R: processing::RateLimiter,
+    {
+        let scoping = self.scoping();
+
+        let limits = rate_limiter
+            .try_consume(scoping.item(DataCategory::Span), self.spans.len())
+            .await;
+        if !limits.is_empty() {
+            return Err(self.reject_err(Error::from(limits)));
+        }
+
+        let limits = rate_limiter
+            .try_consume(scoping.item(DataCategory::SpanIndexed), self.spans.len())
+            .await;
+        if !limits.is_empty() {
+            let total = dynamic_sampling::reject_indexed_spans(self, ctx, limits.into());
+            return Ok(total.map(|total, _| Either::Right(total)));
+        }
+
+        Ok(self.map(|s, _| Either::Left(s)))
+    }
+}

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -25,6 +25,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// The spans are rate limited.
     #[error("rate limited")]
     RateLimited(RateLimits),
     /// Spans filtered due to a filtering rule.

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -96,6 +96,10 @@ impl processing::Processor for LegacySpansProcessor {
             .take_items_by(|item| matches!(item.ty(), ItemType::Span))
             .into_vec();
 
+        if spans.is_empty() {
+            return None;
+        }
+
         let work = SerializedLegacySpans { headers, spans };
         Some(Managed::with_meta_from(envelope, work))
     }

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use either::Either;
 use relay_event_normalization::GeoIpLookup;
-use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::Span;
 use relay_protocol::Annotated;
 use relay_quotas::{DataCategory, RateLimits};
@@ -31,9 +30,6 @@ pub enum Error {
     /// Spans filtered due to a filtering rule.
     #[error("spans filtered")]
     Filtered(relay_filter::FilterStatKey),
-    /// A processor failed to process the spans.
-    #[error("envelope processor failed")]
-    ProcessingFailed(#[from] ProcessingAction),
     /// The span is invalid.
     #[error("invalid: {0}")]
     Invalid(DiscardReason),
@@ -49,7 +45,6 @@ impl OutcomeError for Error {
                 let reason_code = limits.longest().and_then(|limit| limit.reason_code.clone());
                 Some(Outcome::RateLimited(reason_code))
             }
-            Self::ProcessingFailed(_) => Some(Outcome::Invalid(DiscardReason::Internal)),
             Self::Invalid(reason) => Some(Outcome::Invalid(*reason)),
         };
         (outcome, self)

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -170,6 +170,17 @@ impl Forward for LegacySpanOutput {
         s: processing::forward::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
+        let spans = match self {
+            Self::Serialized(spans) => {
+                return Err(spans
+                    .internal_error("a span must have metrics extracted in order to be stored"));
+            }
+            Self::Indexed(spans) => spans,
+        };
+
+        // We're dealing with indexed only spans here, but each individual span has a default
+        // `Counted` implementation which counts in the total and indexed categories, to make sure
+        // we stay in the indexed category, this wrapper is needed.
         #[derive(Debug)]
         struct IndexedOnly(Annotated<Span>);
 
@@ -178,14 +189,6 @@ impl Forward for LegacySpanOutput {
                 smallvec::smallvec![(DataCategory::SpanIndexed, 1)]
             }
         }
-
-        let spans = match self {
-            Self::Serialized(spans) => {
-                return Err(spans
-                    .internal_error("a span must have metrics extracted in order to be stored"));
-            }
-            Self::Indexed(spans) => spans,
-        };
 
         let retention = ctx.retention(|r| r.span.as_ref());
 

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -170,6 +170,15 @@ impl Forward for LegacySpanOutput {
         s: processing::forward::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
+        #[derive(Debug)]
+        struct IndexedOnly(Annotated<Span>);
+
+        impl Counted for IndexedOnly {
+            fn quantities(&self) -> Quantities {
+                smallvec::smallvec![(DataCategory::SpanIndexed, 1)]
+            }
+        }
+
         let spans = match self {
             Self::Serialized(spans) => {
                 return Err(spans
@@ -308,13 +317,5 @@ impl RateLimited for Managed<ExpandedLegacySpans<TotalAndIndexed>> {
         }
 
         Ok(self.map(|s, _| Either::Left(s)))
-    }
-}
-
-struct IndexedOnly(Annotated<Span>);
-
-impl Counted for IndexedOnly {
-    fn quantities(&self) -> Quantities {
-        smallvec::smallvec![(DataCategory::SpanIndexed, 1)]
     }
 }

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -234,7 +234,7 @@ pub struct TotalAndIndexed;
 /// Once metric extraction happened, spans no longer track/represent the total category, this was
 /// transferred over to the metrics.
 ///
-/// Every which is stored, must have metrics extracted and transferred this ownership.
+/// Every stored span, must have metrics extracted and transferred this ownership.
 #[derive(Copy, Clone, Debug)]
 pub struct Indexed;
 

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -44,6 +44,7 @@ pub fn normalize(
     geo_lookup: &GeoIpLookup,
 ) {
     let aggregator_config = ctx.config.aggregator_config_for(MetricNamespace::Spans);
+    let model_data = ctx.global_config.model_metadata();
     let norm = NormalizeSpanConfig {
         received_at: spans.received_at(),
         timestamp_range: aggregator_config.timestamp_range(),
@@ -53,7 +54,7 @@ pub fn normalize(
             ctx.project_info.config.measurements.as_ref(),
             ctx.global_config.measurements.as_ref(),
         )),
-        ai_model_metadata: ctx.global_config.ai_model_metadata.as_ref().ok(),
+        ai_model_metadata: model_data.as_ref(),
         max_name_and_unit_len: aggregator_config
             .max_name_length
             .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -1,0 +1,145 @@
+use relay_event_normalization::{CombinedMeasurementsConfig, GeoIpLookup, MeasurementsConfig};
+use relay_event_schema::processor::{ProcessingAction, ProcessingState, process_value};
+use relay_event_schema::protocol::Span;
+use relay_metrics::MetricNamespace;
+use relay_pii::PiiProcessor;
+use relay_protocol::Annotated;
+
+use crate::managed::Managed;
+use crate::processing::legacy_spans::{
+    Error, ExpandedLegacySpans, Indexed, SerializedLegacySpans, TotalAndIndexed,
+};
+use crate::processing::{self, Context};
+use crate::services::outcome::DiscardReason;
+use crate::services::processor::span::NormalizeSpanConfig;
+use crate::services::processor::{ProcessingError, span};
+use relay_event_normalization::RemoveOtherProcessor;
+
+pub fn expand(spans: Managed<SerializedLegacySpans>) -> Managed<ExpandedLegacySpans> {
+    spans.map(|spans, records| {
+        let SerializedLegacySpans { headers, spans } = spans;
+
+        let spans = spans
+            .into_iter()
+            .filter_map(|item| {
+                let Ok(span) = Annotated::<Span>::from_json_bytes(&item.payload()) else {
+                    records.reject_err(Error::Invalid(DiscardReason::InvalidJson), item);
+                    return None;
+                };
+                Some(span)
+            })
+            .collect();
+
+        ExpandedLegacySpans {
+            headers,
+            spans,
+            category: TotalAndIndexed,
+        }
+    })
+}
+
+pub fn normalize(
+    spans: &mut Managed<ExpandedLegacySpans>,
+    ctx: Context<'_>,
+    geo_lookup: &GeoIpLookup,
+) {
+    let aggregator_config = ctx.config.aggregator_config_for(MetricNamespace::Spans);
+    let norm = NormalizeSpanConfig {
+        received_at: spans.received_at(),
+        timestamp_range: aggregator_config.timestamp_range(),
+        max_tag_value_size: aggregator_config.max_tag_value_length,
+        performance_score: ctx.project_info.config.performance_score.as_ref(),
+        measurements: Some(CombinedMeasurementsConfig::new(
+            ctx.project_info.config.measurements.as_ref(),
+            ctx.global_config.measurements.as_ref(),
+        )),
+        ai_model_metadata: ctx.global_config.ai_model_metadata.as_ref().ok(),
+        max_name_and_unit_len: aggregator_config
+            .max_name_length
+            .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),
+
+        tx_name_rules: &ctx.project_info.config.tx_name_rules,
+        user_agent: spans.headers.meta().user_agent().map(Into::into),
+        client_hints: spans.headers.meta().client_hints().to_owned(),
+        allowed_hosts: ctx.global_config.options.http_span_allowed_hosts.as_slice(),
+        client_ip: spans.headers.meta().client_addr().map(Into::into),
+        geo_lookup,
+        span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
+    };
+
+    spans.retain(
+        |spans| &mut spans.spans,
+        |span, _| {
+            span::normalize(span, norm.clone()).map_err(|err| {
+                relay_log::debug!("failed to normalize span: {err}");
+                Error::Invalid(match err {
+                    ProcessingError::ProcessingFailed(ProcessingAction::InvalidTransaction(_))
+                    | ProcessingError::InvalidTransaction => DiscardReason::InvalidSpan,
+                    _ => DiscardReason::Internal,
+                })
+            })?;
+
+            // Remove additional fields.
+            let _ = process_value(span, &mut RemoveOtherProcessor, ProcessingState::root());
+
+            processing::transactions::spans::validate(span).map_err(|err| {
+                relay_log::debug!(
+                    error = &err as &dyn std::error::Error,
+                    source = "standalone",
+                    "invalid span"
+                );
+                Error::Invalid(DiscardReason::InvalidSpan)
+            })?;
+
+            if span.value().is_none() {
+                return Err(Error::Invalid(DiscardReason::Internal));
+            }
+
+            Ok(())
+        },
+    );
+}
+
+pub fn filter(spans: &mut Managed<ExpandedLegacySpans>, ctx: Context<'_>) {
+    let client_ip = spans.headers.meta().client_addr();
+    let filter_settings = &ctx.project_info.config.filter_settings;
+
+    spans.retain(
+        |spans| &mut spans.spans,
+        |span, _| {
+            let Some(span) = span.value() else {
+                return Ok(());
+            };
+
+            relay_filter::should_filter(
+                span,
+                client_ip,
+                filter_settings,
+                ctx.global_config.filters(),
+            )
+            .map_err(|filter| {
+                relay_log::trace!(
+                    "filtering span {:?} that matched an inbound filter",
+                    span.span_id
+                );
+                Error::Filtered(filter)
+            })
+        },
+    );
+}
+
+pub fn scrub(spans: &mut Managed<ExpandedLegacySpans<Indexed>>, ctx: Context<'_>) {
+    spans.modify(|spans, _| {
+        for span in &mut spans.spans {
+            if let Some(ref config) = ctx.project_info.config.pii_config {
+                let mut processor = PiiProcessor::new(config.compiled());
+                let _ = process_value(span, &mut processor, ProcessingState::root());
+            }
+            let pii_config = ctx.project_info.config.datascrubbing_settings.pii_config();
+            if let Some(config) = pii_config {
+                let mut processor = PiiProcessor::new(config.compiled());
+                let _ = process_value(span, &mut processor, ProcessingState::root());
+            }
+        }
+    });
+}

--- a/relay-server/src/processing/legacy_spans/store.rs
+++ b/relay-server/src/processing/legacy_spans/store.rs
@@ -1,0 +1,35 @@
+use relay_event_schema::protocol::Span;
+use relay_protocol::Annotated;
+
+use crate::processing::Retention;
+use crate::processing::legacy_spans::{Error, Result};
+use crate::services::outcome::DiscardReason;
+use crate::services::store::StoreSpanV2;
+
+macro_rules! required {
+    ($value:expr) => {{
+        match $value {
+            Annotated(Some(value), _) => value,
+            Annotated(None, meta) => {
+                relay_log::debug!(
+                    "dropping span because of missing required field {} with meta {meta:?}",
+                    stringify!($value),
+                );
+                return Err(Error::Invalid(DiscardReason::InvalidSpan));
+            }
+        }
+    }};
+}
+
+/// Converts a [`Span`] into a [`StoreSpanV2`] to be sent to Kafka.
+pub fn convert(span: Annotated<Span>, retentions: Retention) -> Result<Box<StoreSpanV2>> {
+    let span = span.map_value(relay_spans::span_v1_to_span_v2);
+    let span = required!(span);
+
+    Ok(Box::new(StoreSpanV2 {
+        routing_key: span.trace_id.value().copied().map(Into::into),
+        retention_days: retentions.standard,
+        downsampled_retention_days: retentions.downsampled,
+        item: span,
+    }))
+}

--- a/relay-server/src/processing/mod.rs
+++ b/relay-server/src/processing/mod.rs
@@ -27,6 +27,7 @@ pub mod attachments;
 pub mod check_ins;
 pub mod client_reports;
 pub mod errors;
+pub mod legacy_spans;
 pub mod logs;
 pub mod profile_chunks;
 pub mod profiles;

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -472,7 +472,7 @@ pub struct TotalAndIndexed;
 /// Once metric extraction happened, spans no longer track/represent the total category, this was
 /// transferred over to the metrics.
 ///
-/// Every which is stored, must have metrics extracted and transferred this ownership.
+/// Every stored span, must have metrics extracted and transferred this ownership.
 #[derive(Copy, Clone, Debug)]
 pub struct Indexed;
 

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -20,14 +20,14 @@ use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_cogs::{AppFeature, Cogs, FeatureWeights, ResourceId, Token};
 use relay_common::time::UnixTimestamp;
 use relay_config::{Config, HttpEncoding, RelayMode};
-use relay_dynamic_config::{Feature, GlobalConfig};
+use relay_dynamic_config::Feature;
 use relay_event_normalization::{ClockDriftProcessor, GeoIpLookup};
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::{ClientReport, Event, EventId, NetworkReportError, SpanV2};
 use relay_filter::FilterStatKey;
 use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricNamespace};
 use relay_protocol::Annotated;
-use relay_quotas::{DataCategory, Quota, RateLimits, Scoping};
+use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::evaluation::{ReservoirCounters, SamplingDecision};
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
@@ -76,7 +76,8 @@ use {
     crate::services::objectstore::Objectstore,
     crate::services::store::Store,
     itertools::Itertools,
-    relay_quotas::{RateLimitingError, RedisRateLimiter},
+    relay_dynamic_config::GlobalConfig,
+    relay_quotas::{Quota, RateLimitingError, RedisRateLimiter},
     relay_redis::RedisClients,
     std::time::Instant,
 };
@@ -2534,11 +2535,13 @@ impl UpstreamRequest for SendMetricsRequest {
 
 /// Container for global and project level [`Quota`].
 #[derive(Copy, Clone, Debug)]
+#[cfg(feature = "processing")]
 struct CombinedQuotas<'a> {
     global_quotas: &'a [Quota],
     project_quotas: &'a [Quota],
 }
 
+#[cfg(feature = "processing")]
 impl<'a> CombinedQuotas<'a> {
     /// Returns a new [`CombinedQuotas`].
     pub fn new(global_config: &'a GlobalConfig, project_quotas: &'a [Quota]) -> Self {
@@ -2549,6 +2552,7 @@ impl<'a> CombinedQuotas<'a> {
     }
 }
 
+#[cfg(feature = "processing")]
 impl<'a> IntoIterator for CombinedQuotas<'a> {
     type Item = &'a Quota;
     type IntoIter = std::iter::Chain<std::slice::Iter<'a, Quota>, std::slice::Iter<'a, Quota>>;
@@ -2598,7 +2602,7 @@ mod tests {
     #[cfg(feature = "processing")]
     #[test]
     fn test_dynamic_quotas() {
-        let global_config = GlobalConfig {
+        let global_config = relay_dynamic_config::GlobalConfig {
             quotas: vec![mock_quota("foo"), mock_quota("bar")],
             ..Default::default()
         };

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -45,6 +45,7 @@ use crate::processing::attachments::AttachmentProcessor;
 use crate::processing::check_ins::CheckInsProcessor;
 use crate::processing::client_reports::ClientReportsProcessor;
 use crate::processing::errors::{ErrorsProcessor, SwitchProcessingError};
+use crate::processing::legacy_spans::LegacySpansProcessor;
 use crate::processing::logs::LogsProcessor;
 use crate::processing::profile_chunks::ProfileChunksProcessor;
 use crate::processing::profiles::ProfilesProcessor;
@@ -55,7 +56,6 @@ use crate::processing::trace_attachments::TraceAttachmentsProcessor;
 use crate::processing::trace_metrics::TraceMetricsProcessor;
 use crate::processing::transactions::TransactionProcessor;
 use crate::processing::user_reports::UserReportsProcessor;
-use crate::processing::utils::event::event_category;
 use crate::processing::{Forward as _, Output, Outputs, QuotaRateLimiter};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
@@ -67,7 +67,7 @@ use crate::services::upstream::{
     SendRequest, Sign, SignatureType, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
 };
 use crate::statsd::{RelayCounters, RelayDistributions, RelayTimers};
-use crate::utils::{self, CheckLimits, EnvelopeLimiter};
+use crate::utils;
 use crate::{http, processing};
 use relay_threading::AsyncPool;
 use symbolic_unreal::{Unreal4Error, Unreal4ErrorKind};
@@ -75,7 +75,6 @@ use symbolic_unreal::{Unreal4Error, Unreal4ErrorKind};
 use {
     crate::services::objectstore::Objectstore,
     crate::services::store::Store,
-    crate::utils::Enforcement,
     itertools::Itertools,
     relay_quotas::{RateLimitingError, RedisRateLimiter},
     relay_redis::RedisClients,
@@ -85,32 +84,10 @@ use {
 pub mod event;
 mod metrics;
 mod nel;
-#[cfg(feature = "processing")]
-mod span;
+pub mod span;
 
 #[cfg(all(sentry, feature = "processing"))]
 pub mod playstation;
-
-/// Creates the block only if used with `processing` feature.
-///
-/// Provided code block will be executed only if the provided config has `processing_enabled` set.
-macro_rules! if_processing {
-    ($config:expr, $if_true:block) => {
-        #[cfg(feature = "processing")] {
-            if $config.processing_enabled() $if_true
-        }
-    };
-    ($config:expr, $if_true:block else $if_false:block) => {
-        {
-            #[cfg(feature = "processing")] {
-                if $config.processing_enabled() $if_true else $if_false
-            }
-            #[cfg(not(feature = "processing"))] {
-                $if_false
-            }
-        }
-    };
-}
 
 /// The minimum clock drift for correction to apply.
 pub const MINIMUM_CLOCK_DRIFT: Duration = Duration::from_secs(55 * 60);
@@ -701,59 +678,6 @@ impl ProcessingExtractedMetrics {
                 bucket
             }));
     }
-
-    /// Applies rate limits to the contained metrics.
-    ///
-    /// This is used to apply rate limits which have been enforced on sampled items of an envelope
-    /// to also consistently apply to the metrics extracted from these items.
-    #[cfg(feature = "processing")]
-    fn apply_enforcement(&mut self, enforcement: &Enforcement, enforced_consistently: bool) {
-        // Metric namespaces which need to be dropped.
-        let mut drop_namespaces: SmallVec<[_; 2]> = smallvec![];
-        // Metrics belonging to this metric namespace need to have the `extracted_from_indexed`
-        // flag reset to `false`.
-        let mut reset_extracted_from_indexed: SmallVec<[_; 2]> = smallvec![];
-
-        for (namespace, limit, indexed) in [(
-            MetricNamespace::Spans,
-            &enforcement.spans,
-            &enforcement.spans_indexed,
-        )] {
-            if limit.is_active() {
-                drop_namespaces.push(namespace);
-            } else if indexed.is_active() && !enforced_consistently {
-                // If the enforcement was not computed by consistently checking the limits,
-                // the quota for the metrics has not yet been incremented.
-                // In this case we have a dropped indexed payload but a metric which still needs to
-                // be accounted for, make sure the metric will still be rate limited.
-                reset_extracted_from_indexed.push(namespace);
-            }
-        }
-
-        if !drop_namespaces.is_empty() || !reset_extracted_from_indexed.is_empty() {
-            self.retain_mut(|bucket| {
-                let Some(namespace) = bucket.name.try_namespace() else {
-                    return true;
-                };
-
-                if drop_namespaces.contains(&namespace) {
-                    return false;
-                }
-
-                if reset_extracted_from_indexed.contains(&namespace) {
-                    bucket.metadata.extracted_from_indexed = false;
-                }
-
-                true
-            });
-        }
-    }
-
-    #[cfg(feature = "processing")]
-    fn retain_mut(&mut self, mut f: impl FnMut(&mut Bucket) -> bool) {
-        self.metrics.project_metrics.retain_mut(&mut f);
-        self.metrics.sampling_metrics.retain_mut(&mut f);
-    }
 }
 
 fn send_metrics(
@@ -1109,8 +1033,6 @@ struct InnerProcessor {
     addrs: Addrs,
     #[cfg(feature = "processing")]
     rate_limiter: Option<Arc<RedisRateLimiter>>,
-    #[cfg(feature = "processing")]
-    geoip_lookup: GeoIpLookup,
     metric_outcomes: MetricOutcomes,
     processing: Processing,
 }
@@ -1120,6 +1042,7 @@ struct Processing {
     logs: LogsProcessor,
     trace_metrics: TraceMetricsProcessor,
     spans: SpansProcessor,
+    legacy_spans: LegacySpansProcessor,
     check_ins: CheckInsProcessor,
     sessions: SessionsProcessor,
     transactions: TransactionProcessor,
@@ -1183,13 +1106,15 @@ impl EnvelopeProcessorService {
             rate_limiter,
             addrs,
             metric_outcomes,
-            #[cfg(feature = "processing")]
-            geoip_lookup: geoip_lookup.clone(),
             processing: Processing {
                 errors: ErrorsProcessor::new(Arc::clone(&quota_limiter), geoip_lookup.clone()),
                 logs: LogsProcessor::new(Arc::clone(&quota_limiter)),
                 trace_metrics: TraceMetricsProcessor::new(Arc::clone(&quota_limiter)),
                 spans: SpansProcessor::new(Arc::clone(&quota_limiter), geoip_lookup.clone()),
+                legacy_spans: LegacySpansProcessor::new(
+                    Arc::clone(&quota_limiter),
+                    geoip_lookup.clone(),
+                ),
                 check_ins: CheckInsProcessor::new(Arc::clone(&quota_limiter)),
                 sessions: SessionsProcessor::new(Arc::clone(&quota_limiter)),
                 transactions: TransactionProcessor::new(
@@ -1214,48 +1139,6 @@ impl EnvelopeProcessorService {
         Self {
             inner: Arc::new(inner),
         }
-    }
-
-    async fn enforce_quotas<Group>(
-        &self,
-        managed_envelope: &mut TypedEnvelope<Group>,
-        event: Annotated<Event>,
-        extracted_metrics: &mut ProcessingExtractedMetrics,
-        ctx: processing::Context<'_>,
-    ) -> Result<Annotated<Event>, ProcessingError> {
-        // Cached quotas first, they are quick to evaluate and some quotas (indexed) are not
-        // applied in the fast path, all cached quotas can be applied here.
-        let cached_result = RateLimiter::Cached
-            .enforce(managed_envelope, event, extracted_metrics, ctx)
-            .await?;
-
-        if_processing!(self.inner.config, {
-            let rate_limiter = match self.inner.rate_limiter.clone() {
-                Some(rate_limiter) => rate_limiter,
-                None => return Ok(cached_result.event),
-            };
-
-            // Enforce all quotas consistently with Redis.
-            let consistent_result = RateLimiter::Consistent(rate_limiter)
-                .enforce(
-                    managed_envelope,
-                    cached_result.event,
-                    extracted_metrics,
-                    ctx
-                )
-                .await?;
-
-            // Update cached rate limits with the freshly computed ones.
-            if !consistent_result.rate_limits.is_empty() {
-                self.inner
-                    .project_cache
-                    .get(managed_envelope.scoping().project_key)
-                    .rate_limits()
-                    .merge(consistent_result.rate_limits);
-            }
-
-            Ok(consistent_result.event)
-        } else { Ok(cached_result.event) })
     }
 
     async fn process_nel(
@@ -1306,40 +1189,6 @@ impl EnvelopeProcessorService {
             .map(ProcessingResult::Output)
     }
 
-    /// Processes standalone spans.
-    ///
-    /// This function does *not* run for spans extracted from transactions.
-    async fn process_standalone_spans(
-        &self,
-        managed_envelope: &mut TypedEnvelope<SpanGroup>,
-        _project_id: ProjectId,
-        ctx: processing::Context<'_>,
-    ) -> Result<Option<ProcessingExtractedMetrics>, ProcessingError> {
-        let mut extracted_metrics = ProcessingExtractedMetrics::new();
-
-        if_processing!(self.inner.config, {
-            span::process(
-                managed_envelope,
-                &mut Annotated::empty(),
-                &mut extracted_metrics,
-                _project_id,
-                ctx,
-                &self.inner.geoip_lookup,
-            )
-            .await;
-        });
-
-        self.enforce_quotas(
-            managed_envelope,
-            Annotated::empty(),
-            &mut extracted_metrics,
-            ctx,
-        )
-        .await?;
-
-        Ok(Some(extracted_metrics))
-    }
-
     async fn process_envelope(
         &self,
         project_id: ProjectId,
@@ -1382,28 +1231,6 @@ impl EnvelopeProcessorService {
             .envelope_mut()
             .meta_mut()
             .set_project_id(project_id);
-
-        macro_rules! run {
-            ($fn_name:ident $(, $args:expr)*) => {
-                async {
-                    let mut managed_envelope = (managed_envelope, group).try_into()?;
-                    match self.$fn_name(&mut managed_envelope, $($args),*).await {
-                        Ok(extracted_metrics) => Ok(ProcessingResult::Envelope {
-                            managed_envelope: managed_envelope.into_processed(),
-                            extracted_metrics: extracted_metrics.map_or(ProcessingExtractedMetrics::new(), |e| e)
-                        }),
-                        Err(error) => {
-                            relay_log::trace!("Executing {fn} failed: {error}", fn = stringify!($fn_name), error = error);
-                            if let Some(outcome) = error.to_outcome() {
-                                managed_envelope.reject(outcome);
-                            }
-
-                            return Err(error);
-                        }
-                    }
-                }.await
-            };
-        }
 
         relay_log::trace!("Processing {group} group", group = group.variant());
 
@@ -1485,7 +1312,14 @@ impl EnvelopeProcessorService {
                 )
                 .await
             }
-            ProcessingGroup::Span => run!(process_standalone_spans, project_id, ctx),
+            ProcessingGroup::Span => {
+                self.process_with_processor(
+                    &self.inner.processing.legacy_spans,
+                    managed_envelope,
+                    ctx,
+                )
+                .await
+            }
             ProcessingGroup::ProfileChunk => {
                 self.process_with_processor(
                     &self.inner.processing.profile_chunks,
@@ -2387,112 +2221,6 @@ impl Service for EnvelopeProcessorService {
     }
 }
 
-/// Result of the enforcement of rate limiting.
-///
-/// If the event is already `None` or it's rate limited, it will be `None`
-/// within the [`Annotated`].
-struct EnforcementResult {
-    event: Annotated<Event>,
-    #[cfg_attr(not(feature = "processing"), expect(dead_code))]
-    rate_limits: RateLimits,
-}
-
-impl EnforcementResult {
-    /// Creates a new [`EnforcementResult`].
-    pub fn new(event: Annotated<Event>, rate_limits: RateLimits) -> Self {
-        Self { event, rate_limits }
-    }
-}
-
-#[derive(Clone)]
-enum RateLimiter {
-    Cached,
-    #[cfg(feature = "processing")]
-    Consistent(Arc<RedisRateLimiter>),
-}
-
-impl RateLimiter {
-    async fn enforce<Group>(
-        &self,
-        managed_envelope: &mut TypedEnvelope<Group>,
-        event: Annotated<Event>,
-        _extracted_metrics: &mut ProcessingExtractedMetrics,
-        ctx: processing::Context<'_>,
-    ) -> Result<EnforcementResult, ProcessingError> {
-        if managed_envelope.envelope().is_empty() && event.value().is_none() {
-            return Ok(EnforcementResult::new(event, RateLimits::default()));
-        }
-
-        let quotas = CombinedQuotas::new(ctx.global_config, ctx.project_info.get_quotas());
-        if quotas.is_empty() {
-            return Ok(EnforcementResult::new(event, RateLimits::default()));
-        }
-
-        let event_category = event_category(&event);
-
-        // We extract the rate limiters, in case we perform consistent rate limiting, since we will
-        // need Redis access.
-        //
-        // When invoking the rate limiter, capture if the event item has been rate limited to also
-        // remove it from the processing state eventually.
-        let this = self.clone();
-        let mut envelope_limiter =
-            EnvelopeLimiter::new(CheckLimits::All, move |item_scope, _quantity| {
-                let this = this.clone();
-
-                async move {
-                    match this {
-                        #[cfg(feature = "processing")]
-                        RateLimiter::Consistent(rate_limiter) => Ok::<_, ProcessingError>(
-                            rate_limiter
-                                .is_rate_limited(quotas, item_scope, _quantity, false)
-                                .await?,
-                        ),
-                        _ => Ok::<_, ProcessingError>(
-                            ctx.rate_limits.check_with_quotas(quotas, item_scope),
-                        ),
-                    }
-                }
-            });
-
-        // Tell the envelope limiter about the event, since it has been removed from the Envelope at
-        // this stage in processing.
-        if let Some(category) = event_category {
-            envelope_limiter.assume_event(category);
-        }
-
-        let scoping = managed_envelope.scoping();
-        let (enforcement, rate_limits) = metric!(timer(RelayTimers::EventProcessingRateLimiting), type = self.name(), {
-            envelope_limiter
-                .compute(managed_envelope.envelope_mut(), &scoping)
-                .await
-        })?;
-        let event_active = enforcement.is_event_active();
-
-        // Use the same rate limits as used for the envelope on the metrics.
-        // Those rate limits should not be checked for expiry or similar to ensure a consistent
-        // limiting of envelope items and metrics.
-        #[cfg(feature = "processing")]
-        _extracted_metrics.apply_enforcement(&enforcement, matches!(self, Self::Consistent(_)));
-        enforcement.apply_with_outcomes(managed_envelope);
-
-        if event_active {
-            debug_assert!(managed_envelope.envelope().is_empty());
-            return Ok(EnforcementResult::new(Annotated::empty(), rate_limits));
-        }
-
-        Ok(EnforcementResult::new(event, rate_limits))
-    }
-
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Cached => "cached",
-            #[cfg(feature = "processing")]
-            Self::Consistent(_) => "consistent",
-        }
-    }
-}
-
 pub fn encode_payload(body: &Bytes, http_encoding: HttpEncoding) -> Result<Bytes, std::io::Error> {
     let envelope_body: Vec<u8> = match http_encoding {
         HttpEncoding::Identity => return Ok(body.clone()),
@@ -2819,16 +2547,6 @@ impl<'a> CombinedQuotas<'a> {
             project_quotas,
         }
     }
-
-    /// Returns `true` if both global quotas and project quotas are empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns the number of both global and project quotas.
-    pub fn len(&self) -> usize {
-        self.global_quotas.len() + self.project_quotas.len()
-    }
 }
 
 impl<'a> IntoIterator for CombinedQuotas<'a> {
@@ -2888,9 +2606,6 @@ mod tests {
         let project_quotas = vec![mock_quota("baz"), mock_quota("qux")];
 
         let dynamic_quotas = CombinedQuotas::new(&global_config, &project_quotas);
-
-        assert_eq!(dynamic_quotas.len(), 4);
-        assert!(!dynamic_quotas.is_empty());
 
         let quota_ids = dynamic_quotas.into_iter().filter_map(|q| q.id.as_deref());
         assert!(quota_ids.eq(["foo", "bar", "baz", "qux"]));

--- a/relay-server/src/services/processor/span.rs
+++ b/relay-server/src/services/processor/span.rs
@@ -1,306 +1,60 @@
 //! Contains the processing-only functionality.
 
-use std::error::Error;
-
-use crate::envelope::ItemType;
-use crate::managed::{ItemAction, ManagedEnvelope, TypedEnvelope};
-use crate::metrics_extraction::{event, generic};
-use crate::processing;
-use crate::services::outcome::{DiscardReason, Outcome};
-use crate::services::processor::{ProcessingError, ProcessingExtractedMetrics, SpanGroup};
-use crate::statsd::RelayCounters;
-use crate::utils::SamplingResult;
+use crate::services::processor::ProcessingError;
 use chrono::{DateTime, Utc};
-use relay_base_schema::project::ProjectId;
-use relay_config::Config;
-use relay_dynamic_config::{
-    CombinedMetricExtractionConfig, ErrorBoundary, GlobalConfig, ProjectConfig,
-};
 use relay_event_normalization::span::ai::enrich_ai_span;
 use relay_event_normalization::{
     BorrowedSpanOpDefaults, ClientHints, CombinedMeasurementsConfig, FromUserAgentInfo,
-    GeoIpLookup, MeasurementsConfig, ModelMetadata, PerformanceScoreConfig, RawUserAgentInfo,
-    SchemaProcessor, TimestampProcessor, TransactionNameRule, TransactionsProcessor,
-    TrimmingProcessor, normalize_measurements, normalize_performance_score,
-    normalize_transaction_name, span::tag_extraction, validate_span,
+    GeoIpLookup, ModelMetadata, PerformanceScoreConfig, RawUserAgentInfo, SchemaProcessor,
+    TimestampProcessor, TransactionNameRule, TransactionsProcessor, TrimmingProcessor,
+    normalize_measurements, normalize_performance_score, normalize_transaction_name,
+    span::tag_extraction, validate_span,
 };
-use relay_event_schema::processor::{ProcessingAction, ProcessingState, process_value};
-use relay_event_schema::protocol::{BrowserContext, Event, EventId, IpAddr, Span, SpanData};
-use relay_metrics::{MetricNamespace, UnixTimestamp};
-use relay_pii::PiiProcessor;
+use relay_event_schema::processor::{ProcessingState, process_value};
+use relay_event_schema::protocol::{BrowserContext, EventId, IpAddr, Span, SpanData};
+use relay_metrics::UnixTimestamp;
 use relay_protocol::{Annotated, Empty, Value};
-use relay_quotas::DataCategory;
-
-pub async fn process(
-    managed_envelope: &mut TypedEnvelope<SpanGroup>,
-    event: &mut Annotated<Event>,
-    extracted_metrics: &mut ProcessingExtractedMetrics,
-    project_id: ProjectId,
-    ctx: processing::Context<'_>,
-    geo_lookup: &GeoIpLookup,
-) {
-    use relay_event_normalization::RemoveOtherProcessor;
-
-    // If no metrics could be extracted, do not sample anything.
-    let should_sample = matches!(&ctx.project_info.config().metric_extraction, ErrorBoundary::Ok(c) if c.is_supported());
-    let sampling_result = match should_sample {
-        true => {
-            // We only implement trace-based sampling rules for now, which can be computed
-            // once for all spans in the envelope.
-            processing::utils::dynamic_sampling::run(
-                managed_envelope.envelope().headers().dsc(),
-                event.value(),
-                &ctx,
-                None,
-            )
-            .await
-        }
-        false => SamplingResult::Pending,
-    };
-
-    relay_statsd::metric!(
-        counter(RelayCounters::SamplingDecision) += 1,
-        decision = sampling_result.decision().as_str(),
-        item = "span"
-    );
-
-    let span_metrics_extraction_config = match ctx.project_info.config.metric_extraction {
-        ErrorBoundary::Ok(ref config) if config.is_enabled() => Some(config),
-        _ => None,
-    };
-    let ai_model_metadata = ctx.global_config.model_metadata();
-    let normalize_span_config = NormalizeSpanConfig::new(
-        ctx.config,
-        ctx.global_config,
-        ctx.project_info.config(),
-        managed_envelope,
-        managed_envelope
-            .envelope()
-            .meta()
-            .client_addr()
-            .map(IpAddr::from),
-        geo_lookup,
-        ai_model_metadata.as_ref(),
-    );
-
-    let client_ip = managed_envelope.envelope().meta().client_addr();
-    let filter_settings = &ctx.project_info.config.filter_settings;
-    let sampling_decision = sampling_result.decision();
-    let transaction_from_dsc = managed_envelope
-        .envelope()
-        .dsc()
-        .and_then(|dsc| dsc.transaction.clone());
-
-    let mut span_count = 0;
-    managed_envelope.retain_items(|item| {
-        let mut annotated_span = match item.ty() {
-            ItemType::Span => match Annotated::<Span>::from_json_bytes(&item.payload()) {
-                Ok(span) => span,
-                Err(err) => {
-                    relay_log::debug!("failed to parse span: {}", err);
-                    return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidJson));
-                }
-            },
-
-            _ => return ItemAction::Keep,
-        };
-
-        if let Err(e) = normalize(&mut annotated_span, normalize_span_config.clone()) {
-            relay_log::debug!("failed to normalize span: {}", e);
-            return ItemAction::Drop(Outcome::Invalid(match e {
-                ProcessingError::ProcessingFailed(ProcessingAction::InvalidTransaction(_))
-                | ProcessingError::InvalidTransaction => DiscardReason::InvalidSpan,
-                _ => DiscardReason::Internal,
-            }));
-        };
-
-        if let Some(span) = annotated_span.value() {
-            span_count += 1;
-
-            if let Err(filter_stat_key) = relay_filter::should_filter(
-                span,
-                client_ip,
-                filter_settings,
-                ctx.global_config.filters(),
-            ) {
-                relay_log::trace!(
-                    "filtering span {:?} that matched an inbound filter",
-                    span.span_id
-                );
-                return ItemAction::Drop(Outcome::Filtered(filter_stat_key));
-            }
-        }
-
-        if let Some(config) = span_metrics_extraction_config {
-            let Some(span) = annotated_span.value_mut() else {
-                return ItemAction::Drop(Outcome::Invalid(DiscardReason::Internal));
-            };
-            relay_log::trace!("extracting metrics from standalone span {:?}", span.span_id);
-
-            let ErrorBoundary::Ok(global_metrics_config) = &ctx.global_config.metric_extraction
-            else {
-                return ItemAction::Drop(Outcome::Invalid(DiscardReason::Internal));
-            };
-
-            let metrics = generic::extract_metrics(
-                span,
-                CombinedMetricExtractionConfig::new(global_metrics_config, config),
-            );
-
-            extracted_metrics.extend_project_metrics(metrics, Some(sampling_decision));
-
-            let bucket = event::create_span_root_counter(
-                span,
-                transaction_from_dsc.clone(),
-                1,
-                span.is_segment.value().is_some_and(|s| *s),
-                sampling_decision,
-                project_id,
-            );
-            extracted_metrics.extend_sampling_metrics(bucket, Some(sampling_decision));
-
-            item.set_metrics_extracted(true);
-        }
-
-        if sampling_decision.is_drop() {
-            // Drop silently and not with an outcome, we only want to emit an outcome for the
-            // indexed category if the span was dropped by dynamic sampling.
-            // Dropping through the envelope will emit for both categories.
-            return ItemAction::DropSilently;
-        }
-
-        if let Err(e) = scrub(&mut annotated_span, &ctx.project_info.config) {
-            relay_log::error!("failed to scrub span: {e}");
-        }
-
-        // Remove additional fields.
-        process_value(
-            &mut annotated_span,
-            &mut RemoveOtherProcessor,
-            ProcessingState::root(),
-        )
-        .ok();
-
-        // Validate for kafka (TODO: this should be moved to kafka producer)
-        match processing::transactions::spans::validate(&mut annotated_span) {
-            Ok(res) => res,
-            Err(err) => {
-                relay_log::debug!(
-                    error = &err as &dyn Error,
-                    source = "standalone",
-                    "invalid span"
-                );
-                return ItemAction::Drop(Outcome::Invalid(DiscardReason::InvalidSpan));
-            }
-        };
-
-        let Ok(mut new_item) =
-            processing::transactions::spans::create_span_item(annotated_span, ctx.config)
-        // TODO: move function
-        else {
-            return ItemAction::Drop(Outcome::Invalid(DiscardReason::Internal));
-        };
-
-        new_item.set_metrics_extracted(item.metrics_extracted());
-        *item = new_item;
-
-        ItemAction::Keep
-    });
-
-    if sampling_decision.is_drop() {
-        relay_log::trace!(
-            span_count,
-            ?sampling_result,
-            "Dropped spans because of sampling rule",
-        );
-    }
-
-    if let Some(outcome) = sampling_result.into_dropped_outcome() {
-        managed_envelope.track_outcome(outcome, DataCategory::SpanIndexed, span_count);
-    }
-}
 
 /// Config needed to normalize a standalone span.
 #[derive(Clone, Debug)]
-struct NormalizeSpanConfig<'a> {
+pub struct NormalizeSpanConfig<'a> {
     /// The time at which the event was received in this Relay.
-    received_at: DateTime<Utc>,
+    pub received_at: DateTime<Utc>,
     /// Allowed time range for spans.
-    timestamp_range: std::ops::Range<UnixTimestamp>,
+    pub timestamp_range: std::ops::Range<UnixTimestamp>,
     /// The maximum allowed size of tag values in bytes. Longer values will be cropped.
-    max_tag_value_size: usize,
+    pub max_tag_value_size: usize,
     /// Configuration for generating performance score measurements for web vitals
-    performance_score: Option<&'a PerformanceScoreConfig>,
+    pub performance_score: Option<&'a PerformanceScoreConfig>,
     /// Configuration for measurement normalization in transaction events.
     ///
     /// Has an optional [`relay_event_normalization::MeasurementsConfig`] from both the project and the global level.
     /// If at least one is provided, then normalization will truncate custom measurements
     /// and add units of known built-in measurements.
-    measurements: Option<CombinedMeasurementsConfig<'a>>,
+    pub measurements: Option<CombinedMeasurementsConfig<'a>>,
     /// Metadata for AI models including costs and context size.
-    ai_model_metadata: Option<&'a ModelMetadata>,
+    pub ai_model_metadata: Option<&'a ModelMetadata>,
     /// The maximum length for names of custom measurements.
     ///
     /// Measurements with longer names are removed from the transaction event and replaced with a
     /// metadata entry.
-    max_name_and_unit_len: usize,
+    pub max_name_and_unit_len: usize,
     /// Transaction name normalization rules.
-    tx_name_rules: &'a [TransactionNameRule],
+    pub tx_name_rules: &'a [TransactionNameRule],
     /// The user agent parsed from the request.
-    user_agent: Option<String>,
+    pub user_agent: Option<String>,
     /// Client hints parsed from the request.
-    client_hints: ClientHints<String>,
+    pub client_hints: ClientHints<String>,
     /// Hosts that are not replaced by "*" in HTTP span grouping.
-    allowed_hosts: &'a [String],
+    pub allowed_hosts: &'a [String],
     /// The IP address of the SDK that sent the event.
     ///
     /// When `{{auto}}` is specified and there is no other IP address in the payload, such as in the
     /// `request` context, this IP address gets added to `span.data.client_address`.
-    client_ip: Option<IpAddr>,
+    pub client_ip: Option<IpAddr>,
     /// An initialized GeoIP lookup.
-    geo_lookup: &'a GeoIpLookup,
-    span_op_defaults: BorrowedSpanOpDefaults<'a>,
-}
-
-impl<'a> NormalizeSpanConfig<'a> {
-    fn new(
-        config: &'a Config,
-        global_config: &'a GlobalConfig,
-        project_config: &'a ProjectConfig,
-        managed_envelope: &ManagedEnvelope,
-        client_ip: Option<IpAddr>,
-        geo_lookup: &'a GeoIpLookup,
-        ai_model_metadata: Option<&'a ModelMetadata>,
-    ) -> Self {
-        let aggregator_config = config.aggregator_config_for(MetricNamespace::Spans);
-
-        Self {
-            received_at: managed_envelope.received_at(),
-            timestamp_range: aggregator_config.timestamp_range(),
-            max_tag_value_size: aggregator_config.max_tag_value_length,
-            performance_score: project_config.performance_score.as_ref(),
-            measurements: Some(CombinedMeasurementsConfig::new(
-                project_config.measurements.as_ref(),
-                global_config.measurements.as_ref(),
-            )),
-            ai_model_metadata,
-            max_name_and_unit_len: aggregator_config
-                .max_name_length
-                .saturating_sub(MeasurementsConfig::MEASUREMENT_MRI_OVERHEAD),
-
-            tx_name_rules: &project_config.tx_name_rules,
-            user_agent: managed_envelope
-                .envelope()
-                .meta()
-                .user_agent()
-                .map(Into::into),
-            client_hints: managed_envelope.meta().client_hints().to_owned(),
-            allowed_hosts: global_config.options.http_span_allowed_hosts.as_slice(),
-            client_ip,
-            geo_lookup,
-            span_op_defaults: global_config.span_op_defaults.borrow(),
-        }
-    }
+    pub geo_lookup: &'a GeoIpLookup,
+    pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -335,7 +89,7 @@ fn set_segment_attributes(span: &mut Annotated<Span>) {
 }
 
 /// Normalizes a standalone span.
-fn normalize(
+pub fn normalize(
     annotated_span: &mut Annotated<Span>,
     config: NormalizeSpanConfig,
 ) -> Result<(), ProcessingError> {
@@ -515,23 +269,6 @@ fn promote_span_data_fields(span: &mut Span) {
             data.profile_id.set_value(None);
         }
     }
-}
-
-fn scrub(
-    annotated_span: &mut Annotated<Span>,
-    project_config: &ProjectConfig,
-) -> Result<(), ProcessingError> {
-    if let Some(ref config) = project_config.pii_config {
-        let mut processor = PiiProcessor::new(config.compiled());
-        process_value(annotated_span, &mut processor, ProcessingState::root())?;
-    }
-    let pii_config = project_config.datascrubbing_settings.pii_config();
-    if let Some(config) = pii_config {
-        let mut processor = PiiProcessor::new(config.compiled());
-        process_value(annotated_span, &mut processor, ProcessingState::root())?;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -11,7 +11,7 @@ use smallvec::SmallVec;
 
 use crate::envelope::{AttachmentParentType, AttachmentType, Envelope, Item, ItemType};
 use crate::integrations::Integration;
-use crate::managed::{Managed, ManagedEnvelope};
+use crate::managed::Managed;
 use crate::services::outcome::Outcome;
 
 /// Name of the rate limits header.
@@ -667,18 +667,6 @@ impl Enforcement {
     /// 1. The item remains in the envelope.
     /// 2. Enforcements are empty. Rate limiting has occurred at an earlier stage in the pipeline.
     /// 3. Rate limits are empty.
-    pub fn apply_with_outcomes(self, envelope: &mut ManagedEnvelope) {
-        envelope
-            .envelope_mut()
-            .retain_items(|item| self.retain_item(item));
-        self.track_outcomes(envelope);
-    }
-
-    /// Applies the [`Enforcement`] on the [`Envelope`] by removing all items that were rate limited
-    /// and emits outcomes for each rate limited category.
-    ///
-    /// Works exactly like [`Self::apply_with_outcomes`], but instead operates on [`Managed`]
-    /// instead of [`ManagedEnvelope`].
     pub fn apply_to_managed(self, envelope: &mut Managed<Box<Envelope>>) {
         envelope.modify(|envelope, records| {
             envelope.retain_items(|item| self.retain_item(item));
@@ -776,15 +764,6 @@ impl Enforcement {
             | ItemType::Unknown(_) => true,
         }
     }
-
-    /// Invokes track outcome on all enforcements reported by the [`EnvelopeLimiter`].
-    ///
-    /// Relay generally does not emit outcomes for sessions, so those are skipped.
-    fn track_outcomes(self, envelope: &mut ManagedEnvelope) {
-        for (outcome, category, quantity) in self.get_outcomes() {
-            envelope.track_outcome(outcome, category, quantity)
-        }
-    }
 }
 
 /// Which limits to check with the [`EnvelopeLimiter`].
@@ -797,8 +776,6 @@ pub enum CheckLimits {
     /// Additionally even if the item is later dropped by dynamic sampling, it must still be around to extract metrics
     /// and cannot be dropped too early.
     NonIndexed,
-    /// Checks all limits against the envelope.
-    All,
 }
 
 struct Check<F, E, R> {
@@ -861,6 +838,7 @@ where
     /// This ensures that rate limits for the given data category are checked even if there is no
     /// matching item in the envelope. Other items are handled according to the rules as if the
     /// event item were present.
+    #[cfg(test)]
     pub fn assume_event(&mut self, category: DataCategory) {
         self.event_category = Some(category);
     }
@@ -1610,20 +1588,8 @@ mod tests {
                 envelope.add_item(item);
             )*
 
-            let (outcome_aggregator, _) = Addr::custom();
-
-            ManagedEnvelope::new(
-                envelope,
-                outcome_aggregator,
-            )
+            envelope
         }}
-    }
-
-    fn set_extracted(envelope: &mut Envelope, ty: ItemType) {
-        envelope
-            .get_item_by_mut(|item| *item.ty() == ty)
-            .unwrap()
-            .set_metrics_extracted(true);
     }
 
     fn rate_limit(category: DataCategory) -> RateLimit {
@@ -1708,13 +1674,14 @@ mod tests {
 
     async fn enforce_and_apply(
         mock: Arc<Mutex<MockLimiter>>,
-        envelope: &mut ManagedEnvelope,
+        envelope: Box<Envelope>,
         #[allow(unused_variables)] assume_event: Option<DataCategory>,
-    ) -> (Enforcement, RateLimits) {
+    ) -> (Box<Envelope>, Enforcement, RateLimits) {
+        let mut envelope = Managed::from_envelope(envelope, Addr::custom().0);
         let scoping = envelope.scoping();
 
         #[allow(unused_mut)]
-        let mut limiter = EnvelopeLimiter::new(CheckLimits::All, move |s, q| {
+        let mut limiter = EnvelopeLimiter::new(CheckLimits::NonIndexed, move |s, q| {
             let mock = mock.clone();
             async move {
                 let mut mock = mock.lock().await;
@@ -1726,16 +1693,14 @@ mod tests {
             limiter.assume_event(assume_event);
         }
 
-        let (enforcement, limits) = limiter
-            .compute(envelope.envelope_mut(), &scoping)
-            .await
-            .unwrap();
+        let (enforcement, limits) = limiter.compute(&envelope, &scoping).await.unwrap();
 
         // We implemented `clone` only for tests because we don't want to make `apply_with_outcomes`
         // &self because we want move semantics to prevent double tracking.
-        enforcement.clone().apply_with_outcomes(envelope);
+        enforcement.clone().apply_to_managed(&mut envelope);
+        let envelope = envelope.accept(|envelope| envelope);
 
-        (enforcement, limits)
+        (envelope, enforcement, limits)
     }
 
     fn mock_limiter(categories: &[DataCategory]) -> Arc<Mutex<MockLimiter>> {
@@ -1749,61 +1714,61 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_pass_empty() {
-        let mut envelope = envelope![];
+        let envelope = envelope![];
 
         let mock = mock_limiter(&[]);
-        let (_, limits) = enforce_and_apply(mock, &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock, envelope, None).await;
 
         assert!(!limits.is_limited());
-        assert!(envelope.envelope().is_empty());
+        assert!(envelope.is_empty());
     }
 
     #[tokio::test]
     async fn test_enforce_limit_error_event() {
-        let mut envelope = envelope![Event];
+        let envelope = envelope![Event];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert!(envelope.envelope().is_empty());
+        assert!(envelope.is_empty());
         mock.lock().await.assert_call(DataCategory::Error, 1);
     }
 
     #[tokio::test]
     async fn test_enforce_limit_error_with_attachments() {
-        let mut envelope = envelope![Event, Attachment];
+        let envelope = envelope![Event, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert!(envelope.envelope().is_empty());
+        assert!(envelope.is_empty());
         mock.lock().await.assert_call(DataCategory::Error, 1);
     }
 
     #[tokio::test]
     async fn test_enforce_limit_minidump() {
-        let mut envelope = envelope![Attachment::Minidump];
+        let envelope = envelope![Attachment::Minidump];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert!(envelope.envelope().is_empty());
+        assert!(envelope.is_empty());
         mock.lock().await.assert_call(DataCategory::Error, 1);
     }
 
     #[tokio::test]
     async fn test_enforce_limit_attachments() {
-        let mut envelope = envelope![Attachment::Minidump, Attachment];
+        let envelope = envelope![Attachment::Minidump, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Attachment]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         // Attachments would be limited, but crash reports create events and are thus allowed.
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 1);
+        assert_eq!(envelope.len(), 1);
         mock.lock().await.assert_call(DataCategory::Error, 1);
         mock.lock().await.assert_call(DataCategory::Attachment, 20);
     }
@@ -1811,13 +1776,13 @@ mod tests {
     /// Limit stand-alone profiles.
     #[tokio::test]
     async fn test_enforce_limit_profiles() {
-        let mut envelope = envelope![Profile, Profile];
+        let envelope = envelope![Profile, Profile];
 
         let mock = mock_limiter(&[DataCategory::Profile]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 0);
+        assert_eq!(envelope.len(), 0);
         mock.lock().await.assert_call(DataCategory::Profile, 2);
 
         assert_eq!(
@@ -1834,19 +1799,19 @@ mod tests {
     async fn test_enforce_limit_profile_chunks_no_profile_type() {
         // In this test we have profile chunks which have not yet been classified, which means they
         // should not be rate limited.
-        let mut envelope = envelope![ProfileChunk, ProfileChunk];
+        let envelope = envelope![ProfileChunk, ProfileChunk];
 
         let mock = mock_limiter(&[DataCategory::ProfileChunk]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
         assert!(!limits.is_limited());
         assert_eq!(get_outcomes(enforcement), vec![]);
 
         let mock = mock_limiter(&[DataCategory::ProfileChunkUi]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
         assert!(!limits.is_limited());
         assert_eq!(get_outcomes(enforcement), vec![]);
 
-        assert_eq!(envelope.envelope().len(), 2);
+        assert_eq!(envelope.len(), 2);
     }
 
     #[tokio::test]
@@ -1855,16 +1820,16 @@ mod tests {
 
         let mut item = Item::new(ItemType::ProfileChunk);
         item.set_platform("python".to_owned());
-        envelope.envelope_mut().add_item(item);
+        envelope.add_item(item);
         let mut item = Item::new(ItemType::ProfileChunk);
         item.set_platform("javascript".to_owned());
-        envelope.envelope_mut().add_item(item);
+        envelope.add_item(item);
 
         let mock = mock_limiter(&[DataCategory::ProfileChunkUi]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 1);
+        assert_eq!(envelope.len(), 1);
         mock.lock()
             .await
             .assert_call(DataCategory::ProfileChunkUi, 1);
@@ -1882,16 +1847,16 @@ mod tests {
 
         let mut item = Item::new(ItemType::ProfileChunk);
         item.set_platform("python".to_owned());
-        envelope.envelope_mut().add_item(item);
+        envelope.add_item(item);
         let mut item = Item::new(ItemType::ProfileChunk);
         item.set_platform("javascript".to_owned());
-        envelope.envelope_mut().add_item(item);
+        envelope.add_item(item);
 
         let mock = mock_limiter(&[DataCategory::ProfileChunk]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 1);
+        assert_eq!(envelope.len(), 1);
         mock.lock()
             .await
             .assert_call(DataCategory::ProfileChunkUi, 1);
@@ -1906,13 +1871,13 @@ mod tests {
     /// Limit replays.
     #[tokio::test]
     async fn test_enforce_limit_replays() {
-        let mut envelope = envelope![ReplayEvent, ReplayRecording, ReplayVideo];
+        let envelope = envelope![ReplayEvent, ReplayRecording, ReplayVideo];
 
         let mock = mock_limiter(&[DataCategory::Replay]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 0);
+        assert_eq!(envelope.len(), 0);
         mock.lock().await.assert_call(DataCategory::Replay, 3);
 
         assert_eq!(get_outcomes(enforcement), vec![(DataCategory::Replay, 3),]);
@@ -1921,13 +1886,13 @@ mod tests {
     /// Limit monitor checkins.
     #[tokio::test]
     async fn test_enforce_limit_monitor_checkins() {
-        let mut envelope = envelope![CheckIn];
+        let envelope = envelope![CheckIn];
 
         let mock = mock_limiter(&[DataCategory::Monitor]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 0);
+        assert_eq!(envelope.len(), 0);
         mock.lock().await.assert_call(DataCategory::Monitor, 1);
 
         assert_eq!(get_outcomes(enforcement), vec![(DataCategory::Monitor, 1)])
@@ -1935,14 +1900,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_pass_minidump() {
-        let mut envelope = envelope![Attachment::Minidump];
+        let envelope = envelope![Attachment::Minidump];
 
         let mock = mock_limiter(&[DataCategory::Attachment]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         // If only crash report attachments are present, we don't emit a rate limit.
         assert!(!limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 1);
+        assert_eq!(envelope.len(), 1);
         mock.lock().await.assert_call(DataCategory::Error, 1);
         mock.lock().await.assert_call(DataCategory::Attachment, 10);
     }
@@ -1954,38 +1919,38 @@ mod tests {
         let mut item = Item::new(ItemType::Attachment);
         item.set_payload(ContentType::OctetStream, "0123456789");
         item.set_rate_limited(true);
-        envelope.envelope_mut().add_item(item);
+        envelope.add_item(item);
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (_, limits) = enforce_and_apply(mock, &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock, envelope, None).await;
 
         assert!(!limits.is_limited()); // No new rate limits applied.
-        assert_eq!(envelope.envelope().len(), 1); // The item was retained
+        assert_eq!(envelope.len(), 1); // The item was retained
     }
 
     #[tokio::test]
     async fn test_enforce_pass_sessions() {
-        let mut envelope = envelope![Session, Session, Session];
+        let envelope = envelope![Session, Session, Session];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         // If only crash report attachments are present, we don't emit a rate limit.
         assert!(!limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 3);
+        assert_eq!(envelope.len(), 3);
         mock.lock().await.assert_call(DataCategory::Session, 3);
     }
 
     #[tokio::test]
     async fn test_enforce_limit_sessions() {
-        let mut envelope = envelope![Session, Session, Event];
+        let envelope = envelope![Session, Session, Event];
 
         let mock = mock_limiter(&[DataCategory::Session]);
-        let (_, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         // If only crash report attachments are present, we don't emit a rate limit.
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 1);
+        assert_eq!(envelope.len(), 1);
         mock.lock().await.assert_call(DataCategory::Error, 1);
         mock.lock().await.assert_call(DataCategory::Session, 2);
     }
@@ -1993,37 +1958,37 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "processing")]
     async fn test_enforce_limit_assumed_event() {
-        let mut envelope = envelope![];
+        let envelope = envelope![Transaction];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (_, limits) =
-            enforce_and_apply(mock.clone(), &mut envelope, Some(DataCategory::Transaction)).await;
+        let (envelope, _, limits) =
+            enforce_and_apply(mock.clone(), envelope, Some(DataCategory::Transaction)).await;
 
         assert!(limits.is_limited());
-        assert!(envelope.envelope().is_empty()); // obviously
+        assert!(envelope.is_empty()); // obviously
         mock.lock().await.assert_call(DataCategory::Transaction, 1);
     }
 
     #[tokio::test]
     #[cfg(feature = "processing")]
     async fn test_enforce_limit_assumed_attachments() {
-        let mut envelope = envelope![Attachment, Attachment];
+        let envelope = envelope![Event, Attachment, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (_, limits) =
-            enforce_and_apply(mock.clone(), &mut envelope, Some(DataCategory::Error)).await;
+        let (envelope, _, limits) =
+            enforce_and_apply(mock.clone(), envelope, Some(DataCategory::Error)).await;
 
         assert!(limits.is_limited());
-        assert!(envelope.envelope().is_empty());
+        assert!(envelope.is_empty());
         mock.lock().await.assert_call(DataCategory::Error, 1);
     }
 
     #[tokio::test]
     async fn test_enforce_transaction() {
-        let mut envelope = envelope![Transaction];
+        let envelope = envelope![Transaction];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
         assert!(enforcement.event_indexed.is_active());
@@ -2043,8 +2008,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_transaction_non_indexed() {
-        let mut envelope = envelope![Transaction, Profile];
-        let scoping = envelope.scoping();
+        let envelope = envelope![Transaction, Profile];
+        let scoping = envelope
+            .headers()
+            .meta()
+            .get_partial_scoping()
+            .into_scoping();
 
         let mock = mock_limiter(&[DataCategory::TransactionIndexed]);
 
@@ -2056,11 +2025,7 @@ mod tests {
                 mock.check(s, q)
             }
         });
-        let (enforcement, limits) = limiter
-            .compute(envelope.envelope_mut(), &scoping)
-            .await
-            .unwrap();
-        enforcement.clone().apply_with_outcomes(&mut envelope);
+        let (enforcement, limits) = limiter.compute(&envelope, &scoping).await.unwrap();
 
         assert!(!limits.is_limited());
         assert!(!enforcement.event_indexed.is_active());
@@ -2076,26 +2041,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_transaction_no_indexing_quota() {
-        let mut envelope = envelope![Transaction];
+        let envelope = envelope![Transaction];
 
         let mock = mock_limiter(&[DataCategory::TransactionIndexed]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
-        assert!(limits.is_limited());
-        assert!(enforcement.event_indexed.is_active());
+        assert!(!limits.is_limited());
+        assert!(!enforcement.event_indexed.is_active());
         assert!(!enforcement.event.is_active());
         mock.lock().await.assert_call(DataCategory::Transaction, 1);
-        mock.lock()
-            .await
-            .assert_call(DataCategory::TransactionIndexed, 1);
+        mock.lock().await.assert_call(DataCategory::Span, 1);
     }
 
     #[tokio::test]
     async fn test_enforce_transaction_attachment_enforced() {
-        let mut envelope = envelope![Transaction, Attachment];
+        let envelope = envelope![Transaction, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(enforcement.event.is_active());
         assert!(enforcement.attachments_limits.event.is_active());
@@ -2111,10 +2074,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_transaction_profile_enforced() {
-        let mut envelope = envelope![Transaction, Profile];
+        let envelope = envelope![Transaction, Profile];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(enforcement.event.is_active());
         assert!(enforcement.profiles.is_active());
@@ -2136,10 +2099,10 @@ mod tests {
     #[tokio::test]
     async fn test_enforce_transaction_standalone_profile_enforced() {
         // When the transaction is sampled, the profile survives as standalone.
-        let mut envelope = envelope![Profile];
+        let envelope = envelope![Profile];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(enforcement.profiles.is_active());
         mock.lock().await.assert_call(DataCategory::Profile, 1);
@@ -2156,37 +2119,30 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_transaction_attachment_enforced_indexing_quota() {
-        let mut envelope = envelope![Transaction, Attachment];
-        set_extracted(envelope.envelope_mut(), ItemType::Transaction);
+        let envelope = envelope![Transaction, Attachment];
 
         let mock = mock_limiter(&[DataCategory::TransactionIndexed]);
-        let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(!enforcement.event.is_active());
-        assert!(enforcement.event_indexed.is_active());
-        assert!(enforcement.attachments_limits.event.is_active());
+        assert!(!enforcement.event_indexed.is_active());
+        assert!(!enforcement.attachments_limits.event.is_active());
         mock.lock().await.assert_call(DataCategory::Transaction, 1);
+        mock.lock().await.assert_call(DataCategory::Span, 1);
+        mock.lock().await.assert_call(DataCategory::Attachment, 10);
         mock.lock()
             .await
-            .assert_call(DataCategory::TransactionIndexed, 1);
+            .assert_call(DataCategory::AttachmentItem, 1);
 
-        assert_eq!(
-            get_outcomes(enforcement),
-            vec![
-                (DataCategory::TransactionIndexed, 1),
-                (DataCategory::Attachment, 10),
-                (DataCategory::AttachmentItem, 1),
-                (DataCategory::SpanIndexed, 1),
-            ]
-        );
+        assert_eq!(get_outcomes(enforcement), vec![]);
     }
 
     #[tokio::test]
     async fn test_enforce_span() {
-        let mut envelope = envelope![Span, Span];
+        let envelope = envelope![Span, Span];
 
         let mock = mock_limiter(&[DataCategory::Span]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
         assert!(enforcement.spans_indexed.is_active());
@@ -2201,41 +2157,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_span_no_indexing_quota() {
-        let mut envelope = envelope![Span, Span];
+        let envelope = envelope![Span, Span];
 
         let mock = mock_limiter(&[DataCategory::SpanIndexed]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
-        assert!(limits.is_limited());
-        assert!(enforcement.spans_indexed.is_active());
+        assert!(!limits.is_limited());
+        assert!(!enforcement.spans_indexed.is_active());
         assert!(!enforcement.spans.is_active());
         mock.lock().await.assert_call(DataCategory::Span, 2);
-        mock.lock().await.assert_call(DataCategory::SpanIndexed, 2);
 
-        assert_eq!(
-            get_outcomes(enforcement),
-            vec![(DataCategory::SpanIndexed, 2)]
-        );
-    }
-
-    #[tokio::test]
-    async fn test_enforce_span_metrics_extracted_no_indexing_quota() {
-        let mut envelope = envelope![Span, Span];
-        set_extracted(envelope.envelope_mut(), ItemType::Span);
-
-        let mock = mock_limiter(&[DataCategory::SpanIndexed]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
-
-        assert!(limits.is_limited());
-        assert!(enforcement.spans_indexed.is_active());
-        assert!(!enforcement.spans.is_active());
-        mock.lock().await.assert_call(DataCategory::Span, 2);
-        mock.lock().await.assert_call(DataCategory::SpanIndexed, 2);
-
-        assert_eq!(
-            get_outcomes(enforcement),
-            vec![(DataCategory::SpanIndexed, 2)]
-        );
+        assert_eq!(get_outcomes(enforcement), vec![]);
     }
 
     #[test]
@@ -2270,13 +2202,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_limit_logs_count() {
-        let mut envelope = envelope![Log, Log];
+        let envelope = envelope![Log, Log];
 
         let mock = mock_limiter(&[DataCategory::LogItem]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 0);
+        assert_eq!(envelope.len(), 0);
         mock.lock().await.assert_call(DataCategory::LogItem, 2);
 
         assert_eq!(
@@ -2287,13 +2219,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_enforce_limit_logs_bytes() {
-        let mut envelope = envelope![Log, Log];
+        let envelope = envelope![Log, Log];
 
         let mock = mock_limiter(&[DataCategory::LogByte]);
-        let (enforcement, limits) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
 
         assert!(limits.is_limited());
-        assert_eq!(envelope.envelope().len(), 0);
+        assert_eq!(envelope.len(), 0);
         mock.lock().await.assert_call(DataCategory::LogItem, 2);
         mock.lock().await.assert_call(DataCategory::LogByte, 20);
 
@@ -2319,22 +2251,19 @@ mod tests {
             RateLimitTestCase {
                 name: "span_indexed_limit",
                 denied_categories: &[DataCategory::SpanIndexed],
-                expect_attachment_limit_active: true,
-                expected_limiter_calls: &[(DataCategory::Span, 0), (DataCategory::SpanIndexed, 0)],
-                expected_outcomes: &[
+                expect_attachment_limit_active: false,
+                expected_limiter_calls: &[
+                    (DataCategory::Span, 0),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
+                expected_outcomes: &[],
             },
             RateLimitTestCase {
                 name: "attachment_limit",
                 denied_categories: &[DataCategory::Attachment],
                 expect_attachment_limit_active: true,
-                expected_limiter_calls: &[
-                    (DataCategory::Span, 0),
-                    (DataCategory::SpanIndexed, 0),
-                    (DataCategory::Attachment, 7),
-                ],
+                expected_limiter_calls: &[(DataCategory::Span, 0), (DataCategory::Attachment, 7)],
                 expected_outcomes: &[
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
@@ -2346,7 +2275,6 @@ mod tests {
                 expect_attachment_limit_active: true,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 0),
-                    (DataCategory::SpanIndexed, 0),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2361,7 +2289,6 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 0),
-                    (DataCategory::SpanIndexed, 0),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2373,7 +2300,6 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 0),
-                    (DataCategory::SpanIndexed, 0),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2385,7 +2311,6 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 0),
-                    (DataCategory::SpanIndexed, 0),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2402,12 +2327,10 @@ mod tests {
         } in test_cases
         {
             let mut envelope = envelope![];
-            envelope
-                .envelope_mut()
-                .add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
+            envelope.add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
 
             let mock = mock_limiter(denied_categories);
-            let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);
@@ -2451,22 +2374,17 @@ mod tests {
                 name: "span_indexed_limit",
                 denied_categories: &[DataCategory::SpanIndexed, DataCategory::Attachment],
                 expect_attachment_limit_active: true,
-                expected_limiter_calls: &[(DataCategory::Span, 1), (DataCategory::SpanIndexed, 1)],
+                expected_limiter_calls: &[(DataCategory::Span, 1), (DataCategory::Attachment, 7)],
                 expected_outcomes: &[
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
-                    (DataCategory::SpanIndexed, 1),
                 ],
             },
             RateLimitTestCase {
                 name: "attachment_limit",
                 denied_categories: &[DataCategory::Attachment],
                 expect_attachment_limit_active: true,
-                expected_limiter_calls: &[
-                    (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
-                    (DataCategory::Attachment, 7),
-                ],
+                expected_limiter_calls: &[(DataCategory::Span, 1), (DataCategory::Attachment, 7)],
                 expected_outcomes: &[
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
@@ -2478,7 +2396,6 @@ mod tests {
                 expect_attachment_limit_active: true,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2493,7 +2410,6 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2505,7 +2421,6 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2517,7 +2432,6 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2534,12 +2448,10 @@ mod tests {
         } in test_cases
         {
             let mut envelope = envelope![Span];
-            envelope
-                .envelope_mut()
-                .add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
+            envelope.add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
 
             let mock = mock_limiter(denied_categories);
-            let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);
@@ -2568,22 +2480,6 @@ mod tests {
     async fn test_enforce_transaction_span_attachment() {
         let test_cases = &[
             RateLimitTestCase {
-                name: "span_limit",
-                denied_categories: &[DataCategory::Span],
-                expect_attachment_limit_active: true,
-                expected_limiter_calls: &[
-                    (DataCategory::Transaction, 1),
-                    (DataCategory::TransactionIndexed, 1),
-                    (DataCategory::Span, 1),
-                ],
-                expected_outcomes: &[
-                    (DataCategory::Attachment, 7),
-                    (DataCategory::AttachmentItem, 1),
-                    (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
-                ],
-            },
-            RateLimitTestCase {
                 name: "transaction_limit",
                 denied_categories: &[DataCategory::Transaction],
                 expect_attachment_limit_active: true,
@@ -2603,9 +2499,7 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Transaction, 1),
-                    (DataCategory::TransactionIndexed, 1),
                     (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2617,9 +2511,7 @@ mod tests {
                 expect_attachment_limit_active: false,
                 expected_limiter_calls: &[
                     (DataCategory::Transaction, 1),
-                    (DataCategory::TransactionIndexed, 1),
                     (DataCategory::Span, 1),
-                    (DataCategory::SpanIndexed, 1),
                     (DataCategory::Attachment, 7),
                     (DataCategory::AttachmentItem, 1),
                 ],
@@ -2636,12 +2528,10 @@ mod tests {
         } in test_cases
         {
             let mut envelope = envelope![Transaction];
-            envelope
-                .envelope_mut()
-                .add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
+            envelope.add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
 
             let mock = mock_limiter(denied_categories);
-            let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);
@@ -2723,12 +2613,10 @@ mod tests {
         } in test_cases
         {
             let mut envelope = envelope![];
-            envelope
-                .envelope_mut()
-                .add_item(trace_attachment_item(7, None));
+            envelope.add_item(trace_attachment_item(7, None));
 
             let mock = mock_limiter(denied_categories);
-            let (enforcement, _) = enforce_and_apply(mock.clone(), &mut envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);

--- a/relay-server/src/utils/rate_limits.rs
+++ b/relay-server/src/utils/rate_limits.rs
@@ -833,16 +833,6 @@ where
         }
     }
 
-    /// Assume an event with the given category, even if no item is present in the envelope.
-    ///
-    /// This ensures that rate limits for the given data category are checked even if there is no
-    /// matching item in the envelope. Other items are handled according to the rules as if the
-    /// event item were present.
-    #[cfg(test)]
-    pub fn assume_event(&mut self, category: DataCategory) {
-        self.event_category = Some(category);
-    }
-
     /// Process rate limits for the envelope, returning applied limits.
     ///
     /// Returns a tuple of `Enforcement` and `RateLimits`:
@@ -1675,7 +1665,6 @@ mod tests {
     async fn enforce_and_apply(
         mock: Arc<Mutex<MockLimiter>>,
         envelope: Box<Envelope>,
-        #[allow(unused_variables)] assume_event: Option<DataCategory>,
     ) -> (Box<Envelope>, Enforcement, RateLimits) {
         let mut envelope = Managed::from_envelope(envelope, Addr::custom().0);
         let scoping = envelope.scoping();
@@ -1688,10 +1677,6 @@ mod tests {
                 mock.check(s, q)
             }
         });
-        #[cfg(feature = "processing")]
-        if let Some(assume_event) = assume_event {
-            limiter.assume_event(assume_event);
-        }
 
         let (enforcement, limits) = limiter.compute(&envelope, &scoping).await.unwrap();
 
@@ -1717,7 +1702,7 @@ mod tests {
         let envelope = envelope![];
 
         let mock = mock_limiter(&[]);
-        let (envelope, _, limits) = enforce_and_apply(mock, envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock, envelope).await;
 
         assert!(!limits.is_limited());
         assert!(envelope.is_empty());
@@ -1728,7 +1713,7 @@ mod tests {
         let envelope = envelope![Event];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(envelope.is_empty());
@@ -1740,7 +1725,7 @@ mod tests {
         let envelope = envelope![Event, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(envelope.is_empty());
@@ -1752,7 +1737,7 @@ mod tests {
         let envelope = envelope![Attachment::Minidump];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(envelope.is_empty());
@@ -1764,7 +1749,7 @@ mod tests {
         let envelope = envelope![Attachment::Minidump, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Attachment]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         // Attachments would be limited, but crash reports create events and are thus allowed.
         assert!(limits.is_limited());
@@ -1779,7 +1764,7 @@ mod tests {
         let envelope = envelope![Profile, Profile];
 
         let mock = mock_limiter(&[DataCategory::Profile]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 0);
@@ -1802,12 +1787,12 @@ mod tests {
         let envelope = envelope![ProfileChunk, ProfileChunk];
 
         let mock = mock_limiter(&[DataCategory::ProfileChunk]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
         assert!(!limits.is_limited());
         assert_eq!(get_outcomes(enforcement), vec![]);
 
         let mock = mock_limiter(&[DataCategory::ProfileChunkUi]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
         assert!(!limits.is_limited());
         assert_eq!(get_outcomes(enforcement), vec![]);
 
@@ -1826,7 +1811,7 @@ mod tests {
         envelope.add_item(item);
 
         let mock = mock_limiter(&[DataCategory::ProfileChunkUi]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 1);
@@ -1853,7 +1838,7 @@ mod tests {
         envelope.add_item(item);
 
         let mock = mock_limiter(&[DataCategory::ProfileChunk]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 1);
@@ -1874,7 +1859,7 @@ mod tests {
         let envelope = envelope![ReplayEvent, ReplayRecording, ReplayVideo];
 
         let mock = mock_limiter(&[DataCategory::Replay]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 0);
@@ -1889,7 +1874,7 @@ mod tests {
         let envelope = envelope![CheckIn];
 
         let mock = mock_limiter(&[DataCategory::Monitor]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 0);
@@ -1903,7 +1888,7 @@ mod tests {
         let envelope = envelope![Attachment::Minidump];
 
         let mock = mock_limiter(&[DataCategory::Attachment]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         // If only crash report attachments are present, we don't emit a rate limit.
         assert!(!limits.is_limited());
@@ -1922,7 +1907,7 @@ mod tests {
         envelope.add_item(item);
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (envelope, _, limits) = enforce_and_apply(mock, envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock, envelope).await;
 
         assert!(!limits.is_limited()); // No new rate limits applied.
         assert_eq!(envelope.len(), 1); // The item was retained
@@ -1933,7 +1918,7 @@ mod tests {
         let envelope = envelope![Session, Session, Session];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         // If only crash report attachments are present, we don't emit a rate limit.
         assert!(!limits.is_limited());
@@ -1946,7 +1931,7 @@ mod tests {
         let envelope = envelope![Session, Session, Event];
 
         let mock = mock_limiter(&[DataCategory::Session]);
-        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         // If only crash report attachments are present, we don't emit a rate limit.
         assert!(limits.is_limited());
@@ -1961,8 +1946,7 @@ mod tests {
         let envelope = envelope![Transaction];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (envelope, _, limits) =
-            enforce_and_apply(mock.clone(), envelope, Some(DataCategory::Transaction)).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(envelope.is_empty()); // obviously
@@ -1975,8 +1959,7 @@ mod tests {
         let envelope = envelope![Event, Attachment, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Error]);
-        let (envelope, _, limits) =
-            enforce_and_apply(mock.clone(), envelope, Some(DataCategory::Error)).await;
+        let (envelope, _, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(envelope.is_empty());
@@ -1988,7 +1971,7 @@ mod tests {
         let envelope = envelope![Transaction];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(enforcement.event_indexed.is_active());
@@ -2044,7 +2027,7 @@ mod tests {
         let envelope = envelope![Transaction];
 
         let mock = mock_limiter(&[DataCategory::TransactionIndexed]);
-        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(!limits.is_limited());
         assert!(!enforcement.event_indexed.is_active());
@@ -2058,7 +2041,7 @@ mod tests {
         let envelope = envelope![Transaction, Attachment];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(enforcement.event.is_active());
         assert!(enforcement.attachments_limits.event.is_active());
@@ -2077,7 +2060,7 @@ mod tests {
         let envelope = envelope![Transaction, Profile];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(enforcement.event.is_active());
         assert!(enforcement.profiles.is_active());
@@ -2102,7 +2085,7 @@ mod tests {
         let envelope = envelope![Profile];
 
         let mock = mock_limiter(&[DataCategory::Transaction]);
-        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(enforcement.profiles.is_active());
         mock.lock().await.assert_call(DataCategory::Profile, 1);
@@ -2122,7 +2105,7 @@ mod tests {
         let envelope = envelope![Transaction, Attachment];
 
         let mock = mock_limiter(&[DataCategory::TransactionIndexed]);
-        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(!enforcement.event.is_active());
         assert!(!enforcement.event_indexed.is_active());
@@ -2142,7 +2125,7 @@ mod tests {
         let envelope = envelope![Span, Span];
 
         let mock = mock_limiter(&[DataCategory::Span]);
-        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert!(enforcement.spans_indexed.is_active());
@@ -2160,7 +2143,7 @@ mod tests {
         let envelope = envelope![Span, Span];
 
         let mock = mock_limiter(&[DataCategory::SpanIndexed]);
-        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (_, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(!limits.is_limited());
         assert!(!enforcement.spans_indexed.is_active());
@@ -2205,7 +2188,7 @@ mod tests {
         let envelope = envelope![Log, Log];
 
         let mock = mock_limiter(&[DataCategory::LogItem]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 0);
@@ -2222,7 +2205,7 @@ mod tests {
         let envelope = envelope![Log, Log];
 
         let mock = mock_limiter(&[DataCategory::LogByte]);
-        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope, None).await;
+        let (envelope, enforcement, limits) = enforce_and_apply(mock.clone(), envelope).await;
 
         assert!(limits.is_limited());
         assert_eq!(envelope.len(), 0);
@@ -2330,7 +2313,7 @@ mod tests {
             envelope.add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
 
             let mock = mock_limiter(denied_categories);
-            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);
@@ -2451,7 +2434,7 @@ mod tests {
             envelope.add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
 
             let mock = mock_limiter(denied_categories);
-            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);
@@ -2531,7 +2514,7 @@ mod tests {
             envelope.add_item(trace_attachment_item(7, Some(ParentId::SpanId(None))));
 
             let mock = mock_limiter(denied_categories);
-            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);
@@ -2616,7 +2599,7 @@ mod tests {
             envelope.add_item(trace_attachment_item(7, None));
 
             let mock = mock_limiter(denied_categories);
-            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope, None).await;
+            let (_, enforcement, _) = enforce_and_apply(mock.clone(), envelope).await;
 
             for &(category, quantity) in *expected_limiter_calls {
                 mock.lock().await.assert_call(category, quantity);


### PR DESCRIPTION
Rate limiter no longer supports the `CheckLimits::All` variant, therefor all tests had to be adjusted accordingly.

This is a close but not 1:1 port of the processor, order of things has been slightly adjusted, e.g. normalization steps now run together instead of some before and some after dynamic sampling.

This allowed removing some rate limiting and processing code, it has been cleaned up.

There will be a follow-up which cleans out the `processor/` module and moves the processing code into the respective processor.