### PR TITLE
test(attachments): Fix flaky test

### DIFF
--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+import time
+
 import pytest
 import uuid
 import json
@@ -35,55 +38,45 @@ def test_mixed_attachments_with_processing(
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
 
-    chunked_contents = b"heavens no" * 20_000
+    large_content = b"heavens no" * 20_000
     attachments = [
-        ("att_1", "foo.txt", chunked_contents),
+        ("att_1", "foo.txt", large_content),
         ("att_2", "bar.txt", b"hell yeah"),
         ("att_3", "foobar.txt", b""),
     ]
     relay.send_attachments(project_id, event_id, attachments)
 
-    # A chunked attachment
-    attachment_contents = {}
-    attachment_ids = []
-    attachment_num_chunks = {}
+    chunked_data_per_id = defaultdict(bytes)
+    n_chunks = 0
+    inline_attachments = []
+    start = time.time()
+    while (
+        set(chunked_data_per_id.values()) != {large_content}
+        or len(inline_attachments) < 3
+    ):
+        if time.time() - start > 10:
+            raise TimeoutError()
+        _, m = attachments_consumer.get_message()
+        if m["type"] == "attachment_chunk":
+            chunked_data_per_id[m["id"]] += m["payload"]
+            assert m["chunk_index"] == n_chunks
+            n_chunks += 1
+        elif m["type"] == "attachment":
+            inline_attachments.append(m)
+        else:
+            raise AssertionError(f"Unexpected message type: {m['type']}")
+    inline_attachments.sort(key=lambda a: a["attachment"]["name"])
 
-    while set(attachment_contents.values()) != {chunked_contents}:
-        chunk, v = attachments_consumer.get_attachment_chunk()
-        attachment_contents[v["id"]] = attachment_contents.get(v["id"], b"") + chunk
-        if v["id"] not in attachment_ids:
-            attachment_ids.append(v["id"])
-        num_chunks = 1 + attachment_num_chunks.get(v["id"], 0)
-        assert v["chunk_index"] == num_chunks - 1
-        attachment_num_chunks[v["id"]] = num_chunks
+    assert len(chunked_data_per_id) == 1
+    (foo_id,) = chunked_data_per_id
+    assert chunked_data_per_id[foo_id] == large_content
+    assert n_chunks > 1
 
-    (id1,) = attachment_ids
-    assert attachment_contents[id1] == chunked_contents
-    assert attachment_num_chunks[id1] > 1
-
-    attachment = attachments_consumer.get_individual_attachment()
-    assert attachment == {
-        "type": "attachment",
-        "attachment": {
-            "id": id1,
-            "name": "foo.txt",
-            "rate_limited": False,
-            "attachment_type": "event.attachment",
-            "size": len(chunked_contents),
-            "retention_days": 90,
-            "chunks": attachment_num_chunks[id1],
-        },
-        "event_id": event_id,
-        "project_id": project_id,
-    }
-
-    # An inlined attachment
-    attachment = attachments_consumer.get_individual_attachment()
-
+    # Inlined attachment bar
+    bar = inline_attachments[0]
     # The ID is random. Just assert that it is there and non-zero.
-    assert attachment["attachment"].pop("id")
-
-    assert attachment == {
+    assert bar["attachment"].pop("id")
+    assert bar == {
         "type": "attachment",
         "attachment": {
             "name": "bar.txt",
@@ -97,15 +90,28 @@ def test_mixed_attachments_with_processing(
         "project_id": project_id,
     }
 
-    outcomes_consumer.assert_empty()
+    # Inlined metadata for chunked attachment foo
+    foo = inline_attachments[1]
+    assert foo == {
+        "type": "attachment",
+        "attachment": {
+            "id": foo_id,
+            "name": "foo.txt",
+            "rate_limited": False,
+            "attachment_type": "event.attachment",
+            "size": len(large_content),
+            "retention_days": 90,
+            "chunks": n_chunks,
+        },
+        "event_id": event_id,
+        "project_id": project_id,
+    }
 
-    # An empty attachment
-    attachment = attachments_consumer.get_individual_attachment()
-
+    # Empty attachment foobar
+    foobar = inline_attachments[2]
     # The ID is random. Just assert that it is there and non-zero.
-    assert attachment["attachment"].pop("id")
-
-    assert attachment == {
+    assert foobar["attachment"].pop("id")
+    assert foobar == {
         "type": "attachment",
         "attachment": {
             "name": "foobar.txt",
@@ -118,6 +124,8 @@ def test_mixed_attachments_with_processing(
         "event_id": event_id,
         "project_id": project_id,
     }
+
+    outcomes_consumer.assert_empty()
 
 
 def test_attachments_with_objectstore(
@@ -454,9 +462,7 @@ password=mysupersecretpassword123"""
 
     scrubbed_payload = mini_sentry.get_captured_envelope().items[0].payload.bytes
 
-    assert (
-        scrubbed_payload
-        == rb"""Alice Johnson
+    assert scrubbed_payload == rb"""Alice Johnson
 *************************
 +1234567890
 4111 1111 1111 1111
@@ -465,7 +471,6 @@ Charlie Brown ************************* +1928374650 3782 822463 10005
 Dana White ************************ +1029384756 6011 0009 9013 9424
 path=c:\Users\***\mylogfile.txt
 password=mysupersecretpassword123"""
-    )
 
 
 def test_attachments_quotas(

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+import time
+
 import pytest
 import uuid
 import json
@@ -35,55 +38,45 @@ def test_mixed_attachments_with_processing(
     attachments_consumer = attachments_consumer()
     outcomes_consumer = outcomes_consumer()
 
-    chunked_contents = b"heavens no" * 20_000
+    large_content = b"heavens no" * 20_000
     attachments = [
-        ("att_1", "foo.txt", chunked_contents),
+        ("att_1", "foo.txt", large_content),
         ("att_2", "bar.txt", b"hell yeah"),
         ("att_3", "foobar.txt", b""),
     ]
     relay.send_attachments(project_id, event_id, attachments)
 
-    # A chunked attachment
-    attachment_contents = {}
-    attachment_ids = []
-    attachment_num_chunks = {}
+    chunked_data_per_id = defaultdict(bytes)
+    n_chunks = 0
+    inline_attachments = []
+    start = time.time()
+    while (
+        set(chunked_data_per_id.values()) != {large_content}
+        or len(inline_attachments) < 3
+    ):
+        if time.time() - start > 10:
+            raise TimeoutError()
+        _, m = attachments_consumer.get_message()
+        if m["type"] == "attachment_chunk":
+            chunked_data_per_id[m["id"]] += m["payload"]
+            assert m["chunk_index"] == n_chunks
+            n_chunks += 1
+        elif m["type"] == "attachment":
+            inline_attachments.append(m)
+        else:
+            raise AssertionError(f"Unexpected message type: {m['type']}")
+    inline_attachments.sort(key=lambda a: a["attachment"]["name"])
 
-    while set(attachment_contents.values()) != {chunked_contents}:
-        chunk, v = attachments_consumer.get_attachment_chunk()
-        attachment_contents[v["id"]] = attachment_contents.get(v["id"], b"") + chunk
-        if v["id"] not in attachment_ids:
-            attachment_ids.append(v["id"])
-        num_chunks = 1 + attachment_num_chunks.get(v["id"], 0)
-        assert v["chunk_index"] == num_chunks - 1
-        attachment_num_chunks[v["id"]] = num_chunks
+    assert len(chunked_data_per_id) == 1
+    (foo_id,) = chunked_data_per_id
+    assert chunked_data_per_id[foo_id] == large_content
+    assert n_chunks > 1
 
-    (id1,) = attachment_ids
-    assert attachment_contents[id1] == chunked_contents
-    assert attachment_num_chunks[id1] > 1
-
-    attachment = attachments_consumer.get_individual_attachment()
-    assert attachment == {
-        "type": "attachment",
-        "attachment": {
-            "id": id1,
-            "name": "foo.txt",
-            "rate_limited": False,
-            "attachment_type": "event.attachment",
-            "size": len(chunked_contents),
-            "retention_days": 90,
-            "chunks": attachment_num_chunks[id1],
-        },
-        "event_id": event_id,
-        "project_id": project_id,
-    }
-
-    # An inlined attachment
-    attachment = attachments_consumer.get_individual_attachment()
-
+    # Inlined attachment bar
+    bar = inline_attachments[0]
     # The ID is random. Just assert that it is there and non-zero.
-    assert attachment["attachment"].pop("id")
-
-    assert attachment == {
+    assert bar["attachment"].pop("id")
+    assert bar == {
         "type": "attachment",
         "attachment": {
             "name": "bar.txt",
@@ -97,15 +90,28 @@ def test_mixed_attachments_with_processing(
         "project_id": project_id,
     }
 
-    outcomes_consumer.assert_empty()
+    # Inlined metadata for chunked attachment foo
+    foo = inline_attachments[1]
+    assert foo == {
+        "type": "attachment",
+        "attachment": {
+            "id": foo_id,
+            "name": "foo.txt",
+            "rate_limited": False,
+            "attachment_type": "event.attachment",
+            "size": len(large_content),
+            "retention_days": 90,
+            "chunks": n_chunks,
+        },
+        "event_id": event_id,
+        "project_id": project_id,
+    }
 
-    # An empty attachment
-    attachment = attachments_consumer.get_individual_attachment()
-
+    # Empty attachment foobar
+    foobar = inline_attachments[2]
     # The ID is random. Just assert that it is there and non-zero.
-    assert attachment["attachment"].pop("id")
-
-    assert attachment == {
+    assert foobar["attachment"].pop("id")
+    assert foobar == {
         "type": "attachment",
         "attachment": {
             "name": "foobar.txt",
@@ -118,6 +124,8 @@ def test_mixed_attachments_with_processing(
         "event_id": event_id,
         "project_id": project_id,
     }
+
+    outcomes_consumer.assert_empty()
 
 
 def test_attachments_with_objectstore(

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import time
 
 import pytest
 import uuid
@@ -48,24 +47,17 @@ def test_mixed_attachments_with_processing(
 
     chunked_data_per_id = defaultdict(bytes)
     n_chunks = 0
-    inline_attachments = []
-    start = time.time()
-    while (
-        set(chunked_data_per_id.values()) != {large_content}
-        or len(inline_attachments) < 3
-    ):
-        if time.time() - start > 10:
-            raise TimeoutError()
+    attachments = {}
+    while set(chunked_data_per_id.values()) != {large_content} or len(attachments) < 3:
         _, m = attachments_consumer.get_message()
         if m["type"] == "attachment_chunk":
             chunked_data_per_id[m["id"]] += m["payload"]
             assert m["chunk_index"] == n_chunks
             n_chunks += 1
         elif m["type"] == "attachment":
-            inline_attachments.append(m)
+            attachments[m["attachment"]["name"]] = m
         else:
             raise AssertionError(f"Unexpected message type: {m['type']}")
-    inline_attachments.sort(key=lambda a: a["attachment"]["name"])
 
     assert len(chunked_data_per_id) == 1
     (foo_id,) = chunked_data_per_id
@@ -73,7 +65,7 @@ def test_mixed_attachments_with_processing(
     assert n_chunks > 1
 
     # Inlined attachment bar
-    bar = inline_attachments[0]
+    bar = attachments["bar.txt"]
     # The ID is random. Just assert that it is there and non-zero.
     assert bar["attachment"].pop("id")
     assert bar == {
@@ -91,7 +83,7 @@ def test_mixed_attachments_with_processing(
     }
 
     # Inlined metadata for chunked attachment foo
-    foo = inline_attachments[1]
+    foo = attachments["foo.txt"]
     assert foo == {
         "type": "attachment",
         "attachment": {
@@ -108,7 +100,7 @@ def test_mixed_attachments_with_processing(
     }
 
     # Empty attachment foobar
-    foobar = inline_attachments[2]
+    foobar = attachments["foobar.txt"]
     # The ID is random. Just assert that it is there and non-zero.
     assert foobar["attachment"].pop("id")
     assert foobar == {


### PR DESCRIPTION
Fix flaky test `test_mixed_attachments_with_processing` which was always failing locally for me. The fix makes the test agnostic to the order of which messages (attachment chunks and inlined attachments) arrive.

Fixes https://linear.app/getsentry/issue/INGEST-859/integ-tests-failing-locally 