### PR TITLE
fix(playstation): Use correct discard reasons

### DIFF
--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -21,7 +21,7 @@ use crate::extractors::{RawContentType, RequestMeta};
 use crate::managed::Managed;
 use crate::middlewares;
 use crate::service::ServiceState;
-use crate::services::outcome::DiscardReason;
+use crate::services::outcome::{DiscardReason, Outcome};
 use crate::services::projects::cache::Project;
 use crate::services::upload::Upload;
 use crate::utils::{self, AttachmentStrategy};
@@ -157,12 +157,22 @@ async fn multipart_to_envelope(
     )
     .await?;
 
-    let prosperodump_item = items
+    let Some(prosperodump_item) = items
         .iter_mut()
         .find(|item| item.attachment_type() == Some(AttachmentType::Prosperodump))
-        .ok_or(BadStoreRequest::MissingProsperodump)?;
+    else {
+        for item in &items {
+            let _ = item.reject_err(Outcome::Invalid(DiscardReason::MissingProsperodumpUpload));
+        }
+        return Err(BadStoreRequest::MissingProsperodump);
+    };
+
     prosperodump_item.modify(|inner, _| inner.set_payload(OctetStream, inner.payload()));
-    validate_prosperodump(&prosperodump_item.payload())?;
+    validate_prosperodump(&prosperodump_item.payload()).inspect_err(|_| {
+        for item in &items {
+            let _ = item.reject_err(Outcome::Invalid(DiscardReason::InvalidProsperodump));
+        }
+    })?;
 
     let event_id = common::event_id_from_items(&items)?.unwrap_or_else(EventId::new);
     let envelope =

--- a/relay-server/src/services/outcome.rs
+++ b/relay-server/src/services/outcome.rs
@@ -377,6 +377,12 @@ pub enum DiscardReason {
     /// since it resolves the project first, and then checks for the valid project key.
     MultiProjectId,
 
+    /// (Relay) A request without a prosperodump was made to the playstation endpoint.
+    MissingProsperodumpUpload,
+
+    /// (Relay) The prosperodump submitted to the playstation endpoint was invalid.
+    InvalidProsperodump,
+
     /// (Relay) A minidump file was missing for the minidump endpoint.
     MissingMinidumpUpload,
 
@@ -509,6 +515,8 @@ impl DiscardReason {
             DiscardReason::DisallowedMethod => "disallowed_method",
             DiscardReason::ContentType => "content_type",
             DiscardReason::MultiProjectId => "multi_project_id",
+            DiscardReason::MissingProsperodumpUpload => "missing_prosperodump_upload",
+            DiscardReason::InvalidProsperodump => "invalid_prosperodump",
             DiscardReason::MissingMinidumpUpload => "missing_minidump_upload",
             DiscardReason::InvalidMinidump => "invalid_minidump",
             DiscardReason::SecurityReportType => "security_report_type",


### PR DESCRIPTION
Use more specific discard reasons - `MissingProsperodumpUpload` and `InvalidProsperodump` - than the default, `Internal`, in the playstation endpoint. This allows playstation customers to better understand why attachments were dropped. 