### PR TITLE
test(kafka): Make Kafka configuration and consumers more resilient

### DIFF
--- a/tests/integration/fixtures/processing.py
+++ b/tests/integration/fixtures/processing.py
@@ -1,17 +1,25 @@
 from collections import defaultdict
+from copy import deepcopy
 import json
+import os
+import time
+import uuid
+
 from google.protobuf.json_format import MessageToDict
 import msgpack
-import uuid
 
 from objectstore_client import Client, Usecase
 import pytest
-import os
 import confluent_kafka as kafka
-from copy import deepcopy
 
 from sentry_relay.consts import DataCategory
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
+
+TRANSIENT_CONSUMER_ERROR_CODES = {
+    kafka.KafkaError.NOT_COORDINATOR,
+    kafka.KafkaError.COORDINATOR_NOT_AVAILABLE,
+    kafka.KafkaError.COORDINATOR_LOAD_IN_PROGRESS,
+}
 
 
 @pytest.fixture
@@ -187,12 +195,14 @@ def kafka_consumer(request, get_topic_name, processing_config):
         settings = {
             "bootstrap.servers": servers,
             "group.id": "test-consumer-%s" % uuid.uuid4().hex,
-            "enable.auto.commit": True,
+            "enable.auto.commit": False,
             "auto.offset.reset": "earliest",
         }
 
         consumer = kafka.Consumer(settings)
-        consumer.assign([kafka.TopicPartition(t, 0) for t in topics])
+        consumer.assign(
+            [kafka.TopicPartition(t, 0, kafka.OFFSET_BEGINNING) for t in topics]
+        )
 
         def die():
             consumer.close()
@@ -217,7 +227,25 @@ class ConsumerBase:
     def poll(self, timeout=None):
         if timeout is None:
             timeout = self.timeout
-        return self.consumer.poll(timeout=timeout)
+
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+
+            message = self.consumer.poll(timeout=remaining)
+            if message is None:
+                return None
+
+            error = message.error()
+            if error is None:
+                return message
+
+            if error.retriable() or error.code() in TRANSIENT_CONSUMER_ERROR_CODES:
+                continue
+
+            return message
 
     def poll_many(self, timeout=None, n=None):
         if timeout is None:
@@ -260,7 +288,10 @@ class ConsumerBase:
         """
         # First, give Relay a bit of time to process
         rv = self.poll(timeout=0.2)
-        assert rv is None, f"{self.__class__.__name__} not empty: {rv.value()}"
+        assert rv is None, (
+            f"{self.__class__.__name__} not empty: "
+            f"{rv.error() if rv.error() is not None else rv.value()}"
+        )
 
         # Then, send a custom message to ensure we're not just timing out
         message = json.dumps({"__test__": uuid.uuid4().hex}).encode("utf8")
@@ -268,6 +299,7 @@ class ConsumerBase:
         self.test_producer.flush(timeout=5)
 
         rv = self.poll(timeout=timeout)
+        assert rv is not None, f"{self.__class__.__name__} did not receive test message"
         assert rv.error() is None
         assert rv.value() == message, rv.value()
 


### PR DESCRIPTION
Attempt to fix Kafka failures in CI that keep showing up.

<details>
<summary>Stack Trace</summary>

[Test Run](https://github.com/getsentry/relay/actions/runs/25101673952/job/73552248489)

```
_ test_error_message_filters_are_applied[formatting matching message-processing relay] _
[gw4] linux -- Python 3.13.5 /home/runner/work/relay/relay/.venv/bin/python3
Traceback (most recent call last):
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 341, in from_call
    result: TResult | None = func()
                             ~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 242, in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 182, in _multicall
    return outcome.get_result()
           ~~~~~~~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/threadexception.py", line 92, in pytest_runtest_call
    yield from thread_exception_runtest_hook()
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/threadexception.py", line 68, in thread_exception_runtest_hook
    yield
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/unraisableexception.py", line 95, in pytest_runtest_call
    yield from unraisable_exception_runtest_hook()
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/unraisableexception.py", line 70, in unraisable_exception_runtest_hook
    yield
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/logging.py", line 846, in pytest_runtest_call
    yield from self._runtest_for(item, "call")
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/logging.py", line 829, in _runtest_for
    yield
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/capture.py", line 880, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 167, in _multicall
    teardown.throw(outcome._exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/skipping.py", line 257, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/runner.py", line 174, in pytest_runtest_call
    item.runtest()
    ~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/python.py", line 1627, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/relay/relay/.venv/lib/python3.13/site-packages/_pytest/python.py", line 159, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/runner/work/relay/relay/tests/integration/test_filters.py", line 100, in test_error_message_filters_are_applied
    events_consumer = events_consumer()
  File "/home/runner/work/relay/relay/tests/integration/fixtures/processing.py", line 367, in inner
    consumer = cls(timeout=timeout, *kafka_consumer(topic or default_topic))
  File "/home/runner/work/relay/relay/tests/integration/fixtures/processing.py", line 215, in __init__
    self.assert_empty()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/tests/integration/fixtures/processing.py", line 263, in assert_empty
    assert rv is None, f"{self.__class__.__name__} not empty: {rv.value()}"
           ^^^^^^^^^^
AssertionError: EventsConsumer not empty: b'Failed to fetch committed offsets for 0 partition(s) in group "test-consumer-5d08a362e298404080fc3c6785137c20": Broker: Not coordinator'
```
</details>

Fix mostly inspired by Codex, with some effort to confirm the findings, but mostly an educated guess mixed with some hope that we never see these failures again.