### PR TITLE
test(relay): Parse port from stderr instead of assigning randomly

### DIFF
--- a/relay-server/src/services/server/mod.rs
+++ b/relay-server/src/services/server/mod.rs
@@ -198,13 +198,22 @@ impl Service for HttpServer {
             internal_listener,
         } = self;
 
-        let listen_addr = config.listen_addr();
+        let listen_addr = listener
+            .local_addr()
+            .unwrap_or_else(|_| config.listen_addr());
+        let internal_listen_addr = internal_listener.as_ref().and_then(|listener| {
+            listener
+                .local_addr()
+                .ok()
+                .or_else(|| config.listen_addr_internal())
+        });
 
         relay_log::info!("spawning http server");
         relay_log::info!("  listening on http://{listen_addr}/");
-        if let Some(internal_addr) = config.listen_addr_internal() {
+        if let Some(internal_addr) = internal_listen_addr {
             relay_log::info!("  listening on http://{internal_addr}/ [internal]");
         }
+
         relay_statsd::metric!(counter(RelayCounters::ServerStarting) += 1);
 
         if let Some(internal_listener) = internal_listener {

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -224,15 +224,15 @@ def relay(mini_sentry, background_process, config_dir, get_relay_binary):
             relay_bin + ["-c", str(dir), "run"], stderr=subprocess.PIPE
         )
 
-        while True:
-            line = process.stderr.readline()
-            sys.stderr.buffer.write(line)
-            sys.stderr.buffer.flush()
-
+        stderr = dup_to_queue(process.stderr, sys.stderr.buffer)
+        # Port should show up rather quickly.
+        port = None
+        for _ in range(50):
+            line = stderr.get(timeout=3)
             if port := try_parse_port(line):
-                redirect_pipe(process.stderr, sys.stderr.buffer)
                 break
 
+        assert port is not None, "port could not be parsed from stderr"
         relay = Relay(
             (host, port),
             process,
@@ -285,13 +285,17 @@ def try_parse_port(line):
         pass
 
 
-def redirect_pipe(src, dst):
-    def redirect():
+def dup_to_queue(src, dst):
+    queue = Queue()
+
+    def redirect(src, dst, queue):
         while True:
             line = src.readline()
             if not line:
                 break
             dst.write(line)
             dst.flush()
+            queue.put(line)
 
-    threading.Thread(target=redirect, daemon=True).start()
+    threading.Thread(target=redirect, args=(src, dst, queue), daemon=True).start()
+    return queue

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -7,7 +7,9 @@ import signal
 import stat
 import requests
 import subprocess
+import threading
 from collections import defaultdict
+from urllib.parse import urlparse
 
 import yaml
 import pytest
@@ -128,7 +130,7 @@ def relay_credentials():
 
 
 @pytest.fixture
-def relay(mini_sentry, random_port, background_process, config_dir, get_relay_binary):
+def relay(mini_sentry, background_process, config_dir, get_relay_binary):
     def inner(
         upstream,
         options=None,
@@ -142,13 +144,12 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
     ):
         relay_bin = get_relay_binary(version)
         host = "127.0.0.1"
-        port = random_port()
 
         default_opts = {
             "relay": {
                 "upstream": upstream.url,
                 "host": host,
-                "port": port,
+                "port": 0,
                 "tls_port": None,
                 "tls_private_key": None,
                 "tls_cert": None,
@@ -219,7 +220,18 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
             "version": version,
         }
 
-        process = background_process(relay_bin + ["-c", str(dir), "run"])
+        process = background_process(
+            relay_bin + ["-c", str(dir), "run"], stderr=subprocess.PIPE
+        )
+
+        while True:
+            line = process.stderr.readline()
+            sys.stderr.buffer.write(line)
+            sys.stderr.buffer.flush()
+
+            if port := try_parse_port(line):
+                redirect_pipe(process.stderr, sys.stderr.buffer)
+                break
 
         relay = Relay(
             (host, port),
@@ -264,3 +276,22 @@ def get_internal_address(options, server_address):
     host = relay.get("internal_host")
     port = relay.get("internal_port")
     return (host or server_address[0], port or server_address[1])
+
+
+def try_parse_port(line):
+    try:
+        return urlparse(line.rsplit(b"listening on ", 1)[1]).port
+    except IndexError:
+        pass
+
+
+def redirect_pipe(src, dst):
+    def redirect():
+        while True:
+            line = src.readline()
+            if not line:
+                break
+            dst.write(line)
+            dst.flush()
+
+    threading.Thread(target=redirect, daemon=True).start()

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -227,11 +227,11 @@ def relay(mini_sentry, background_process, config_dir, get_relay_binary):
         # This part here really isn't the greatest.
         #
         # Before this change, the tests would query the OS for an unused port,
-        # then assign that port to Relay via its configuration. In slower CI environments
-        # where tests run in parallel this can lead to a race condition where two tests select
-        # the same port, resulting in a test failure.
+        # then assign that port to Relay via its configuration. In slower CI environments,
+        # with tests running in parallel, this can lead to a race condition -> two tests select
+        # the same port.
         #
-        # This is an attempt of a fix which instead leads Relay select a port and bind to it,
+        # This is an attempt of a fix, which instead lets Relay select a port and bind to it,
         # then reads the port from the Relay logs. This heavily couples the test framework
         # to Relay's logs, which isn't great, but also not the worst.
         #

--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -224,6 +224,22 @@ def relay(mini_sentry, background_process, config_dir, get_relay_binary):
             relay_bin + ["-c", str(dir), "run"], stderr=subprocess.PIPE
         )
 
+        # This part here really isn't the greatest.
+        #
+        # Before this change, the tests would query the OS for an unused port,
+        # then assign that port to Relay via its configuration. In slower CI environments
+        # where tests run in parallel this can lead to a race condition where two tests select
+        # the same port, resulting in a test failure.
+        #
+        # This is an attempt of a fix which instead leads Relay select a port and bind to it,
+        # then reads the port from the Relay logs. This heavily couples the test framework
+        # to Relay's logs, which isn't great, but also not the worst.
+        #
+        # From the alternatives considered (locking, Redis, selecting ports by worker id, retries, ..),
+        # this was the approach taken.
+        # If this leads to problems (memory consumption or others), consider selecting ports
+        # with the pytest worker id, this seemed like a decent alternative.
+        # `pytest-retry` may also be an acceptable approach.
         stderr = dup_to_queue(process.stderr, sys.stderr.buffer)
         # Port should show up rather quickly.
         port = None


### PR DESCRIPTION
The old behaviour picked a free port, then passed it to Relay via its config. When running the tests in parallel there is a race condition where two tests can pick the same port and then one of the two Relay instances will fail to bind the port.

Instead let Relay pick a random port, then parse the port from stderr instead.

This only redirects `stderr` as it keeps the tty settings on stdout, which means Relay will continue to print colorful logs if attached to a terminal. We're also only interested in the tracing logs.
There is an alternative where maybe we can configure the tracing crate with multiple outputs instead, but I haven't explored that option fully and how many changes this would require.