### PR TITLE
fix: Add missing outcomes in multipart endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Backfill `app.vitals.start.value` and `app.vitals.start.type` for V1 transactions from `app_start_cold` and `app_start_warm`, matching existing V2 behavior. ([#5883](https://github.com/getsentry/relay/pull/5883))
 - The PII rule for `token` is less strict to not always scrub usage in LLM contexts. ([#5886](https://github.com/getsentry/relay/pull/5886))
 - Respond with status code 413 when chunked multipart requests are too large. ([#5880](https://github.com/getsentry/relay/pull/5880))
+- Add missing outcomes for the Playstation, Minidump, and Attachments endpoints. ([#5866](https://github.com/getsentry/relay/pull/5866))
 
 ## 26.4.1
 

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -11,6 +11,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{AttachmentType, Envelope, Item};
 use crate::extractors::RequestMeta;
+use crate::managed::Managed;
 use crate::service::ServiceState;
 use crate::utils::{self, AttachmentStrategy, read_attachment_bytes_into_item};
 
@@ -29,24 +30,31 @@ impl AttachmentStrategy for AttachmentsAttachmentStrategy {
     fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+    ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send {
         read_attachment_bytes_into_item(field, item, config, false)
     }
 }
 
-async fn extract_envelope(
+async fn multipart_to_envelope(
     meta: RequestMeta,
     path: AttachmentPath,
     multipart: Multipart<'static>,
-    config: &Config,
+    state: &ServiceState,
 ) -> Result<Box<Envelope>, BadStoreRequest> {
-    let items = utils::multipart_items(multipart, config, AttachmentsAttachmentStrategy).await?;
+    let items = utils::multipart_items(
+        multipart,
+        state.config(),
+        state.outcome_aggregator().clone(),
+        &meta,
+        AttachmentsAttachmentStrategy,
+    )
+    .await?;
 
     let mut envelope = Envelope::from_request(Some(path.event_id), meta);
     for item in items {
-        envelope.add_item(item);
+        item.accept(|i| envelope.add_item(i));
     }
 
     Ok(envelope)
@@ -59,7 +67,7 @@ pub async fn handle(
     request: Request,
 ) -> axum::response::Result<impl IntoResponse> {
     let multipart = utils::multipart_from_request(request)?;
-    let envelope = extract_envelope(meta, path, multipart, state.config()).await?;
+    let envelope = multipart_to_envelope(meta, path, multipart, &state).await?;
     common::handle_envelope(&state, envelope)
         .await?
         .check_rate_limits()?;

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -8,7 +8,7 @@ use relay_quotas::RateLimits;
 use relay_statsd::metric;
 use serde::Deserialize;
 
-use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, Items};
+use crate::envelope::{AttachmentType, Envelope, EnvelopeError, Item, ItemType, ManagedItems};
 use crate::managed::{Managed, Rejected};
 use crate::service::ServiceState;
 use crate::services::buffer::{ProjectKeyPair, PushError};
@@ -262,7 +262,7 @@ pub fn event_id_from_formdata(data: &[u8]) -> Result<Option<EventId>, BadStoreRe
 ///
 /// Extracting the event id from chunked formdata fields on the Minidump endpoint (`sentry__1`,
 /// `sentry__2`, ...) is not supported. In this case, `None` is returned.
-pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreRequest> {
+pub fn event_id_from_items(items: &ManagedItems) -> Result<Option<EventId>, BadStoreRequest> {
     if let Some(item) = items.iter().find(|item| item.ty() == &ItemType::Event)
         && let Some(event_id) = event_id_from_json(&item.payload())?
     {

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -13,17 +13,18 @@ use std::convert::Infallible;
 use std::error::Error;
 use std::io::Cursor;
 use std::io::Read;
+use std::sync::Arc;
 use tower_http::limit::RequestBodyLimitLayer;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT};
 use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
-use crate::envelope::ContentType::Minidump;
-use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
+use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType};
 use crate::extractors::{RawContentType, RequestMeta};
+use crate::managed::{self, Managed, Meta};
 use crate::middlewares;
 use crate::service::ServiceState;
-use crate::services::outcome::{DiscardAttachmentType, DiscardItemType};
+use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason, Outcome};
 use crate::utils::{self, AttachmentStrategy, read_attachment_bytes_into_item};
 
 /// The field name of a minidump in the multipart form-data upload.
@@ -166,15 +167,28 @@ async fn extract_embedded_minidump(payload: Bytes) -> Result<Option<Bytes>, BadS
     Ok(None)
 }
 
+fn outcome_for_err(err: &BadStoreRequest) -> Option<Outcome> {
+    match err {
+        BadStoreRequest::Overflow(_) => Some(Outcome::Invalid(DiscardReason::TooLarge(
+            DiscardItemType::Attachment(DiscardAttachmentType::Minidump),
+        ))),
+        BadStoreRequest::InvalidCompressionContainer(_) => {
+            Some(Outcome::Invalid(DiscardReason::InvalidCompression))
+        }
+        BadStoreRequest::InvalidMinidump => Some(Outcome::Invalid(DiscardReason::InvalidMinidump)),
+        _ => None,
+    }
+}
+
 struct MinidumpAttachmentStrategy;
 
 impl AttachmentStrategy for MinidumpAttachmentStrategy {
     fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+    ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send {
         read_attachment_bytes_into_item(field, item, config, false)
     }
 
@@ -190,59 +204,102 @@ impl AttachmentStrategy for MinidumpAttachmentStrategy {
     }
 }
 
-async fn extract_multipart(
+async fn multipart_to_envelope(
     multipart: Multipart<'static>,
     meta: RequestMeta,
-    config: &Config,
+    state: &ServiceState,
 ) -> Result<Box<Envelope>, BadStoreRequest> {
-    let mut items = utils::multipart_items(multipart, config, MinidumpAttachmentStrategy).await?;
+    let config = state.config();
+    let mut items = utils::multipart_items(
+        multipart,
+        config,
+        state.outcome_aggregator().clone(),
+        &meta,
+        MinidumpAttachmentStrategy,
+    )
+    .await?;
 
-    let minidump_item = items
+    let Some(minidump_item) = items
         .iter_mut()
         .find(|item| item.attachment_type() == Some(AttachmentType::Minidump))
-        .ok_or(BadStoreRequest::MissingMinidump)?;
+    else {
+        managed::reject_all(
+            &items,
+            Outcome::Invalid(DiscardReason::MissingMinidumpUpload),
+        );
+        return Err(BadStoreRequest::MissingMinidump);
+    };
 
     let embedded_opt = extract_embedded_minidump(minidump_item.payload()).await?;
     if let Some(embedded) = embedded_opt {
-        minidump_item.set_payload(Minidump, embedded);
+        minidump_item.set_attachment_payload(Some(ContentType::Minidump), embedded);
     }
 
-    minidump_item.set_payload(
-        Minidump,
-        decode_minidump(minidump_item.payload(), config.max_attachment_size())?,
-    );
+    let decoded = match decode_minidump(minidump_item.payload(), config.max_attachment_size()) {
+        Ok(d) => d,
+        Err(e) => {
+            if let Some(outcome) = outcome_for_err(&e) {
+                managed::reject_all(&items, outcome);
+            }
+            return Err(e);
+        }
+    };
+    minidump_item.set_attachment_payload(Some(ContentType::Minidump), decoded);
 
-    validate_minidump(&minidump_item.payload())?;
+    match validate_minidump(&minidump_item.payload()) {
+        Ok(m) => m,
+        Err(e) => {
+            managed::reject_all(&items, Outcome::Invalid(DiscardReason::InvalidMinidump));
+            return Err(e);
+        }
+    };
 
     if let Some(minidump_filename) = minidump_item.filename() {
-        minidump_item.set_filename(remove_container_extension(minidump_filename).to_owned());
+        let filename = remove_container_extension(minidump_filename).to_owned();
+        minidump_item.modify(|inner, _records| inner.set_filename(filename));
     }
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
     let mut envelope = Envelope::from_request(Some(event_id), meta);
 
     for item in items {
-        envelope.add_item(item);
+        item.accept(|i| envelope.add_item(i));
     }
 
     Ok(envelope)
 }
 
-fn extract_raw_minidump(
+fn raw_minidump_to_envelope(
     data: Bytes,
     meta: RequestMeta,
-    max_size: usize,
+    state: &ServiceState,
 ) -> Result<Box<Envelope>, BadStoreRequest> {
     let mut item = Item::new(ItemType::Attachment);
-
-    item.set_payload(Minidump, decode_minidump(data, max_size)?);
-    validate_minidump(&item.payload())?;
     item.set_filename(MINIDUMP_FILE_NAME);
     item.set_attachment_type(AttachmentType::Minidump);
+    let outcome_meta = Arc::new(Meta::from_request_meta(
+        &meta,
+        state.outcome_aggregator().clone(),
+    ));
+    let mut item = Managed::from_parts(item, outcome_meta);
+    item.set_attachment_payload(Some(ContentType::Minidump), data.clone());
+    let payload = match decode_minidump(data, state.config().max_attachment_size()) {
+        Ok(d) => d,
+        Err(e) => {
+            if let Some(outcome) = outcome_for_err(&e) {
+                let _ = item.reject_err(outcome);
+            }
+            return Err(e);
+        }
+    };
+    item.set_attachment_payload(Some(ContentType::Minidump), payload);
+    validate_minidump(&item.payload()).inspect_err(|_| {
+        let _ = item.reject_err(Outcome::Invalid(DiscardReason::InvalidMinidump));
+    })?;
 
     // Create an envelope with a random event id.
     let mut envelope = Envelope::from_request(Some(EventId::new()), meta);
-    envelope.add_item(item);
+    item.accept(|item| envelope.add_item(item));
     Ok(envelope)
 }
 
@@ -257,12 +314,11 @@ async fn handle(
     // Minidump request payloads do not have the same structure as usual events from other SDKs. The
     // minidump can either be transmitted as request body, or as `upload_file_minidump` in a
     // multipart formdata request.
-    let config = state.config();
     let envelope = if MINIDUMP_RAW_CONTENT_TYPES.contains(&content_type.as_ref()) {
-        extract_raw_minidump(request.extract().await?, meta, config.max_attachment_size())?
+        raw_minidump_to_envelope(request.extract().await?, meta, &state)?
     } else {
         let multipart = utils::multipart_from_request(request)?;
-        extract_multipart(multipart, meta, config).await?
+        multipart_to_envelope(multipart, meta, &state).await?
     };
 
     let id = envelope.event_id();
@@ -448,9 +504,20 @@ mod tests {
         let config = Config::default();
 
         let multipart = utils::multipart_from_request(request).unwrap();
-        let items = utils::multipart_items(multipart, &config, MinidumpAttachmentStrategy)
-            .await
+        let (outcome_aggregator, _rx) = relay_system::Addr::custom();
+        let dsn = "https://a94ae32be2584e0bbd7a4cbb95971fee:@sentry.io/42"
+            .parse()
             .unwrap();
+        let meta = RequestMeta::new(dsn);
+        let items = utils::multipart_items(
+            multipart,
+            &config,
+            outcome_aggregator,
+            &meta,
+            MinidumpAttachmentStrategy,
+        )
+        .await
+        .unwrap();
 
         // we expect the multipart body to contain
         // * one arbitrary attachment from the user (a `config.json`)

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -103,7 +103,10 @@ fn decoder_from(minidump_data: Bytes) -> Option<Box<dyn Read>> {
 /// or returns the provided minidump payload untouched if no format where detected.
 ///
 /// Returns an `Overflow` error if the decompressed size exceeds `max_size`.
-fn decode_minidump(minidump_data: Bytes, max_size: usize) -> Result<Bytes, BadStoreRequest> {
+fn decode_minidump(
+    minidump_data: Bytes,
+    max_size: usize,
+) -> Result<Bytes, (BadStoreRequest, Outcome)> {
     let Some(decoder) = decoder_from(minidump_data.clone()) else {
         // this means we haven't detected any compression container
         // proceed to process the payload untouched (as a plain minidump).
@@ -115,16 +118,24 @@ fn decode_minidump(minidump_data: Bytes, max_size: usize) -> Result<Bytes, BadSt
     match run_decoder(decoder) {
         Ok(decoded) => {
             if decoded.len() > max_size {
-                return Err(BadStoreRequest::Overflow(DiscardItemType::Attachment(
-                    DiscardAttachmentType::Minidump,
-                )));
+                return Err((
+                    BadStoreRequest::Overflow(DiscardItemType::Attachment(
+                        DiscardAttachmentType::Minidump,
+                    )),
+                    Outcome::Invalid(DiscardReason::TooLarge(DiscardItemType::Attachment(
+                        DiscardAttachmentType::Minidump,
+                    ))),
+                ));
             }
             Ok(Bytes::from(decoded))
         }
         Err(err) => {
             // we detected a compression container but failed to decode it
             relay_log::trace!("invalid compression container");
-            Err(BadStoreRequest::InvalidCompressionContainer(err))
+            Err((
+                BadStoreRequest::InvalidCompressionContainer(err),
+                Outcome::Invalid(DiscardReason::InvalidCompression),
+            ))
         }
     }
 }
@@ -165,19 +176,6 @@ async fn extract_embedded_minidump(payload: Bytes) -> Result<Option<Bytes>, BadS
     }
 
     Ok(None)
-}
-
-fn outcome_for_err(err: &BadStoreRequest) -> Outcome {
-    match err {
-        BadStoreRequest::Overflow(_) => Outcome::Invalid(DiscardReason::TooLarge(
-            DiscardItemType::Attachment(DiscardAttachmentType::Minidump),
-        )),
-        BadStoreRequest::InvalidCompressionContainer(_) => {
-            Outcome::Invalid(DiscardReason::InvalidCompression)
-        }
-        BadStoreRequest::InvalidMinidump => Outcome::Invalid(DiscardReason::InvalidMinidump),
-        _ => Outcome::Invalid(DiscardReason::Internal),
-    }
 }
 
 struct MinidumpAttachmentStrategy;
@@ -238,8 +236,9 @@ async fn multipart_to_envelope(
     let decoded = match decode_minidump(minidump_item.payload(), config.max_attachment_size()) {
         Ok(d) => d,
         Err(e) => {
-            managed::reject_all(&items, outcome_for_err(&e));
-            return Err(e);
+            let (error, outcome) = e;
+            managed::reject_all(&items, outcome);
+            return Err(error);
         }
     };
     minidump_item.set_attachment_payload(Some(ContentType::Minidump), decoded);
@@ -284,8 +283,9 @@ fn raw_minidump_to_envelope(
     let payload = match decode_minidump(data, state.config().max_attachment_size()) {
         Ok(d) => d,
         Err(e) => {
-            let _ = item.reject_err(outcome_for_err(&e));
-            return Err(e);
+            let (error, outcome) = e;
+            let _ = item.reject_err(outcome);
+            return Err(error);
         }
     };
     item.set_attachment_payload(Some(ContentType::Minidump), payload);
@@ -429,7 +429,15 @@ mod tests {
 
         // With a limit smaller than the decompressed size, decoding should fail with Overflow
         let result = decode_minidump(compressed, 50);
-        assert!(matches!(result, Err(BadStoreRequest::Overflow(_))));
+        assert!(matches!(
+            result,
+            Err((
+                BadStoreRequest::Overflow(_),
+                Outcome::Invalid(DiscardReason::TooLarge(DiscardItemType::Attachment(
+                    DiscardAttachmentType::Minidump,
+                ))),
+            ))
+        ));
 
         Ok(())
     }

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -240,12 +240,9 @@ async fn multipart_to_envelope(
     };
     minidump_item.set_attachment_payload(Some(ContentType::Minidump), decoded);
 
-    match validate_minidump(&minidump_item.payload()) {
-        Ok(m) => m,
-        Err(e) => {
-            managed::reject_all(&items, Outcome::Invalid(DiscardReason::InvalidMinidump));
-            return Err(e);
-        }
+    if let Err(e) = validate_minidump(&minidump_item.payload()) {
+        managed::reject_all(&items, Outcome::Invalid(DiscardReason::InvalidMinidump));
+        return Err(e);
     };
 
     if let Some(minidump_filename) = minidump_item.filename() {

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -167,16 +167,16 @@ async fn extract_embedded_minidump(payload: Bytes) -> Result<Option<Bytes>, BadS
     Ok(None)
 }
 
-fn outcome_for_err(err: &BadStoreRequest) -> Option<Outcome> {
+fn outcome_for_err(err: &BadStoreRequest) -> Outcome {
     match err {
-        BadStoreRequest::Overflow(_) => Some(Outcome::Invalid(DiscardReason::TooLarge(
+        BadStoreRequest::Overflow(_) => Outcome::Invalid(DiscardReason::TooLarge(
             DiscardItemType::Attachment(DiscardAttachmentType::Minidump),
-        ))),
+        )),
         BadStoreRequest::InvalidCompressionContainer(_) => {
-            Some(Outcome::Invalid(DiscardReason::InvalidCompression))
+            Outcome::Invalid(DiscardReason::InvalidCompression)
         }
-        BadStoreRequest::InvalidMinidump => Some(Outcome::Invalid(DiscardReason::InvalidMinidump)),
-        _ => None,
+        BadStoreRequest::InvalidMinidump => Outcome::Invalid(DiscardReason::InvalidMinidump),
+        _ => Outcome::Invalid(DiscardReason::Internal),
     }
 }
 
@@ -238,9 +238,7 @@ async fn multipart_to_envelope(
     let decoded = match decode_minidump(minidump_item.payload(), config.max_attachment_size()) {
         Ok(d) => d,
         Err(e) => {
-            if let Some(outcome) = outcome_for_err(&e) {
-                managed::reject_all(&items, outcome);
-            }
+            managed::reject_all(&items, outcome_for_err(&e));
             return Err(e);
         }
     };
@@ -286,9 +284,7 @@ fn raw_minidump_to_envelope(
     let payload = match decode_minidump(data, state.config().max_attachment_size()) {
         Ok(d) => d,
         Err(e) => {
-            if let Some(outcome) = outcome_for_err(&e) {
-                let _ = item.reject_err(outcome);
-            }
+            let _ = item.reject_err(outcome_for_err(&e));
             return Err(e);
         }
     };

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -274,15 +274,14 @@ fn raw_minidump_to_envelope(
     ));
     let mut item = Managed::from_parts(item, outcome_meta);
     item.set_attachment_payload(Some(ContentType::Minidump), data.clone());
-    let payload = match decode_minidump(data, state.config().max_attachment_size()) {
-        Ok(d) => d,
+    match decode_minidump(data, state.config().max_attachment_size()) {
+        Ok(d) => item.set_attachment_payload(Some(ContentType::Minidump), d),
         Err(e) => {
             let (error, outcome) = e;
             let _ = item.reject_err(outcome);
             return Err(error);
         }
     };
-    item.set_attachment_payload(Some(ContentType::Minidump), payload);
     validate_minidump(&item.payload()).inspect_err(|_| {
         let _ = item.reject_err(Outcome::Invalid(DiscardReason::InvalidMinidump));
     })?;

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -118,13 +118,10 @@ fn decode_minidump(
     match run_decoder(decoder) {
         Ok(decoded) => {
             if decoded.len() > max_size {
+                let dit = DiscardItemType::Attachment(DiscardAttachmentType::Minidump);
                 return Err((
-                    BadStoreRequest::Overflow(DiscardItemType::Attachment(
-                        DiscardAttachmentType::Minidump,
-                    )),
-                    Outcome::Invalid(DiscardReason::TooLarge(DiscardItemType::Attachment(
-                        DiscardAttachmentType::Minidump,
-                    ))),
+                    BadStoreRequest::Overflow(dit),
+                    Outcome::Invalid(DiscardReason::TooLarge(dit)),
                 ));
             }
             Ok(Bytes::from(decoded))

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -21,12 +21,13 @@ use serde::Serialize;
 use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
-use crate::envelope::ContentType::{self, OctetStream};
+use crate::envelope::ContentType;
 use crate::envelope::{AttachmentPlaceholder, AttachmentType, Envelope, Item};
 use crate::extractors::{RawContentType, RequestMeta};
+use crate::managed::{self, Managed};
 use crate::middlewares;
 use crate::service::ServiceState;
-use crate::services::outcome::DiscardReason;
+use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::projects::cache::Project;
 use crate::services::upload::{Create, Stream, Upload};
 use crate::utils::{self, MeteredStream};
@@ -90,9 +91,9 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
     async fn add_to_item(
         &self,
         field: Field<'static>,
-        mut item: Item,
+        mut item: Managed<Item>,
         config: &Config,
-    ) -> Result<Option<Item>, multer::Error> {
+    ) -> Result<Option<Managed<Item>>, multer::Error> {
         let upload = match self.upload_service {
             Some(upload) if self.infer_type(&field) != AttachmentType::Prosperodump => upload,
             _ => return utils::read_attachment_bytes_into_item(field, item, config, true).await,
@@ -131,8 +132,8 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
                 content_type: content_type.as_ref().map(|c| c.to_string()),
             })
         {
-            item.set_payload(ContentType::AttachmentRef, payload);
-            item.set_attachment_length(byte_counter.get());
+            let byte_count = byte_counter.get();
+            item.set_attachment_ref_placeholder(payload, byte_count);
             Ok(Some(item))
         } else {
             Ok(None)
@@ -157,11 +158,11 @@ fn validate_prosperodump(data: &[u8]) -> Result<(), BadStoreRequest> {
     Ok(())
 }
 
-async fn extract_multipart(
+async fn multipart_to_envelope(
     multipart: Multipart<'static>,
     meta: RequestMeta,
-    state: &ServiceState,
     project: &Project<'_>,
+    state: &ServiceState,
 ) -> Result<Box<Envelope>, BadStoreRequest> {
     let project_config = project
         .state()
@@ -184,22 +185,36 @@ async fn extract_multipart(
         scoping,
         upload_service,
     };
-    let mut items = utils::multipart_items(multipart, state.config(), attachment_strategy).await?;
+    let mut items = utils::multipart_items(
+        multipart,
+        state.config(),
+        state.outcome_aggregator().clone(),
+        &meta,
+        attachment_strategy,
+    )
+    .await?;
 
-    let prosperodump_item = items
+    let Some(prosperodump_item) = items
         .iter_mut()
         .find(|item| item.attachment_type() == Some(AttachmentType::Prosperodump))
-        .ok_or(BadStoreRequest::MissingProsperodump)?;
+    else {
+        managed::reject_all(
+            &items,
+            Outcome::Invalid(DiscardReason::MissingProsperodumpUpload),
+        );
+        return Err(BadStoreRequest::MissingProsperodump);
+    };
+    prosperodump_item
+        .set_attachment_payload(Some(ContentType::OctetStream), prosperodump_item.payload());
 
-    prosperodump_item.set_payload(OctetStream, prosperodump_item.payload());
-
-    validate_prosperodump(&prosperodump_item.payload())?;
+    validate_prosperodump(&prosperodump_item.payload()).inspect_err(|_| {
+        managed::reject_all(&items, Outcome::Invalid(DiscardReason::InvalidProsperodump));
+    })?;
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
     let mut envelope = Envelope::from_request(Some(event_id), meta);
-
     for item in items {
-        envelope.add_item(item);
+        item.accept(|i| envelope.add_item(i));
     }
 
     Ok(envelope)
@@ -224,7 +239,7 @@ async fn handle(
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
     let multipart = utils::multipart_from_request(request)?;
-    let mut envelope = extract_multipart(multipart, meta, &state, &project).await?;
+    let mut envelope = multipart_to_envelope(multipart, meta, &project, &state).await?;
     envelope.require_feature(Feature::PlaystationIngestion);
 
     let id = envelope.event_id();

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -127,13 +127,13 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
             })
             && let Ok(location) = location.into_header_value()
             && let Ok(location) = location.to_str()
-            && let Ok(payload) = serde_json::to_vec(&AttachmentPlaceholder {
+            && let Ok(placeholder) = serde_json::to_vec(&AttachmentPlaceholder {
                 location,
                 content_type: content_type.as_ref().map(|c| c.to_string()),
             })
         {
-            let byte_count = byte_counter.get();
-            item.set_attachment_ref_placeholder(payload, byte_count);
+            let attachment_size = byte_counter.get();
+            item.set_attachment_ref_placeholder(placeholder, attachment_size);
             Ok(Some(item))
         } else {
             Ok(None)

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -12,6 +12,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::envelope::{AttachmentType, ContentType, EnvelopeError};
 use crate::integrations::{Integration, LogsIntegration, SpansIntegration};
+use crate::managed::Managed;
 use crate::statsd::RelayTimers;
 
 #[derive(Clone, Debug)]
@@ -773,6 +774,7 @@ impl Item {
 }
 
 pub type Items = SmallVec<[Item; 3]>;
+pub type ManagedItems = SmallVec<[Managed<Item>; 3]>;
 pub type ItemIter<'a> = std::slice::Iter<'a, Item>;
 pub type ItemIterMut<'a> = std::slice::IterMut<'a, Item>;
 

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -8,6 +8,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use itertools::Either;
 use relay_event_schema::protocol::EventId;
@@ -16,6 +17,8 @@ use relay_system::Addr;
 use smallvec::SmallVec;
 
 use crate::Envelope;
+use crate::envelope::{ContentType, Item, ItemType};
+use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
@@ -156,6 +159,41 @@ impl Managed<Box<Envelope>> {
         });
 
         Self::from_parts(envelope, meta)
+    }
+}
+
+impl Managed<Item> {
+    /// Set the payload of an attachment item and update the outcome records to reflect the new size.
+    pub fn set_attachment_payload(&mut self, ct: Option<ContentType>, payload: impl Into<Bytes>) {
+        if *self.ty() != ItemType::Attachment {
+            relay_log::warn!("Managed::set_attachment_payload was called on non-attachment.");
+            return;
+        }
+        self.modify(|inner, records| {
+            let old = inner.attachment_body_size() as isize;
+            if let Some(ct) = ct {
+                inner.set_payload(ct, payload);
+            } else {
+                inner.set_payload_without_content_type(payload);
+            };
+            let new = inner.attachment_body_size() as isize;
+            records.modify_by(DataCategory::Attachment, new - old);
+        });
+    }
+
+    /// Set the placeholder of an `AttachmentRef` item and update the outcome records accordingly.
+    pub fn set_attachment_ref_placeholder(
+        &mut self,
+        placeholder: impl Into<Bytes>,
+        attachment_size: usize,
+    ) {
+        self.modify(|inner, records| {
+            let old = inner.attachment_body_size() as isize;
+            inner.set_payload(ContentType::AttachmentRef, placeholder);
+            inner.set_attachment_length(attachment_size);
+            let new = inner.attachment_body_size() as isize;
+            records.modify_by(DataCategory::Attachment, new - old);
+        });
     }
 }
 
@@ -565,6 +603,15 @@ impl<T: Counted> Managed<T> {
         Rejected(error)
     }
 
+    /// Creates a new [`Managed`] instance.
+    pub(crate) fn from_parts(value: T, meta: Arc<Meta>) -> Self {
+        Self {
+            value,
+            meta,
+            done: AtomicBool::new(false),
+        }
+    }
+
     fn do_reject(&self, outcome: Option<Outcome>) {
         // Always set the internal state to `done`, even if there is no outcome to be emitted.
         // All bookkeeping has been done.
@@ -617,14 +664,6 @@ impl<T: Counted> Managed<T> {
         );
 
         (value, meta)
-    }
-
-    fn from_parts(value: T, meta: Arc<Meta>) -> Self {
-        Self {
-            value,
-            meta,
-            done: AtomicBool::new(false),
-        }
     }
 
     fn is_done(&self) -> bool {
@@ -695,9 +734,9 @@ impl<T: Counted> std::ops::Deref for Managed<T> {
     }
 }
 
-/// Internal metadata attached with a [`Managed`] instance.
+/// Metadata attached to a [`Managed`] instance.
 #[derive(Debug, Clone)]
-struct Meta {
+pub(crate) struct Meta {
     /// Outcome aggregator service.
     outcome_aggregator: Addr<TrackOutcome>,
     /// Received timestamp, when the contained payload/information was received.
@@ -713,7 +752,21 @@ struct Meta {
 }
 
 impl Meta {
-    pub fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
+    /// Creates a `Meta` instance from a request's meta
+    pub(crate) fn from_request_meta(
+        request_meta: &RequestMeta,
+        outcome_aggregator: Addr<TrackOutcome>,
+    ) -> Meta {
+        Meta {
+            outcome_aggregator,
+            received_at: request_meta.received_at(),
+            scoping: request_meta.get_partial_scoping().into_scoping(),
+            event_id: None,
+            remote_addr: request_meta.remote_addr(),
+        }
+    }
+
+    fn track_outcome(&self, outcome: Outcome, category: DataCategory, quantity: usize) {
         self.outcome_aggregator.send(TrackOutcome {
             timestamp: self.received_at,
             scoping: self.scoping,
@@ -883,11 +936,11 @@ impl<'a> RecordKeeper<'a> {
                 Some(c) if *c >= *quantity => *c -= *quantity,
                 Some(c) => emit!(
                     category,
-                    "New item has {quantity} items in category '{category}', but original (after emitted outcomes) only has {c} left"
+                    "New item has quantity {quantity} in category '{category}', but original (after emitted outcomes) only has {c} left"
                 ),
                 None => emit!(
                     category,
-                    "New item has {quantity} items in category '{category}', but after emitted outcomes there are none left"
+                    "New item has quantity {quantity} in category '{category}', but after emitted outcomes there are none left"
                 ),
             }
         }
@@ -1083,6 +1136,13 @@ where
     I: Iterator<Item = S> + FusedIterator,
     S: Counted,
 {
+}
+
+/// Call [`Managed::reject_err`] with the specified error for each item.
+pub fn reject_all(managed_items: &[Managed<impl Counted>], error: impl OutcomeError + Clone) {
+    for item in managed_items {
+        let _ = item.reject_err(error.clone());
+    }
 }
 
 #[cfg(test)]

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -604,7 +604,7 @@ impl<T: Counted> Managed<T> {
     }
 
     /// Creates a new [`Managed`] instance.
-    pub(crate) fn from_parts(value: T, meta: Arc<Meta>) -> Self {
+    pub fn from_parts(value: T, meta: Arc<Meta>) -> Self {
         Self {
             value,
             meta,
@@ -736,7 +736,7 @@ impl<T: Counted> std::ops::Deref for Managed<T> {
 
 /// Metadata attached to a [`Managed`] instance.
 #[derive(Debug, Clone)]
-pub(crate) struct Meta {
+pub struct Meta {
     /// Outcome aggregator service.
     outcome_aggregator: Addr<TrackOutcome>,
     /// Received timestamp, when the contained payload/information was received.
@@ -753,7 +753,7 @@ pub(crate) struct Meta {
 
 impl Meta {
     /// Creates a `Meta` instance from a request's meta
-    pub(crate) fn from_request_meta(
+    pub fn from_request_meta(
         request_meta: &RequestMeta,
         outcome_aggregator: Addr<TrackOutcome>,
     ) -> Meta {

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -377,6 +377,12 @@ pub enum DiscardReason {
     /// since it resolves the project first, and then checks for the valid project key.
     MultiProjectId,
 
+    /// (Relay) A request was made to the playstation endpoint without a prosperodump file.
+    MissingProsperodumpUpload,
+
+    /// (Relay) The file submitted as prosperodump is not a valid prosperodump file.
+    InvalidProsperodump,
+
     /// (Relay) A minidump file was missing for the minidump endpoint.
     MissingMinidumpUpload,
 
@@ -509,6 +515,8 @@ impl DiscardReason {
             DiscardReason::DisallowedMethod => "disallowed_method",
             DiscardReason::ContentType => "content_type",
             DiscardReason::MultiProjectId => "multi_project_id",
+            DiscardReason::MissingProsperodumpUpload => "missing_prosperodump_upload",
+            DiscardReason::InvalidProsperodump => "invalid_prosperodump",
             DiscardReason::MissingMinidumpUpload => "missing_minidump_upload",
             DiscardReason::InvalidMinidump => "invalid_minidump",
             DiscardReason::SecurityReportType => "security_report_type",

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -368,8 +368,8 @@ mod tests {
         assert!(multipart.next_field().await.unwrap().is_none());
     }
 
-    fn test_request_meta() -> RequestMeta {
-        let dsn = "https://a94ae32be2584e0bbd7a4cbb95971fee:@sentry.io/42"
+    fn mock_request_meta() -> RequestMeta {
+        let dsn = "https://a94ae32be2582e0bbd7a4cbb95971fee:@sentry.io/42"
             .parse()
             .unwrap();
         RequestMeta::new(dsn)
@@ -417,7 +417,7 @@ mod tests {
         }
 
         let (outcome_aggregator, _rx) = Addr::custom();
-        let meta = test_request_meta();
+        let meta = mock_request_meta();
         let res = multipart_items(
             multipart,
             &config,
@@ -472,7 +472,7 @@ mod tests {
         }
 
         let (outcome_aggregator, _rx) = Addr::custom();
-        let meta = test_request_meta();
+        let meta = mock_request_meta();
         let result = multipart_items(
             multipart,
             config,

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -241,7 +241,20 @@ pub async fn multipart_items(
             item.set_attachment_type(attachment_type);
             item.set_filename(file_name);
             let item = Managed::from_parts(item, outcome_meta.clone());
-            let item = attachment_strategy.add_to_item(field, item, config).await?;
+            let item = attachment_strategy
+                .add_to_item(field, item, config)
+                .await
+                .inspect_err(|e| {
+                    if let multer::Error::FieldSizeExceeded { .. } = e {
+                        let dat = DiscardAttachmentType::from(attachment_type);
+                        managed::reject_all(
+                            &items,
+                            Outcome::Invalid(DiscardReason::TooLarge(DiscardItemType::Attachment(
+                                dat,
+                            ))),
+                        )
+                    }
+                })?;
             if let Some(item) = item {
                 // This increases the attachments byte count even if the item is an attachment ref.
                 // This is by design as the total number of bytes read into memory should be

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -1,17 +1,24 @@
 use std::future::Future;
 use std::io;
+use std::sync::Arc;
 
 use axum::extract::Request;
 use bytes::Bytes;
 use futures::TryStreamExt;
 use multer::{Field, Multipart};
 use relay_config::Config;
+use relay_system::Addr;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncReadExt;
 use tokio_util::io::StreamReader;
 
 use crate::endpoints::common::BadStoreRequest;
-use crate::envelope::{AttachmentType, ContentType, Item, ItemType, Items};
+use crate::envelope::{AttachmentType, ContentType, Item, ItemType, ManagedItems};
+use crate::extractors::RequestMeta;
+use crate::managed::{self, Managed, Meta};
+use crate::services::outcome::{
+    DiscardAttachmentType, DiscardItemType, DiscardReason, Outcome, TrackOutcome,
+};
 
 /// Type used for encoding string lengths.
 type Len = u32;
@@ -174,18 +181,20 @@ pub trait AttachmentStrategy {
     fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send;
 }
 
 pub async fn read_attachment_bytes_into_item(
     field: Field<'static>,
-    mut item: Item,
+    mut item: Managed<Item>,
     config: &Config,
     ignore_size_exceeded: bool,
-) -> Result<Option<Item>, multer::Error> {
-    let content_type = field.content_type().cloned();
+) -> Result<Option<Managed<Item>>, multer::Error> {
+    let content_type = field
+        .content_type()
+        .map(|ct| ct.as_ref().parse().unwrap_or(ContentType::OctetStream));
     let field_name = field.name().map(String::from);
     let limit = config.max_attachment_size();
     let mut buf = Vec::new();
@@ -194,7 +203,14 @@ pub async fn read_attachment_bytes_into_item(
         .read_to_end(&mut buf)
         .await
         .map_err(|e| multer::Error::StreamReadFailed(Box::new(e)))?;
-    if buf.len() > limit {
+    let bytes = Bytes::from(buf);
+    let n_bytes = bytes.len();
+    item.set_attachment_payload(content_type, bytes);
+    if n_bytes > limit {
+        let attachment_type = item.attachment_type().unwrap_or(AttachmentType::Attachment);
+        let _ = item.reject_err(Outcome::Invalid(DiscardReason::TooLarge(
+            DiscardItemType::Attachment(DiscardAttachmentType::from(attachment_type)),
+        )));
         return match ignore_size_exceeded {
             true => Ok(None),
             false => Err(multer::Error::FieldSizeExceeded {
@@ -203,27 +219,20 @@ pub async fn read_attachment_bytes_into_item(
             }),
         };
     }
-    let bytes = Bytes::from(buf);
-    if let Some(content_type) = content_type {
-        let ct = content_type
-            .as_ref()
-            .parse()
-            .unwrap_or(ContentType::OctetStream);
-        item.set_payload(ct, bytes);
-    } else {
-        item.set_payload_without_content_type(bytes);
-    }
     Ok(Some(item))
 }
 
 pub async fn multipart_items(
     mut multipart: Multipart<'static>,
     config: &Config,
+    outcome_aggregator: Addr<TrackOutcome>,
+    request_meta: &RequestMeta,
     attachment_strategy: impl AttachmentStrategy,
-) -> Result<Items, multer::Error> {
-    let mut items = Items::new();
+) -> Result<ManagedItems, multer::Error> {
+    let mut items = ManagedItems::new();
     let mut form_data = FormDataWriter::new();
     let mut attachments_size = 0;
+    let outcome_meta = Arc::new(Meta::from_request_meta(request_meta, outcome_aggregator));
 
     while let Some(field) = multipart.next_field().await? {
         if let Some(file_name) = field.file_name() {
@@ -231,18 +240,25 @@ pub async fn multipart_items(
             let attachment_type = attachment_strategy.infer_type(&field);
             item.set_attachment_type(attachment_type);
             item.set_filename(file_name);
+            let item = Managed::from_parts(item, outcome_meta.clone());
             let item = attachment_strategy.add_to_item(field, item, config).await?;
             if let Some(item) = item {
                 // This increases the attachments byte count even if the item is an attachment ref.
                 // This is by design as the total number of bytes read into memory should be
                 // constrained.
                 attachments_size += item.len();
+                items.push(item);
                 if attachments_size > config.max_attachments_size() {
+                    managed::reject_all(
+                        &items,
+                        Outcome::Invalid(DiscardReason::TooLarge(DiscardItemType::Attachment(
+                            DiscardAttachmentType::Attachment,
+                        ))),
+                    );
                     return Err(multer::Error::StreamSizeExceeded {
                         limit: config.max_attachments_size() as u64,
                     });
                 }
-                items.push(item);
             }
         } else if let Some(field_name) = field.name().map(str::to_owned) {
             // Ensure to decode this SAFELY to match Django's POST data behavior. This allows us to
@@ -260,6 +276,7 @@ pub async fn multipart_items(
         // Content type is `Text` (since it is not a json object but multiple
         // json arrays serialized one after the other).
         item.set_payload(ContentType::Text, form_data);
+        let item = Managed::from_parts(item, outcome_meta);
         items.push(item);
     }
 
@@ -351,6 +368,13 @@ mod tests {
         assert!(multipart.next_field().await.unwrap().is_none());
     }
 
+    fn test_request_meta() -> RequestMeta {
+        let dsn = "https://a94ae32be2584e0bbd7a4cbb95971fee:@sentry.io/42"
+            .parse()
+            .unwrap();
+        RequestMeta::new(dsn)
+    }
+
     #[tokio::test]
     async fn test_individual_size_limit_exceeded() {
         let data = "--X-BOUNDARY\r\n\
@@ -380,9 +404,10 @@ mod tests {
             fn add_to_item(
                 &self,
                 field: Field<'static>,
-                item: Item,
+                item: Managed<Item>,
                 config: &Config,
-            ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+            ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send
+            {
                 read_attachment_bytes_into_item(field, item, config, false)
             }
 
@@ -391,7 +416,16 @@ mod tests {
             }
         }
 
-        let res = multipart_items(multipart, &config, MockAttachmentStrategy).await;
+        let (outcome_aggregator, _rx) = Addr::custom();
+        let meta = test_request_meta();
+        let res = multipart_items(
+            multipart,
+            &config,
+            outcome_aggregator,
+            &meta,
+            MockAttachmentStrategy,
+        )
+        .await;
         assert!(res.is_err_and(|x| matches!(x, multer::Error::FieldSizeExceeded { .. })));
     }
 
@@ -425,9 +459,10 @@ mod tests {
             fn add_to_item(
                 &self,
                 field: Field<'static>,
-                item: Item,
+                item: Managed<Item>,
                 config: &Config,
-            ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+            ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send
+            {
                 read_attachment_bytes_into_item(field, item, config, true)
             }
 
@@ -436,7 +471,16 @@ mod tests {
             }
         }
 
-        let result = multipart_items(multipart, config, MockAttachmentStrategy).await;
+        let (outcome_aggregator, _rx) = Addr::custom();
+        let meta = test_request_meta();
+        let result = multipart_items(
+            multipart,
+            config,
+            outcome_aggregator,
+            &meta,
+            MockAttachmentStrategy,
+        )
+        .await;
 
         // Should be warned if the overall stream limit is being breached.
         assert!(result.is_err_and(|x| matches!(x, multer::Error::StreamSizeExceeded { limit: _ })));

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -667,11 +667,9 @@ def test_minidump_invalid_compression_outcome(
     mini_sentry.add_full_project_config(project_id)
     outcomes_consumer = outcomes_consumer()
     relay = relay_with_processing()
-
-    # Gzip magic bytes followed by garbage triggers the gzip decoder but
-    # fails decoding, hitting the InvalidCompressionContainer path.
     content = b"\x1f\x8b" + b"not a valid gzip stream"
     attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp.gz", content)]
+
     with pytest.raises(HTTPError) as exc_info:
         relay.send_minidump(project_id=project_id, files=attachments)
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from urllib3.filepost import encode_multipart_formdata
 
 from sentry_relay.consts import DataCategory
+from .asserts import time_within_delta
 from .test_attachment_ref import upload_and_make_ref
 
 MINIDUMP_ATTACHMENT_NAME = "upload_file_minidump"
@@ -277,30 +278,68 @@ def test_minidump_invalid_json(mini_sentry, relay):
     assert_only_minidump(envelope)
 
 
-def test_minidump_invalid_magic(mini_sentry, relay):
+def test_minidump_invalid_magic(mini_sentry, relay_with_processing, outcomes_consumer):
     project_id = 42
-    relay = relay(mini_sentry)
     mini_sentry.add_full_project_config(project_id)
+    outcomes_consumer = outcomes_consumer()
+    relay = relay_with_processing()
 
-    attachments = [
-        (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "content without MDMP magic"),
-    ]
-
-    with pytest.raises(HTTPError):
+    content = b"content without MDMP magic"
+    attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", content)]
+    with pytest.raises(HTTPError) as exc_info:
         relay.send_minidump(project_id=project_id, files=attachments)
 
-
-def test_minidump_invalid_field(mini_sentry, relay):
-    project_id = 42
-    relay = relay(mini_sentry)
-    mini_sentry.add_full_project_config(project_id)
-
-    attachments = [
-        ("unknown_field_name", "minidump.dmp", "MDMP content"),
+    assert exc_info.value.response.status_code == 400
+    assert outcomes_consumer.get_outcomes() == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "invalid_minidump",
+            "category": DataCategory.ATTACHMENT.value,
+            "quantity": len(content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "invalid_minidump",
+            "category": DataCategory.ATTACHMENT_ITEM.value,
+            "quantity": 1,
+        },
     ]
 
-    with pytest.raises(HTTPError):
+
+def test_minidump_invalid_field(mini_sentry, relay_with_processing, outcomes_consumer):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    outcomes_consumer = outcomes_consumer()
+    relay = relay_with_processing()
+
+    content = b"MDMP content"
+    attachments = [("unknown_field_name", "minidump.dmp", content)]
+    with pytest.raises(HTTPError) as exc_info:
         relay.send_minidump(project_id=project_id, files=attachments)
+
+    assert exc_info.value.response.status_code == 400
+    assert outcomes_consumer.get_outcomes() == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "missing_minidump_upload",
+            "category": DataCategory.ATTACHMENT.value,
+            "quantity": len(content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "missing_minidump_upload",
+            "category": DataCategory.ATTACHMENT_ITEM.value,
+            "quantity": 1,
+        },
+    ]
 
 
 @pytest.mark.parametrize(
@@ -573,6 +612,88 @@ def test_minidump_with_processing_invalid(
             "retention_days": 90,
             "chunks": num_chunks,
         }
+    ]
+
+
+def test_minidump_max_attachment_size_exceeded(
+    mini_sentry, relay_with_processing, outcomes_consumer
+):
+    project_id = 42
+    dmp_path = os.path.join(os.path.dirname(__file__), "fixtures/native/minidump.dmp")
+    with open(dmp_path, "rb") as f:
+        content = f.read()
+
+    mini_sentry.add_full_project_config(project_id)
+    outcomes_consumer = outcomes_consumer()
+    relay = relay_with_processing(
+        {
+            "limits": {
+                "max_attachment_size": len(content) - 1,
+                "max_attachments_size": 1000 * 1024 * 1024,
+            }
+        }
+    )
+
+    attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", content)]
+    with pytest.raises(HTTPError) as exc_info:
+        relay.send_minidump(project_id=project_id, files=attachments)
+
+    assert exc_info.value.response.status_code == 400
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:minidump",
+            "category": DataCategory.ATTACHMENT.value,
+            "quantity": len(content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:minidump",
+            "category": DataCategory.ATTACHMENT_ITEM.value,
+            "quantity": 1,
+        },
+    ]
+
+
+def test_minidump_invalid_compression_outcome(
+    mini_sentry, relay_with_processing, outcomes_consumer
+):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    outcomes_consumer = outcomes_consumer()
+    relay = relay_with_processing()
+
+    # Gzip magic bytes followed by garbage triggers the gzip decoder but
+    # fails decoding, hitting the InvalidCompressionContainer path.
+    content = b"\x1f\x8b" + b"not a valid gzip stream"
+    attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp.gz", content)]
+    with pytest.raises(HTTPError) as exc_info:
+        relay.send_minidump(project_id=project_id, files=attachments)
+
+    assert exc_info.value.response.status_code == 400
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "invalid_compression",
+            "category": DataCategory.ATTACHMENT.value,
+            "quantity": len(content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "invalid_compression",
+            "category": DataCategory.ATTACHMENT_ITEM.value,
+            "quantity": 1,
+        },
     ]
 
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -621,20 +621,24 @@ def test_minidump_max_attachment_size_exceeded(
     project_id = 42
     dmp_path = os.path.join(os.path.dirname(__file__), "fixtures/native/minidump.dmp")
     with open(dmp_path, "rb") as f:
-        content = f.read()
+        minidump_content = f.read()
+    attachment_content = b"yo"
 
     mini_sentry.add_full_project_config(project_id)
     outcomes_consumer = outcomes_consumer()
     relay = relay_with_processing(
         {
             "limits": {
-                "max_attachment_size": len(content) - 1,
+                "max_attachment_size": len(minidump_content) - 1,
                 "max_attachments_size": 1000 * 1024 * 1024,
             }
         }
     )
 
-    attachments = [(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", content)]
+    attachments = [
+        ("attachment1", "attach1.txt", attachment_content),
+        (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", minidump_content),
+    ]
     with pytest.raises(HTTPError) as exc_info:
         relay.send_minidump(project_id=project_id, files=attachments)
 
@@ -647,7 +651,23 @@ def test_minidump_max_attachment_size_exceeded(
             "outcome": 3,
             "reason": "too_large:attachment:minidump",
             "category": DataCategory.ATTACHMENT.value,
-            "quantity": len(content),
+            "quantity": len(minidump_content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:minidump",
+            "category": DataCategory.ATTACHMENT_ITEM.value,
+            "quantity": 1,
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:minidump",
+            "category": DataCategory.ATTACHMENT.value,
+            "quantity": len(attachment_content),
         },
         {
             "timestamp": time_within_delta(),

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -267,7 +267,7 @@ def test_playstation_no_feature_flag(
     ]
 
 
-def test_playstation_wrong_file(
+def test_playstation_invalid_prosperodump(
     mini_sentry, relay_processing_with_playstation, outcomes_consumer
 ):
     PROJECT_ID = 42
@@ -282,6 +282,62 @@ def test_playstation_wrong_file(
     response = exc_info.value.response
     assert response.status_code == 400, "Expected a 400 status code"
     assert response.json()["detail"] == "invalid prosperodump"
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "invalid_prosperodump",
+            "category": 4,
+            "quantity": len(playstation_dump),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "invalid_prosperodump",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
+
+
+def test_playstation_missing_prosperodump(
+    mini_sentry, relay_processing_with_playstation, outcomes_consumer
+):
+    PROJECT_ID = 42
+    video_content = b"yo"
+    prosperodump = None
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
+    outcomes_consumer = outcomes_consumer()
+    relay = relay_processing_with_playstation()
+
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        _ = relay.send_playstation_request(PROJECT_ID, prosperodump, video_content)
+
+    response = exc_info.value.response
+    assert response.status_code == 400, "Expected a 400 status code"
+    assert response.json()["detail"] == "missing prosperodump"
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "missing_prosperodump_upload",
+            "category": 4,
+            "quantity": len(video_content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "missing_prosperodump_upload",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_playstation_max_attachments_size_exceeded(
@@ -306,7 +362,25 @@ def test_playstation_max_attachments_size_exceeded(
     response = exc_info.value.response
     assert response.status_code == 413, response.json()
     assert response.json() == {"detail": "request content exceeded size limits"}
-    outcomes_consumer.assert_empty()
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:attachment",
+            "category": 4,
+            "quantity": len(playstation_dump),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:attachment",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_playstation_max_attachment_size_exceeded(
@@ -330,7 +404,25 @@ def test_playstation_max_attachment_size_exceeded(
 
     response = exc_info.value.response
     assert response.status_code == 400, "Expected a 400 status code"
-    assert len(outcomes_consumer.get_outcomes()) == 0
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:prosperodump",
+            "category": 4,
+            "quantity": len(playstation_dump),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "too_large:attachment:prosperodump",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_playstation_max_stream_size_exceeded(


### PR DESCRIPTION
Add missing outcomes across endpoints using multiparts (playstation, minidump, attachments) by wrapping items `Managed`. Where possible inside each endpoint, use more detailed `DiscardReasons` instead of the default `Internal`.

Fixes https://linear.app/getsentry/issue/INGEST-786/missing-outcome-in-playstation-endpoint
