### PR TITLE
feat(minidump): Add compressed minidump counter

### DIFF
--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -29,6 +29,7 @@ use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason, Outcome};
 use crate::services::upload::Upload;
+use crate::statsd::RelayCounters;
 use crate::utils::{self, AttachmentStrategy, read_attachment_bytes_into_item};
 
 /// The field name of a minidump in the multipart form-data upload.
@@ -113,6 +114,9 @@ fn decode_minidump(minidump_data: Bytes, max_size: usize) -> Result<Bytes, BadSt
         // proceed to process the payload untouched (as a plain minidump).
         return Ok(minidump_data);
     };
+
+    // Determine if this is a niche use-case of if this happens frequently.
+    relay_statsd::metric!(counter(RelayCounters::CompressedMinidump) += 1);
 
     let decoder = decoder.take(max_size.saturating_add(1) as u64);
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -985,6 +985,8 @@ pub enum RelayCounters {
     ErrorProcessed,
     /// The number of times the new unreal expansion logic in the endpoint is hit.
     UnrealEndpointExpansion,
+    /// The number of times that relay receives a compressed minidump.
+    CompressedMinidump,
 }
 
 impl CounterMetric for RelayCounters {
@@ -1045,6 +1047,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProfileChunksWithoutPlatform => "profile_chunk.no_platform",
             RelayCounters::ErrorProcessed => "event.error.processed",
             RelayCounters::UnrealEndpointExpansion => "unreal.endpoint_expansion",
+            RelayCounters::CompressedMinidump => "minidump.compressed.count",
         }
     }
 }


### PR DESCRIPTION
To ascertain if customers are sending us compressed minidumps this adds a counter  to `decode_minidump`. If it turns out that this is used a lot it might make sense to also support this for minidumps that are send to objectstore.