### PR TITLE
feat(buffer): Optional round-robin partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Use `ModelMetadata` config with context size and utilization. ([#5814](https://github.com/getsentry/relay/pull/5814))
 - Handle minidump placeholders. ([#5849](https://github.com/getsentry/relay/pull/5849))
+- Add config option to spread envelopes evenly across buffer partitions. ([#5853](https://github.com/getsentry/relay/pull/5853))
 
 **Internal**:
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -968,7 +968,7 @@ pub enum EnvelopeSpoolPartitioning {
     ProjectKeyPair,
     /// Envelopes are distributed across partitions in a round-robin fashion.
     ///
-    /// This "hot" partitions when a single project pair dominates traffic, but has
+    /// This prevents "hot" partitions when a single project pair dominates traffic, but has
     /// trade-offs:
     /// - Per-project LIFO ordering is no longer preserved across partitions.
     /// - Per-partition memory footprint grows since every partition sees every project.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -968,10 +968,10 @@ pub enum EnvelopeSpoolPartitioning {
     ProjectKeyPair,
     /// Envelopes are distributed across partitions in a round-robin fashion.
     ///
-    /// This removes hot-partition risk when a single project pair dominates traffic, but has
-    /// - Per-`ProjectKeyPair` LIFO ordering is no longer preserved across partitions.
+    /// This "hot" partitions when a single project pair dominates traffic, but has
     /// trade-offs:
-    /// - Per-partition project-state footprint grows since every partition sees every project.
+    /// - Per-project LIFO ordering is no longer preserved across partitions.
+    /// - Per-partition memory footprint grows since every partition sees every project.
     RoundRobin,
 }
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -957,11 +957,11 @@ fn spool_envelopes_partitions() -> NonZeroU8 {
     NonZeroU8::new(1).unwrap()
 }
 
-/// Strategy used to assign envelopes to buffer partitions in [`PartitionedEnvelopeBuffer`].
+/// Strategy used to assign envelopes to buffer partitions.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EnvelopeSpoolPartitioning {
-    /// Envelopes with the same [`ProjectKeyPair`] land on the same partition (default).
+    /// Envelopes with the same project key pair land on the same partition (default).
     ///
     /// Keeps per-project state, disk files, and event ordering co-located on one partition.
     #[default]

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -957,6 +957,24 @@ fn spool_envelopes_partitions() -> NonZeroU8 {
     NonZeroU8::new(1).unwrap()
 }
 
+/// Strategy used to assign envelopes to buffer partitions in [`PartitionedEnvelopeBuffer`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeSpoolPartitioning {
+    /// Envelopes with the same [`ProjectKeyPair`] land on the same partition (default).
+    ///
+    /// Keeps per-project state, disk files, and event ordering co-located on one partition.
+    #[default]
+    ProjectKeyPair,
+    /// Envelopes are distributed across partitions in a round-robin fashion.
+    ///
+    /// This removes hot-partition risk when a single project pair dominates traffic, but has
+    /// - Per-`ProjectKeyPair` LIFO ordering is no longer preserved across partitions.
+    /// trade-offs:
+    /// - Per-partition project-state footprint grows since every partition sees every project.
+    RoundRobin,
+}
+
 /// Persistent buffering configuration for incoming envelopes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvelopeSpool {
@@ -1034,6 +1052,13 @@ pub struct EnvelopeSpool {
     /// Defaults to 1.
     #[serde(default = "spool_envelopes_partitions")]
     pub partitions: NonZeroU8,
+    /// Strategy used to assign envelopes to buffer partitions.
+    ///
+    /// Defaults to partitioning by `ProjectKeyPair`, which keeps all envelopes of a given project
+    /// pair on the same partition. See [`EnvelopeSpoolPartitioning`] for alternatives and
+    /// trade-offs.
+    #[serde(default)]
+    pub partitioning: EnvelopeSpoolPartitioning,
     /// Whether the database defined in `path` is on an ephemeral storage disk.
     ///
     /// With `ephemeral: true`, Relay does not spool in-flight data to disk
@@ -1054,6 +1079,7 @@ impl Default for EnvelopeSpool {
             disk_usage_refresh_frequency_ms: spool_disk_usage_refresh_frequency_ms(),
             max_backpressure_memory_percent: spool_max_backpressure_memory_percent(),
             partitions: spool_envelopes_partitions(),
+            partitioning: EnvelopeSpoolPartitioning::default(),
             ephemeral: false,
         }
     }
@@ -2405,6 +2431,11 @@ impl Config {
     /// Returns the number of partitions for the buffer.
     pub fn spool_partitions(&self) -> NonZeroU8 {
         self.values.spool.envelopes.partitions
+    }
+
+    /// Returns the strategy used to assign envelopes to buffer partitions.
+    pub fn spool_partitioning(&self) -> EnvelopeSpoolPartitioning {
+        self.values.spool.envelopes.partitioning
     }
 
     /// Returns `true` if the data is stored on ephemeral disks.

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -78,7 +78,7 @@ pub struct Registry {
     pub relay_cache: Addr<RelayCache>,
     pub global_config: Addr<GlobalConfigManager>,
     pub upstream_relay: Addr<UpstreamRelay>,
-    pub envelope_buffer: PartitionedEnvelopeBuffer,
+    pub envelope_buffer: Arc<PartitionedEnvelopeBuffer>,
     pub project_cache_handle: ProjectCacheHandle,
     pub autoscaling: Option<Addr<AutoscalingMetrics>>,
     #[cfg(feature = "processing")]

--- a/relay-server/src/services/autoscaling.rs
+++ b/relay-server/src/services/autoscaling.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::MemoryStat;
 use crate::services::buffer::PartitionedEnvelopeBuffer;
 use crate::services::processor::EnvelopeProcessorServicePool;
@@ -11,7 +13,7 @@ pub struct AutoscalingMetricService {
     /// For exposing internal memory usage of relay.
     memory_stat: MemoryStat,
     /// Reference to the spooler to get item count and total used size.
-    envelope_buffer: PartitionedEnvelopeBuffer,
+    envelope_buffer: Arc<PartitionedEnvelopeBuffer>,
     /// Runtime handle to expose service utilization metrics.
     handle: Handle,
     /// Gives access to runtime metrics.
@@ -27,7 +29,7 @@ pub struct AutoscalingMetricService {
 impl AutoscalingMetricService {
     pub fn new(
         memory_stat: MemoryStat,
-        envelope_buffer: PartitionedEnvelopeBuffer,
+        envelope_buffer: Arc<PartitionedEnvelopeBuffer>,
         handle: Handle,
         async_pool: EnvelopeProcessorServicePool,
     ) -> Self {

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -79,15 +79,6 @@ pub struct PartitionedEnvelopeBuffer {
     partitioning: Partitioning,
 }
 
-/// Internal representation of the partition-selection strategy.
-#[derive(Debug, Clone)]
-enum Partitioning {
-    /// Partition by project key pair, using a fixed-seed hasher for deterministic placement.
-    ProjectKeyPair(RandomState),
-    /// Distribute envelopes round-robin across partitions using a shared atomic counter.
-    RoundRobin(Arc<AtomicUsize>),
-}
-
 impl PartitionedEnvelopeBuffer {
     /// Creates a new [`PartitionedEnvelopeBuffer`] by instantiating inside all the necessary
     /// [`ObservableEnvelopeBuffer`]s.
@@ -180,6 +171,15 @@ impl PartitionedEnvelopeBuffer {
 
         RandomState::with_seeds(K0, K1, K2, K3)
     }
+}
+
+/// Internal representation of the partition-selection strategy.
+#[derive(Debug, Clone)]
+enum Partitioning {
+    /// Partition by project key pair, using a fixed-seed hasher for deterministic placement.
+    ProjectKeyPair(RandomState),
+    /// Distribute envelopes round-robin across partitions using a shared atomic counter.
+    RoundRobin(Arc<AtomicUsize>),
 }
 
 impl Partitioning {

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -73,9 +73,11 @@ impl FromMessage<Self> for EnvelopeBuffer {
 
 /// Abstraction that wraps a list of [`ObservableEnvelopeBuffer`]s to which [`Envelope`] are routed
 /// based on the configured [`EnvelopeSpoolPartitioning`] strategy.
-#[derive(Debug, Clone)]
+///
+/// Share between owners via `Arc<PartitionedEnvelopeBuffer>`.
+#[derive(Debug)]
 pub struct PartitionedEnvelopeBuffer {
-    buffers: Arc<Vec<ObservableEnvelopeBuffer>>,
+    buffers: Vec<ObservableEnvelopeBuffer>,
     partitioning: Partitioning,
 }
 
@@ -92,7 +94,7 @@ impl PartitionedEnvelopeBuffer {
         envelope_processor: Addr<EnvelopeProcessor>,
         outcome_aggregator: Addr<TrackOutcome>,
         services: &dyn ServiceSpawn,
-    ) -> Self {
+    ) -> Arc<Self> {
         let partitioning = Partitioning::new(config.spool_partitioning());
 
         let mut envelope_buffers = Vec::with_capacity(partitions.get() as usize);
@@ -113,10 +115,10 @@ impl PartitionedEnvelopeBuffer {
             envelope_buffers.push(envelope_buffer);
         }
 
-        Self {
-            buffers: Arc::new(envelope_buffers),
+        Arc::new(Self {
+            buffers: envelope_buffers,
             partitioning,
-        }
+        })
     }
 
     /// Returns the [`ObservableEnvelopeBuffer`] to which the [`Envelope`] for the supplied
@@ -174,12 +176,12 @@ impl PartitionedEnvelopeBuffer {
 }
 
 /// Internal representation of the partition-selection strategy.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum Partitioning {
     /// Partition by project key pair, using a fixed-seed hasher for deterministic placement.
     ProjectKeyPair(RandomState),
     /// Distribute envelopes round-robin across partitions using a shared atomic counter.
-    RoundRobin(Arc<AtomicUsize>),
+    RoundRobin(AtomicUsize),
 }
 
 impl Partitioning {
@@ -188,9 +190,7 @@ impl Partitioning {
             EnvelopeSpoolPartitioning::ProjectKeyPair => {
                 Self::ProjectKeyPair(PartitionedEnvelopeBuffer::build_hasher())
             }
-            EnvelopeSpoolPartitioning::RoundRobin => {
-                Self::RoundRobin(Arc::new(AtomicUsize::new(0)))
-            }
+            EnvelopeSpoolPartitioning::RoundRobin => Self::RoundRobin(AtomicUsize::new(0)),
         }
     }
 }
@@ -1044,7 +1044,7 @@ mod tests {
         let observable2 = buffer2.start_in(&TokioServiceSpawn);
 
         let partitioned = PartitionedEnvelopeBuffer {
-            buffers: Arc::new(vec![observable1, observable2]),
+            buffers: vec![observable1, observable2],
             partitioning: Partitioning::new(EnvelopeSpoolPartitioning::ProjectKeyPair),
         };
 
@@ -1107,7 +1107,7 @@ mod tests {
         )
         .start_in(&TokioServiceSpawn);
 
-        let buffers = Arc::new(vec![observable1, observable2]);
+        let buffers = vec![observable1, observable2];
         let pair = ProjectKeyPair::from_envelope(new_managed_envelope(false, "foo").envelope());
 
         // Default strategy: same pair always maps to the same partition.

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -4,13 +4,13 @@ use std::error::Error;
 use std::num::NonZeroU8;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
 use std::time::Duration;
 
 use ahash::RandomState;
 use chrono::DateTime;
 use chrono::Utc;
-use relay_config::Config;
+use relay_config::{Config, EnvelopeSpoolPartitioning};
 use relay_system::Receiver;
 use relay_system::ServiceSpawn;
 use relay_system::ServiceSpawnExt as _;
@@ -72,11 +72,20 @@ impl FromMessage<Self> for EnvelopeBuffer {
 }
 
 /// Abstraction that wraps a list of [`ObservableEnvelopeBuffer`]s to which [`Envelope`] are routed
-/// based on their [`ProjectKeyPair`].
+/// based on the configured [`EnvelopeSpoolPartitioning`] strategy.
 #[derive(Debug, Clone)]
 pub struct PartitionedEnvelopeBuffer {
     buffers: Arc<Vec<ObservableEnvelopeBuffer>>,
-    hasher: RandomState,
+    partitioning: Partitioning,
+}
+
+/// Internal representation of the partition-selection strategy.
+#[derive(Debug, Clone)]
+enum Partitioning {
+    /// Partition by `ProjectKeyPair`, using a fixed-seed hasher for deterministic placement.
+    ProjectKeyPair(RandomState),
+    /// Distribute envelopes round-robin across partitions using a shared atomic counter.
+    RoundRobin(Arc<AtomicUsize>),
 }
 
 impl PartitionedEnvelopeBuffer {
@@ -93,6 +102,8 @@ impl PartitionedEnvelopeBuffer {
         outcome_aggregator: Addr<TrackOutcome>,
         services: &dyn ServiceSpawn,
     ) -> Self {
+        let partitioning = Partitioning::new(config.spool_partitioning());
+
         let mut envelope_buffers = Vec::with_capacity(partitions.get() as usize);
         for partition_id in 0..partitions.get() {
             let envelope_buffer = EnvelopeBufferService::new(
@@ -113,18 +124,25 @@ impl PartitionedEnvelopeBuffer {
 
         Self {
             buffers: Arc::new(envelope_buffers),
-            hasher: Self::build_hasher(),
+            partitioning,
         }
     }
 
-    /// Returns the [`ObservableEnvelopeBuffer`] to which [`Envelope`]s having the supplied
-    /// [`ProjectKeyPair`] will be sent.
+    /// Returns the [`ObservableEnvelopeBuffer`] to which the [`Envelope`] for the supplied
+    /// [`ProjectKeyPair`] should be sent.
     ///
-    /// The rationale of using this partitioning strategy is to reduce memory usage across buffers
-    /// since each individual buffer will only take care of a subset of projects.
+    /// With [`EnvelopeSpoolPartitioning::ProjectKeyPair`], envelopes for a given pair always land
+    /// on the same partition, which keeps per-project state, on-disk files, and LIFO ordering
+    /// co-located. With [`EnvelopeSpoolPartitioning::RoundRobin`], envelopes are spread evenly
+    /// across partitions and `project_key_pair` is ignored for routing purposes.
     pub fn buffer(&self, project_key_pair: ProjectKeyPair) -> &ObservableEnvelopeBuffer {
-        let buffer_index =
-            (self.hasher.hash_one(project_key_pair) % self.buffers.len() as u64) as usize;
+        let len = self.buffers.len();
+        let buffer_index = match &self.partitioning {
+            Partitioning::ProjectKeyPair(hasher) => {
+                (hasher.hash_one(project_key_pair) % len as u64) as usize
+            }
+            Partitioning::RoundRobin(counter) => counter.fetch_add(1, Ordering::Relaxed) % len,
+        };
         self.buffers
             .get(buffer_index)
             .expect("buffers should not be empty")
@@ -161,6 +179,19 @@ impl PartitionedEnvelopeBuffer {
         const K3: u64 = 0xbadc0de901234567;
 
         RandomState::with_seeds(K0, K1, K2, K3)
+    }
+}
+
+impl Partitioning {
+    fn new(strategy: EnvelopeSpoolPartitioning) -> Self {
+        match strategy {
+            EnvelopeSpoolPartitioning::ProjectKeyPair => {
+                Self::ProjectKeyPair(PartitionedEnvelopeBuffer::build_hasher())
+            }
+            EnvelopeSpoolPartitioning::RoundRobin => {
+                Self::RoundRobin(Arc::new(AtomicUsize::new(0)))
+            }
+        }
     }
 }
 
@@ -1014,7 +1045,7 @@ mod tests {
 
         let partitioned = PartitionedEnvelopeBuffer {
             buffers: Arc::new(vec![observable1, observable2]),
-            hasher: PartitionedEnvelopeBuffer::build_hasher(),
+            partitioning: Partitioning::new(EnvelopeSpoolPartitioning::ProjectKeyPair),
         };
 
         // Create two envelopes with different project keys
@@ -1041,5 +1072,63 @@ mod tests {
         assert!(envelope_processor_rx.recv().await.is_some());
         assert!(envelope_processor_rx.recv().await.is_some());
         assert!(envelope_processor_rx.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_partitioned_buffer_routing() {
+        let (_global_tx, global_rx) = watch::channel(global_config::Status::Ready(Arc::new(
+            GlobalConfig::default(),
+        )));
+        let (outcome_aggregator, _outcome_rx) = Addr::custom();
+        let project_cache_handle = ProjectCacheHandle::for_test();
+        let (envelope_processor, _envelope_processor_rx) = Addr::custom();
+
+        let services = Services {
+            envelope_processor,
+            project_cache_handle: project_cache_handle.clone(),
+            outcome_aggregator,
+        };
+
+        let config = Arc::new(Config::default());
+        let observable1 = EnvelopeBufferService::new(
+            0,
+            config.clone(),
+            MemoryStat::default(),
+            global_rx.clone(),
+            services.clone(),
+        )
+        .start_in(&TokioServiceSpawn);
+        let observable2 = EnvelopeBufferService::new(
+            1,
+            config.clone(),
+            MemoryStat::default(),
+            global_rx.clone(),
+            services.clone(),
+        )
+        .start_in(&TokioServiceSpawn);
+
+        let buffers = Arc::new(vec![observable1, observable2]);
+        let pair = ProjectKeyPair::from_envelope(new_managed_envelope(false, "foo").envelope());
+
+        // Default strategy: same pair always maps to the same partition.
+        let by_pair = PartitionedEnvelopeBuffer {
+            buffers: buffers.clone(),
+            partitioning: Partitioning::new(EnvelopeSpoolPartitioning::ProjectKeyPair),
+        };
+        let expected = by_pair.buffer(pair) as *const _;
+        for _ in 0..8 {
+            assert_eq!(expected, by_pair.buffer(pair) as *const _);
+        }
+
+        // Round-robin: same pair cycles through both partitions.
+        let round_robin = PartitionedEnvelopeBuffer {
+            buffers,
+            partitioning: Partitioning::new(EnvelopeSpoolPartitioning::RoundRobin),
+        };
+        let first = round_robin.buffer(pair) as *const _;
+        let second = round_robin.buffer(pair) as *const _;
+        let third = round_robin.buffer(pair) as *const _;
+        assert_ne!(first, second);
+        assert_eq!(first, third);
     }
 }

--- a/relay-server/src/services/buffer/mod.rs
+++ b/relay-server/src/services/buffer/mod.rs
@@ -82,7 +82,7 @@ pub struct PartitionedEnvelopeBuffer {
 /// Internal representation of the partition-selection strategy.
 #[derive(Debug, Clone)]
 enum Partitioning {
-    /// Partition by `ProjectKeyPair`, using a fixed-seed hasher for deterministic placement.
+    /// Partition by project key pair, using a fixed-seed hasher for deterministic placement.
     ProjectKeyPair(RandomState),
     /// Distribute envelopes round-robin across partitions using a shared atomic counter.
     RoundRobin(Arc<AtomicUsize>),

--- a/relay-server/src/services/health_check.rs
+++ b/relay-server/src/services/health_check.rs
@@ -86,7 +86,7 @@ pub struct HealthCheckService {
     memory_checker: MemoryChecker,
     aggregator: Option<RouterHandle>,
     upstream_relay: Addr<UpstreamRelay>,
-    envelope_buffer: PartitionedEnvelopeBuffer,
+    envelope_buffer: Arc<PartitionedEnvelopeBuffer>,
 }
 
 impl HealthCheckService {
@@ -96,7 +96,7 @@ impl HealthCheckService {
         memory_checker: MemoryChecker,
         aggregator: Option<RouterHandle>,
         upstream_relay: Addr<UpstreamRelay>,
-        envelope_buffer: PartitionedEnvelopeBuffer,
+        envelope_buffer: Arc<PartitionedEnvelopeBuffer>,
     ) -> Self {
         Self {
             config,


### PR DESCRIPTION
Add the option to distribute envelopes across buffer partitions evenly.

This removes the advantage of LIFO-per-project and increases memory pressure (every partition will eventually keep state for every project key pair), but prevents "hot" partitions that are usually caused by individual large projects.

ref: INGEST-855