### PR TITLE
feat(upload): Log config fetching failures

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -259,8 +259,7 @@ async fn handle_patch(
     Ok(response)
 }
 
-#[must_use]
-fn check_kill_switch(state: &ServiceState) -> Result<(), axum::response::ErrorResponse> {
+fn check_kill_switch(state: &ServiceState) -> Result<(), StatusCode> {
     if !state.global_config_handle().is_ready() {
         relay_log::warn!("global config not available");
     }
@@ -270,7 +269,7 @@ fn check_kill_switch(state: &ServiceState) -> Result<(), axum::response::ErrorRe
         .options
         .endpoint_fetch_config_enabled
     {
-        return Err(StatusCode::SERVICE_UNAVAILABLE.into());
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
     Ok(())
 }

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -147,6 +147,9 @@ async fn handle_post(
     headers: HeaderMap,
 ) -> axum::response::Result<impl IntoResponse> {
     relay_log::trace!("Checking project fetching killswitch");
+    if !state.global_config_handle().is_ready() {
+        relay_log::warn!("global config not available");
+    }
     if !state
         .global_config_handle()
         .current()
@@ -172,7 +175,10 @@ async fn handle_post(
         .project_cache_handle()
         .ready(meta.public_key(), config.query_timeout()) // uses same timeout as `Upstream`
         .await
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+        .ok_or_else(|| {
+            relay_log::warn!("timeout waiting for project config");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
 
     relay_log::trace!("Checking request");
     let scoping = check_request(&state, meta, upload_length, project).await?;
@@ -206,6 +212,7 @@ async fn handle_patch(
         .options
         .endpoint_fetch_config_enabled
     {
+        relay_log::warn!("timeout waiting for project config");
         return Err(StatusCode::SERVICE_UNAVAILABLE.into());
     }
 
@@ -223,7 +230,10 @@ async fn handle_patch(
         .project_cache_handle()
         .ready(meta.public_key(), config.query_timeout()) // uses same timeout as `Upstream`
         .await
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+        .ok_or_else(|| {
+            relay_log::warn!("timeout waiting for project config");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
 
     relay_log::trace!("Checking request");
     let scoping = check_request(&state, meta, length, project).await?;

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -146,18 +146,8 @@ async fn handle_post(
     meta: RequestMeta,
     headers: HeaderMap,
 ) -> axum::response::Result<impl IntoResponse> {
-    relay_log::trace!("Checking project fetching killswitch");
-    if !state.global_config_handle().is_ready() {
-        relay_log::warn!("global config not available");
-    }
-    if !state
-        .global_config_handle()
-        .current()
-        .options
-        .endpoint_fetch_config_enabled
-    {
-        return Err(StatusCode::SERVICE_UNAVAILABLE.into());
-    }
+    relay_log::trace!("Checking project fetching kill switch");
+    check_kill_switch(&state)?;
 
     relay_log::trace!("Validating headers");
     let upload_length = tus::validate_post_headers(&headers, meta.request_trust().is_trusted())
@@ -205,16 +195,7 @@ async fn handle_patch(
     Query(upload::LocationQueryParams { length, signature }): Query<upload::LocationQueryParams>,
     body: Body,
 ) -> axum::response::Result<impl IntoResponse> {
-    relay_log::trace!("Checking project fetching killswitch");
-    if !state
-        .global_config_handle()
-        .current()
-        .options
-        .endpoint_fetch_config_enabled
-    {
-        relay_log::warn!("timeout waiting for project config");
-        return Err(StatusCode::SERVICE_UNAVAILABLE.into());
-    }
+    check_kill_switch(&state)?;
 
     relay_log::trace!("Validating headers");
     tus::validate_patch_headers(&headers).map_err(Error::from)?;
@@ -276,6 +257,22 @@ async fn handle_patch(
         .insert(tus::UPLOAD_OFFSET, upload_offset.into());
 
     Ok(response)
+}
+
+#[must_use]
+fn check_kill_switch(state: &ServiceState) -> Result<(), axum::response::ErrorResponse> {
+    if !state.global_config_handle().is_ready() {
+        relay_log::warn!("global config not available");
+    }
+    if !state
+        .global_config_handle()
+        .current()
+        .options
+        .endpoint_fetch_config_enabled
+    {
+        return Err(StatusCode::SERVICE_UNAVAILABLE.into());
+    }
+    Ok(())
 }
 
 async fn create(

--- a/relay-server/src/services/global_config.rs
+++ b/relay-server/src/services/global_config.rs
@@ -160,6 +160,11 @@ impl GlobalConfigHandle {
         Self { watch }
     }
 
+    /// Returns `true` if the global config was loaded from the upstream.
+    pub fn is_ready(&self) -> bool {
+        self.watch.borrow().is_ready()
+    }
+
     /// Returns the currently loaded or a default global config.
     ///
     /// When no global config has been received from upstream yet,

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -52,7 +52,7 @@ pub enum Error {
     UpstreamRequest(#[from] UpstreamRequestError),
     #[error("request timeout: {0}")]
     Timeout(#[from] tokio::time::error::Elapsed),
-    #[error("upstream response: {0}")]
+    #[error("error response from upstream: {0}")]
     Upstream(#[source] reqwest::Error),
     #[error("upstream provided invalid location: {0:?}")]
     InvalidLocation(Option<HeaderValue>),


### PR DESCRIPTION
PoPs are getting 503s from processing Relays:

- We know it's not are error from the `Upload` service because we see no "create failed" or "upload failed" errors.
- We know it is from processing relays themselves, not some proxy, because the 503s show up in the `responses.status_codes` metric.

This PR instruments additional locations where the `/upload` endpoint might return 503s.

ref: https://linear.app/getsentry/issue/INGEST-910