### PR TITLE
ref(quotas): Convert DataCategories from an array to a bitfield

### DIFF
--- a/relay-base-schema/src/data_category.rs
+++ b/relay-base-schema/src/data_category.rs
@@ -515,7 +515,7 @@ impl CategoryUnit {
     /// Returns `None` for `DataCategory::Unknown`.
     ///
     /// Note: Takes a reference to avoid unnecessary copying and allow direct use with iterators.
-    pub fn from_category(category: &DataCategory) -> Option<Self> {
+    pub fn from_category(category: DataCategory) -> Option<Self> {
         match category {
             DataCategory::Default
             | DataCategory::Error
@@ -637,40 +637,40 @@ mod tests {
     fn test_category_unit_from_category() {
         // Count categories
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::Error),
+            CategoryUnit::from_category(DataCategory::Error),
             Some(CategoryUnit::Count)
         );
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::Transaction),
+            CategoryUnit::from_category(DataCategory::Transaction),
             Some(CategoryUnit::Count)
         );
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::Span),
+            CategoryUnit::from_category(DataCategory::Span),
             Some(CategoryUnit::Count)
         );
 
         // Bytes categories
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::Attachment),
+            CategoryUnit::from_category(DataCategory::Attachment),
             Some(CategoryUnit::Bytes)
         );
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::LogByte),
+            CategoryUnit::from_category(DataCategory::LogByte),
             Some(CategoryUnit::Bytes)
         );
 
         // Milliseconds categories
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::ProfileDuration),
+            CategoryUnit::from_category(DataCategory::ProfileDuration),
             Some(CategoryUnit::Milliseconds)
         );
         assert_eq!(
-            CategoryUnit::from_category(&DataCategory::ProfileDurationUi),
+            CategoryUnit::from_category(DataCategory::ProfileDurationUi),
             Some(CategoryUnit::Milliseconds)
         );
 
         // Unknown returns None
-        assert_eq!(CategoryUnit::from_category(&DataCategory::Unknown), None);
+        assert_eq!(CategoryUnit::from_category(DataCategory::Unknown), None);
     }
 
     #[test]

