### PR TITLE
fix(schema): Implement remove other for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal**:
 
-- Remove unknown type variants instead of sending them on. ([#5962](https://github.com/getsentry/relay/pull/5962))
+- Remove unknown debug image variants in errors. ([#5962](https://github.com/getsentry/relay/pull/5962))
 - Bump `sentry-conventions` to 0.6.0-4. ([#5944](https://github.com/getsentry/relay/pull/5944))
 
 ## 26.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Internal**:
 
+- Remove unknown type variants instead of sending them on. ([#5962](https://github.com/getsentry/relay/pull/5962))
 - Bump `sentry-conventions` to 0.6.0-4. ([#5944](https://github.com/getsentry/relay/pull/5944))
 
 ## 26.4.2

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -45,7 +45,10 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
             let bi = &variant.bindings()[0];
             let ident = &bi.binding;
             let variant_attrs = parse_variant_attributes(variant.ast().attrs)?;
-            let field_attrs = parse_field_attributes(0, bi.ast(), &mut true)?;
+            let mut field_attrs = parse_field_attributes(0, bi.ast(), &mut true)?;
+            // `fallback_variant` is defined on the variant, so is `retain`, but `retain` is passed
+            // as a field attr.
+            field_attrs.retain |= variant_attrs.retain;
             let field_attrs_tokens = field_attrs.as_tokens(&type_attrs, Some(quote!(parent_attrs)));
 
             let process_value = if variant_attrs.fallback_variant {
@@ -385,6 +388,7 @@ impl Size {
 #[derive(Default, Debug)]
 struct VariantAttrs {
     fallback_variant: bool,
+    retain: bool,
 }
 
 fn parse_variant_attributes(attrs: &[syn::Attribute]) -> syn::Result<VariantAttrs> {
@@ -399,6 +403,9 @@ fn parse_variant_attributes(attrs: &[syn::Attribute]) -> syn::Result<VariantAttr
 
             if ident == "fallback_variant" {
                 rv.fallback_variant = true;
+            } else if ident == "retain" {
+                let s = meta.value()?.parse::<LitBool>()?;
+                rv.retain = s.value();
             } else {
                 // Ignore other attributes used by `FromValue`/`IntoValue` derive macros.
                 if let Ok(v) = meta.value() {

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -44,9 +44,25 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
 
             let bi = &variant.bindings()[0];
             let ident = &bi.binding;
+            let variant_attrs = parse_variant_attributes(variant.ast().attrs)?;
             let field_attrs = parse_field_attributes(0, bi.ast(), &mut true)?;
             let field_attrs_tokens = field_attrs.as_tokens(&type_attrs, Some(quote!(parent_attrs)));
 
+            let process_value = if variant_attrs.fallback_variant {
+                quote! {
+                    __processor.process_other(#ident, &__state)?;
+                }
+            } else {
+                quote! {
+                    ::relay_event_schema::processor::ProcessValue::process_value(
+                        #ident,
+                        __meta,
+                        __processor,
+                        &__state
+                    )?;
+
+                }
+            };
             Ok(quote! {
                 let parent_attrs = __state.attrs();
                 let attrs = #field_attrs_tokens;
@@ -65,12 +81,7 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
                     &__state
                 )?;
 
-                ::relay_event_schema::processor::ProcessValue::process_value(
-                    #ident,
-                    __meta,
-                    __processor,
-                    &__state
-                )?;
+                #process_value
 
                 __processor.after_process(
                     Some(#ident),
@@ -371,7 +382,38 @@ impl Size {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
+struct VariantAttrs {
+    fallback_variant: bool,
+}
+
+fn parse_variant_attributes(attrs: &[syn::Attribute]) -> syn::Result<VariantAttrs> {
+    let mut rv = VariantAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("metastructure") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            let ident = meta.path.require_ident()?;
+
+            if ident == "fallback_variant" {
+                rv.fallback_variant = true;
+            } else {
+                // Ignore other attributes used by `FromValue`/`IntoValue` derive macros.
+                if let Ok(v) = meta.value() {
+                    let _ = v.parse::<Lit>()?;
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    Ok(rv)
+}
+
+#[derive(Default, Debug)]
 struct FieldAttrs {
     additional_properties: bool,
     omit_from_schema: bool,

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -46,8 +46,8 @@ fn derive_process_value(mut s: synstructure::Structure<'_>) -> syn::Result<Token
             let ident = &bi.binding;
             let variant_attrs = parse_variant_attributes(variant.ast().attrs)?;
             let mut field_attrs = parse_field_attributes(0, bi.ast(), &mut true)?;
-            // `fallback_variant` is defined on the variant, so is `retain`, but `retain` is passed
-            // as a field attr.
+            // `fallback_variant` is defined on the variant, so is `retain`, but downstream code
+            // expects `retain` to be set as a field attribute.
             field_attrs.retain |= variant_attrs.retain;
             let field_attrs_tokens = field_attrs.as_tokens(&type_attrs, Some(quote!(parent_attrs)));
 

--- a/relay-event-normalization/src/remove_other.rs
+++ b/relay-event-normalization/src/remove_other.rs
@@ -76,8 +76,8 @@ impl Processor for RemoveOtherProcessor {
 #[cfg(test)]
 mod tests {
     use relay_event_schema::processor::process_value;
-    use relay_event_schema::protocol::{Context, Contexts, OsContext, User, Values};
-    use relay_protocol::{FromValue, get_value};
+    use relay_event_schema::protocol::{Context, Contexts, DebugImage, OsContext, User, Values};
+    use relay_protocol::{Empty, FromValue, get_value};
     use similar_asserts::assert_eq;
 
     use super::*;
@@ -159,6 +159,25 @@ mod tests {
         .unwrap();
 
         assert!(get_value!(event.user!).other.is_empty());
+    }
+
+    #[test]
+    fn test_remove_enum_fallback_variant() {
+        let mut debug_image = Annotated::new(DebugImage::Other({
+            let mut other = Object::new();
+            other.insert("foo".to_owned(), Value::U64(42).into());
+            other.insert("bar".to_owned(), Value::U64(42).into());
+            other
+        }));
+
+        process_value(
+            &mut debug_image,
+            &mut RemoveOtherProcessor,
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert!(debug_image.is_empty());
     }
 
     #[test]

--- a/relay-event-schema/src/protocol/contexts/mod.rs
+++ b/relay-event-schema/src/protocol/contexts/mod.rs
@@ -117,7 +117,7 @@ pub enum Context {
     /// Unity information.
     Unity(Box<UnityContext>),
     /// Additional arbitrary fields for forwards compatibility.
-    #[metastructure(fallback_variant)]
+    #[metastructure(fallback_variant, retain = true)]
     Other(#[metastructure(pii = "true")] Object<Value>),
 }
 

--- a/relay-event-schema/src/protocol/debugmeta.rs
+++ b/relay-event-schema/src/protocol/debugmeta.rs
@@ -487,7 +487,7 @@ pub enum DebugImage {
     /// JVM based debug image.
     Jvm(Box<JvmDebugImage>),
     /// A debug image that is unknown to this protocol specification.
-    #[metastructure(fallback_variant)]
+    #[metastructure(fallback_variant, retain = false)]
     Other(Object<Value>),
 }
 


### PR DESCRIPTION
Apparently this was never implemented for `ProcessValue`, I think I am calling the right `enter`/`exit` functions, but would appreciated a second set of eyes and thoughts whether this is actually correct.

One big side-track trying to implement #5280