### PR TITLE
test(minidump): Return 413 on size limit

### DIFF
--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -417,7 +417,13 @@ class SentryLike:
         return response
 
     def send_minidump(
-        self, project_id, params=None, files=None, dsn_key_idx=0, raise_for_status=True
+        self,
+        project_id,
+        params=None,
+        files=None,
+        *,
+        dsn_key_idx=0,
+        raise_for_status=True,
     ):
         """
         :param project_id: the project id
@@ -526,7 +532,9 @@ class SentryLike:
         response.raise_for_status()
         return response
 
-    def send_attachments(self, project_id, event_id, files, dsn_key_idx=0):
+    def send_attachments(
+        self, project_id, event_id, files, *, dsn_key_idx=0, raise_for_status=True
+    ):
         files = {
             name: (file_name, file_content) for (name, file_name, file_content) in files
         }
@@ -545,7 +553,8 @@ class SentryLike:
             },
             files=files,
         )
-        response.raise_for_status()
+        if raise_for_status:
+            response.raise_for_status()
         return response
 
     def send_check_in(self, project_id, check_in):

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -416,7 +416,9 @@ class SentryLike:
         response.raise_for_status()
         return response
 
-    def send_minidump(self, project_id, params=None, files=None, dsn_key_idx=0):
+    def send_minidump(
+        self, project_id, params=None, files=None, dsn_key_idx=0, raise_for_status=True
+    ):
         """
         :param project_id: the project id
         :param params: a list of tuples (param_name, param_value)
@@ -446,7 +448,8 @@ class SentryLike:
             files=all_files,
         )
 
-        response.raise_for_status()
+        if raise_for_status:
+            response.raise_for_status()
         return response
 
     def send_unreal_request(self, project_id, file_content, dsn_key_idx=0):

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -454,9 +454,7 @@ password=mysupersecretpassword123"""
 
     scrubbed_payload = mini_sentry.get_captured_envelope().items[0].payload.bytes
 
-    assert (
-        scrubbed_payload
-        == rb"""Alice Johnson
+    assert scrubbed_payload == rb"""Alice Johnson
 *************************
 +1234567890
 4111 1111 1111 1111
@@ -465,7 +463,6 @@ Charlie Brown ************************* +1928374650 3782 822463 10005
 Dana White ************************ +1029384756 6011 0009 9013 9424
 path=c:\Users\***\mylogfile.txt
 password=mysupersecretpassword123"""
-    )
 
 
 def test_attachments_quotas(
@@ -766,3 +763,23 @@ def test_form_data_is_rejected(
 
     # Verify no more attachments were processed
     attachments_consumer.assert_empty()
+
+
+@pytest.mark.parametrize(
+    "limit,expected_status_code",
+    [("max_attachment_size", 400), ("max_attachments_size", 413)],
+)
+def test_size_limits(mini_sentry, relay, limit, expected_status_code):
+    proj_id = 42
+    relay = relay(mini_sentry, {"limits": {limit: 10}})
+    mini_sentry.add_full_project_config(proj_id)
+
+    event_id = "515539018c9b4260a6f999572f1661ee"
+    response = relay.send_attachments(
+        proj_id,
+        event_id,
+        [("some_field", "myfile.txt", "hello world!")],
+        raise_for_status=False,
+    )
+
+    assert response.status_code == expected_status_code

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -789,8 +789,11 @@ def test_minidump_placeholder(
     assert objectstore_session.get(stored_id).payload.read() == minidump_data
 
 
-@pytest.mark.parametrize("limit", ["max_attachment_size", "max_attachments_size"])
-def test_minidump_multipart_too_large(mini_sentry, relay, limit):
+@pytest.mark.parametrize(
+    "limit,expected_status_code",
+    [("max_attachment_size", 400), ("max_attachments_size", 413)],
+)
+def test_size_limits(mini_sentry, relay, limit, expected_status_code):
     project_id = 42
     relay = relay(
         mini_sentry,
@@ -814,4 +817,4 @@ def test_minidump_multipart_too_large(mini_sentry, relay, limit):
     response = relay.send_minidump(
         project_id=project_id, files=attachments, params=params, raise_for_status=False
     )
-    assert response.status_code == 413
+    assert response.status_code == expected_status_code

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -787,3 +787,31 @@ def test_minidump_placeholder(
     stored_id = attachment["stored_id"]
     objectstore_session = objectstore("attachments", project_id)
     assert objectstore_session.get(stored_id).payload.read() == minidump_data
+
+
+@pytest.mark.parametrize("limit", ["max_attachment_size", "max_attachments_size"])
+def test_minidump_multipart_too_large(mini_sentry, relay, limit):
+    project_id = 42
+    relay = relay(
+        mini_sentry,
+        {
+            "limits": {
+                limit: 10,
+            }
+        },
+    )
+    mini_sentry.add_full_project_config(project_id)
+
+    attachments = [
+        (MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content"),
+    ]
+
+    params = [
+        ("sentry[event_id]", "2dd132e467174db48dbaddabd3cbed57"),
+        ("sentry[user][id]", "123"),
+    ]
+
+    response = relay.send_minidump(
+        project_id=project_id, files=attachments, params=params, raise_for_status=False
+    )
+    assert response.status_code == 413


### PR DESCRIPTION
Document the fact that the minidump multipart endpoint now acts the same as the attachments endpoint (fixed in https://github.com/getsentry/relay/pull/5827): 

1. Violation of the single attachment limit results in a 400 response,
2. Violation of the total attachment limit results in a 413 response

Closes https://github.com/getsentry/relay/issues/5838 