### PR TITLE
ref(geoip): Log geoip build epoch on startup

### DIFF
--- a/relay-event-normalization/src/geo.rs
+++ b/relay-event-normalization/src/geo.rs
@@ -44,10 +44,8 @@ impl GeoIpLookup {
     ///
     /// Returns `None` for an [`Self::empty`] database.
     pub fn build_epoch(&self) -> Option<UnixTimestamp> {
-        self.0
-            .as_ref()
-            .map(|reader| reader.metadata.build_epoch)
-            .map(UnixTimestamp::from_secs)
+        let reader = self.0.as_ref()?;
+        Some(UnixTimestamp::from_secs(reader.metadata.build_epoch))
     }
 
     /// Looks up an IP address.

--- a/relay-event-normalization/src/geo.rs
+++ b/relay-event-normalization/src/geo.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use std::path::Path;
 use std::sync::Arc;
 
+use relay_common::time::UnixTimestamp;
 use relay_event_schema::protocol::Geo;
 use relay_protocol::Annotated;
 
@@ -37,6 +38,16 @@ impl GeoIpLookup {
     /// Creates a new [`GeoIpLookup`] instance without any data loaded.
     pub fn empty() -> Self {
         Self(None)
+    }
+
+    /// Unix timestamp when the database was built.
+    ///
+    /// Returns `None` for an [`Self::empty`] database.
+    pub fn build_epoch(&self) -> Option<UnixTimestamp> {
+        self.0
+            .as_ref()
+            .map(|reader| reader.metadata.build_epoch)
+            .map(UnixTimestamp::from_secs)
     }
 
     /// Looks up an IP address.

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -991,6 +991,10 @@ impl EnvelopeProcessorService {
             )
             .unwrap_or_else(GeoIpLookup::empty);
 
+        if let Some(build_epoch) = geoip_lookup.build_epoch() {
+            relay_log::info!("Loaded GeoIP database (build: {build_epoch})");
+        }
+
         #[cfg(feature = "processing")]
         let rate_limiter = redis.as_ref().map(|redis| {
             RedisRateLimiter::new(redis.quotas.clone())


### PR DESCRIPTION
Maybe not the cleanest to do in the constructor, open for suggestions:
- Considered moving the geo ip construction out of the constructor but that's yet another arg
- Considered doing it in the geoip constructor

This should help with questions of "X should be Y, are we using the latest db?"