### PR TITLE
fix(multipart): Wrap items in Managed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Backfill `app.vitals.start.value` and `app.vitals.start.type` for V1 transactions from `app_start_cold` and `app_start_warm`, matching existing V2 behavior. ([#5883](https://github.com/getsentry/relay/pull/5883))
 - The PII rule for `token` is less strict to not always scrub usage in LLM contexts. ([#5886](https://github.com/getsentry/relay/pull/5886))
 - Respond with status code 413 when chunked multipart requests are too large. ([#5880](https://github.com/getsentry/relay/pull/5880))
+- Add missing outcomes for the Playstation, Minidump, and Attachments endpoints. ([#5918](https://github.com/getsentry/relay/pull/5918))
 
 **Internal**:
 

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -5,12 +5,14 @@ use axum::routing::{MethodRouter, post};
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_event_schema::protocol::EventId;
+use relay_quotas::DataCategory;
 use serde::Deserialize;
 use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::endpoints::common::{self, BadStoreRequest};
 use crate::envelope::{AttachmentType, Envelope, Item};
 use crate::extractors::RequestMeta;
+use crate::managed::Managed;
 use crate::service::ServiceState;
 use crate::utils::{self, AttachmentStrategy, read_attachment_bytes_into_item};
 
@@ -29,24 +31,39 @@ impl AttachmentStrategy for AttachmentsAttachmentStrategy {
     fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+    ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send {
         read_attachment_bytes_into_item(field, item, config, false)
     }
 }
 
-async fn extract_envelope(
+async fn multipart_to_envelope(
     meta: RequestMeta,
     path: AttachmentPath,
     multipart: Multipart<'static>,
-    config: &Config,
-) -> Result<Box<Envelope>, BadStoreRequest> {
-    let items = utils::multipart_items(multipart, config, AttachmentsAttachmentStrategy).await?;
+    state: &ServiceState,
+) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
+    let items = utils::multipart_items(
+        multipart,
+        state.config(),
+        AttachmentsAttachmentStrategy,
+        &meta,
+        state.outcome_aggregator(),
+    )
+    .await?;
 
-    let mut envelope = Envelope::from_request(Some(path.event_id), meta);
+    let envelope = Envelope::from_request(Some(path.event_id), meta);
+    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
+    let mut has_event = false;
     for item in items {
-        envelope.add_item(item);
+        envelope.merge_with(item, |envelope, item, records| {
+            if !has_event && item.creates_event() {
+                records.modify_by(DataCategory::Error, 1);
+                has_event = true;
+            }
+            envelope.add_item(item);
+        });
     }
 
     Ok(envelope)
@@ -59,8 +76,8 @@ pub async fn handle(
     request: Request,
 ) -> axum::response::Result<impl IntoResponse> {
     let multipart = utils::multipart_from_request(request)?;
-    let envelope = extract_envelope(meta, path, multipart, state.config()).await?;
-    common::handle_envelope(&state, envelope)
+    let envelope = multipart_to_envelope(meta, path, multipart, &state).await?;
+    common::handle_managed_envelope(&state, envelope)
         .await?
         .check_rate_limits()?;
     Ok(StatusCode::CREATED)

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -53,7 +53,7 @@ async fn multipart_to_envelope(
     .await?;
 
     let envelope =
-        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), path.event_id)?;
+        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), path.event_id);
     Ok(envelope)
 }
 

--- a/relay-server/src/endpoints/attachments.rs
+++ b/relay-server/src/endpoints/attachments.rs
@@ -5,7 +5,6 @@ use axum::routing::{MethodRouter, post};
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_event_schema::protocol::EventId;
-use relay_quotas::DataCategory;
 use serde::Deserialize;
 use tower_http::limit::RequestBodyLimitLayer;
 
@@ -53,19 +52,8 @@ async fn multipart_to_envelope(
     )
     .await?;
 
-    let envelope = Envelope::from_request(Some(path.event_id), meta);
-    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
-    let mut has_event = false;
-    for item in items {
-        envelope.merge_with(item, |envelope, item, records| {
-            if !has_event && item.creates_event() {
-                records.modify_by(DataCategory::Error, 1);
-                has_event = true;
-            }
-            envelope.add_item(item);
-        });
-    }
-
+    let envelope =
+        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), path.event_id)?;
     Ok(envelope)
 }
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -10,14 +10,14 @@ use futures::stream::BoxStream;
 use multer::Field;
 use relay_config::{Config, RelayMode};
 use relay_event_schema::protocol::{EventId, EventType};
-use relay_quotas::{RateLimits, Scoping};
+use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_statsd::metric;
 use relay_system::Addr;
 use serde::Deserialize;
 
 use crate::envelope::{
     AttachmentPlaceholder, AttachmentType, ContentType, Envelope, EnvelopeError, Item, ItemType,
-    Items,
+    ManagedItems,
 };
 use crate::managed::{Managed, Rejected};
 use crate::service::ServiceState;
@@ -274,7 +274,7 @@ pub fn event_id_from_formdata(data: &[u8]) -> Result<Option<EventId>, BadStoreRe
 ///
 /// Extracting the event id from chunked formdata fields on the Minidump endpoint (`sentry__1`,
 /// `sentry__2`, ...) is not supported. In this case, `None` is returned.
-pub fn event_id_from_items(items: &Items) -> Result<Option<EventId>, BadStoreRequest> {
+pub fn event_id_from_items(items: &ManagedItems) -> Result<Option<EventId>, BadStoreRequest> {
     if let Some(item) = items.iter().find(|item| item.ty() == &ItemType::Event)
         && let Some(event_id) = event_id_from_json(&item.payload())?
     {
@@ -351,6 +351,17 @@ fn queue_envelope(
         .map_err(|e| e.map(BadStoreRequest::QueueFailed))
 }
 
+/// Convert `envelope` to a managed envelope and call [`handle_managed_envelope`].
+///
+/// See [`handle_managed_envelope`] for full details.
+pub async fn handle_envelope(
+    state: &ServiceState,
+    envelope: Box<Envelope>,
+) -> Result<HandledEnvelope, Rejected<BadStoreRequest>> {
+    let envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
+    handle_managed_envelope(state, envelope).await
+}
+
 /// Handles an envelope store request.
 ///
 /// Sentry envelopes may come either directly from an HTTP request (the envelope endpoint calls this
@@ -359,13 +370,11 @@ fn queue_envelope(
 ///
 /// This returns `Some(EventId)` if the envelope contains an event, either explicitly as payload or
 /// implicitly through an item that will create an event during ingestion.
-pub async fn handle_envelope(
+pub async fn handle_managed_envelope(
     state: &ServiceState,
-    envelope: Box<Envelope>,
+    mut envelope: Managed<Box<Envelope>>,
 ) -> Result<HandledEnvelope, Rejected<BadStoreRequest>> {
     emit_envelope_metrics(&envelope);
-
-    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
 
     if state.memory_checker().check_memory().is_exceeded() {
         return Err(envelope.reject_err((
@@ -485,12 +494,12 @@ fn emit_envelope_metrics(envelope: &Envelope) {
 /// Returns `None` if uploading fails due to any reason.
 pub async fn upload_to_objectstore(
     field: Field<'static>,
-    mut item: Item,
+    mut item: Managed<Item>,
     config: &Config,
     scoping: Scoping,
     upload: &Addr<Upload>,
     referrer: &'static str,
-) -> Option<Item> {
+) -> Option<Managed<Item>> {
     let content_type = field.content_type().map(ToString::to_string);
     let stream: BoxStream<'static, io::Result<Bytes>> = Box::pin(field.map_err(io::Error::other));
     let stream = MeteredStream::new(stream, referrer);
@@ -530,14 +539,19 @@ pub async fn upload_to_objectstore(
         .ok()?;
     let location = location.into_header_value().ok()?;
     let location = location.to_str().ok()?;
-    let payload = serde_json::to_vec(&AttachmentPlaceholder {
+    let placeholder = serde_json::to_vec(&AttachmentPlaceholder {
         location,
         content_type,
     })
     .ok()?;
 
-    item.set_payload(ContentType::AttachmentRef, payload);
-    item.set_attachment_length(byte_counter.get());
+    item.modify(|inner, records| {
+        let old = inner.attachment_body_size() as isize;
+        inner.set_payload(ContentType::AttachmentRef, placeholder);
+        inner.set_attachment_length(byte_counter.get());
+        let new = inner.attachment_body_size() as isize;
+        records.modify_by(DataCategory::Attachment, new - old);
+    });
     Some(item)
 }
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -549,7 +549,7 @@ pub async fn upload_to_objectstore(
     item.modify(|inner, records| {
         inner.set_payload(ContentType::AttachmentRef, placeholder);
         inner.set_attachment_length(byte_counter.get());
-        records.lenient(DataCategory::Attachment);
+        records.lenient(DataCategory::Attachment); // item was empty before
     });
     Some(item)
 }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -559,7 +559,7 @@ pub fn managed_items_to_envelope(
     meta: RequestMeta,
     outcome_aggregator: &Addr<TrackOutcome>,
     event_id: EventId,
-) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
+) -> Managed<Box<Envelope>> {
     let envelope = Envelope::from_request(Some(event_id), meta);
     let mut envelope = Managed::from_envelope(envelope, outcome_aggregator.clone());
     let mut has_event = false;
@@ -572,7 +572,7 @@ pub fn managed_items_to_envelope(
             envelope.add_item(item);
         });
     }
-    Ok(envelope)
+    envelope
 }
 
 #[derive(Debug)]

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -547,11 +547,9 @@ pub async fn upload_to_objectstore(
     .ok()?;
 
     item.modify(|inner, records| {
-        let old = inner.attachment_body_size() as isize;
         inner.set_payload(ContentType::AttachmentRef, placeholder);
         inner.set_attachment_length(byte_counter.get());
-        let new = inner.attachment_body_size() as isize;
-        records.modify_by(DataCategory::Attachment, new - old);
+        records.lenient(DataCategory::Attachment);
     });
     Some(item)
 }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -19,10 +19,11 @@ use crate::envelope::{
     AttachmentPlaceholder, AttachmentType, ContentType, Envelope, EnvelopeError, Item, ItemType,
     ManagedItems,
 };
+use crate::extractors::RequestMeta;
 use crate::managed::{Managed, Rejected};
 use crate::service::ServiceState;
 use crate::services::buffer::{ProjectKeyPair, PushError};
-use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome};
+use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::{BucketSource, MetricData, ProcessMetrics};
 use crate::services::upload::{Create, Stream, Upload};
 use crate::statsd::{RelayCounters, RelayDistributions};
@@ -553,6 +554,27 @@ pub async fn upload_to_objectstore(
         records.modify_by(DataCategory::Attachment, new - old);
     });
     Some(item)
+}
+
+pub fn managed_items_to_envelope(
+    items: ManagedItems,
+    meta: RequestMeta,
+    outcome_aggregator: &Addr<TrackOutcome>,
+    event_id: EventId,
+) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
+    let envelope = Envelope::from_request(Some(event_id), meta);
+    let mut envelope = Managed::from_envelope(envelope, outcome_aggregator.clone());
+    let mut has_event = false;
+    for item in items {
+        envelope.merge_with(item, |envelope, item, records| {
+            if !has_event && item.creates_event() {
+                records.modify_by(DataCategory::Error, 1);
+                has_event = true;
+            }
+            envelope.add_item(item);
+        });
+    }
+    Ok(envelope)
 }
 
 #[derive(Debug)]

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -25,6 +25,7 @@ use crate::endpoints::common::{self, BadStoreRequest, TextResponse, upload_to_ob
 use crate::envelope::ContentType::Minidump;
 use crate::envelope::{AttachmentType, Envelope, Item, ItemType};
 use crate::extractors::{RawContentType, RequestMeta};
+use crate::managed::Managed;
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason};
@@ -189,9 +190,9 @@ impl<'a> AttachmentStrategy for MinidumpAttachmentStrategy<'a> {
     async fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> Result<Option<Item>, multer::Error> {
+    ) -> Result<Option<Managed<Item>>, multer::Error> {
         match self.upload_context {
             Some(UploadContext { upload, scoping })
                 if item.attachment_type() == Some(AttachmentType::Attachment) =>
@@ -214,11 +215,11 @@ impl<'a> AttachmentStrategy for MinidumpAttachmentStrategy<'a> {
     }
 }
 
-async fn extract_multipart(
+async fn multipart_to_envelope(
     multipart: Multipart<'static>,
     meta: RequestMeta,
     state: &ServiceState,
-) -> Result<Box<Envelope>, BadStoreRequest> {
+) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
     let config = state.config();
 
     let upload_context = if should_fetch_project_config(state, meta.project_id()) {
@@ -237,34 +238,53 @@ async fn extract_multipart(
 
     let minidump_attachment_strategy = MinidumpAttachmentStrategy { upload_context };
 
-    let mut items = utils::multipart_items(multipart, config, minidump_attachment_strategy).await?;
+    let mut items = utils::multipart_items(
+        multipart,
+        config,
+        minidump_attachment_strategy,
+        &meta,
+        state.outcome_aggregator(),
+    )
+    .await?;
 
     let minidump_item = items
         .iter_mut()
         .find(|item| item.attachment_type() == Some(AttachmentType::Minidump))
         .ok_or(BadStoreRequest::MissingMinidump)?;
 
-    let embedded_opt = extract_embedded_minidump(minidump_item.payload()).await?;
-    if let Some(embedded) = embedded_opt {
-        minidump_item.set_payload(Minidump, embedded);
-    }
+    let payload = minidump_item.payload();
+    let payload = extract_embedded_minidump(payload.clone())
+        .await?
+        .unwrap_or(payload);
+    let payload = decode_minidump(payload, config.max_attachment_size())?;
 
-    minidump_item.set_payload(
-        Minidump,
-        decode_minidump(minidump_item.payload(), config.max_attachment_size())?,
-    );
+    minidump_item.modify(|inner, records| {
+        let old = inner.attachment_body_size() as isize;
+        inner.set_payload(Minidump, payload);
+        let new = inner.attachment_body_size() as isize;
+        records.modify_by(DataCategory::Attachment, new - old);
+    });
 
     validate_minidump(&minidump_item.payload())?;
 
-    if let Some(minidump_filename) = minidump_item.filename() {
-        minidump_item.set_filename(remove_container_extension(minidump_filename).to_owned());
-    }
+    minidump_item.modify(|inner, _| {
+        if let Some(minidump_filename) = inner.filename() {
+            inner.set_filename(remove_container_extension(minidump_filename).to_owned())
+        }
+    });
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
-    let mut envelope = Envelope::from_request(Some(event_id), meta);
-
+    let envelope = Envelope::from_request(Some(event_id), meta);
+    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
+    let mut has_event = false;
     for item in items {
-        envelope.add_item(item);
+        envelope.merge_with(item, |envelope, item, records| {
+            if !has_event && item.creates_event() {
+                records.modify_by(DataCategory::Error, 1);
+                has_event = true;
+            }
+            envelope.add_item(item);
+        });
     }
 
     Ok(envelope)
@@ -320,21 +340,32 @@ fn upload_context_for_project<'a>(
     }
 }
 
-fn extract_raw_minidump(
+fn raw_minidump_to_envelope(
     data: Bytes,
     meta: RequestMeta,
-    max_size: usize,
-) -> Result<Box<Envelope>, BadStoreRequest> {
+    state: &ServiceState,
+) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
     let mut item = Item::new(ItemType::Attachment);
-
-    item.set_payload(Minidump, decode_minidump(data, max_size)?);
-    validate_minidump(&item.payload())?;
     item.set_filename(MINIDUMP_FILE_NAME);
     item.set_attachment_type(AttachmentType::Minidump);
+    item.set_payload(Minidump, data.clone());
+    let mut item = Managed::with_meta_from_request_meta(&meta, state.outcome_aggregator(), item);
+    let decoded_payload = decode_minidump(data, state.config().max_attachment_size())?;
+    item.modify(|inner, records| {
+        let old = inner.attachment_body_size() as isize;
+        inner.set_payload(Minidump, decoded_payload);
+        let new = inner.attachment_body_size() as isize;
+        records.modify_by(DataCategory::Attachment, new - old);
+    });
+    validate_minidump(&item.payload())?;
 
     // Create an envelope with a random event id.
-    let mut envelope = Envelope::from_request(Some(EventId::new()), meta);
-    envelope.add_item(item);
+    let envelope = Envelope::from_request(Some(EventId::new()), meta);
+    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
+    envelope.merge_with(item, |envelope, item, records| {
+        records.modify_by(DataCategory::Error, 1);
+        envelope.add_item(item);
+    });
     Ok(envelope)
 }
 
@@ -349,18 +380,17 @@ async fn handle(
     // Minidump request payloads do not have the same structure as usual events from other SDKs. The
     // minidump can either be transmitted as request body, or as `upload_file_minidump` in a
     // multipart formdata request.
-    let config = state.config();
     let envelope = if MINIDUMP_RAW_CONTENT_TYPES.contains(&content_type.as_ref()) {
-        extract_raw_minidump(request.extract().await?, meta, config.max_attachment_size())?
+        raw_minidump_to_envelope(request.extract().await?, meta, &state)?
     } else {
         let multipart = utils::multipart_from_request(request)?;
-        extract_multipart(multipart, meta, &state).await?
+        multipart_to_envelope(multipart, meta, &state).await?
     };
 
     let id = envelope.event_id();
 
     // Never respond with a 429 since clients often retry these
-    common::handle_envelope(&state, envelope)
+    common::handle_managed_envelope(&state, envelope)
         .await?
         .ignore_rate_limits();
 
@@ -541,6 +571,11 @@ mod tests {
 
         let config = Config::default();
 
+        let request_meta = RequestMeta::new(
+            "https://a94ae32be2582e0bbd7a4cbb95971fee:@sentry.io/42"
+                .parse()
+                .unwrap(),
+        );
         let multipart = utils::multipart_from_request(request).unwrap();
         let items = utils::multipart_items(
             multipart,
@@ -548,6 +583,8 @@ mod tests {
             MinidumpAttachmentStrategy {
                 upload_context: None,
             },
+            &request_meta,
+            &Addr::dummy(),
         )
         .await
         .unwrap();

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -273,7 +273,7 @@ async fn multipart_to_envelope(
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
     let envelope =
-        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), event_id)?;
+        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), event_id);
     Ok(envelope)
 }
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -340,7 +340,7 @@ fn raw_minidump_to_envelope(
     let decoded_payload = decode_minidump(data, state.config().max_attachment_size())?;
     item.modify(|inner, records| {
         inner.set_payload(Minidump, decoded_payload);
-        records.lenient(DataCategory::Attachment);
+        records.lenient(DataCategory::Attachment); // decoding the minidump changes its size
     });
     validate_minidump(&item.payload())?;
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -274,19 +274,8 @@ async fn multipart_to_envelope(
     });
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
-    let envelope = Envelope::from_request(Some(event_id), meta);
-    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
-    let mut has_event = false;
-    for item in items {
-        envelope.merge_with(item, |envelope, item, records| {
-            if !has_event && item.creates_event() {
-                records.modify_by(DataCategory::Error, 1);
-                has_event = true;
-            }
-            envelope.add_item(item);
-        });
-    }
-
+    let envelope =
+        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), event_id)?;
     Ok(envelope)
 }
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -259,10 +259,8 @@ async fn multipart_to_envelope(
     let payload = decode_minidump(payload, config.max_attachment_size())?;
 
     minidump_item.modify(|inner, records| {
-        let old = inner.attachment_body_size() as isize;
         inner.set_payload(Minidump, payload);
-        let new = inner.attachment_body_size() as isize;
-        records.modify_by(DataCategory::Attachment, new - old);
+        records.lenient(DataCategory::Attachment);
     });
 
     validate_minidump(&minidump_item.payload())?;
@@ -341,10 +339,8 @@ fn raw_minidump_to_envelope(
     let mut item = Managed::with_meta_from_request_meta(&meta, state.outcome_aggregator(), item);
     let decoded_payload = decode_minidump(data, state.config().max_attachment_size())?;
     item.modify(|inner, records| {
-        let old = inner.attachment_body_size() as isize;
         inner.set_payload(Minidump, decoded_payload);
-        let new = inner.attachment_body_size() as isize;
-        records.modify_by(DataCategory::Attachment, new - old);
+        records.lenient(DataCategory::Attachment);
     });
     validate_minidump(&item.payload())?;
 

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -18,6 +18,7 @@ use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
 use crate::envelope::ContentType::OctetStream;
 use crate::envelope::{AttachmentType, Envelope, Item};
 use crate::extractors::{RawContentType, RequestMeta};
+use crate::managed::Managed;
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::DiscardReason;
@@ -83,9 +84,9 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
     async fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> Result<Option<Item>, multer::Error> {
+    ) -> Result<Option<Managed<Item>>, multer::Error> {
         match self.upload_service {
             Some(upload) if self.infer_type(&field) != AttachmentType::Prosperodump => {
                 Ok(common::upload_to_objectstore(
@@ -120,12 +121,12 @@ fn validate_prosperodump(data: &[u8]) -> Result<(), BadStoreRequest> {
     Ok(())
 }
 
-async fn extract_multipart(
+async fn multipart_to_envelope(
     multipart: Multipart<'static>,
     meta: RequestMeta,
     state: &ServiceState,
     project: &Project<'_>,
-) -> Result<Box<Envelope>, BadStoreRequest> {
+) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
     let project_config = project
         .state()
         .clone()
@@ -147,22 +148,36 @@ async fn extract_multipart(
         scoping,
         upload_service,
     };
-    let mut items = utils::multipart_items(multipart, state.config(), attachment_strategy).await?;
+    let mut items = utils::multipart_items(
+        multipart,
+        state.config(),
+        attachment_strategy,
+        &meta,
+        state.outcome_aggregator(),
+    )
+    .await?;
 
     let prosperodump_item = items
         .iter_mut()
         .find(|item| item.attachment_type() == Some(AttachmentType::Prosperodump))
         .ok_or(BadStoreRequest::MissingProsperodump)?;
 
-    prosperodump_item.set_payload(OctetStream, prosperodump_item.payload());
+    prosperodump_item.modify(|inner, _| inner.set_payload(OctetStream, inner.payload()));
 
     validate_prosperodump(&prosperodump_item.payload())?;
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
-    let mut envelope = Envelope::from_request(Some(event_id), meta);
-
+    let envelope = Envelope::from_request(Some(event_id), meta);
+    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
+    let mut has_event = false;
     for item in items {
-        envelope.add_item(item);
+        envelope.merge_with(item, |envelope, item, records| {
+            if !has_event && item.creates_event() {
+                records.modify_by(DataCategory::Error, 1);
+                has_event = true;
+            }
+            envelope.add_item(item);
+        });
     }
 
     Ok(envelope)
@@ -187,13 +202,13 @@ async fn handle(
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
     let multipart = utils::multipart_from_request(request)?;
-    let mut envelope = extract_multipart(multipart, meta, &state, &project).await?;
-    envelope.require_feature(Feature::PlaystationIngestion);
+    let mut envelope = multipart_to_envelope(multipart, meta, &state, &project).await?;
+    envelope.modify(|inner, _| inner.require_feature(Feature::PlaystationIngestion));
 
     let id = envelope.event_id();
 
     // Never respond with a 429 since clients often retry these
-    common::handle_envelope(&state, envelope)
+    common::handle_managed_envelope(&state, envelope)
         .await?
         .ignore_rate_limits();
 

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -166,7 +166,7 @@ async fn multipart_to_envelope(
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
     let envelope =
-        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), event_id)?;
+        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), event_id);
     Ok(envelope)
 }
 

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -161,25 +161,12 @@ async fn multipart_to_envelope(
         .iter_mut()
         .find(|item| item.attachment_type() == Some(AttachmentType::Prosperodump))
         .ok_or(BadStoreRequest::MissingProsperodump)?;
-
     prosperodump_item.modify(|inner, _| inner.set_payload(OctetStream, inner.payload()));
-
     validate_prosperodump(&prosperodump_item.payload())?;
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
-    let envelope = Envelope::from_request(Some(event_id), meta);
-    let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
-    let mut has_event = false;
-    for item in items {
-        envelope.merge_with(item, |envelope, item, records| {
-            if !has_event && item.creates_event() {
-                records.modify_by(DataCategory::Error, 1);
-                has_event = true;
-            }
-            envelope.add_item(item);
-        });
-    }
-
+    let envelope =
+        common::managed_items_to_envelope(items, meta, state.outcome_aggregator(), event_id)?;
     Ok(envelope)
 }
 

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -12,6 +12,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::envelope::{AttachmentType, ContentType, EnvelopeError};
 use crate::integrations::{Integration, LogsIntegration, SpansIntegration};
+use crate::managed::Managed;
 use crate::statsd::RelayTimers;
 
 #[derive(Clone, Debug)]
@@ -769,6 +770,7 @@ impl Item {
     }
 }
 
+pub type ManagedItems = SmallVec<[Managed<Item>; 3]>;
 pub type Items = SmallVec<[Item; 3]>;
 pub type ItemIter<'a> = std::slice::Iter<'a, Item>;
 pub type ItemIterMut<'a> = std::slice::IterMut<'a, Item>;

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -16,6 +16,7 @@ use relay_system::Addr;
 use smallvec::SmallVec;
 
 use crate::Envelope;
+use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
@@ -181,7 +182,7 @@ impl<T: Counted> Managed<T> {
     ///
     /// The [`Managed`] instance, inherits all metadata from the passed [`ManagedEnvelope`],
     /// like received time or scoping.
-    pub fn with_meta_from(envelope: &ManagedEnvelope, value: T) -> Self {
+    pub fn with_meta_from_managed_envelope(envelope: &ManagedEnvelope, value: T) -> Self {
         Self::from_parts(
             value,
             Arc::new(Meta {
@@ -190,6 +191,24 @@ impl<T: Counted> Managed<T> {
                 scoping: envelope.scoping(),
                 event_id: envelope.envelope().event_id(),
                 remote_addr: envelope.meta().remote_addr(),
+            }),
+        )
+    }
+
+    /// Creates new [`Managed`] instance with the provided `value` and metadata from `request_meta`.
+    pub fn with_meta_from_request_meta(
+        request_meta: &RequestMeta,
+        outcome_aggregator: &Addr<TrackOutcome>,
+        value: T,
+    ) -> Self {
+        Self::from_parts(
+            value,
+            Arc::new(Meta {
+                outcome_aggregator: outcome_aggregator.clone(),
+                received_at: request_meta.received_at(),
+                scoping: request_meta.get_partial_scoping().into_scoping(),
+                event_id: None,
+                remote_addr: request_meta.remote_addr(),
             }),
         )
     }
@@ -1104,7 +1123,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     struct CountedVec(Vec<u32>);

--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -83,7 +83,7 @@ impl processing::Processor for AttachmentProcessor {
             headers,
             attachments,
         };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/check_ins/mod.rs
+++ b/relay-server/src/processing/check_ins/mod.rs
@@ -72,7 +72,7 @@ impl processing::Processor for CheckInsProcessor {
             .into_vec();
 
         let work = SerializedCheckIns { headers, check_ins };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/client_reports/mod.rs
+++ b/relay-server/src/processing/client_reports/mod.rs
@@ -79,7 +79,7 @@ impl processing::Processor for ClientReportsProcessor {
         }
 
         let work = SerializedClientReports { headers, reports };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/errors/mod.rs
+++ b/relay-server/src/processing/errors/mod.rs
@@ -100,7 +100,7 @@ impl processing::Processor for ErrorsProcessor {
             headers: envelope.envelope().headers().clone(),
             items,
         };
-        Some(Managed::with_meta_from(envelope, errors))
+        Some(Managed::with_meta_from_managed_envelope(envelope, errors))
     }
 
     async fn process(

--- a/relay-server/src/processing/forward_unknown/mod.rs
+++ b/relay-server/src/processing/forward_unknown/mod.rs
@@ -44,7 +44,7 @@ impl processing::Processor for ForwardUnknownProcessor {
             return None;
         }
 
-        Some(Managed::with_meta_from(
+        Some(Managed::with_meta_from_managed_envelope(
             envelope,
             UnknownItems {
                 headers: envelope.envelope().headers().clone(),

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -97,7 +97,7 @@ impl processing::Processor for LegacySpansProcessor {
         }
 
         let work = SerializedLegacySpans { headers, spans };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/logs/mod.rs
+++ b/relay-server/src/processing/logs/mod.rs
@@ -136,7 +136,7 @@ impl processing::Processor for LogsProcessor {
             items,
             invalid,
         };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/profile_chunks/mod.rs
+++ b/relay-server/src/processing/profile_chunks/mod.rs
@@ -86,7 +86,7 @@ impl processing::Processor for ProfileChunksProcessor {
             return None;
         }
 
-        Some(Managed::with_meta_from(
+        Some(Managed::with_meta_from_managed_envelope(
             envelope,
             SerializedProfileChunks {
                 headers: envelope.envelope().headers().clone(),

--- a/relay-server/src/processing/profiles/mod.rs
+++ b/relay-server/src/processing/profiles/mod.rs
@@ -92,7 +92,7 @@ impl Processor for ProfilesProcessor {
         }
 
         let profiles = SerializedProfiles { headers, profiles };
-        Some(Managed::with_meta_from(envelope, profiles))
+        Some(Managed::with_meta_from_managed_envelope(envelope, profiles))
     }
 
     async fn process(

--- a/relay-server/src/processing/replays/mod.rs
+++ b/relay-server/src/processing/replays/mod.rs
@@ -186,7 +186,7 @@ impl processing::Processor for ReplaysProcessor {
             videos,
         };
 
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/sessions/mod.rs
+++ b/relay-server/src/processing/sessions/mod.rs
@@ -78,7 +78,7 @@ impl processing::Processor for SessionsProcessor {
             updates,
             aggregates,
         };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -166,7 +166,7 @@ impl processing::Processor for SpansProcessor {
             return None;
         }
 
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/trace_attachments/mod.rs
+++ b/relay-server/src/processing/trace_attachments/mod.rs
@@ -106,7 +106,7 @@ impl Processor for TraceAttachmentsProcessor {
 
         (!items.is_empty()).then(|| {
             let work = SerializedAttachments { headers, items };
-            Managed::with_meta_from(envelope, work)
+            Managed::with_meta_from_managed_envelope(envelope, work)
         })
     }
 

--- a/relay-server/src/processing/trace_metrics/mod.rs
+++ b/relay-server/src/processing/trace_metrics/mod.rs
@@ -122,7 +122,7 @@ impl processing::Processor for TraceMetricsProcessor {
         }
 
         let work = SerializedTraceMetrics { headers, metrics };
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/transactions/mod.rs
+++ b/relay-server/src/processing/transactions/mod.rs
@@ -121,7 +121,7 @@ impl Processor for TransactionProcessor {
             profiles,
         };
 
-        Some(Managed::with_meta_from(envelope, work))
+        Some(Managed::with_meta_from_managed_envelope(envelope, work))
     }
 
     async fn process(

--- a/relay-server/src/processing/user_reports/mod.rs
+++ b/relay-server/src/processing/user_reports/mod.rs
@@ -78,7 +78,7 @@ impl Processor for UserReportsProcessor {
         }
 
         let reports = SerializedUserReports { headers, reports };
-        Some(Managed::with_meta_from(envelope, reports))
+        Some(Managed::with_meta_from_managed_envelope(envelope, reports))
     }
 
     async fn process(

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -439,7 +439,7 @@ impl StoreService {
                 // through `EnvelopeSummary`, but `Managed<Box<Envelope>>` does not.
                 // -> Reject the old way and return a dummy item.
                 envelope.reject(Outcome::Invalid(DiscardReason::Internal));
-                Err(Managed::with_meta_from(&envelope, ()).reject_err(error))
+                Err(Managed::with_meta_from_managed_envelope(&envelope, ()).reject_err(error))
             }
         }
     }

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -6,12 +6,17 @@ use bytes::Bytes;
 use futures::TryStreamExt;
 use multer::{Field, Multipart};
 use relay_config::Config;
+use relay_quotas::DataCategory;
+use relay_system::Addr;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncReadExt;
 use tokio_util::io::StreamReader;
 
 use crate::endpoints::common::BadStoreRequest;
-use crate::envelope::{AttachmentType, ContentType, Item, ItemType, Items};
+use crate::envelope::{AttachmentType, ContentType, Item, ItemType, ManagedItems};
+use crate::extractors::RequestMeta;
+use crate::managed::Managed;
+use crate::services::outcome::TrackOutcome;
 
 /// Type used for encoding string lengths.
 type Len = u32;
@@ -174,18 +179,20 @@ pub trait AttachmentStrategy {
     fn add_to_item(
         &self,
         field: Field<'static>,
-        item: Item,
+        item: Managed<Item>,
         config: &Config,
-    ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send;
 }
 
 pub async fn read_attachment_bytes_into_item(
     field: Field<'static>,
-    mut item: Item,
+    mut item: Managed<Item>,
     config: &Config,
     ignore_size_exceeded: bool,
-) -> Result<Option<Item>, multer::Error> {
-    let content_type = field.content_type().cloned();
+) -> Result<Option<Managed<Item>>, multer::Error> {
+    let content_type = field
+        .content_type()
+        .map(|ct| ct.as_ref().parse().unwrap_or(ContentType::OctetStream));
     let field_name = field.name().map(String::from);
     let limit = config.max_attachment_size();
     let mut buf = Vec::new();
@@ -194,7 +201,19 @@ pub async fn read_attachment_bytes_into_item(
         .read_to_end(&mut buf)
         .await
         .map_err(|e| multer::Error::StreamReadFailed(Box::new(e)))?;
-    if buf.len() > limit {
+    let bytes = Bytes::from(buf);
+    let n_bytes = bytes.len();
+    item.modify(|inner, records| {
+        let old = inner.attachment_body_size() as isize;
+        if let Some(content_type) = content_type {
+            inner.set_payload(content_type, bytes);
+        } else {
+            inner.set_payload_without_content_type(bytes);
+        };
+        let new = inner.attachment_body_size() as isize;
+        records.modify_by(DataCategory::Attachment, new - old);
+    });
+    if n_bytes > limit {
         return match ignore_size_exceeded {
             true => Ok(None),
             false => Err(multer::Error::FieldSizeExceeded {
@@ -203,16 +222,6 @@ pub async fn read_attachment_bytes_into_item(
             }),
         };
     }
-    let bytes = Bytes::from(buf);
-    if let Some(content_type) = content_type {
-        let ct = content_type
-            .as_ref()
-            .parse()
-            .unwrap_or(ContentType::OctetStream);
-        item.set_payload(ct, bytes);
-    } else {
-        item.set_payload_without_content_type(bytes);
-    }
     Ok(Some(item))
 }
 
@@ -220,10 +229,13 @@ pub async fn multipart_items(
     mut multipart: Multipart<'static>,
     config: &Config,
     attachment_strategy: impl AttachmentStrategy,
-) -> Result<Items, multer::Error> {
-    let mut items = Items::new();
+    request_meta: &RequestMeta,
+    outcome_aggregator: &Addr<TrackOutcome>,
+) -> Result<ManagedItems, multer::Error> {
+    let mut items = ManagedItems::new();
     let mut form_data = FormDataWriter::new();
     let mut attachments_size = 0;
+    let meta_provider = Managed::with_meta_from_request_meta(request_meta, outcome_aggregator, ());
 
     while let Some(field) = multipart.next_field().await? {
         if let Some(file_name) = field.file_name() {
@@ -231,6 +243,7 @@ pub async fn multipart_items(
             let attachment_type = attachment_strategy.infer_type(&field);
             item.set_attachment_type(attachment_type);
             item.set_filename(file_name);
+            let item = meta_provider.wrap(item);
             let item = attachment_strategy.add_to_item(field, item, config).await?;
             if let Some(item) = item {
                 // This increases the attachments byte count even if the item is an attachment ref.
@@ -260,7 +273,7 @@ pub async fn multipart_items(
         // Content type is `Text` (since it is not a json object but multiple
         // json arrays serialized one after the other).
         item.set_payload(ContentType::Text, form_data);
-        items.push(item);
+        items.push(meta_provider.wrap(item));
     }
 
     Ok(items)
@@ -285,6 +298,13 @@ mod tests {
     use std::convert::Infallible;
 
     use super::*;
+
+    fn mock_request_meta() -> RequestMeta {
+        let dsn = "https://a94ae32be2582e0bbd7a4cbb95971fee:@sentry.io/42"
+            .parse()
+            .unwrap();
+        RequestMeta::new(dsn)
+    }
 
     #[test]
     fn test_get_boundary() {
@@ -380,9 +400,10 @@ mod tests {
             fn add_to_item(
                 &self,
                 field: Field<'static>,
-                item: Item,
+                item: Managed<Item>,
                 config: &Config,
-            ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+            ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send
+            {
                 read_attachment_bytes_into_item(field, item, config, false)
             }
 
@@ -391,7 +412,14 @@ mod tests {
             }
         }
 
-        let res = multipart_items(multipart, &config, MockAttachmentStrategy).await;
+        let res = multipart_items(
+            multipart,
+            &config,
+            MockAttachmentStrategy,
+            &mock_request_meta(),
+            &Addr::dummy(),
+        )
+        .await;
         assert!(res.is_err_and(|x| matches!(x, multer::Error::FieldSizeExceeded { .. })));
     }
 
@@ -425,9 +453,10 @@ mod tests {
             fn add_to_item(
                 &self,
                 field: Field<'static>,
-                item: Item,
+                item: Managed<Item>,
                 config: &Config,
-            ) -> impl Future<Output = Result<Option<Item>, multer::Error>> + Send {
+            ) -> impl Future<Output = Result<Option<Managed<Item>>, multer::Error>> + Send
+            {
                 read_attachment_bytes_into_item(field, item, config, true)
             }
 
@@ -436,7 +465,14 @@ mod tests {
             }
         }
 
-        let result = multipart_items(multipart, config, MockAttachmentStrategy).await;
+        let result = multipart_items(
+            multipart,
+            config,
+            MockAttachmentStrategy,
+            &mock_request_meta(),
+            &Addr::dummy(),
+        )
+        .await;
 
         // Should be warned if the overall stream limit is being breached.
         assert!(result.is_err_and(|x| matches!(x, multer::Error::StreamSizeExceeded { limit: _ })));

--- a/relay-server/src/utils/multipart.rs
+++ b/relay-server/src/utils/multipart.rs
@@ -204,14 +204,12 @@ pub async fn read_attachment_bytes_into_item(
     let bytes = Bytes::from(buf);
     let n_bytes = bytes.len();
     item.modify(|inner, records| {
-        let old = inner.attachment_body_size() as isize;
         if let Some(content_type) = content_type {
             inner.set_payload(content_type, bytes);
         } else {
             inner.set_payload_without_content_type(bytes);
         };
-        let new = inner.attachment_body_size() as isize;
-        records.modify_by(DataCategory::Attachment, new - old);
+        records.lenient(DataCategory::Attachment);
     });
     if n_bytes > limit {
         return match ignore_size_exceeded {

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -267,7 +267,7 @@ def test_playstation_no_feature_flag(
     ]
 
 
-def test_playstation_wrong_file(
+def test_playstation_invalid_prosperodump(
     mini_sentry, relay_processing_with_playstation, outcomes_consumer
 ):
     PROJECT_ID = 42
@@ -282,6 +282,62 @@ def test_playstation_wrong_file(
     response = exc_info.value.response
     assert response.status_code == 400, "Expected a 400 status code"
     assert response.json()["detail"] == "invalid prosperodump"
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 4,
+            "quantity": len(playstation_dump),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
+
+
+def test_playstation_missing_prosperodump(
+    mini_sentry, relay_processing_with_playstation, outcomes_consumer
+):
+    PROJECT_ID = 42
+    video_content = b"yo"
+    prosperodump = None
+    mini_sentry.add_full_project_config(PROJECT_ID, extra=playstation_project_config())
+    outcomes_consumer = outcomes_consumer()
+    relay = relay_processing_with_playstation()
+
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        _ = relay.send_playstation_request(PROJECT_ID, prosperodump, video_content)
+
+    response = exc_info.value.response
+    assert response.status_code == 400, "Expected a 400 status code"
+    assert response.json()["detail"] == "missing prosperodump"
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 4,
+            "quantity": len(video_content),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_playstation_max_attachments_size_exceeded(
@@ -306,7 +362,24 @@ def test_playstation_max_attachments_size_exceeded(
     response = exc_info.value.response
     assert response.status_code == 413, response.json()
     assert response.json() == {"detail": "request content exceeded size limits"}
-    outcomes_consumer.assert_empty()
+    assert outcomes_consumer.get_outcomes() == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 4,
+            "quantity": len(playstation_dump),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_playstation_max_attachment_size_exceeded(
@@ -330,7 +403,25 @@ def test_playstation_max_attachment_size_exceeded(
 
     response = exc_info.value.response
     assert response.status_code == 400, "Expected a 400 status code"
-    assert len(outcomes_consumer.get_outcomes()) == 0
+    outcomes = outcomes_consumer.get_outcomes()
+    assert outcomes == [
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 4,
+            "quantity": len(playstation_dump),
+        },
+        {
+            "timestamp": time_within_delta(),
+            "project_id": 42,
+            "outcome": 3,
+            "reason": "internal",
+            "category": 22,
+            "quantity": 1,
+        },
+    ]
 
 
 def test_playstation_max_stream_size_exceeded(


### PR DESCRIPTION
Wrap multipart items with `Managed` so that outcomes are emitted when something goes wrong (i.e. when items get dropped).

Fixes https://linear.app/getsentry/issue/RELAY-231/use-managed-in-multipart