### PR TITLE
feat(conventions): Add "undeprecating" function

### DIFF
--- a/relay-conventions/build/attributes.rs
+++ b/relay-conventions/build/attributes.rs
@@ -195,6 +195,68 @@ pub fn parse_segments(key: &str) -> impl Iterator<Item = &str> {
     key.split('.')
 }
 
+/// Returns:
+/// * `Some(attribute, replacement)` if `attribute` is deprecated with `replacement`
+/// * `Some(attribute, attribute)` if `attribute` is not deprecated
+/// * `None` if `attribute` is deprecated without replacement
+pub fn constant_pair(attribute: &Attribute) -> Option<(String, String)> {
+    let Attribute {
+        key,
+        brief: _,
+        pii: _,
+        deprecation,
+        alias: _,
+    } = attribute;
+
+    let replacement = match deprecation {
+        Some(d) => d.replacement.as_deref()?,
+        None => key,
+    };
+
+    Some((name_constant(key), name_constant(replacement)))
+}
+
+/// Writes a function that returns the replacement name for an attribute.
+pub fn write_replacement_fn(
+    out: &mut impl std::io::Write,
+    constants: impl Iterator<Item = (String, String)>,
+) {
+    writeln!(
+        out,
+        r#"/// Returns the "undeprecated" version of an attribute."#
+    )
+    .unwrap();
+    writeln!(out, r#"/// This means:"#).unwrap();
+    writeln!(
+        out,
+        r#"/// * If the attribute is not deprecated, it is returned itself."#
+    )
+    .unwrap();
+    writeln!(out, r#"/// * If the attribute is deprecated and has a replacement, the replacement is returned."#).unwrap();
+    writeln!(
+        out,
+        r#"/// * If the attribute is deprecated without a replacement, `None` is returned."#
+    )
+    .unwrap();
+    writeln!(
+        out,
+        r#"/// * If the attribute is not defined in `sentry-conventions`, `None` is returned."#
+    )
+    .unwrap();
+    writeln!(out, "#[allow(deprecated)]").unwrap();
+
+    writeln!(out, r#"pub fn replacement(key: &str) -> Option<&str> {{"#).unwrap();
+    writeln!(out, r#"    match key {{"#).unwrap();
+
+    for (old, new) in constants {
+        writeln!(out, r#"        {old} => Some({new}),"#).unwrap();
+    }
+
+    writeln!(out, r#"        _ => None,"#).unwrap();
+    writeln!(out, r#"    }}"#).unwrap();
+    writeln!(out, r#"}}"#).unwrap();
+}
+
 #[derive(Default)]
 pub struct RawNode {
     pub children: BTreeMap<String, RawNode>,

--- a/relay-conventions/build/attributes.rs
+++ b/relay-conventions/build/attributes.rs
@@ -230,7 +230,7 @@ pub fn write_canonical_fn(
 /// * If the attribute is deprecated without a replacement, `None` is returned.
 /// * If the attribute is not defined in `sentry-conventions`, `None` is returned.
 #[allow(deprecated)]
-pub fn canonical(key: &str) -> Option<&str> {{
+pub fn canonical(key: &str) -> Option<&'static str> {{
     use crate::consts::*;
     match key {{"#
     )

--- a/relay-conventions/build/attributes.rs
+++ b/relay-conventions/build/attributes.rs
@@ -217,13 +217,13 @@ pub fn constant_pair(attribute: &Attribute) -> Option<(String, String)> {
 }
 
 /// Writes a function that returns the replacement name for an attribute.
-pub fn write_replacement_fn(
+pub fn write_canonical_fn(
     out: &mut impl std::io::Write,
     constants: impl Iterator<Item = (String, String)>,
 ) {
     writeln!(
         out,
-        r#"/// Returns the "undeprecated" version of an attribute."#
+        r#"/// Returns the "canonical" version of an attribute."#
     )
     .unwrap();
     writeln!(out, r#"/// This means:"#).unwrap();
@@ -245,7 +245,8 @@ pub fn write_replacement_fn(
     .unwrap();
     writeln!(out, "#[allow(deprecated)]").unwrap();
 
-    writeln!(out, r#"pub fn replacement(key: &str) -> Option<&str> {{"#).unwrap();
+    writeln!(out, r#"pub fn canonical(key: &str) -> Option<&str> {{"#).unwrap();
+    writeln!(out, r#"    use crate::consts::*;"#).unwrap();
     writeln!(out, r#"    match key {{"#).unwrap();
 
     for (old, new) in constants {

--- a/relay-conventions/build/attributes.rs
+++ b/relay-conventions/build/attributes.rs
@@ -223,39 +223,30 @@ pub fn write_canonical_fn(
 ) {
     writeln!(
         out,
-        r#"/// Returns the "canonical" version of an attribute."#
+        r#"/// Returns the "canonical" version of an attribute.
+/// This means:
+/// * If the attribute is not deprecated, it is returned itself.
+/// * If the attribute is deprecated and has a replacement, the replacement is returned.
+/// * If the attribute is deprecated without a replacement, `None` is returned.
+/// * If the attribute is not defined in `sentry-conventions`, `None` is returned.
+#[allow(deprecated)]
+pub fn canonical(key: &str) -> Option<&str> {{
+    use crate::consts::*;
+    match key {{"#
     )
     .unwrap();
-    writeln!(out, r#"/// This means:"#).unwrap();
-    writeln!(
-        out,
-        r#"/// * If the attribute is not deprecated, it is returned itself."#
-    )
-    .unwrap();
-    writeln!(out, r#"/// * If the attribute is deprecated and has a replacement, the replacement is returned."#).unwrap();
-    writeln!(
-        out,
-        r#"/// * If the attribute is deprecated without a replacement, `None` is returned."#
-    )
-    .unwrap();
-    writeln!(
-        out,
-        r#"/// * If the attribute is not defined in `sentry-conventions`, `None` is returned."#
-    )
-    .unwrap();
-    writeln!(out, "#[allow(deprecated)]").unwrap();
-
-    writeln!(out, r#"pub fn canonical(key: &str) -> Option<&str> {{"#).unwrap();
-    writeln!(out, r#"    use crate::consts::*;"#).unwrap();
-    writeln!(out, r#"    match key {{"#).unwrap();
 
     for (old, new) in constants {
         writeln!(out, r#"        {old} => Some({new}),"#).unwrap();
     }
 
-    writeln!(out, r#"        _ => None,"#).unwrap();
-    writeln!(out, r#"    }}"#).unwrap();
-    writeln!(out, r#"}}"#).unwrap();
+    writeln!(
+        out,
+        r#"        _ => None,
+    }}
+}}"#
+    )
+    .unwrap();
 }
 
 #[derive(Default)]

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -1,6 +1,7 @@
 mod attributes;
 mod name;
 
+use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -25,11 +26,15 @@ fn main() {
 }
 
 fn write_attribute_rs(crate_dir: &Path) {
-    use attributes::{Attribute, RawNode, format_attribute_info, format_constant, parse_segments};
+    use attributes::{
+        Attribute, RawNode, constant_pair, format_attribute_info, format_constant, parse_segments,
+        write_replacement_fn,
+    };
 
     let attribute_consts_path =
         Path::new(&env::var("OUT_DIR").unwrap()).join("attribute_consts.rs");
     let mut attribute_consts_file = BufWriter::new(File::create(&attribute_consts_path).unwrap());
+    let mut attribute_replacement_map = BTreeMap::new();
 
     let mut root = RawNode::default();
 
@@ -44,6 +49,11 @@ fn write_attribute_rs(crate_dir: &Path) {
 
             // Write attribute constant
             writeln!(&mut attribute_consts_file, "{}\n", format_constant(&attr)).unwrap();
+
+            // Insert deprecated -> replacement into map
+            if let Some((old, new)) = constant_pair(&attr) {
+                attribute_replacement_map.insert(old, new);
+            }
 
             // Put attribute info in the hierarchical map
             let info = format_attribute_info(&attr);
@@ -62,6 +72,11 @@ fn write_attribute_rs(crate_dir: &Path) {
             }
         }
     }
+
+    write_replacement_fn(
+        &mut attribute_consts_file,
+        attribute_replacement_map.into_iter(),
+    );
 
     let attribute_map_path = Path::new(&env::var("OUT_DIR").unwrap()).join("attribute_map.rs");
     let mut attribute_map_file = BufWriter::new(File::create(&attribute_map_path).unwrap());

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -28,7 +28,7 @@ fn main() {
 fn write_attribute_rs(crate_dir: &Path) {
     use attributes::{
         Attribute, RawNode, constant_pair, format_attribute_info, format_constant, parse_segments,
-        write_replacement_fn,
+        write_canonical_fn,
     };
 
     let attribute_consts_path =
@@ -73,8 +73,11 @@ fn write_attribute_rs(crate_dir: &Path) {
         }
     }
 
-    write_replacement_fn(
-        &mut attribute_consts_file,
+    let canonical_fn_path = Path::new(&env::var("OUT_DIR").unwrap()).join("canonical_fn.rs");
+    let mut canonical_fn_file = BufWriter::new(File::create(&canonical_fn_path).unwrap());
+
+    write_canonical_fn(
+        &mut canonical_fn_file,
         attribute_replacement_map.into_iter(),
     );
 

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -73,6 +73,7 @@ pub mod consts {
 }
 
 include!(concat!(env!("OUT_DIR"), "/attribute_map.rs"));
+include!(concat!(env!("OUT_DIR"), "/canonical_fn.rs"));
 include!(concat!(env!("OUT_DIR"), "/name_fn.rs"));
 
 /// Whether an attribute should be PII-strippable/should be subject to datascrubbers


### PR DESCRIPTION
This adds an auto-generated function `replacement` to `relay-conventions` which, given an attribute name, returns the "current version" of that attribute. Internally it's a big match statement.

The reason I want to do this is so that we can seamlessly look up e.g. the `browser.web_vital.cls.value` attribute if we see `cls` in a performance profile.

<img width="860" height="457" alt="Screenshot 2026-05-06 at 13 42 11" src="https://github.com/user-attachments/assets/a693ad40-efa8-49b3-856d-d994a1393ef7" />

ref: INGEST-896.