### PR TITLE
ref(redis): Instrument Redis connection creation errors

### DIFF
--- a/relay-redis/src/pool.rs
+++ b/relay-redis/src/pool.rs
@@ -14,7 +14,7 @@ use crate::redis::cluster_async::ClusterConnection;
 use crate::redis::{
     Cmd, IntoConnectionInfo, Pipeline, RedisError, RedisFuture, RedisResult, Value,
 };
-use crate::statsd::RedisTimers;
+use crate::statsd::{RedisCounters, RedisTimers};
 
 use relay_statsd::metric;
 
@@ -64,7 +64,7 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
             let elapsed = start.elapsed();
 
             self.detach |= Self::should_be_detached(result.as_ref());
-            emit_metrics(result.as_ref(), elapsed, self.client_name, cmd_name(cmd));
+            emit_cmd_metrics(result.as_ref(), elapsed, self.client_name, cmd_name(cmd));
 
             result
         }
@@ -86,7 +86,7 @@ impl<C: redis::aio::ConnectionLike + Send> redis::aio::ConnectionLike for Tracke
             let elapsed = start.elapsed();
 
             self.detach |= Self::should_be_detached(result.as_ref());
-            emit_metrics(result.as_ref(), elapsed, self.client_name, "pipeline");
+            emit_cmd_metrics(result.as_ref(), elapsed, self.client_name, "pipeline");
 
             result
         }
@@ -179,10 +179,15 @@ impl Manager for CustomClusterManager {
     type Error = RedisError;
 
     async fn create(&self) -> Result<TrackedConnection<ClusterConnection>, RedisError> {
-        self.client
+        let result = self
+            .client
             .get_async_connection()
             .await
-            .map(|c| TrackedConnection::new(self.name, c))
+            .map(|c| TrackedConnection::new(self.name, c));
+
+        emit_connection_create_metric(&result, self.name);
+
+        result
     }
 
     async fn recycle(
@@ -193,6 +198,7 @@ impl Manager for CustomClusterManager {
         // If the connection is marked to be detached, we return and error, signaling that this
         // connection must be detached from the pool.
         if conn.detach {
+            emit_connection_recycle_metric(self.name);
             return Err(RecycleError::Message(
                 "the tracked connection was marked as detached".into(),
             ));
@@ -277,10 +283,15 @@ impl Manager for CustomSingleManager {
     type Error = RedisError;
 
     async fn create(&self) -> Result<TrackedConnection<MultiplexedConnection>, RedisError> {
-        self.client
+        let result = self
+            .client
             .get_multiplexed_async_connection_with_config(&self.connection_config)
             .await
-            .map(|c| TrackedConnection::new(self.name, c))
+            .map(|c| TrackedConnection::new(self.name, c));
+
+        emit_connection_create_metric(&result, self.name);
+
+        result
     }
 
     async fn recycle(
@@ -291,6 +302,7 @@ impl Manager for CustomSingleManager {
         // If the connection is marked to be detached, we return and error, signaling that this
         // connection must be detached from the pool.
         if conn.detach {
+            emit_connection_recycle_metric(self.name);
             return Err(RecycleError::Message(
                 "the tracked connection was marked as detached".into(),
             ));
@@ -306,7 +318,7 @@ impl From<Object<CustomSingleManager>> for CustomSingleConnection {
     }
 }
 
-fn emit_metrics<T>(result: Result<T, &RedisError>, elapsed: Duration, client: &str, cmd: &str) {
+fn emit_cmd_metrics<T>(result: Result<T, &RedisError>, elapsed: Duration, client: &str, cmd: &str) {
     let result = match result {
         Ok(_) => "ok",
         Err(e) if e.is_timeout() => "timeout",
@@ -329,6 +341,26 @@ fn cmd_name(cmd: &Cmd) -> &str {
         // Non exhaustive enum.
         Some(_) | None => "<unknown>",
     }
+}
+
+fn emit_connection_create_metric<T>(result: &Result<T, RedisError>, client: &str) {
+    let result = match result {
+        Ok(_) => "ok",
+        Err(_) => "error",
+    };
+
+    metric!(
+        counter(RedisCounters::CreateConnection) += 1,
+        client = client,
+        result = result,
+    )
+}
+
+fn emit_connection_recycle_metric(client: &str) {
+    metric!(
+        counter(RedisCounters::RecycleConnection) += 1,
+        client = client,
+    )
 }
 
 /// Creates TCP settings configured with tcp `nodelay` and `keepalive`.

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -133,16 +133,11 @@ impl AsyncRedisClient {
     /// Returns a new [`AsyncRedisConnection`] that can be used to execute Redis commands.
     /// The connection is automatically returned to the pool when dropped.
     pub async fn get_connection(&self) -> Result<AsyncRedisConnection, RedisError> {
-        let connection = match self {
-            Self::Cluster(pool) => {
-                AsyncRedisConnection::Cluster(pool.get().await.map_err(RedisError::Pool)?)
-            }
-            Self::Single(pool) => {
-                AsyncRedisConnection::Single(pool.get().await.map_err(RedisError::Pool)?)
-            }
-        };
-
-        Ok(connection)
+        match self {
+            Self::Cluster(pool) => pool.get().await.map(AsyncRedisConnection::Cluster),
+            Self::Single(pool) => pool.get().await.map(AsyncRedisConnection::Single),
+        }
+        .map_err(RedisError::Pool)
     }
 
     /// Returns statistics about the current state of the connection pool.

--- a/relay-redis/src/statsd.rs
+++ b/relay-redis/src/statsd.rs
@@ -1,4 +1,27 @@
-use relay_statsd::TimerMetric;
+use relay_statsd::{CounterMetric, TimerMetric};
+
+pub enum RedisCounters {
+    /// Counter incremented every time a connection is created.
+    ///
+    /// This metric is tagged with:
+    /// - `result`: Whether the connection was successfully created.
+    /// - `client`: The name of the Redis client sending the command.
+    CreateConnection,
+    /// Counter incremented every time a connection was recycled due to an error.
+    ///
+    /// This metric is tagged with:
+    /// - `client`: The name of the Redis client sending the command.
+    RecycleConnection,
+}
+
+impl CounterMetric for RedisCounters {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::CreateConnection => "redis.connection.create",
+            Self::RecycleConnection => "redis.connection.recycle",
+        }
+    }
+}
 
 pub enum RedisTimers {
     /// The time from sending a Redis command or pipeline to receiving


### PR DESCRIPTION
Adds additional Redis metrics for connections. We've observed connection failures on connect, instead of when sending the command, this shows a hole in the instrumentation which this PR is supposed to fix.

Decided to go with this slightly code duplication approach, preferred it over:
- Moving the metrics to the client `get_connection` as other metrics are emitted also at the connection level
- Having some kind of wrapper `Manager` which wraps a different manger which then adds the metrics

Refs: #5854