--- a/relay-cabi/src/constants.rs
+++ b/relay-cabi/src/constants.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn relay_category_unit_parse(name: *const RelayStr) -> i8 
 #[unsafe(no_mangle)]
 #[relay_ffi::catch_unwind]
 pub unsafe extern "C" fn relay_data_category_unit(category: DataCategory) -> i8 {
-    match CategoryUnit::from_category(&category) {
+    match CategoryUnit::from_category(category) {
         Some(unit) => unit as i8,
         None => CATEGORY_UNIT_NONE,
     }

--- a/relay-dynamic-config/src/project.rs
+++ b/relay-dynamic-config/src/project.rs
@@ -124,7 +124,7 @@ impl ProjectConfig {
             // This is probably not intended behavior.
             for quota in &self.quotas {
                 if let Some(id) = quota.id.as_deref() {
-                    for category in &*quota.categories {
+                    for category in quota.categories.iter() {
                         if let Some(indexed) = category.index_category()
                             && quota.categories.contains(&indexed)
                         {

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -183,7 +183,7 @@ impl Serialize for DataCategories {
     where
         S: serde::Serializer,
     {
-        let mut ser = serializer.serialize_seq(Some(self.size()))?;
+        let mut ser = serializer.serialize_seq(Some(self.len()))?;
         for category in self.iter() {
             ser.serialize_element(&category)?;
         }
@@ -195,7 +195,7 @@ impl DataCategories {
     fn category_to_mask(category: DataCategory) -> u64 {
         if matches!(category, DataCategory::Unknown) {
             // Handle Unknown by throwing it into the last bit.
-            1u64 << (8 * std::mem::size_of::<u64>() - 1)
+            1u64 << 63
         } else {
             1u64 << (category as u8)
         }
@@ -227,7 +227,7 @@ impl DataCategories {
     pub fn add(&self, category: DataCategory) -> Option<Self> {
         let category_mask = DataCategories::category_to_mask(category);
 
-        if self.0 & category_mask != 0 {
+        if (self.0 & category_mask) != 0 {
             return None;
         }
 
@@ -237,7 +237,7 @@ impl DataCategories {
     /// Returns true iff the category is contained.
     pub fn contains(&self, category: &DataCategory) -> bool {
         let category_mask = DataCategories::category_to_mask(*category);
-        self.0 & category_mask != 0
+        (self.0 & category_mask) != 0
     }
 
     /// Returns an iterator over this [`DataCategories`] container.
@@ -255,7 +255,7 @@ impl DataCategories {
     }
 
     /// Returns the number of categories in this container.
-    pub fn size(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.count_ones() as usize
     }
 

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use relay_base_schema::metrics::MetricNamespace;
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::{ProjectId, ProjectKey};
+use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
@@ -141,7 +142,7 @@ impl ItemScoping {
     }
 
     /// Checks whether the category matches any of the quota's categories.
-    pub(crate) fn matches_categories(&self, categories: &[DataCategory]) -> bool {
+    pub(crate) fn matches_categories(&self, categories: &DataCategories) -> bool {
         // An empty list of categories means that this quota matches all categories. Note that we
         // skip `Unknown` categories silently. If the list of categories only contains `Unknown`s,
         // we do **not** match, since apparently the quota is meant for some data this Relay does
@@ -174,23 +175,49 @@ impl ItemScoping {
 /// An efficient container for data categories that avoids allocations.
 ///
 /// It is a read only and has set like properties, allowing for fast comparisons.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize)]
-#[serde(transparent)]
-pub struct DataCategories(Arc<[DataCategory]>);
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
+pub struct DataCategories(u128);
+
+impl Serialize for DataCategories {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut ser = serializer.serialize_seq(Some(self.size()))?;
+        for category in self.iter() {
+            ser.serialize_element(&category)?;
+        }
+        ser.end()
+    }
+}
 
 impl DataCategories {
+    fn category_to_mask(category: DataCategory) -> u128 {
+        if matches!(category, DataCategory::Unknown) {
+            // Handle Unknown by throwing it into the last bit.
+            1u128 << (8 * std::mem::size_of::<u128>() - 1)
+        } else {
+            1u128 << (category as u8)
+        }
+    }
+
+    fn bit_number_to_category(bit_number: u8) -> DataCategory {
+        bit_number.try_into().unwrap_or(DataCategory::Unknown)
+    }
+
     /// Creates new and empty [`DataCategories`].
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Creates a new [`Self`] from a [`SmallVec`].
-    ///
-    /// Sorts and de-duplicates the contents to uphold the invariants of the type.
-    fn new_sort_and_dedup<const N: usize>(mut s: SmallVec<[DataCategory; N]>) -> Self {
-        s.sort_unstable();
-        s.dedup();
-        Self(s.as_slice().into())
+    /// Creates a new [`DataCategories`] from the supplied slice of [`DataCategory`] values.
+    pub fn from_slice(slice: &[DataCategory]) -> Self {
+        let mut categories = 0;
+        for category in slice {
+            categories |= DataCategories::category_to_mask(*category);
+        }
+
+        Self(categories)
     }
 
     /// Adds a data category to [`Self`].
@@ -198,23 +225,77 @@ impl DataCategories {
     /// Returns `None` if the category was already contained, otherwise creates a new [`Self`] with
     /// the `category` added.
     pub fn add(&self, category: DataCategory) -> Option<Self> {
-        // We know the list of contained data categories is small -> we can just do a linear search
-        // instead of a binary search.
-        if self.0.contains(&category) {
+        let category_mask = DataCategories::category_to_mask(category);
+
+        if self.0 & category_mask != 0 {
             return None;
         }
 
-        let mut new = SmallVec::<[DataCategory; 12]>::from(&*self.0);
-        new.push(category);
-        Some(new.into())
+        Some(Self(self.0 | category_mask))
+    }
+
+    /// Returns true iff the category is contained.
+    pub fn contains(&self, category: &DataCategory) -> bool {
+        let category_mask = DataCategories::category_to_mask(*category);
+        self.0 & category_mask != 0
+    }
+
+    /// Returns an iterator over this [`DataCategories`] container.
+    pub fn iter(&self) -> DataCategoryIterator {
+        // We start our iteration from the lsb, so the number of trailings zeroes is our 0-based
+        // starting index.
+        let bit_start = self.0.trailing_zeros();
+
+        // Shift our bitfield so that the first bit is in the 0th place.
+        let (categories, _) = self.0.overflowing_shr(bit_start);
+        DataCategoryIterator {
+            categories,
+            current_bit: bit_start as u8,
+            remaining_bits: self.0.count_ones() as u8,
+        }
+    }
+
+    /// Returns the number of categories in this container.
+    pub fn size(&self) -> usize {
+        self.0.count_ones() as usize
+    }
+
+    /// Returns true iff this container contains no categories.
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
     }
 }
 
-impl std::ops::Deref for DataCategories {
-    type Target = [DataCategory];
+/// An iterator over a [`DataCategories`] container.
+pub struct DataCategoryIterator {
+    categories: u128,
+    current_bit: u8,
+    remaining_bits: u8,
+}
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl Iterator for DataCategoryIterator {
+    type Item = DataCategory;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_bits == 0 {
+            return None;
+        }
+        let category = DataCategories::bit_number_to_category(self.current_bit);
+
+        // Consume the last bit
+        self.categories &= u128::MAX - 1;
+
+        // Find the next set bit
+        let trailing_zeroes = self.categories.trailing_zeros() as u8;
+
+        // Put that bit in the 0th (to-consume) position
+        (self.categories, _) = self.categories.overflowing_shr(trailing_zeroes as u32);
+
+        // Update the current bit state
+        self.current_bit += trailing_zeroes;
+        self.remaining_bits -= 1;
+
+        Some(category)
     }
 }
 
@@ -223,26 +304,26 @@ impl<'de> Deserialize<'de> for DataCategories {
     where
         D: serde::Deserializer<'de>,
     {
-        SmallVec::<[DataCategory; 12]>::deserialize(deserializer).map(Self::new_sort_and_dedup)
+        SmallVec::<[DataCategory; 12]>::deserialize(deserializer).map(Self::from)
     }
 }
 
 impl<const N: usize> From<SmallVec<[DataCategory; N]>> for DataCategories {
     fn from(categories: SmallVec<[DataCategory; N]>) -> Self {
-        Self::new_sort_and_dedup(categories)
+        Self::from_slice(&categories)
     }
 }
 
 impl<const N: usize> From<[DataCategory; N]> for DataCategories {
     fn from(categories: [DataCategory; N]) -> Self {
-        Self::new_sort_and_dedup(SmallVec::from_buf(categories))
+        Self::from_slice(&categories)
     }
 }
 
 impl FromIterator<DataCategory> for DataCategories {
     fn from_iter<T: IntoIterator<Item = DataCategory>>(iter: T) -> Self {
         let v: SmallVec<[DataCategory; 12]> = iter.into_iter().collect();
-        Self::new_sort_and_dedup(v)
+        Self::from_slice(&v)
     }
 }
 
@@ -488,6 +569,8 @@ impl Quota {
 
 #[cfg(test)]
 mod tests {
+    use relay_base_schema::data_category::UnknownDataCategory;
+
     use super::*;
 
     #[test]
@@ -1040,5 +1123,29 @@ mod tests {
         assert!(c.add(DataCategory::Span).is_none());
         let c = c.add(DataCategory::Transaction).unwrap();
         assert_eq!(c, [DataCategory::Span, DataCategory::Transaction].into());
+    }
+
+    #[test]
+    fn test_reserve_last_bit_data_category() {
+        // Ensure we don't accidentally use 127 as a valid DataCategory.
+        let r: Result<DataCategory, UnknownDataCategory> = 127u32.try_into();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn test_bitmapping_identity() {
+        assert_eq!(
+            DataCategories::category_to_mask(DataCategory::Unknown),
+            1u128 << 127
+        );
+        for i in 0..127u32 {
+            let r: Result<DataCategory, UnknownDataCategory> = i.try_into();
+            if let Ok(dc) = r {
+                assert_eq!(DataCategories::bit_number_to_category(i as u8), dc);
+                assert_eq!(DataCategories::category_to_mask(dc), 1 << i);
+            } else {
+                break;
+            }
+        }
     }
 }

--- a/relay-quotas/src/quota.rs
+++ b/relay-quotas/src/quota.rs
@@ -142,7 +142,7 @@ impl ItemScoping {
     }
 
     /// Checks whether the category matches any of the quota's categories.
-    pub(crate) fn matches_categories(&self, categories: &DataCategories) -> bool {
+    pub(crate) fn matches_categories(&self, categories: DataCategories) -> bool {
         // An empty list of categories means that this quota matches all categories. Note that we
         // skip `Unknown` categories silently. If the list of categories only contains `Unknown`s,
         // we do **not** match, since apparently the quota is meant for some data this Relay does
@@ -176,7 +176,7 @@ impl ItemScoping {
 ///
 /// It is a read only and has set like properties, allowing for fast comparisons.
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
-pub struct DataCategories(u128);
+pub struct DataCategories(u64);
 
 impl Serialize for DataCategories {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -192,12 +192,12 @@ impl Serialize for DataCategories {
 }
 
 impl DataCategories {
-    fn category_to_mask(category: DataCategory) -> u128 {
+    fn category_to_mask(category: DataCategory) -> u64 {
         if matches!(category, DataCategory::Unknown) {
             // Handle Unknown by throwing it into the last bit.
-            1u128 << (8 * std::mem::size_of::<u128>() - 1)
+            1u64 << (8 * std::mem::size_of::<u64>() - 1)
         } else {
-            1u128 << (category as u8)
+            1u64 << (category as u8)
         }
     }
 
@@ -251,7 +251,6 @@ impl DataCategories {
         DataCategoryIterator {
             categories,
             current_bit: bit_start as u8,
-            remaining_bits: self.0.count_ones() as u8,
         }
     }
 
@@ -268,22 +267,21 @@ impl DataCategories {
 
 /// An iterator over a [`DataCategories`] container.
 pub struct DataCategoryIterator {
-    categories: u128,
+    categories: u64,
     current_bit: u8,
-    remaining_bits: u8,
 }
 
 impl Iterator for DataCategoryIterator {
     type Item = DataCategory;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining_bits == 0 {
+        if self.categories == 0 {
             return None;
         }
         let category = DataCategories::bit_number_to_category(self.current_bit);
 
         // Consume the last bit
-        self.categories &= u128::MAX - 1;
+        self.categories &= u64::MAX - 1;
 
         // Find the next set bit
         let trailing_zeroes = self.categories.trailing_zeros() as u8;
@@ -293,7 +291,6 @@ impl Iterator for DataCategoryIterator {
 
         // Update the current bit state
         self.current_bit += trailing_zeroes;
-        self.remaining_bits -= 1;
 
         Some(category)
     }
@@ -562,7 +559,7 @@ impl Quota {
     /// based on its scope, categories, and namespace.
     pub fn matches(&self, scoping: ItemScoping) -> bool {
         self.matches_scope(scoping)
-            && scoping.matches_categories(&self.categories)
+            && scoping.matches_categories(self.categories)
             && scoping.matches_namespaces(&self.namespace)
     }
 }
@@ -1127,8 +1124,8 @@ mod tests {
 
     #[test]
     fn test_reserve_last_bit_data_category() {
-        // Ensure we don't accidentally use 127 as a valid DataCategory.
-        let r: Result<DataCategory, UnknownDataCategory> = 127u32.try_into();
+        // Ensure we don't accidentally use 63 as a valid DataCategory.
+        let r: Result<DataCategory, UnknownDataCategory> = 63u32.try_into();
         assert!(r.is_err());
     }
 
@@ -1136,9 +1133,9 @@ mod tests {
     fn test_bitmapping_identity() {
         assert_eq!(
             DataCategories::category_to_mask(DataCategory::Unknown),
-            1u128 << 127
+            1u64 << 63
         );
-        for i in 0..127u32 {
+        for i in 0..63u32 {
             let r: Result<DataCategory, UnknownDataCategory> = i.try_into();
             if let Ok(dc) = r {
                 assert_eq!(DataCategories::bit_number_to_category(i as u8), dc);

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -210,7 +210,7 @@ impl RateLimit {
     /// information. The categories and other properties are copied from the quota.
     pub fn from_quota(quota: &Quota, scoping: Scoping, retry_after: RetryAfter) -> Self {
         Self {
-            categories: quota.categories.clone(),
+            categories: quota.categories,
             scope: RateLimitScope::for_quota(scoping, quota.scope),
             reason_code: quota.reason_code.clone(),
             retry_after,
@@ -526,13 +526,8 @@ impl CachedRateLimits {
             // rate limits to clients, we clone the limits with the inherited category.
             // This ensures old SDKs rate limit correctly, but also it simplifies client
             // implementations. Only Relay needs to make this decision.
-            for i in 0..limit.categories.len() {
-                let Some(category) = limit.categories.get(i) else {
-                    debug_assert!(false, "logical error");
-                    break;
-                };
-
-                for inherited in inherited_categories(category) {
+            for category in limit.categories.iter() {
+                for inherited in inherited_categories(&category) {
                     if let Some(categories) = limit.categories.add(*inherited) {
                         limit.categories = categories;
                     }

--- a/relay-quotas/src/rate_limit.rs
+++ b/relay-quotas/src/rate_limit.rs
@@ -224,7 +224,7 @@ impl RateLimit {
     /// category and namespace match those of the rate limit.
     pub fn matches(&self, scoping: ItemScoping) -> bool {
         self.matches_scope(scoping)
-            && scoping.matches_categories(&self.categories)
+            && scoping.matches_categories(self.categories)
             && scoping.matches_namespaces(&self.namespaces)
     }
 


### PR DESCRIPTION
Converts the Arc<[DataCategory]> into a u128.  I opted for a large bitfield, as we're already at 39 DataCategory elements, but I can reduce if needed.

I did some bit-twiddling in the iterator to make it constant time, but it might be a bit clearer with a simple for-loop; I'll replace if there's pushback.