### PR TITLE
ref(errors): Move event processor code to processing

### DIFF
--- a/relay-server/src/processing/errors/errors/raw_security.rs
+++ b/relay-server/src/processing/errors/errors/raw_security.rs
@@ -66,7 +66,7 @@ impl Counted for RawSecurity {
     }
 }
 
-pub fn event_from_security_report(
+fn event_from_security_report(
     item: Item,
     meta: &RequestMeta,
 ) -> Result<(Annotated<Event>, usize), ProcessingError> {

--- a/relay-server/src/processing/errors/errors/raw_security.rs
+++ b/relay-server/src/processing/errors/errors/raw_security.rs
@@ -1,12 +1,17 @@
-use relay_event_schema::protocol::Metrics;
+use relay_base_schema::events::EventType;
+use relay_event_schema::protocol::{
+    Csp, Event, ExpectCt, ExpectStaple, Hpkp, LenientString, Metrics, SecurityReportType,
+};
 use relay_protocol::Annotated;
 use relay_quotas::DataCategory;
 
 use crate::envelope::{Item, ItemType};
+use crate::extractors::RequestMeta;
 use crate::managed::{Counted, Quantities, RecordKeeper};
 use crate::processing::ForwardContext;
 use crate::processing::errors::Result;
 use crate::processing::errors::errors::{Context, Expansion, SentryError, utils};
+use crate::services::processor::ProcessingError;
 
 #[derive(Debug)]
 pub struct RawSecurity;
@@ -23,10 +28,7 @@ impl SentryError for RawSecurity {
 
         let mut metrics = Metrics::default();
 
-        let (event, len) = crate::services::processor::event::event_from_security_report(
-            item,
-            ctx.envelope.meta(),
-        )?;
+        let (event, len) = event_from_security_report(item, ctx.envelope.meta())?;
 
         metrics.bytes_ingested_event = Annotated::new(len as u64);
 
@@ -62,4 +64,66 @@ impl Counted for RawSecurity {
     fn quantities(&self) -> Quantities {
         Default::default()
     }
+}
+
+pub fn event_from_security_report(
+    item: Item,
+    meta: &RequestMeta,
+) -> Result<(Annotated<Event>, usize), ProcessingError> {
+    let len = item.len();
+    let mut event = Event::default();
+
+    let bytes = item.payload();
+    let data = &bytes;
+    let Some(report_type) =
+        SecurityReportType::from_json(data).map_err(ProcessingError::InvalidJson)?
+    else {
+        return Err(ProcessingError::InvalidSecurityType(bytes));
+    };
+
+    let (apply_result, event_type) = match report_type {
+        SecurityReportType::Csp => (Csp::apply_to_event(data, &mut event), EventType::Csp),
+        SecurityReportType::ExpectCt => (
+            ExpectCt::apply_to_event(data, &mut event),
+            EventType::ExpectCt,
+        ),
+        SecurityReportType::ExpectStaple => (
+            ExpectStaple::apply_to_event(data, &mut event),
+            EventType::ExpectStaple,
+        ),
+        SecurityReportType::Hpkp => (Hpkp::apply_to_event(data, &mut event), EventType::Hpkp),
+        SecurityReportType::Unsupported => return Err(ProcessingError::UnsupportedSecurityType),
+    };
+
+    if let Err(json_error) = apply_result {
+        // logged in extract_event
+        relay_log::configure_scope(|scope| {
+            scope.set_extra("payload", String::from_utf8_lossy(data).into());
+        });
+
+        return Err(ProcessingError::InvalidSecurityReport(json_error));
+    }
+
+    if let Some(release) = item.sentry_release() {
+        event.release = Annotated::from(LenientString(release.to_owned()));
+    }
+
+    if let Some(env) = item.sentry_environment() {
+        event.environment = Annotated::from(env.to_owned());
+    }
+
+    if let Some(origin) = meta.origin() {
+        event
+            .request
+            .get_or_insert_with(Default::default)
+            .headers
+            .get_or_insert_with(Default::default)
+            .insert("Origin".into(), Annotated::new(origin.to_string().into()));
+    }
+
+    // Explicitly set the event type. This is required so that a `Security` item can be created
+    // instead of a regular `Event` item.
+    event.ty = Annotated::new(event_type);
+
+    Ok((Annotated::new(event), len))
 }

--- a/relay-server/src/processing/errors/errors/utils/attachment.rs
+++ b/relay-server/src/processing/errors/errors/utils/attachment.rs
@@ -1,78 +1,60 @@
-//! Event processor related code.
-
-use relay_base_schema::events::EventType;
 use relay_config::Config;
-use relay_event_schema::protocol::{
-    Breadcrumb, Csp, Event, ExpectCt, ExpectStaple, Hpkp, LenientString, SecurityReportType, Values,
-};
+use relay_event_schema::protocol::{Breadcrumb, Event, Values};
 use relay_protocol::{Annotated, Array, Object};
-use serde_json::Value as SerdeValue;
 
 use crate::envelope::Item;
-use crate::extractors::RequestMeta;
-use crate::services::processor::{ExtractedEvent, ProcessingError};
-use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
+use crate::services::processor::ProcessingError;
 
-pub fn event_from_security_report(
-    item: Item,
-    meta: &RequestMeta,
-) -> Result<ExtractedEvent, ProcessingError> {
-    let len = item.len();
-    let mut event = Event::default();
+pub fn event_from_attachments(
+    config: &Config,
+    event_item: Option<Item>,
+    breadcrumbs_item1: Option<Item>,
+    breadcrumbs_item2: Option<Item>,
+) -> Result<(Annotated<Event>, usize), ProcessingError> {
+    let len = event_item.as_ref().map_or(0, |item| item.len())
+        + breadcrumbs_item1.as_ref().map_or(0, |item| item.len())
+        + breadcrumbs_item2.as_ref().map_or(0, |item| item.len());
 
-    let bytes = item.payload();
-    let data = &bytes;
-    let Some(report_type) =
-        SecurityReportType::from_json(data).map_err(ProcessingError::InvalidJson)?
-    else {
-        return Err(ProcessingError::InvalidSecurityType(bytes));
-    };
+    let mut event = extract_attached_event(config, event_item)?;
+    let mut breadcrumbs1 = parse_msgpack_breadcrumbs(config, breadcrumbs_item1)?;
+    let mut breadcrumbs2 = parse_msgpack_breadcrumbs(config, breadcrumbs_item2)?;
 
-    let (apply_result, event_type) = match report_type {
-        SecurityReportType::Csp => (Csp::apply_to_event(data, &mut event), EventType::Csp),
-        SecurityReportType::ExpectCt => (
-            ExpectCt::apply_to_event(data, &mut event),
-            EventType::ExpectCt,
-        ),
-        SecurityReportType::ExpectStaple => (
-            ExpectStaple::apply_to_event(data, &mut event),
-            EventType::ExpectStaple,
-        ),
-        SecurityReportType::Hpkp => (Hpkp::apply_to_event(data, &mut event), EventType::Hpkp),
-        SecurityReportType::Unsupported => return Err(ProcessingError::UnsupportedSecurityType),
-    };
+    let timestamp1 = breadcrumbs1
+        .iter()
+        .rev()
+        .find_map(|breadcrumb| breadcrumb.value().and_then(|b| b.timestamp.value()));
 
-    if let Err(json_error) = apply_result {
-        // logged in extract_event
-        relay_log::configure_scope(|scope| {
-            scope.set_extra("payload", String::from_utf8_lossy(data).into());
+    let timestamp2 = breadcrumbs2
+        .iter()
+        .rev()
+        .find_map(|breadcrumb| breadcrumb.value().and_then(|b| b.timestamp.value()));
+
+    // Sort breadcrumbs by date. We presume that last timestamp from each row gives the
+    // relative sequence of the whole sequence, i.e., we don't need to splice the sequences
+    // to get the breadrumbs sorted.
+    if timestamp1 > timestamp2 {
+        std::mem::swap(&mut breadcrumbs1, &mut breadcrumbs2);
+    }
+
+    // Limit the total length of the breadcrumbs. We presume that if we have both
+    // breadcrumbs with items one contains the maximum number of breadcrumbs allowed.
+    let max_length = std::cmp::max(breadcrumbs1.len(), breadcrumbs2.len());
+
+    breadcrumbs1.extend(breadcrumbs2);
+
+    if breadcrumbs1.len() > max_length {
+        // Keep only the last max_length elements from the vectors
+        breadcrumbs1.drain(0..(breadcrumbs1.len() - max_length));
+    }
+
+    if !breadcrumbs1.is_empty() {
+        event.get_or_insert_with(Event::default).breadcrumbs = Annotated::new(Values {
+            values: Annotated::new(breadcrumbs1),
+            other: Object::default(),
         });
-
-        return Err(ProcessingError::InvalidSecurityReport(json_error));
     }
 
-    if let Some(release) = item.sentry_release() {
-        event.release = Annotated::from(LenientString(release.to_owned()));
-    }
-
-    if let Some(env) = item.sentry_environment() {
-        event.environment = Annotated::from(env.to_owned());
-    }
-
-    if let Some(origin) = meta.origin() {
-        event
-            .request
-            .get_or_insert_with(Default::default)
-            .headers
-            .get_or_insert_with(Default::default)
-            .insert("Origin".into(), Annotated::new(origin.to_string().into()));
-    }
-
-    // Explicitly set the event type. This is required so that a `Security` item can be created
-    // instead of a regular `Event` item.
-    event.ty = Annotated::new(event_type);
-
-    Ok((Annotated::new(event), len))
+    Ok((event, len))
 }
 
 fn extract_attached_event(
@@ -130,95 +112,6 @@ fn parse_msgpack_breadcrumbs(
     }
 
     Ok(breadcrumbs)
-}
-
-pub fn event_from_attachments(
-    config: &Config,
-    event_item: Option<Item>,
-    breadcrumbs_item1: Option<Item>,
-    breadcrumbs_item2: Option<Item>,
-) -> Result<ExtractedEvent, ProcessingError> {
-    let len = event_item.as_ref().map_or(0, |item| item.len())
-        + breadcrumbs_item1.as_ref().map_or(0, |item| item.len())
-        + breadcrumbs_item2.as_ref().map_or(0, |item| item.len());
-
-    let mut event = extract_attached_event(config, event_item)?;
-    let mut breadcrumbs1 = parse_msgpack_breadcrumbs(config, breadcrumbs_item1)?;
-    let mut breadcrumbs2 = parse_msgpack_breadcrumbs(config, breadcrumbs_item2)?;
-
-    let timestamp1 = breadcrumbs1
-        .iter()
-        .rev()
-        .find_map(|breadcrumb| breadcrumb.value().and_then(|b| b.timestamp.value()));
-
-    let timestamp2 = breadcrumbs2
-        .iter()
-        .rev()
-        .find_map(|breadcrumb| breadcrumb.value().and_then(|b| b.timestamp.value()));
-
-    // Sort breadcrumbs by date. We presume that last timestamp from each row gives the
-    // relative sequence of the whole sequence, i.e., we don't need to splice the sequences
-    // to get the breadrumbs sorted.
-    if timestamp1 > timestamp2 {
-        std::mem::swap(&mut breadcrumbs1, &mut breadcrumbs2);
-    }
-
-    // Limit the total length of the breadcrumbs. We presume that if we have both
-    // breadcrumbs with items one contains the maximum number of breadcrumbs allowed.
-    let max_length = std::cmp::max(breadcrumbs1.len(), breadcrumbs2.len());
-
-    breadcrumbs1.extend(breadcrumbs2);
-
-    if breadcrumbs1.len() > max_length {
-        // Keep only the last max_length elements from the vectors
-        breadcrumbs1.drain(0..(breadcrumbs1.len() - max_length));
-    }
-
-    if !breadcrumbs1.is_empty() {
-        event.get_or_insert_with(Event::default).breadcrumbs = Annotated::new(Values {
-            values: Annotated::new(breadcrumbs1),
-            other: Object::default(),
-        });
-    }
-
-    Ok((event, len))
-}
-
-pub fn merge_formdata(target: &mut SerdeValue, item: &Item) {
-    let payload = item.payload();
-    let mut aggregator = ChunkedFormDataAggregator::new();
-
-    for entry in FormDataIter::new(&payload) {
-        if entry.key() == "sentry" || entry.key().starts_with("sentry___") {
-            // Custom clients can submit longer payloads and should JSON encode event data into
-            // the optional `sentry` field or a `sentry___<namespace>` field.
-            match serde_json::from_str(entry.value()) {
-                Ok(event) => utils::merge_values(target, event),
-                Err(_) => relay_log::debug!("invalid json event payload in sentry form field"),
-            }
-        } else if let Some(index) = utils::get_sentry_chunk_index(entry.key(), "sentry__") {
-            // Electron SDK splits up long payloads into chunks starting at sentry__1 with an
-            // incrementing counter. Assemble these chunks here and then decode them below.
-            aggregator.insert(index, entry.value());
-        } else if let Some(keys) = utils::get_sentry_entry_indexes(entry.key()) {
-            // Try to parse the nested form syntax `sentry[key][key]` This is required for the
-            // Breakpad client library, which only supports string values of up to 64
-            // characters.
-            utils::update_nested_value(target, &keys, entry.value());
-        } else {
-            // Merge additional form fields from the request with `extra` data from the event
-            // payload and set defaults for processing. This is sent by clients like Breakpad or
-            // Crashpad.
-            utils::update_nested_value(target, &["extra", entry.key()], entry.value());
-        }
-    }
-
-    if !aggregator.is_empty() {
-        match serde_json::from_str(&aggregator.join()) {
-            Ok(event) => utils::merge_values(target, event),
-            Err(_) => relay_log::debug!("invalid json event payload in sentry__* form fields"),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/relay-server/src/processing/errors/errors/utils/formdata.rs
+++ b/relay-server/src/processing/errors/errors/utils/formdata.rs
@@ -1,0 +1,41 @@
+use serde_json::Value as SerdeValue;
+
+use crate::envelope::Item;
+use crate::utils::{self, ChunkedFormDataAggregator, FormDataIter};
+
+pub fn merge_formdata(target: &mut SerdeValue, item: &Item) {
+    let payload = item.payload();
+    let mut aggregator = ChunkedFormDataAggregator::new();
+
+    for entry in FormDataIter::new(&payload) {
+        if entry.key() == "sentry" || entry.key().starts_with("sentry___") {
+            // Custom clients can submit longer payloads and should JSON encode event data into
+            // the optional `sentry` field or a `sentry___<namespace>` field.
+            match serde_json::from_str(entry.value()) {
+                Ok(event) => utils::merge_values(target, event),
+                Err(_) => relay_log::debug!("invalid json event payload in sentry form field"),
+            }
+        } else if let Some(index) = utils::get_sentry_chunk_index(entry.key(), "sentry__") {
+            // Electron SDK splits up long payloads into chunks starting at sentry__1 with an
+            // incrementing counter. Assemble these chunks here and then decode them below.
+            aggregator.insert(index, entry.value());
+        } else if let Some(keys) = utils::get_sentry_entry_indexes(entry.key()) {
+            // Try to parse the nested form syntax `sentry[key][key]` This is required for the
+            // Breakpad client library, which only supports string values of up to 64
+            // characters.
+            utils::update_nested_value(target, &keys, entry.value());
+        } else {
+            // Merge additional form fields from the request with `extra` data from the event
+            // payload and set defaults for processing. This is sent by clients like Breakpad or
+            // Crashpad.
+            utils::update_nested_value(target, &["extra", entry.key()], entry.value());
+        }
+    }
+
+    if !aggregator.is_empty() {
+        match serde_json::from_str(&aggregator.join()) {
+            Ok(event) => utils::merge_values(target, event),
+            Err(_) => relay_log::debug!("invalid json event payload in sentry__* form fields"),
+        }
+    }
+}

--- a/relay-server/src/processing/errors/errors/utils/mod.rs
+++ b/relay-server/src/processing/errors/errors/utils/mod.rs
@@ -8,6 +8,9 @@ use crate::processing::errors::errors::Context;
 use crate::services::outcome::DiscardItemType;
 use crate::services::processor::ProcessingError;
 
+mod attachment;
+mod formdata;
+
 macro_rules! if_not_processing {
     ($ctx:expr, $if_true:block) => {
         match $ctx {
@@ -142,12 +145,7 @@ pub fn take_event_from_attachments(
         return Ok(Annotated::empty());
     }
 
-    let (event, len) = crate::services::processor::event::event_from_attachments(
-        ctx.processing.config,
-        ev,
-        b1,
-        b2,
-    )?;
+    let (event, len) = attachment::event_from_attachments(ctx.processing.config, ev, b1, b2)?;
     metrics.bytes_ingested_event = Annotated::new(len as u64);
 
     Ok(event)
@@ -167,7 +165,7 @@ pub fn take_event_from_formdata(
 
     let event = {
         let mut value = serde_json::Value::Object(Default::default());
-        crate::services::processor::event::merge_formdata(&mut value, &form_data);
+        formdata::merge_formdata(&mut value, &form_data);
         Annotated::deserialize_with_meta(value).map_err(ProcessingError::InvalidJson)
     }?;
     metrics.bytes_ingested_event = Annotated::new(form_data.len() as u64);

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -23,10 +23,9 @@ use relay_config::{Config, HttpEncoding};
 use relay_dynamic_config::Feature;
 use relay_event_normalization::{ClockDriftProcessor, GeoIpLookup};
 use relay_event_schema::processor::ProcessingAction;
-use relay_event_schema::protocol::{ClientReport, Event, EventId, SpanV2};
+use relay_event_schema::protocol::{ClientReport, EventId, SpanV2};
 use relay_filter::FilterStatKey;
 use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricNamespace};
-use relay_protocol::Annotated;
 use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::evaluation::{ReservoirCounters, SamplingDecision};
 use relay_statsd::metric;
@@ -560,8 +559,6 @@ impl From<Unreal4Error> for ProcessingError {
         }
     }
 }
-
-type ExtractedEvent = (Annotated<Event>, usize);
 
 /// A container for extracted metrics during processing.
 ///
@@ -2432,8 +2429,9 @@ mod tests {
     use relay_event_normalization::{
         NormalizationConfig, RedactionRule, TransactionNameConfig, TransactionNameRule,
     };
-    use relay_event_schema::protocol::TransactionSource;
+    use relay_event_schema::protocol::{Event, TransactionSource};
     use relay_pii::DataScrubbingConfig;
+    use relay_protocol::Annotated;
     use similar_asserts::assert_eq;
 
     use crate::testutils::{create_test_processor, create_test_processor_with_addrs};

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -83,7 +83,6 @@ use {
     std::time::Instant,
 };
 
-pub mod event;
 mod metrics;
 
 #[cfg(all(sentry, feature = "processing"))]


### PR DESCRIPTION
A follow-up from the removal of the old processor code. Move event/error code from processor to processing. Just moving files around.