### PR TITLE
docs(relay-server): Fix 'occured' -> 'occurred' typo in global_config doc comment

### DIFF
--- a/relay-server/src/services/global_config.rs
+++ b/relay-server/src/services/global_config.rs
@@ -135,7 +135,7 @@ pub enum Status {
     Ready(Arc<GlobalConfig>),
     /// The global config is requested from the upstream but it has not arrived yet.
     ///
-    /// This variant should never be sent after the first `Ready` has occured.
+    /// This variant should never be sent after the first `Ready` has occurred.
     #[default]
     Pending,
 }


### PR DESCRIPTION
Fixes a typo in the `UpstreamQueryResult::Pending` doc comment in `relay-server/src/services/global_config.rs`.