### PR TITLE
fix(objectstore): Do not apply default timeout to streams

### DIFF
--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -574,8 +574,13 @@ impl ObjectstoreServiceInner {
         key: Option<String>,
     ) -> Result<ObjectstoreKey, Error> {
         let retention_hours = retention.checked_mul(24);
-        self.upload(kind, session, key, Body::Bytes(payload), retention_hours)
-            .await
+        tokio::time::timeout(
+            self.timeout,
+            self.upload(kind, session, key, Body::Bytes(payload), retention_hours),
+        )
+        .await
+        .map_err(Error::from)
+        .flatten()
     }
 
     async fn upload(
@@ -587,7 +592,7 @@ impl ObjectstoreServiceInner {
         retention_hours: Option<u16>,
     ) -> Result<ObjectstoreKey, Error> {
         let mut attempts = 0;
-        let result = tokio::time::timeout(self.timeout, async {
+        let result = {
             let mut result = None;
             loop {
                 let Some(body) = body.try_clone() else {
@@ -611,10 +616,7 @@ impl ObjectstoreServiceInner {
             result
                 .expect("try_clone() should succeed at least once")
                 .map_err(Error::from)
-        })
-        .await
-        .map_err(Error::from)
-        .flatten();
+        };
 
         if result.is_ok() {
             relay_statsd::metric!(
@@ -654,7 +656,7 @@ impl ObjectstoreServiceInner {
             timer(RelayTimers::AttachmentUploadDuration),
             type = kind.as_str(),
             {
-                request.send().await
+                dbg!(request.send().await)
             }
         )?;
 

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -656,7 +656,7 @@ impl ObjectstoreServiceInner {
             timer(RelayTimers::AttachmentUploadDuration),
             type = kind.as_str(),
             {
-                dbg!(request.send().await)
+                request.send().await
             }
         )?;
 

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -574,13 +574,8 @@ impl ObjectstoreServiceInner {
         key: Option<String>,
     ) -> Result<ObjectstoreKey, Error> {
         let retention_hours = retention.checked_mul(24);
-        tokio::time::timeout(
-            self.timeout,
-            self.upload(kind, session, key, Body::Bytes(payload), retention_hours),
-        )
-        .await
-        .map_err(Error::from)
-        .flatten()
+        self.upload(kind, session, key, Body::Bytes(payload), retention_hours)
+            .await
     }
 
     async fn upload(
@@ -592,7 +587,11 @@ impl ObjectstoreServiceInner {
         retention_hours: Option<u16>,
     ) -> Result<ObjectstoreKey, Error> {
         let mut attempts = 0;
-        let result = {
+        let timeout = match &body {
+            Body::Bytes(_) => self.timeout,
+            Body::Stream(_) => Duration::MAX,
+        };
+        let result = tokio::time::timeout(timeout, async {
             let mut result = None;
             loop {
                 let Some(body) = body.try_clone() else {
@@ -616,7 +615,10 @@ impl ObjectstoreServiceInner {
             result
                 .expect("try_clone() should succeed at least once")
                 .map_err(Error::from)
-        };
+        })
+        .await
+        .map_err(Error::from)
+        .flatten();
 
         if result.is_ok() {
             relay_statsd::metric!(

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -519,7 +519,7 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
     The retry delay gives time for the mock objectstore to start, and the
     second attempt succeeds because the stream has not been consumed yet.
     """
-    mini_sentry.fail_on_relay_errors = False
+    mini_sentry.fail_on_relay_error = False
     project_id = 42
     project_key = mini_sentry.get_dsn_public_key(project_id)
 
@@ -544,15 +544,18 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
     assert response.status_code == 500
 
 
-def test_objectstore_timeout(mini_sentry, relay_with_processing, project_config):
+def test_objectstore_timeout(
+    mini_sentry, relay_with_processing, project_config, objectstore
+):
     mini_sentry.allow_chunked = True
+    mini_sentry.fail_on_relay_error = False
     project_id = 42
     project_key = mini_sentry.get_dsn_public_key(project_id)
 
     @mini_sentry.app.route("/v1/objects/attachments/<scope>/<key>", methods=["PUT"])
     def slow_objectstore(**opts):
         time.sleep(2)
-        return 204
+        raise NotImplementedError
 
     relay = relay_with_processing(
         options={
@@ -567,7 +570,7 @@ def test_objectstore_timeout(mini_sentry, relay_with_processing, project_config)
 
     response = upload_something(relay, project_id, project_key)
 
-    assert response.status_code == 204
+    assert response.status_code == 500  # not 504
 
 
 def upload_something(relay, project_id, project_key):

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -519,7 +519,6 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
     The retry delay gives time for the mock objectstore to start, and the
     second attempt succeeds because the stream has not been consumed yet.
     """
-    mini_sentry.fail_on_relay_error = False
     project_id = 42
     project_key = mini_sentry.get_dsn_public_key(project_id)
 

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -586,7 +586,7 @@ def upload_something(relay, project_id, project_key):
     )
     assert response.status_code == 201
 
-    response = relay.patch(
+    return relay.patch(
         f"{response.headers['Location']}&sentry_key={project_key}",
         headers={
             "Content-Length": str(len(data)),
@@ -596,27 +596,3 @@ def upload_something(relay, project_id, project_key):
         },
         data=data,
     )
-    # Create the upload (this does NOT contact objectstore).
-    data = b"hello world"
-    response = relay.post(
-        f"/api/{project_id}/upload/?sentry_key={project_key}",
-        headers={
-            "Content-Length": "0",
-            "Tus-Resumable": "1.0.0",
-            "Upload-Length": str(len(data)),
-        },
-    )
-    assert response.status_code == 201
-
-    response = relay.patch(
-        f"{response.headers['Location']}&sentry_key={project_key}",
-        headers={
-            "Content-Length": str(len(data)),
-            "Content-Type": "application/offset+octet-stream",
-            "Tus-Resumable": "1.0.0",
-            "Upload-Offset": "0",
-        },
-        data=data,
-    )
-
-    return response

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -563,3 +563,50 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
         failure
     )
     assert response.status_code == 500
+
+
+def test_objectstore_timeout(mini_sentry, relay_with_processing, project_config):
+    mini_sentry.allow_chunked = True
+    project_id = 42
+    project_key = mini_sentry.get_dsn_public_key(project_id)
+
+    @mini_sentry.app.route("/v1/objects/attachments/<scope>/<key>", methods=["PUT"])
+    def slow_objectstore(**opts):
+        time.sleep(2)
+        return 204
+
+    relay = relay_with_processing(
+        options={
+            "processing": {
+                "objectstore": {
+                    "objectstore_url": mini_sentry.url,
+                    "timeout": 1,
+                }
+            }
+        }
+    )
+
+    # Create the upload (this does NOT contact objectstore).
+    data = b"hello world"
+    response = relay.post(
+        f"/api/{project_id}/upload/?sentry_key={project_key}",
+        headers={
+            "Content-Length": "0",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Length": str(len(data)),
+        },
+    )
+    assert response.status_code == 201
+
+    response = relay.patch(
+        f"{response.headers['Location']}&sentry_key={project_key}",
+        headers={
+            "Content-Length": str(len(data)),
+            "Content-Type": "application/offset+octet-stream",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Offset": "0",
+        },
+        data=data,
+    )
+
+    assert response.status_code == 204

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -535,28 +535,7 @@ def test_objectstore_retries(mini_sentry, relay_with_processing, project_config)
         }
     )
 
-    # Create the upload (this does NOT contact objectstore).
-    data = b"hello world"
-    response = relay.post(
-        f"/api/{project_id}/upload/?sentry_key={project_key}",
-        headers={
-            "Content-Length": "0",
-            "Tus-Resumable": "1.0.0",
-            "Upload-Length": str(len(data)),
-        },
-    )
-    assert response.status_code == 201
-
-    response = relay.patch(
-        f"{response.headers['Location']}&sentry_key={project_key}",
-        headers={
-            "Content-Length": str(len(data)),
-            "Content-Type": "application/offset+octet-stream",
-            "Tus-Resumable": "1.0.0",
-            "Upload-Offset": "0",
-        },
-        data=data,
-    )
+    response = upload_something(relay, project_id, project_key)
 
     failure = mini_sentry.test_failures.get(timeout=10)
     assert "failed to upload 1 attachment(s) to objectstore in 3 attempt(s)" in str(
@@ -586,6 +565,34 @@ def test_objectstore_timeout(mini_sentry, relay_with_processing, project_config)
         }
     )
 
+    response = upload_something(relay, project_id, project_key)
+
+    assert response.status_code == 204
+
+
+def upload_something(relay, project_id, project_key):
+    # Create the upload (this does NOT contact objectstore).
+    data = b"hello world"
+    response = relay.post(
+        f"/api/{project_id}/upload/?sentry_key={project_key}",
+        headers={
+            "Content-Length": "0",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Length": str(len(data)),
+        },
+    )
+    assert response.status_code == 201
+
+    response = relay.patch(
+        f"{response.headers['Location']}&sentry_key={project_key}",
+        headers={
+            "Content-Length": str(len(data)),
+            "Content-Type": "application/offset+octet-stream",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Offset": "0",
+        },
+        data=data,
+    )
     # Create the upload (this does NOT contact objectstore).
     data = b"hello world"
     response = relay.post(
@@ -609,4 +616,4 @@ def test_objectstore_timeout(mini_sentry, relay_with_processing, project_config)
         data=data,
     )
 
-    assert response.status_code == 204
+    return response


### PR DESCRIPTION
With https://github.com/getsentry/relay/issues/5851 I violated what the comment on the config says:

```rust
    /// NOTE: This timeout applies to attachments that are already in-memory. Streaming uploads
    /// might take longer and are restricted independently by [`Upload::timeout`].
```

This PR fixes the regression and adds a test for it.