### PR TITLE
ref(trim): Replace manual pop-if with pop-if

### DIFF
--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -93,13 +93,10 @@ impl Processor for TrimmingProcessor {
         _: &mut Meta,
         state: &ProcessingState<'_>,
     ) -> ProcessingResult {
-        if let Some(size_state) = self.size_state.last() {
-            // If our current depth is the one where we found a bag_size attribute, this means we
-            // are done processing a databag. Pop the bag size state.
-            if state.depth() == size_state.encountered_at_depth {
-                self.size_state.pop().unwrap();
-            }
-        }
+        // If our current depth is the one where we found a bag_size attribute, this means we
+        // are done processing a databag. Pop the bag size state.
+        self.size_state
+            .pop_if(|size_state| state.depth() == size_state.encountered_at_depth);
 
         // After processing a value, update the remaining bag sizes. We have a separate if-let
         // here in case somebody defines nested databags (a struct with bag_size that contains


### PR DESCRIPTION
https://github.com/getsentry/relay/actions/runs/24498477061/job/71598992018

```
error: manual implementation of `Vec::pop_if`
   --> relay-event-normalization/src/trimming.rs:96:9
    |
 96 |         if let Some(size_state) = self.size_state.last() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
 99 |             if state.depth() == size_state.encountered_at_depth {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
100 |                 self.size_state.pop().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#manual_pop_if
    = note: `-D clippy::manual-pop-if` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_pop_if)]`
help: try
    |
 96 -         if let Some(size_state) = self.size_state.last() {
 97 -             // If our current depth is the one where we found a bag_size attribute, this means we
 98 -             // are done processing a databag. Pop the bag size state.
 99 -             if state.depth() == size_state.encountered_at_depth {
100 -                 self.size_state.pop().unwrap();
101 -             }
102 -         }
 96 +         self.size_state.pop_if(|size_state| state.depth() == size_state.encountered_at_depth);
    |
```