### PR TITLE
feat(endpoints): Add project config fetching killswitch

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -170,25 +170,13 @@ pub struct Options {
     )]
     pub eap_span_outcomes_rollout_rate: f32,
 
-    /// Rollout rate for expanding the unreal report in the endpoint rather than during processing.
-    ///
-    /// Rate needs to be between `0.0` and `1.0`.
+    /// Kill-switch for fetching project configs in endpoints.
     #[serde(
-        rename = "relay.unreal-report-expansion.rollout-rate",
+        rename = "relay.endpoint-fetch-config.enabled",
         deserialize_with = "default_on_error",
         skip_serializing_if = "is_default"
     )]
-    pub unreal_report_expansion_rollout_rate: f32,
-
-    /// Rollout rate for fetching the project config in the minidump endpoint.
-    ///
-    /// Rate needs to be between `0.0` and `1.0`.
-    #[serde(
-        rename = "relay.minidump-endpoint-fetch-config.rollout-rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub minidump_endpoint_fetch_config_rollout_rate: f32,
+    pub endpoint_fetch_config_enabled: bool,
 
     /// All other unknown options.
     #[serde(flatten)]

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -28,9 +28,7 @@ use crate::managed::Managed;
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason, Outcome};
-use crate::services::projects::cache::Project;
 use crate::services::upload::Upload;
-use crate::statsd::RelayCounters;
 use crate::utils::{self, AttachmentStrategy, read_attachment_bytes_into_item};
 
 /// The field name of a minidump in the multipart form-data upload.
@@ -315,12 +313,26 @@ async fn multipart_to_envelope(
     Ok(envelope)
 }
 
-/// Creates an [UploadContext] for a given project.
-fn upload_context_for_project<'a>(
+/// Creates an [UploadContext].
+async fn upload_context<'a>(
     meta: &RequestMeta,
     state: &'a ServiceState,
-    project: Project<'_>,
-) -> Result<UploadContext<'a>, BadStoreRequest> {
+) -> Result<Option<UploadContext<'a>>, BadStoreRequest> {
+    if !state
+        .global_config_handle()
+        .current()
+        .options
+        .endpoint_fetch_config_enabled
+    {
+        return Ok(None);
+    }
+
+    let project = state
+        .project_cache_handle()
+        .ready(meta.public_key(), state.config().query_timeout())
+        .await
+        .ok_or(BadStoreRequest::ProjectUnavailable)?;
+
     let project_config = project
         .state()
         .clone()
@@ -359,12 +371,12 @@ fn upload_context_for_project<'a>(
         UploadDecision::Upload
     };
 
