### PR TITLE
ref(minidump): Add metric for project fetching in the endpoint

### DIFF
--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -30,6 +30,7 @@ use crate::service::ServiceState;
 use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason};
 use crate::services::projects::cache::Project;
 use crate::services::upload::Upload;
+use crate::statsd::RelayCounters;
 use crate::utils::{self, AttachmentStrategy, read_attachment_bytes_into_item};
 
 /// The field name of a minidump in the multipart form-data upload.
@@ -221,6 +222,9 @@ async fn extract_multipart(
     let config = state.config();
 
     let upload_context = if should_fetch_project_config(state, meta.project_id()) {
+        // Ensure that we really make it here.
+        relay_statsd::metric!(counter(RelayCounters::MinidumpEndpointConfigFetching) += 1);
+
         let project = state
             .project_cache_handle()
             .ready(meta.public_key(), config.query_timeout())

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -985,6 +985,8 @@ pub enum RelayCounters {
     ErrorProcessed,
     /// The number of times the new unreal expansion logic in the endpoint is hit.
     UnrealEndpointExpansion,
+    /// The number of times the new logic for fetching the project config in the endpoint is hit.
+    MinidumpEndpointConfigFetching,
 }
 
 impl CounterMetric for RelayCounters {
@@ -1045,6 +1047,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProfileChunksWithoutPlatform => "profile_chunk.no_platform",
             RelayCounters::ErrorProcessed => "event.error.processed",
             RelayCounters::UnrealEndpointExpansion => "unreal.endpoint_expansion",
+            RelayCounters::MinidumpEndpointConfigFetching => "minidump.endpoint_config_fetch",
         }
     }
 }


### PR DESCRIPTION
Similar to https://github.com/getsentry/relay/pull/5847 will be used to sanity check us during the rollout of the project config logic in the endpoint.