### PR TITLE
fix(forward): Never forward X-Forwarded-For

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**:
 
 - Backfill `app.vitals.start.value` and `app.vitals.start.type` for V1 transactions from `app_start_cold` and `app_start_warm`, matching existing V2 behavior. ([#5883](https://github.com/getsentry/relay/pull/5883))
+- Never forward `X-Forwarded-For` like headers in the generic forward endpoints, as a precaution for misconfigured reverse proxies. ([#5916](https://github.com/getsentry/relay/pull/5916))
 - The PII rule for `token` is less strict to not always scrub usage in LLM contexts. ([#5886](https://github.com/getsentry/relay/pull/5886))
 - Respond with status code 413 when chunked multipart requests are too large. ([#5880](https://github.com/getsentry/relay/pull/5880))
 

--- a/relay-server/src/utils/forward.rs
+++ b/relay-server/src/utils/forward.rs
@@ -37,6 +37,10 @@ static IGNORED_REQUEST_HEADERS: &[HeaderName] = &[
     header::HOST,
     header::CONTENT_ENCODING,
     header::CONTENT_LENGTH,
+    header::FORWARDED,
+    HeaderName::from_static("X-Forwarded-For"),
+    HeaderName::from_static("X-Forwarded-Host"),
+    HeaderName::from_static("X-Forwarded-Proto"),
 ];
 
 /// Default timeout for the forward request.
@@ -184,7 +188,9 @@ impl UpstreamRequest for ForwardRequest {
         }
 
         if let Some(forwarded_for) = &self.forwarded_for {
-            builder.header("X-Forwarded-For", forwarded_for.as_ref());
+            // Never set `X-Forwarded-For` here, we want to ensure the upstream knows, that this
+            // is not a trusted value.
+            builder.header("X-Sentry-Forwarded-For", forwarded_for.as_ref());
         }
 
         let Some(body) = self.body.take() else {
@@ -273,6 +279,8 @@ impl ForwardRequestBuilder {
     ///
     /// The builder takes care of removing headers which can or should not be forwarded to a
     /// different http server.
+    ///
+    /// To set a forwarded for header [`with_forwarded_for`] must be used.
     pub fn with_headers(mut self, mut headers: HeaderMap) -> Self {
         let headers_to_remove = HOP_BY_HOP_HEADERS.iter().chain(IGNORED_REQUEST_HEADERS);
         for header in headers_to_remove {
@@ -284,6 +292,11 @@ impl ForwardRequestBuilder {
     }
 
     /// Adds an optional forwarded for header.
+    ///
+    /// This sets `X-Sentry-Forwarded-For` and not `X-Forwarded-For` to ensure there is no
+    /// accidental confusion of the forwarded header with the upstream.
+    /// `X-Sentry-Forwarded-For` is an inherently untrusted header and can be used to infer client
+    /// ip addresses only for telemetry purposes, never for authentication.
     pub fn with_forwarded_for(mut self, ff: impl Into<Option<ForwardedFor>>) -> Self {
         self.request.forwarded_for = ff.into();
         self


### PR DESCRIPTION
Closes: INGEST-887

Never forward any variant for `forwarded` headers to the upstream. Instead make it explicit and use `X-Sentry-Forwarded-For` to indicate this is an untrusted value. Relay already parses `X-Sentry-Forwarded-For` for telemetry reasons and is intended to bypass reverse proxies rewriting `X-Forwarded-For`.