-    Ok(UploadContext {
+    Ok(Some(UploadContext {
         upload: state.upload(),
         scoping,
         upload_attachments,
         upload_minidumps,
-    })
+    }))
 }
 
 async fn raw_minidump_to_envelope(
@@ -433,40 +445,23 @@ async fn handle(
     // minidump can either be transmitted as request body, or as `upload_file_minidump` in a
     // multipart formdata request.
     let config = state.config();
+    let upload_context = upload_context(&meta, &state).await?;
 
-    let upload_context = if state
-        .global_config_handle()
-        .current()
-        .options
-        .endpoint_fetch_config_enabled
+    if let Some(upload_context) = &upload_context
+        && let UploadDecision::Drop(limits) = &upload_context.upload_minidumps
     {
-        // Ensure that we really make it here.
-        relay_statsd::metric!(counter(RelayCounters::MinidumpEndpointConfigFetching) += 1);
-
-        let project = state
-            .project_cache_handle()
-            .ready(meta.public_key(), config.query_timeout())
-            .await
-            .ok_or(BadStoreRequest::ProjectUnavailable)?;
-        let context = upload_context_for_project(&meta, &state, project)?;
-
-        if let UploadDecision::Drop(limits) = &context.upload_minidumps {
-            // This is a best effort outcome, in the sense that we also drop some attachments but
-            // since we know neither the amount or size we can't emit an accurate outcome for them.
-            let _ = Managed::with_meta_from_request_meta(
-                &meta,
-                state.outcome_aggregator(),
-                (DataCategory::Error, 1),
-            )
-            .reject_err(Outcome::RateLimited(
-                limits.longest().and_then(|l| l.reason_code.clone()),
-            ));
-            return Ok(TextResponse(Some(EventId::new())));
-        }
-        Some(context)
-    } else {
-        None
-    };
+        // This is a best effort outcome, in the sense that we also drop some attachments but
+        // since we know neither the amount or size we can't emit an accurate outcome for them.
+        let _ = Managed::with_meta_from_request_meta(
+            &meta,
+            state.outcome_aggregator(),
+            (DataCategory::Error, 1),
+        )
+        .reject_err(Outcome::RateLimited(
+            limits.longest().and_then(|l| l.reason_code.clone()),
+        ));
+        return Ok(TextResponse(Some(EventId::new())));
+    }
 
     let envelope = if MINIDUMP_RAW_CONTENT_TYPES.contains(&content_type.as_ref()) {
         raw_minidump_to_envelope(request, meta, &state, content_type, config, upload_context)

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -316,21 +316,6 @@ async fn multipart_to_envelope(
     Ok(envelope)
 }
 
-fn should_fetch_project_config(state: &ServiceState, project_id: Option<ProjectId>) -> bool {
-    // In the minidump endpoint we should always have a project_id.
-    let Some(project_id) = project_id else {
-        return false;
-    };
-    let global_config = state.global_config_handle().current();
-    utils::is_rolled_out(
-        project_id.value(),
-        global_config
-            .options
-            .minidump_endpoint_fetch_config_rollout_rate,
-    )
-    .is_keep()
-}
-
 /// Creates an [UploadContext] for a given project.
 fn upload_context_for_project<'a>(
     meta: &RequestMeta,
@@ -450,7 +435,12 @@ async fn handle(
     // multipart formdata request.
     let config = state.config();
 
-    let upload_context = if should_fetch_project_config(&state, meta.project_id()) {
+    let upload_context = if state
+        .global_config_handle()
+        .current()
+        .options
+        .endpoint_fetch_config_enabled
+    {
         // Ensure that we really make it here.
         relay_statsd::metric!(counter(RelayCounters::MinidumpEndpointConfigFetching) += 1);
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -7,7 +7,6 @@ use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use liblzma::read::XzDecoder;
 use multer::{Field, Multipart};
-use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -4,7 +4,6 @@
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
-use http::StatusCode;
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_dynamic_config::Feature;
@@ -75,7 +74,7 @@ struct UploadContext<'a> {
 async fn upload_context<'a>(
     state: &'a ServiceState,
     meta: &RequestMeta,
-) -> Result<Option<UploadContext<'a>>, axum::response::ErrorResponse> {
+) -> Result<Option<UploadContext<'a>>, BadStoreRequest> {
     if !state
         .global_config_handle()
         .current()
@@ -89,12 +88,14 @@ async fn upload_context<'a>(
         .project_cache_handle()
         .ready(meta.public_key(), state.config().query_timeout())
         .await
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+        .ok_or(BadStoreRequest::ProjectUnavailable)?;
+
     let project_config = project
         .state()
         .clone()
         .enabled()
         .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+
     let scoping = project_config
         .scoping(meta.public_key())
         .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -22,7 +22,6 @@ use crate::managed::Managed;
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::DiscardReason;
-use crate::services::projects::cache::Project;
 use crate::services::upload::Upload;
 use crate::utils::{self, AttachmentStrategy};
 

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -64,9 +64,60 @@ struct Parts {
     upload: &'static [&'static str],
 }
 
-struct PlaystationAttachmentStrategy<'a> {
-    upload_service: Option<&'a Addr<Upload>>,
+struct UploadContext<'a> {
+    upload: &'a Addr<Upload>,
     scoping: Scoping,
+}
+
+/// Created an [UploadContext].
+///
+/// Requires both the `endpoint_fetch_config_enabled` option and `PlaystationUploads`
+/// feature to be enabled as well as attachments not being ratelimited.
+async fn upload_context<'a>(
+    state: &'a ServiceState,
+    meta: &RequestMeta,
+) -> Result<Option<UploadContext<'a>>, axum::response::ErrorResponse> {
+    if !state
+        .global_config_handle()
+        .current()
+        .options
+        .endpoint_fetch_config_enabled
+    {
+        return Ok(None);
+    }
+
+    let project = state
+        .project_cache_handle()
+        .ready(meta.public_key(), state.config().query_timeout())
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let project_config = project
+        .state()
+        .clone()
+        .enabled()
+        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+    let scoping = project_config
+        .scoping(meta.public_key())
+        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+
+    let attachment_rate_limits = project.rate_limits().current_limits().check_with_quotas(
+        project_config.get_quotas(),
+        scoping.item(DataCategory::Attachment),
+    );
+
+    match project_config.has_feature(Feature::PlaystationUploads)
+        && !attachment_rate_limits.is_limited()
+    {
+        true => Ok(Some(UploadContext {
+            upload: state.upload(),
+            scoping,
+        })),
+        false => Ok(None),
+    }
+}
+
+struct PlaystationAttachmentStrategy<'a> {
+    upload_context: Option<UploadContext<'a>>,
 }
 
 impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
