### PR TITLE
ref(forward): Never forward in processing Relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 **Internal**:
 
 - Stream attachments received at `/minidump` to objectstore. ([#5877](https://github.com/getsentry/relay/pull/5877))
+- Never forward unknown requests in processing Relays. ([#5915](https://github.com/getsentry/relay/pull/5915))
 - Distinguish between objectstore stream timeouts and regular timeouts on a config level. ([#5878](https://github.com/getsentry/relay/pull/5878))
 
 

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -892,6 +892,9 @@ pub struct Http {
     /// Controls whether the forward endpoint is enabled.
     ///
     /// The forward endpoint forwards unknown API requests to the upstream.
+    ///
+    /// Relay instances with processing enabled are expected to support the latest API and do never
+    /// support forwarding requests to Sentry.
     pub forward: bool,
     /// Enables an async DNS resolver through the `hickory-dns` crate, which uses an LRU cache for
     /// the resolved entries. This helps to limit the amount of requests made to the upstream DNS
@@ -2218,8 +2221,11 @@ impl Config {
     }
 
     /// Returns `true` if Relay supports forwarding unknown API requests.
+    ///
+    /// Relay instances with processing enabled are expected to support the latest API and do never
+    /// support forwarding requests to Sentry.
     pub fn http_forward(&self) -> bool {
-        self.values.http.forward
+        self.values.http.forward && !self.processing_enabled()
     }
 
     /// Returns whether this Relay should emit outcomes.


### PR DESCRIPTION
There is never a need to forward requests through to Sentry anymore.

This used to be useful where certain endpoints were only implemented by Sentry and not Relay. Now since Relay explicitly implements the register and challenge endpoints, there is no need for this anymore.

Refs: INGEST-887 - an adjacent fix for self hosted.