### PR TITLE
ref(spans): Don't set `sentry.was_transaction`

### DIFF
--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -121,8 +121,6 @@ mod not_yet_defined {
     // TODO: replace with conventions defined attribute name once the conventions code gen is updated.
     pub const LEGACY_HTTP_REQUEST_METHOD: &str = "http.request_method";
 
-    pub const WAS_TRANSACTION: &str = "sentry.was_transaction";
-
     // TODO(mjq): Evaluate and remove usages of this constant, or restore it in
     // conventions. This was deleted from conventions in
     // https://github.com/getsentry/sentry-conventions/pull/256 but is still

--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -316,13 +316,6 @@ fn create_metrics(
             metadata,
         });
 
-        // This pipeline is only used for standalone spans, which are never extracted from a
-        // transaction.
-        //
-        // If this changes in the future this flag *must* be adjusted accordingly.
-        #[cfg(debug_assertions)]
-        assert_segments_not_was_transaction(spans);
-
         metrics.project_metrics.push(Bucket {
             timestamp,
             width: 0,
@@ -359,20 +352,4 @@ fn create_metrics(
     }
 
     metrics
-}
-
-/// Asserts all segments spans are not marked as being created from a transaction.
-#[cfg(debug_assertions)]
-fn assert_segments_not_was_transaction(spans: &[ExpandedSpan]) {
-    use relay_conventions::WAS_TRANSACTION;
-    use relay_protocol::Value;
-
-    for span in spans.iter().flat_map(|s| s.span.value()) {
-        let was_transaction = span
-            .attributes
-            .value()
-            .and_then(|attr| attr.get_value(WAS_TRANSACTION));
-
-        debug_assert!(matches!(was_transaction, None | Some(&Value::Bool(false))));
-    }
 }

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -36,7 +36,7 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
         received: _, // needs to go into the Kafka span eventually, but makes no sense in Span V2 schema.
         measurements,
         platform,
-        was_transaction: _was_transaction,
+        was_transaction: _,
         kind,
         performance_issues_spans,
         other: _,

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -36,7 +36,7 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
         received: _, // needs to go into the Kafka span eventually, but makes no sense in Span V2 schema.
         measurements,
         platform,
-        was_transaction,
+        was_transaction: _was_transaction,
         kind,
         performance_issues_spans,
         other: _,
@@ -54,7 +54,6 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     attributes.insert("sentry.origin", origin);
     attributes.insert("sentry.profile_id", profile_id.map_value(|v| v.to_string()));
     attributes.insert("sentry.platform", platform);
-    attributes.insert("sentry.was_transaction", was_transaction);
     attributes.insert(
         "sentry._internal.performance_issues_spans",
         performance_issues_spans,
@@ -426,10 +425,6 @@ mod tests {
             "sentry.user": {
               "type": "string",
               "value": "id:user123"
-            },
-            "sentry.was_transaction": {
-              "type": "boolean",
-              "value": true
             }
           },
           "_meta": {

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -1218,7 +1218,6 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "gen_ai.invoke_agent",
                 },
-                "sentry.was_transaction": {"type": "boolean", "value": True},
                 "server_name": {"type": "string", "value": "some_machine.local"},
             },
             "downsampled_retention_days": 90,

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -227,7 +227,6 @@ def test_span_extraction(
             "sentry.user.id": {"type": "string", "value": user_id},
             "sentry.user.ip": {"type": "string", "value": "192.168.0.1"},
             "sentry.user": {"type": "string", "value": f"id:{user_id}"},
-            "sentry.was_transaction": {"type": "boolean", "value": True},
         },
         "downsampled_retention_days": 90,
         "end_timestamp": end_timestamp.timestamp(),


### PR DESCRIPTION
This attribute is written during span V1 -> V2 conversion based on a V1 span's `was_transaction` field. However, it is not defined in conventions and has no known use apart from debugging. Moreover, a span having the `sentry.event_id` attribute set should be equivalent to it having `sentry.was_transaction: true`, so the attribute is redundant.

Fixes #5885. Fixes RELAY-226.