@@ -87,16 +138,16 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
         item: Managed<Item>,
         config: &Config,
     ) -> Result<Option<Managed<Item>>, multer::Error> {
-        match self.upload_service {
-            Some(upload) if self.infer_type(&field) != AttachmentType::Prosperodump => {
+        match &self.upload_context {
+            Some(upload_context) if self.infer_type(&field) != AttachmentType::Prosperodump => {
                 let content_type = field.content_type().map(ToString::to_string);
                 Ok(common::upload_to_objectstore(
                     field,
                     content_type,
                     item,
                     config,
-                    self.scoping,
-                    upload,
+                    upload_context.scoping,
+                    upload_context.upload,
                     "playstation",
                 )
                 .await)
@@ -127,33 +178,12 @@ async fn multipart_to_envelope(
     multipart: Multipart<'static>,
     meta: RequestMeta,
     state: &ServiceState,
-    project: &Project<'_>,
+    upload_context: Option<UploadContext<'_>>,
 ) -> Result<Managed<Box<Envelope>>, BadStoreRequest> {
-    let project_config = project
-        .state()
-        .clone()
-        .enabled()
-        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
-    let scoping = project_config
-        .scoping(meta.public_key())
-        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
-    let attachment_rate_limits = || {
-        project.rate_limits().current_limits().check_with_quotas(
-            project_config.get_quotas(),
-            scoping.item(DataCategory::Attachment),
-        )
-    };
-    let upload_service = (project_config.has_feature(Feature::PlaystationUploads)
-        && !attachment_rate_limits().is_limited())
-    .then_some(state.upload());
-    let attachment_strategy = PlaystationAttachmentStrategy {
-        scoping,
-        upload_service,
-    };
     let mut items = utils::multipart_items(
         multipart,
         state.config(),
-        attachment_strategy,
+        PlaystationAttachmentStrategy { upload_context },
         &meta,
         state.outcome_aggregator(),
     )
@@ -183,15 +213,9 @@ async fn handle(
         return Ok(axum::Json(create_data_request_response()).into_response());
     }
 
-    let config = state.config();
-    let project = state
-        .project_cache_handle()
-        .ready(meta.public_key(), config.query_timeout())
-        .await
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-
+    let upload_context = upload_context(&state, &meta).await?;
     let multipart = utils::multipart_from_request(request)?;
-    let mut envelope = multipart_to_envelope(multipart, meta, &state, &project).await?;
+    let mut envelope = multipart_to_envelope(multipart, meta, &state, upload_context).await?;
     envelope.modify(|inner, _| inner.require_feature(Feature::PlaystationIngestion));
 
     let id = envelope.event_id();

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -16,7 +16,7 @@ use crate::service::ServiceState;
 use crate::services::outcome::{DiscardItemType, DiscardReason};
 use crate::services::processor::ProcessingError;
 use crate::statsd::RelayCounters;
-use crate::utils::{self, extract_items};
+use crate::utils::extract_items;
 
 #[derive(Debug, Deserialize)]
 struct UnrealQuery {

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -52,14 +52,8 @@ impl UnrealParams {
         }
 
         let global_config = state.global_config_handle().current();
-        let project_id = envelope.meta().project_id().map(|p| p.value()).unwrap_or(0);
-        let endpoint_expansion_rolled_out = utils::is_rolled_out(
-            project_id,
-            global_config.options.unreal_report_expansion_rollout_rate,
-        )
-        .is_keep();
 
-        if endpoint_expansion_rolled_out {
+        if global_config.options.endpoint_fetch_config_enabled {
             // Ensure that we really make it here.
             relay_statsd::metric!(counter(RelayCounters::UnrealEndpointExpansion) += 1);
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -985,8 +985,6 @@ pub enum RelayCounters {
     ErrorProcessed,
     /// The number of times the new unreal expansion logic in the endpoint is hit.
     UnrealEndpointExpansion,
-    /// The number of times the new logic for fetching the project config in the endpoint is hit.
-    MinidumpEndpointConfigFetching,
 }
 
 impl CounterMetric for RelayCounters {
@@ -1047,7 +1045,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProfileChunksWithoutPlatform => "profile_chunk.no_platform",
             RelayCounters::ErrorProcessed => "event.error.processed",
             RelayCounters::UnrealEndpointExpansion => "unreal.endpoint_expansion",
-            RelayCounters::MinidumpEndpointConfigFetching => "minidump.endpoint_config_fetch",
         }
     }
 }

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -3,6 +3,7 @@ mod dynamic_sampling;
 mod error;
 mod multipart;
 mod param_parser;
+#[cfg(feature = "processing")]
 mod pick;
 mod rate_limits;
 mod retry;
@@ -31,6 +32,7 @@ pub use self::multipart::*;
 #[cfg(feature = "processing")]
 pub use self::native::*;
 pub use self::param_parser::*;
+#[cfg(feature = "processing")]
 pub use self::pick::*;
 pub use self::rate_limits::*;
 pub use self::retry::*;

--- a/relay-server/src/utils/pick.rs
+++ b/relay-server/src/utils/pick.rs
@@ -25,6 +25,7 @@ pub fn is_rolled_out(id: u64, rate: f32) -> PickResult {
 
 impl PickResult {
     /// Returns `true` if the sampling result is [`PickResult::Keep`].
+    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub fn is_keep(self) -> bool {
         matches!(self, PickResult::Keep)
     }

--- a/tests/integration/fixtures/mini_sentry.py
+++ b/tests/integration/fixtures/mini_sentry.py
@@ -560,5 +560,6 @@ GLOBAL_CONFIG = {
     "options": {
         "relay.span-usage-metric": True,
         "relay.session.processing.rollout": 1.0,
+        "relay.endpoint-fetch-config.enabled": True,
     },
 }

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -826,7 +826,7 @@ def test_size_limits(mini_sentry, relay, limit, expected_status_code):
 
 
 @pytest.mark.parametrize(
-    "rollout_enabled,upload_attachments,upload_minidump",
+    "config_fetch,upload_attachments,upload_minidump",
     [
         (False, True, True),  # if the option is not set we don't check the features
         (True, True, False),
@@ -839,7 +839,7 @@ def test_minidump_objectstore_uploads(
     mini_sentry,
     relay,
     dummy_upload,
-    rollout_enabled,
+    config_fetch,
     upload_attachments,
     upload_minidump,
 ):
@@ -857,8 +857,8 @@ def test_minidump_objectstore_uploads(
             "projects:relay-minidump-uploads"
         )
     mini_sentry.global_config["options"][
-        "relay.minidump-endpoint-fetch-config.rollout-rate"
-    ] = (1.0 if rollout_enabled else 0.0)
+        "relay.endpoint-fetch-config.enabled"
+    ] = config_fetch
 
     relay = relay(mini_sentry)
 
@@ -880,7 +880,7 @@ def test_minidump_objectstore_uploads(
     minidump = by_name["minidump.dmp"]
     logs = by_name["log.txt"]
 
-    if rollout_enabled and upload_attachments:
+    if config_fetch and upload_attachments:
         assert (
             logs.headers["content_type"] == "application/vnd.sentry.attachment-ref+json"
         )
@@ -894,7 +894,7 @@ def test_minidump_objectstore_uploads(
         )
         assert logs.payload.bytes == log_content
 
-    if rollout_enabled and upload_minidump:
+    if config_fetch and upload_minidump:
         assert (
             minidump.headers["content_type"]
             == "application/vnd.sentry.attachment-ref+json"
@@ -973,9 +973,7 @@ def test_minidump_objectstore_uploads_rate_limits(
                 "reasonCode": "test_endpoint_check",
             }
         ]
-    mini_sentry.global_config["options"][
-        "relay.minidump-endpoint-fetch-config.rollout-rate"
-    ] = 1.0
+    mini_sentry.global_config["options"]["relay.endpoint-fetch-config.enabled"] = True
 
     relay = relay(
         mini_sentry,

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -15,8 +15,8 @@ def load_dump_file(base_file_name: str):
 
 
 @pytest.mark.parametrize("dump_file_name", ["unreal_crash", "unreal_crash_apple"])
-@pytest.mark.parametrize("rollout_rate", [0.0, 1.0])
-def test_unreal_crash(mini_sentry, relay, dump_file_name, rollout_rate):
+@pytest.mark.parametrize("config_fetch", [False, True])
+def test_unreal_crash(mini_sentry, relay, dump_file_name, config_fetch):
     """
     Asserts that non-processing Relays forward the Unreal report either as a
     single unreal_report item or as expanded attachment items depending on
@@ -24,11 +24,11 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, rollout_rate):
     """
     project_id = 42
     mini_sentry.global_config["options"][
-        "relay.unreal-report-expansion.rollout-rate"
-    ] = rollout_rate
+        "relay.endpoint-fetch-config.enabled"
+    ] = config_fetch
     relay = relay(mini_sentry)
     project_config = mini_sentry.add_full_project_config(project_id)
-    if rollout_rate:
+    if config_fetch:
         project_config["config"].setdefault("features", []).extend(
             ["organizations:relay-unreal-endpoint-expansion"]
         )
@@ -43,7 +43,7 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, rollout_rate):
     assert event_id == envelope.headers.get("event_id")
     items = envelope.items
 
-    if rollout_rate == 0.0:
+    if not config_fetch:
         assert len(items) == 1
         unreal_item = items[0]
         assert unreal_item.headers
@@ -58,7 +58,7 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, rollout_rate):
 
 
 @pytest.mark.parametrize("dump_file_name", ["unreal_crash", "unreal_crash_apple"])
-@pytest.mark.parametrize("rollout_rate", [0.0, 1.0])
+@pytest.mark.parametrize("config_fetch", [False, True])
 def test_unreal_crash_full_pipeline(
     mini_sentry,
     relay,
@@ -67,22 +67,22 @@ def test_unreal_crash_full_pipeline(
     attachments_consumer,
     outcomes_consumer,
     dump_file_name,
-    rollout_rate,
+    config_fetch,
 ):
     """
     Even if unreal report is expanded in the endpoint the end to end logic should remain unchanged.
     """
     project_id = 42
     mini_sentry.global_config["options"][
-        "relay.unreal-report-expansion.rollout-rate"
-    ] = rollout_rate
+        "relay.endpoint-fetch-config.enabled"
+    ] = config_fetch
 
     credentials = relay_credentials()
     processing = relay_with_processing(static_credentials=credentials)
     pop = relay(processing, credentials=credentials)
 
     project_config = mini_sentry.add_full_project_config(project_id)
-    if rollout_rate:
+    if config_fetch:
         project_config["config"].setdefault("features", []).extend(
             ["organizations:relay-unreal-endpoint-expansion"]
         )


### PR DESCRIPTION
Replaces the per endpoint options for controlling the project fetching in the endpoint with a global one (`relay.endpoint-fetch-config.enabled`). Idea being that if these cause an issue they can all be disabled in one go.

**Note:** For the playstation endpoint some logic changes were needed since the project fetching was done unconditionally.  

Rollout plan:
- [x] https://github.com/getsentry/sentry/pull/114947 (define new option)
- [x] This PR
- [x] https://github.com/getsentry/sentry-options-automator/pull/7681 (unset old options)
- [ ] https://github.com/getsentry/sentry/pull/114951 (un define old options)

Fix: INGEST-873