### PR TITLE
test(http): Inject a custom, fixed user agent for all tests

### DIFF
--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -5,6 +5,8 @@ from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
 from sentry_relay.auth import SecretKey
 
+DEFAULT_USER_AGENT = "RelayIntegrationTests/1.0.0 Firefox/42.0"
+
 
 class SentryLike:
 
@@ -562,14 +564,21 @@ class SentryLike:
         envelope.add_item(Item(payload=PayloadRef(json=check_in), type="check_in"))
         self.send_envelope(project_id, envelope)
 
-    def request(self, method, path, timeout=None, is_internal=False, **kwargs):
+    def request(
+        self, method, path, timeout=None, is_internal=False, headers=None, **kwargs
+    ):
         assert path.startswith("/")
 
         if timeout is None:
             timeout = 10
 
+        headers = headers or {}
+        headers.setdefault("User-Agent", DEFAULT_USER_AGENT)
+
         url = self.url if not is_internal else self.internal_url
-        return requests.request(method, url + path, timeout=timeout, **kwargs)
+        return requests.request(
+            method, url + path, timeout=timeout, headers=headers, **kwargs
+        )
 
     def post(self, path, **kwargs):
         return self.request("post", path, **kwargs)

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -64,9 +64,9 @@ def test_nel_converted_to_logs(mini_sentry, relay):
                     },
                     "browser.name": {
                         "type": "string",
-                        "value": "Python Requests",
+                        "value": "Firefox",
                     },
