### PR TITLE
ref(spans): Move span normalization to processing

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -307,11 +307,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_stacktraces(event);
     normalize_exceptions(event); // Browser extension filters look at the stacktrace
     normalize_user_agent(event, config.normalize_user_agent); // Legacy browsers filter
-    normalize_event_measurements(
-        event,
-        config.measurements.clone(),
-        config.max_name_and_unit_len,
-    ); // Measurements are part of the metric extraction
+    normalize_event_measurements(event, config.measurements, config.max_name_and_unit_len); // Measurements are part of the metric extraction
     backfill_app_vitals_start(event);
     if let Some(version) = normalize_performance_score(event, config.performance_score) {
         event

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -115,7 +115,7 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 
 /// Container for global and project level [`MeasurementsConfig`]. The purpose is to handle
 /// the merging logic.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct CombinedMeasurementsConfig<'a> {
     project: Option<&'a MeasurementsConfig>,
     global: Option<&'a MeasurementsConfig>,

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -16,6 +16,7 @@ use crate::processing::{
 use crate::services::outcome::{DiscardReason, Outcome};
 
 mod dynamic_sampling;
+mod normalize;
 mod process;
 #[cfg(feature = "processing")]
 mod store;

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -91,7 +91,7 @@ fn set_segment_attributes(span: &mut Annotated<Span>) {
 /// Normalizes a standalone span.
 pub fn normalize(
     annotated_span: &mut Annotated<Span>,
-    config: NormalizeSpanConfig,
+    config: &NormalizeSpanConfig,
 ) -> Result<(), ProcessingError> {
     let NormalizeSpanConfig {
         received_at,
@@ -127,11 +127,11 @@ pub fn normalize(
     )?;
 
     if let Some(span) = annotated_span.value() {
-        validate_span(span, Some(&timestamp_range))?;
+        validate_span(span, Some(timestamp_range))?;
     }
     process_value(
         annotated_span,
-        &mut TransactionsProcessor::new(Default::default(), span_op_defaults),
+        &mut TransactionsProcessor::new(Default::default(), *span_op_defaults),
         ProcessingState::root(),
     )?;
 
@@ -173,14 +173,14 @@ pub fn normalize(
         normalize_measurements(
             measurement_values,
             meta,
-            measurements,
-            Some(max_name_and_unit_len),
+            *measurements,
+            Some(*max_name_and_unit_len),
             span.start_timestamp.0,
             span.timestamp.0,
         );
     }
 
-    span.received = Annotated::new(received_at.into());
+    span.received = Annotated::new((*received_at).into());
 
     if let Some(transaction) = span
         .data
@@ -195,7 +195,7 @@ pub fn normalize(
     let is_mobile = false; // TODO: find a way to determine is_mobile from a standalone span.
     let tags = tag_extraction::extract_tags(
         span,
-        max_tag_value_size,
+        *max_tag_value_size,
         None,
         None,
         is_mobile,
@@ -205,9 +205,9 @@ pub fn normalize(
     );
     span.sentry_tags = Annotated::new(tags);
 
-    normalize_performance_score(span, performance_score);
+    normalize_performance_score(span, *performance_score);
 
-    enrich_ai_span(span, ai_model_metadata);
+    enrich_ai_span(span, *ai_model_metadata);
 
     tag_extraction::extract_measurements(span, is_mobile);
 
@@ -566,7 +566,7 @@ mod tests {
         )
         .unwrap();
 
-        normalize(&mut span, normalize_config()).unwrap();
+        normalize(&mut span, &normalize_config()).unwrap();
 
         assert_eq!(
             get_value!(span.data.client_address!).as_str(),
@@ -590,7 +590,7 @@ mod tests {
         )
         .unwrap();
 
-        normalize(&mut span, normalize_config()).unwrap();
+        normalize(&mut span, &normalize_config()).unwrap();
 
         assert_eq!(
             get_value!(span.data.client_address!).as_str(),
@@ -611,7 +611,7 @@ mod tests {
         )
         .unwrap();
 
-        normalize(&mut span, normalize_config()).unwrap();
+        normalize(&mut span, &normalize_config()).unwrap();
 
         assert_eq!(
             get_value!(span.data.client_address!).as_str(),
@@ -635,7 +635,7 @@ mod tests {
         )
         .unwrap();
 
-        normalize(&mut span, normalize_config()).unwrap();
+        normalize(&mut span, &normalize_config()).unwrap();
 
         let data = get_value!(span.data!);
         assert_eq!(data.exclusive_time, Annotated::empty());
@@ -657,7 +657,7 @@ mod tests {
         )
         .unwrap();
 
-        normalize(&mut span, normalize_config()).unwrap();
+        normalize(&mut span, &normalize_config()).unwrap();
 
         let data = get_value!(span.data!);
         assert_eq!(data.exclusive_time, Annotated::empty());
@@ -699,7 +699,7 @@ mod tests {
         )
             .unwrap();
 
-        normalize(&mut span, normalize_config()).unwrap();
+        normalize(&mut span, &normalize_config()).unwrap();
 
         let data = get_value!(span.data!);
 

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -7,12 +7,11 @@ use relay_protocol::Annotated;
 
 use crate::managed::Managed;
 use crate::processing::legacy_spans::{
-    Error, ExpandedLegacySpans, Indexed, SerializedLegacySpans, TotalAndIndexed,
+    Error, ExpandedLegacySpans, Indexed, SerializedLegacySpans, TotalAndIndexed, normalize,
 };
 use crate::processing::{self, Context};
 use crate::services::outcome::DiscardReason;
-use crate::services::processor::span::NormalizeSpanConfig;
-use crate::services::processor::{ProcessingError, span};
+use crate::services::processor::ProcessingError;
 use relay_event_normalization::RemoveOtherProcessor;
 
 pub fn expand(spans: Managed<SerializedLegacySpans>) -> Managed<ExpandedLegacySpans> {
@@ -45,7 +44,7 @@ pub fn normalize(
 ) {
     let aggregator_config = ctx.config.aggregator_config_for(MetricNamespace::Spans);
     let model_data = ctx.global_config.ai_model_metadata();
-    let norm = NormalizeSpanConfig {
+    let norm = normalize::NormalizeSpanConfig {
         received_at: spans.received_at(),
         timestamp_range: aggregator_config.timestamp_range(),
         max_tag_value_size: aggregator_config.max_tag_value_length,
@@ -71,7 +70,7 @@ pub fn normalize(
     spans.retain(
         |spans| &mut spans.spans,
         |span, _| {
-            span::normalize(span, norm.clone()).map_err(|err| {
+            normalize::normalize(span, &norm).map_err(|err| {
                 relay_log::debug!("failed to normalize span: {err}");
                 Error::Invalid(match err {
                     ProcessingError::ProcessingFailed(ProcessingAction::InvalidTransaction(_))

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -85,7 +85,6 @@ use {
 
 pub mod event;
 mod metrics;
-pub mod span;
 
 #[cfg(all(sentry, feature = "processing"))]
 pub mod playstation;


### PR DESCRIPTION
Follow-up of the refactor, also borrows instead of clones the config (drive by).