### PR TITLE
fix(pii): Only apply token matcher to keys instead of key and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@
 
 **Bug Fixes**:
 
-- Only enforce the `token` PII rule on keys instead of also values, 
-  allowing `token` to be used in LLM contexts without removing the entire value. ([#5886](https://github.com/getsentry/relay/pull/5886))
+- The PII rule for `token` is less strict to not always scrub usage in LLM contexts. ([#5886](https://github.com/getsentry/relay/pull/5886))
 
 
 ## 26.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Implement client/sdk controlled ingestion settings for v2 span containers. ([#5881](https://github.com/getsentry/relay/pull/5881))
 - Update several `gen_ai` attributes to their latest representation. ([#5798](https://github.com/getsentry/relay/pull/5798))
 
+**Bug Fixes**:
+
+- Only enforce the `token` PII rule on keys instead of also values, 
+  allowing `token` to be used in LLM contexts without removing the entire value. ([#5886](https://github.com/getsentry/relay/pull/5886))
+
+
 ## 26.4.1
 
 **Breaking Changes**:

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -1011,6 +1011,7 @@ mod tests {
                     ]
                 },
                 "extra": {
+                    "url": "foo.bar/endpoint?token=sensitive",
                     "foo-token-bar": "sensitive",
                     "llm": "token count",
                 },

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -1013,6 +1013,7 @@ mod tests {
                 "extra": {
                     "url": "foo.bar/endpoint?token=sensitive",
                     "url2": "foo.bar/endpoint?token_foobar=sensitive",
+                    "aaa": "token:12345",
                     "foo-token-bar": "sensitive",
                     "llm": "token count",
                 },

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -463,26 +463,19 @@ fn apply_rule_to_value(
     }
 
     for (pattern_type, regex, replace_behavior) in regexes::get_regex_for_rule_type(&rule.ty) {
-        match pattern_type {
-            PatternType::KeyValue => {
-                if regex.is_match(key.unwrap_or("")) {
-                    if value.is_some() && should_redact_chunks {
-                        // If we're given a string value here, redact the value like we would with
-                        // @anything.
-                        apply_regex!(&ANYTHING_REGEX, replace_behavior);
-                    } else {
-                        meta.add_remark(Remark::new(RemarkType::Removed, rule.origin.clone()));
-                        return Err(ProcessingAction::DeleteValueHard);
-                    }
-                } else {
-                    // If we did not redact using the key, we will redact the entire value if the key
-                    // appears in it.
-                    apply_regex!(regex, replace_behavior);
-                }
+        if matches!(pattern_type, PatternType::Key | PatternType::KeyValue)
+            && key.is_some_and(|key| regex.is_match(key))
+        {
+            if value.is_some() && should_redact_chunks {
+                // If we're given a string value here, redact the value like we would with
+                // @anything.
+                apply_regex!(&ANYTHING_REGEX, replace_behavior);
+            } else {
+                meta.add_remark(Remark::new(RemarkType::Removed, rule.origin.clone()));
+                return Err(ProcessingAction::DeleteValueHard);
             }
-            PatternType::Value => {
-                apply_regex!(regex, replace_behavior);
-            }
+        } else if matches!(pattern_type, PatternType::Value | PatternType::KeyValue) {
+            apply_regex!(regex, replace_behavior);
         }
     }
 
@@ -1005,6 +998,39 @@ mod tests {
         let mut processor = PiiProcessor::new(config.compiled());
         process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
         assert_annotated_snapshot!(event);
+    }
+
+    #[test]
+    fn test_only_match_token_on_keys() {
+        let mut data = Event::from_value(
+            json!({
+                "request": {
+                    "headers": [
+                        ["X-Token", "oof this is very sensitive"],
+                        ["Token", "also bad"],
+                    ]
+                },
+                "extra": {
+                    "foo-token-bar": "sensitive",
+                    "llm": "token count",
+                },
+            })
+            .into(),
+        );
+
+        let scrubbing_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_ip_addresses: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+
+        let pii_config = to_pii_config(&scrubbing_config).unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+
+        assert_annotated_snapshot!(&data);
     }
 
     #[test]

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -1012,6 +1012,7 @@ mod tests {
                 },
                 "extra": {
                     "url": "foo.bar/endpoint?token=sensitive",
+                    "url2": "foo.bar/endpoint?token_foobar=sensitive",
                     "foo-token-bar": "sensitive",
                     "llm": "token count",
                 },

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -342,7 +342,7 @@ regex!(TOKEN_KEY_REGEX, r"(?i)(token)");
 
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|^otp$|^two[-_]factor$)"
+    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token=|^otp$|^two[-_]factor$)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -342,7 +342,7 @@ regex!(TOKEN_KEY_REGEX, r"(?i)(token)");
 
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token[^\s]*=|^otp$|^two[-_]factor$)"
+    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token[^\s]*[:=]|^otp$|^two[-_]factor$)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -342,7 +342,7 @@ regex!(TOKEN_KEY_REGEX, r"(?i)(token)");
 
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token=|^otp$|^two[-_]factor$)"
+    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token[^\s]*=|^otp$|^two[-_]factor$)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -9,6 +9,8 @@ use crate::config::RuleType;
 pub enum PatternType {
     /// Pattern-match on key and value
     KeyValue,
+    /// Pattern-match on key only, apply replacement on the value.
+    Key,
     /// Pattern-match on value only
     Value,
 }
@@ -50,6 +52,7 @@ pub fn get_regex_for_rule_type(
     ty: &RuleType,
 ) -> SmallVec<[(PatternType, &Regex, ReplaceBehavior); 2]> {
     let v = PatternType::Value;
+    let k = PatternType::Key;
     let kv = PatternType::KeyValue;
 
     match ty {
@@ -68,6 +71,7 @@ pub fn get_regex_for_rule_type(
                 // Bearer token was moved to its own regest and type out of the passwords, but we
                 // still keep it here for backwards compatibility.
                 (v, &*BEARER_TOKEN_REGEX, ReplaceBehavior::replace_match()),
+                (k, &*TOKEN_KEY_REGEX, ReplaceBehavior::replace_value()),
                 (kv, &*PASSWORD_KEY_REGEX, ReplaceBehavior::replace_value()),
             ]
         }
@@ -334,9 +338,11 @@ regex!(
 
 regex!(BEARER_TOKEN_REGEX, r"(?i)\b(Bearer\s+)([^\s]+)");
 
+regex!(TOKEN_KEY_REGEX, r"(?i)(token)");
+
 regex!(
     PASSWORD_KEY_REGEX,
-    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|token|^otp$|^two[-_]factor$)"
+    r"(?i)(password|secret|passwd|api[-_]key|apikey|auth|credentials|mysql_pwd|privatekey|private[-_]key|^otp$|^two[-_]factor$)"
 );
 
 #[cfg(test)]

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
@@ -1,0 +1,73 @@
+---
+source: relay-pii/src/processor.rs
+expression: "&data"
+---
+{
+  "request": {
+    "headers": [
+      [
+        "X-Token",
+        "[Filtered]"
+      ],
+      [
+        "Token",
+        "[Filtered]"
+      ]
+    ]
+  },
+  "extra": {
+    "foo-token-bar": "[Filtered]",
+    "llm": "token count"
+  },
+  "_meta": {
+    "extra": {
+      "foo-token-bar": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 9
+        }
+      }
+    },
+    "request": {
+      "headers": {
+        "0": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 26
+            }
+          }
+        },
+        "1": {
+          "1": {
+            "": {
+              "rem": [
+                [
+                  "@password:filter",
+                  "s",
+                  0,
+                  10
+                ]
+              ],
+              "len": 8
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
@@ -18,7 +18,8 @@ expression: "&data"
   "extra": {
     "foo-token-bar": "[Filtered]",
     "llm": "token count",
-    "url": "[Filtered]"
+    "url": "[Filtered]",
+    "url2": "[Filtered]"
   },
   "_meta": {
     "extra": {
@@ -46,6 +47,19 @@ expression: "&data"
             ]
           ],
           "len": 32
+        }
+      },
+      "url2": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 39
         }
       }
     },

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
@@ -16,6 +16,7 @@ expression: "&data"
     ]
   },
   "extra": {
+    "aaa": "[Filtered]",
     "foo-token-bar": "[Filtered]",
     "llm": "token count",
     "url": "[Filtered]",
@@ -23,6 +24,19 @@ expression: "&data"
   },
   "_meta": {
     "extra": {
+      "aaa": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 11
+        }
+      },
       "foo-token-bar": {
         "": {
           "rem": [

--- a/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
+++ b/relay-pii/src/snapshots/relay_pii__processor__tests__only_match_token_on_keys.snap
@@ -17,7 +17,8 @@ expression: "&data"
   },
   "extra": {
     "foo-token-bar": "[Filtered]",
-    "llm": "token count"
+    "llm": "token count",
+    "url": "[Filtered]"
   },
   "_meta": {
     "extra": {
@@ -32,6 +33,19 @@ expression: "&data"
             ]
           ],
           "len": 9
+        }
+      },
+      "url": {
+        "": {
+          "rem": [
+            [
+              "@password:filter",
+              "s",
+              0,
+              10
+            ]
+          ],
+          "len": 32
         }
       }
     },


### PR DESCRIPTION
With the rise of LLMs, the token `token` (hehe) now is often used in context which are not sensitive. In sensitive contexts the `token` is most often used as a key to describe a value, e.g. in HTTP headers.

To balance the PII concerns with simply providing a useful product to our users, we'll start enforcing the `token` password rule only on keys (removing the value) and making the password (value) rule more strict.