### PR TITLE
ref(eap): Remove `http.request_method` attribute

### DIFF
--- a/relay-conventions/src/consts.rs
+++ b/relay-conventions/src/consts.rs
@@ -115,12 +115,6 @@ convention_attributes!(
 /// Really do not add to this list, at all, ever. The only reason this opt-out even exists to make a
 /// transition easier for attributes which Relay already uses but aren't yet in conventions.
 mod not_yet_defined {
-    // The legacy http request method attribute used by transactions spans.
-    // Could not be added to sentry conventions at the time due to an attribute naming conflict that
-    // requires updating the sentry conventions code gen.
-    // TODO: replace with conventions defined attribute name once the conventions code gen is updated.
-    pub const LEGACY_HTTP_REQUEST_METHOD: &str = "http.request_method";
-
     // TODO(mjq): Evaluate and remove usages of this constant, or restore it in
     // conventions. This was deleted from conventions in
     // https://github.com/getsentry/sentry-conventions/pull/256 but is still

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -603,7 +603,6 @@ fn normalize_http_attributes(
 
     let method = attributes
         .get_value(HTTP_REQUEST_METHOD)
-        .or_else(|| attributes.get_value(LEGACY_HTTP_REQUEST_METHOD))
         .and_then(|v| v.as_str())
         .or(description_method);
 
@@ -1796,6 +1795,49 @@ mod tests {
           "http.request_method": {
             "type": "string",
             "value": "GET"
+          }
+        }
+        "#,
+        )
+        .unwrap();
+
+        normalize_attribute_names(&mut attributes);
+        normalize_http_attributes(&mut attributes, &[]);
+
+        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        {
+          "http.request.method": {
+            "type": "string",
+            "value": "GET"
+          },
+          "http.request_method": {
+            "type": "string",
+            "value": "GET"
+          },
+          "sentry.category": {
+            "type": "string",
+            "value": "http"
+          },
+          "sentry.op": {
+            "type": "string",
+            "value": "http.client"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_http_attributes_from_description() {
+        let mut attributes = Annotated::<Attributes>::from_json(
+            r#"
+        {
+          "sentry.category": {
+            "type": "string",
+            "value": "http"
+          },
+          "sentry.op": {
+            "type": "string",
+            "value": "http.client"
           },
           "sentry.description": {
             "type": "string",
@@ -1811,10 +1853,6 @@ mod tests {
         insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
         {
           "http.request.method": {
-            "type": "string",
-            "value": "GET"
-          },
-          "http.request_method": {
             "type": "string",
             "value": "GET"
           },


### PR DESCRIPTION
This updates `sentry-conventions` to `d8efc9a`, in which `http.request_method` has been added as a deprecated alias of `http.request.method`, with backfilling enabled. Consequently, the `LEGACY_HTTP_REQUEST_METHOD` constant can be removed.
