### PR TITLE
feat(upload): Retry upstream requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Bump `sentry-conventions` to 0.6.0-4. ([#5944](https://github.com/getsentry/relay/pull/5944))
 - Enable compression for forwarded uploads. ([#5965](https://github.com/getsentry/relay/pull/5965))
 - Change the default partitioning for the envelope buffer from semantic to round-robin. ([#5967](https://github.com/getsentry/relay/pull/5967))
+- Enable retries for upload requests to upstream. ([#5975](https://github.com/getsentry/relay/pull/5975))
 
 ## 26.4.2
 

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -87,6 +87,8 @@ impl IntoResponse for Error {
                     {
                         StatusCode::BAD_REQUEST
                     }
+                    UpstreamRequestError::RateLimited(_) => StatusCode::TOO_MANY_REQUESTS,
+                    UpstreamRequestError::ResponseError(status, _) => status,
                     _ => return e.into_response(),
                 },
                 upload::Error::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -593,8 +593,10 @@ impl UpstreamRequest for UploadRequest {
             stream, encoding, ..
         } = &mut self.kind
         {
-            let body = RetryableStream::new(stream.clone())
-                .expect("retry() returns false once the stream is taken");
+            let Some(body) = RetryableStream::new(stream.clone()) else {
+                relay_log::error!("upload request stream was already consumed");
+                return Err(HttpError::Misconfigured);
+            };
             tus::add_upload_headers(builder);
 
             let body = encode_body(body, *encoding);

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -38,7 +38,7 @@ use crate::services::upstream::{
     SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
 };
 use crate::utils::MeteredStream;
-use crate::utils::{BoundedStream, tus};
+use crate::utils::{BoundedStream, RetryableStream, TakeOnce, tus};
 
 /// The URL template for uploading bytes to a known location.
 pub const UPLOAD_PATCH_PATH: &str = "/api/{project_id}/upload/{key}/";
@@ -462,7 +462,8 @@ enum RequestKind {
     },
     Upload {
         location: SignedLocation,
-        stream: Option<BoundedStream<MeteredStream<ByteStream>>>,
+        stream: TakeOnce<BoundedStream<MeteredStream<ByteStream>>>,
+        length: Option<usize>,
         encoding: HttpEncoding,
     },
 }
@@ -507,13 +508,15 @@ impl UploadRequest {
             location,
             stream,
         } = stream;
+        let length = stream.length();
 
         (
             Self {
                 scoping,
                 kind: RequestKind::Upload {
                     location,
-                    stream: Some(stream),
+                    stream: TakeOnce::new(stream),
+                    length,
                     encoding: HttpEncoding::Zstd, // just a default, will be overwritten by .configure()
                 },
                 sender,
@@ -525,11 +528,7 @@ impl UploadRequest {
     /// Returns the length of the upload, if known.
     fn length(&self) -> Option<usize> {
         match &self.kind {
-            RequestKind::Create { length } => *length,
-            RequestKind::Upload { stream, .. } => {
-                debug_assert!(stream.is_some());
-                stream.as_ref().and_then(BoundedStream::length)
-            }
+            RequestKind::Create { length } | RequestKind::Upload { length, .. } => *length,
         }
     }
 }
@@ -573,11 +572,15 @@ impl UpstreamRequest for UploadRequest {
     }
 
     fn retry(&self) -> bool {
-        false
+        match &self.kind {
+            RequestKind::Create { .. } => true,
+            // Once the body has been polled, it cannot be replayed — give up instead.
+            RequestKind::Upload { stream, .. } => !stream.is_taken(),
+        }
     }
 
     fn intercept_status_errors(&self) -> bool {
-        false // same as ForwardRequest
+        true
     }
 
     fn set_relay_id(&self) -> bool {
@@ -590,10 +593,8 @@ impl UpstreamRequest for UploadRequest {
             stream, encoding, ..
         } = &mut self.kind
         {
-            let Some(body) = stream.take() else {
-                relay_log::error!("upload request was retried or never initialized");
-                return Err(HttpError::Misconfigured);
-            };
+            let body = RetryableStream::new(stream.clone())
+                .expect("retry() returns false once the stream is taken");
             tus::add_upload_headers(builder);
 
             let body = encode_body(body, *encoding);

--- a/relay-server/src/utils/stream/mod.rs
+++ b/relay-server/src/utils/stream/mod.rs
@@ -1,9 +1,7 @@
 mod bounded;
 mod metered;
-#[cfg(feature = "processing")]
 mod retryable;
 
 pub use bounded::*;
 pub use metered::*;
-#[cfg(feature = "processing")]
 pub use retryable::*;

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -106,7 +106,7 @@ def test_forward_patch(
 
 
 def test_post_retries(mini_sentry, relay, project_config):
-    """POST (create) requests forwarded to the upstream are not retried.
+    """POST (create) requests forwarded to the upstream are retried.
 
     The upstream returns 503 on the first attempt and succeeds on the second.
     """
@@ -133,8 +133,8 @@ def test_post_retries(mini_sentry, relay, project_config):
             "Upload-Length": "11",
         },
     )
-    assert response.status_code == 503, response.text
-    assert create_attempts == 1
+    assert response.status_code == 201, response.text
+    assert create_attempts == 2
 
 
 def test_upload_missing_tus_version(mini_sentry, relay, dummy_upload, project_config):

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -108,9 +108,7 @@ def test_forward_patch(
 def test_post_retries(mini_sentry, relay, project_config):
     """POST (create) requests forwarded to the upstream are not retried.
 
-    The upstream returns 503 on the first attempt and would succeed on the second.
-    Since `UploadRequest::retry()` returns `false`, the 503 is propagated to the
-    client instead of triggering a retry.
+    The upstream returns 503 on the first attempt and succeeds on the second.
     """
     mini_sentry.allow_chunked = True
 
@@ -137,42 +135,6 @@ def test_post_retries(mini_sentry, relay, project_config):
     )
     assert response.status_code == 503, response.text
     assert create_attempts == 1
-
-
-def test_patch_retries(mini_sentry, relay, project_config):
-    """PATCH (upload) requests forwarded to the upstream are not retried.
-
-    The upstream returns 503 on the first attempt and would succeed on the second.
-    Since `UploadRequest::retry()` returns `false`, the 503 is propagated to the
-    client instead of triggering a retry.
-    """
-    mini_sentry.allow_chunked = True
-
-    patch_attempts = 0
-
-    @mini_sentry.app.route("/api/<project>/upload/<key>/", methods=["PATCH"])
-    def upload(**opts):
-        nonlocal patch_attempts
-        patch_attempts += 1
-        if patch_attempts == 1:
-            return Response("", status=503)
-        return Response("", status=204, headers={"Location": DUMMY_UPLOAD_LOCATION})
-
-    project_id = 42
-    project_key = mini_sentry.get_dsn_public_key(project_id)
-    relay = relay(mini_sentry)
-
-    response = relay.patch(
-        f"{DUMMY_UPLOAD_LOCATION}&sentry_key={project_key}",
-        headers={
-            "Tus-Resumable": "1.0.0",
-            "Content-Type": "application/offset+octet-stream",
-            "Upload-Offset": "0",
-        },
-        data=b"hello world",
-    )
-    assert response.status_code == 503, response.text
-    assert patch_attempts == 1
 
 
 def test_upload_missing_tus_version(mini_sentry, relay, dummy_upload, project_config):

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -105,6 +105,76 @@ def test_forward_patch(
         )
 
 
+def test_post_retries(mini_sentry, relay, project_config):
+    """POST (create) requests forwarded to the upstream are not retried.
+
+    The upstream returns 503 on the first attempt and would succeed on the second.
+    Since `UploadRequest::retry()` returns `false`, the 503 is propagated to the
+    client instead of triggering a retry.
+    """
+    mini_sentry.allow_chunked = True
+
+    create_attempts = 0
+
+    @mini_sentry.app.route("/api/<project>/upload/", methods=["POST"])
+    def create(**opts):
+        nonlocal create_attempts
+        create_attempts += 1
+        if create_attempts == 1:
+            return Response("", status=503)
+        return Response("", status=201, headers={"Location": DUMMY_UPLOAD_LOCATION})
+
+    project_id = 42
+    project_key = mini_sentry.get_dsn_public_key(project_id)
+    relay = relay(mini_sentry)
+
+    response = relay.post(
+        f"/api/{project_id}/upload/?sentry_key={project_key}",
+        headers={
+            "Tus-Resumable": "1.0.0",
+            "Upload-Length": "11",
+        },
+    )
+    assert response.status_code == 503, response.text
+    assert create_attempts == 1
+
+
+def test_patch_retries(mini_sentry, relay, project_config):
+    """PATCH (upload) requests forwarded to the upstream are not retried.
+
+    The upstream returns 503 on the first attempt and would succeed on the second.
+    Since `UploadRequest::retry()` returns `false`, the 503 is propagated to the
+    client instead of triggering a retry.
+    """
+    mini_sentry.allow_chunked = True
+
+    patch_attempts = 0
+
+    @mini_sentry.app.route("/api/<project>/upload/<key>/", methods=["PATCH"])
+    def upload(**opts):
+        nonlocal patch_attempts
+        patch_attempts += 1
+        if patch_attempts == 1:
+            return Response("", status=503)
+        return Response("", status=204, headers={"Location": DUMMY_UPLOAD_LOCATION})
+
+    project_id = 42
+    project_key = mini_sentry.get_dsn_public_key(project_id)
+    relay = relay(mini_sentry)
+
+    response = relay.patch(
+        f"{DUMMY_UPLOAD_LOCATION}&sentry_key={project_key}",
+        headers={
+            "Tus-Resumable": "1.0.0",
+            "Content-Type": "application/offset+octet-stream",
+            "Upload-Offset": "0",
+        },
+        data=b"hello world",
+    )
+    assert response.status_code == 503, response.text
+    assert patch_attempts == 1
+
+
 def test_upload_missing_tus_version(mini_sentry, relay, dummy_upload, project_config):
 
     project_id = 42


### PR DESCRIPTION
Retry requests from the `Upload` service to the upstream relay, for example on 503s. Streaming PATCH requests can only be retried if no part of the body has been sent.

ref: INGEST-910