-                    "browser.version": {"type": "string", "value": "2.33"},
+                    "browser.version": {"type": "string", "value": "42.0"},
                     "sentry.observed_timestamp_nanos": {
                         "type": "string",
                         "value": time_within_delta(expect_resolution="ns"),

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -221,7 +221,7 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
         # If an external Relay/Client makes modifications, sizes can change,
         # this is fuzzy due to slight changes in sizes due to added timestamps
         # and may need to be adjusted when changing normalization.
-        ("managed", 114, 445),
+        ("managed", 106, 437),
     ],
 )
 def test_ourlog_extraction_with_sentry_logs(
@@ -313,8 +313,8 @@ def test_ourlog_extraction_with_sentry_logs(
         {
             "attributes": {
                 "sentry.body": {"stringValue": "This is really bad"},
-                "browser.name": {"stringValue": "Python Requests"},
-                "browser.version": {"stringValue": "2.33"},
+                "browser.name": {"stringValue": "Firefox"},
+                "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.payload_size_bytes": {"intValue": mock.ANY},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
@@ -388,8 +388,8 @@ def test_ourlog_extraction_with_sentry_logs(
                     "stringValue": '{"meta":{"value":{"1":{"":{"rem":[["@creditcard","s",0,12]],"len":16}}}}}'
                 },
                 "sentry.body": {"stringValue": "Example log record"},
-                "browser.name": {"stringValue": "Python Requests"},
-                "browser.version": {"stringValue": "2.33"},
+                "browser.name": {"stringValue": "Firefox"},
+                "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "info"},
                 "sentry.payload_size_bytes": {"intValue": mock.ANY},
                 "http.response_content_length": {"intValue": "17"},
@@ -504,8 +504,8 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
         "span_id": "eee19b7ec3c1b174",
         "attributes": {
             "test_pii": {"type": "string", "value": expected_scrubbed},
-            "browser.name": {"type": "string", "value": "Python Requests"},
-            "browser.version": {"type": "string", "value": "2.33"},
+            "browser.name": {"type": "string", "value": "Firefox"},
+            "browser.version": {"type": "string", "value": "42.0"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),
@@ -691,13 +691,13 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             "sentry._meta.fields.attributes.custom_field": {
                 "stringValue": '{"meta":{"value":{"":{"rem":[["remove_custom_field","s",0,10]],"len":12}}}}'
             },
-            "browser.version": {"stringValue": "2.33"},
+            "browser.version": {"stringValue": "42.0"},
             "custom_field": {"stringValue": "[REDACTED]"},
             "sentry.body": {"stringValue": "Test log"},
             "sentry.severity_text": {"stringValue": "info"},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
             "sentry.payload_size_bytes": mock.ANY,
-            "browser.name": {"stringValue": "Python Requests"},
+            "browser.name": {"stringValue": "Firefox"},
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
@@ -745,8 +745,8 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
     assert items_consumer.get_item() == {
         "attributes": {
             "sentry.body": {"stringValue": "Example log record 2"},
-            "browser.name": {"stringValue": "Python Requests"},
-            "browser.version": {"stringValue": "2.33"},
+            "browser.name": {"stringValue": "Firefox"},
+            "browser.version": {"stringValue": "42.0"},
             "sentry.severity_text": {"stringValue": "warn"},
             "sentry.payload_size_bytes": {"intValue": mock.ANY},
             **timestamps(ts),
@@ -1173,11 +1173,11 @@ def test_ourlog_container_metadata(
                 {
                     "browser.name": {
                         "type": "string",
-                        "value": "Python Requests",
+                        "value": "Firefox",
                     },
                     "browser.version": {
                         "type": "string",
-                        "value": "2.33",
+                        "value": "42.0",
                     },
                 },
             ),

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -597,7 +597,7 @@ def test_span_ingestion_with_performance_scores(
                 "condition": {
                     "op": "eq",
                     "name": "event.contexts.browser.name",
-                    "value": "Python Requests",
+                    "value": "Firefox",
                 },
             },
             {
@@ -608,7 +608,7 @@ def test_span_ingestion_with_performance_scores(
                 "condition": {
                     "op": "eq",
                     "name": "event.contexts.browser.name",
-                    "value": "Python Requests",
+                    "value": "Firefox",
                 },
             },
         ],

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -126,8 +126,8 @@ def test_spansv2_basic(
             "valid_int": {"value": 9223372036854775807, "type": "integer"},
             "invalid_int": None,
             "invalid": None,
-            "browser.name": {"type": "string", "value": "Python Requests"},
-            "browser.version": {"type": "string", "value": "2.33"},
+            "browser.name": {"type": "string", "value": "Firefox"},
+            "browser.version": {"type": "string", "value": "42.0"},
             "sentry.dsc.environment": {"type": "string", "value": "prod"},
             "sentry.dsc.public_key": {
                 "type": "string",
@@ -246,7 +246,7 @@ def test_spansv2_trimming_basic(
             # This is sufficient for all builtin attributes not
             # to be trimmed. The span fields that aren't trimmed
             # also still count for the size limit.
-            "trimming": {"span": {"maxSize": 439}},
+            "trimming": {"span": {"maxSize": 431}},
         }
     )
 
@@ -321,8 +321,8 @@ def test_spansv2_trimming_basic(
                 "value": "This is actually a pretty long string",
             },
             "custom.invalid.attribute": None,
-            "browser.name": {"type": "string", "value": "Python Requests"},
-            "browser.version": {"type": "string", "value": "2.33"},
+            "browser.name": {"type": "string", "value": "Firefox"},
+            "browser.version": {"type": "string", "value": "42.0"},
             "sentry.dsc.environment": {"type": "string", "value": "prod"},
             "sentry.dsc.public_key": {
                 "type": "string",
@@ -342,7 +342,7 @@ def test_spansv2_trimming_basic(
         },
         "_meta": {
             "attributes": {
-                "": {"len": 491},
+                "": {"len": 483},
                 "custom.array.attribute": {
                     "value": {
                         "2": {

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -929,11 +929,11 @@ def test_trace_metric_container_metadata(
                 {
                     "browser.name": {
                         "type": "string",
-                        "value": "Python Requests",
+                        "value": "Firefox",
                     },
                     "browser.version": {
                         "type": "string",
-                        "value": "2.33",
+                        "value": "42.0",
                     },
                 },
             ),


### PR DESCRIPTION
With the recent requests update we also had to change tests, which isn't great. This configures a default user agent which can still be changed.

The user agent defaults to `Firefox 42.0` as the custom one doesn't pass the UA parser.