### PR TITLE
fix(upload): Bump default concurrency

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1737,7 +1737,7 @@ pub struct Upload {
 impl Default for Upload {
     fn default() -> Self {
         Self {
-            max_concurrent_requests: 10,
+            max_concurrent_requests: 100,
             timeout: 5 * 60,  // five minutes
             max_age: 60 * 60, // 1h
         }


### PR DESCRIPTION
10 was a very conservative initial limit for load shedding upload requests. I ran into this limit while load testing. Instead of increasing it on demand when needed, increase the default.

The original limit can especially become too low in processing Relays, where requests from many PoP Relays hit a much smaller set of processing nodes.