### PR TITLE
feat(upload): Count every upload as metric

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -99,7 +99,7 @@ impl IntoResponse for Error {
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
                 upload::Error::InvalidSignature => StatusCode::BAD_REQUEST,
-                upload::Error::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+                upload::Error::ObjectstoreServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
                 #[cfg(feature = "processing")]
                 upload::Error::Objectstore(service_error) => match service_error.kind {
                     objectstore::ErrorKind::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -37,6 +37,7 @@ use crate::services::objectstore::{self, Objectstore};
 use crate::services::upstream::{
     SendRequest, UpstreamRelay, UpstreamRequest, UpstreamRequestError,
 };
+use crate::statsd::RelayCounters;
 use crate::utils::MeteredStream;
 use crate::utils::{BoundedStream, tus};
 
@@ -60,8 +61,8 @@ pub enum Error {
     SigningFailed,
     #[error("invalid signature")]
     InvalidSignature,
-    #[error("service unavailable")]
-    ServiceUnavailable(#[source] SendError),
+    #[error("objectstore service unavailable: {0}")]
+    ObjectstoreServiceUnavailable(#[source] SendError),
     #[cfg(feature = "processing")]
     #[error("objectstore service: {0}")]
     Objectstore(#[from] objectstore::Error),
@@ -71,17 +72,35 @@ pub enum Error {
     Internal(#[source] http::header::InvalidHeaderValue),
 }
 
+impl Error {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Error::Send(_) => "send_failed",
+            Error::UpstreamRequest(_) => "upstream_request",
+            Error::Timeout(_) => "timeout",
+            Error::Upstream(_) => "upstream_response",
+            Error::InvalidLocation(_) => "invalid_location",
+            Error::SigningFailed => "signing_failed",
+            Error::InvalidSignature => "invalid_signature",
+            Error::ObjectstoreServiceUnavailable(_) => "service_unavailable",
+            Error::Objectstore(_) => "objectstore_error",
+            Error::LoadShed => "load_shed",
+            Error::Internal(_) => "internal",
+        }
+    }
+}
+
 /// The message interface for this service.
 pub enum Upload {
     /// Creates an upload resource.
     ///
     /// Returns the trusted identifier of the upload.
-    Create(Create, Sender<Result<SignedLocation, Error>>),
+    Create(Create, InstrumentedSender),
     /// Upload a stream of bytes for a given location.
     ///
     /// The service also returns the signed location. This is redundant, but creates a simpler
     /// flow for the caller side.
-    Upload(Stream, Sender<Result<SignedLocation, Error>>),
+    Upload(Stream, InstrumentedSender),
 }
 
 impl Interface for Upload {}
@@ -115,7 +134,13 @@ impl FromMessage<Create> for Upload {
     type Response = AsyncResponse<Result<SignedLocation, Error>>;
 
     fn from_message(message: Create, sender: Sender<Result<SignedLocation, Error>>) -> Self {
-        Self::Create(message, sender)
+        Self::Create(
+            message,
+            InstrumentedSender {
+                metric: RelayCounters::UploadCreate,
+                inner: sender,
+            },
+        )
     }
 }
 
@@ -123,7 +148,13 @@ impl FromMessage<Stream> for Upload {
     type Response = AsyncResponse<Result<SignedLocation, Error>>;
 
     fn from_message(message: Stream, sender: Sender<Result<SignedLocation, Error>>) -> Self {
-        Self::Upload(message, sender)
+        Self::Upload(
+            message,
+            InstrumentedSender {
+                metric: RelayCounters::UploadUpload,
+                inner: sender,
+            },
+        )
     }
 }
 
@@ -172,6 +203,23 @@ fn create_backend(
 pub struct Service {
     timeout: Duration,
     backend: Backend,
+}
+
+/// A response channel that emits a metric for each response.
+pub struct InstrumentedSender {
+    metric: RelayCounters,
+    inner: Sender<Result<SignedLocation, Error>>,
+}
+
+impl InstrumentedSender {
+    fn send(self, result: Result<SignedLocation, Error>) {
+        let result_msg = match &result {
+            Ok(_) => "success",
+            Err(e) => e.as_str(),
+        };
+        relay_statsd::metric!(counter(self.metric) += 1, result = result_msg,);
+        self.inner.send(result)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -243,7 +291,7 @@ impl Service {
                         stream,
                     })
                     .await
-                    .map_err(Error::ServiceUnavailable)??
+                    .map_err(Error::ObjectstoreServiceUnavailable)??
                     .into_inner();
                 let length = Some(byte_counter.get());
 

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -83,6 +83,7 @@ impl Error {
             Error::SigningFailed => "signing_failed",
             Error::InvalidSignature => "invalid_signature",
             Error::ObjectstoreServiceUnavailable(_) => "service_unavailable",
+            #[cfg(feature = "processing")]
             Error::Objectstore(_) => "objectstore_error",
             Error::LoadShed => "load_shed",
             Error::Internal(_) => "internal",

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -73,7 +73,7 @@ pub enum Error {
 }
 
 impl Error {
-    fn as_str(&self) -> &'static str {
+    fn variant(&self) -> &'static str {
         match self {
             Error::Send(_) => "send_failed",
             Error::UpstreamRequest(_) => "upstream_request",
@@ -216,9 +216,9 @@ impl InstrumentedSender {
     fn send(self, result: Result<SignedLocation, Error>) {
         let result_msg = match &result {
             Ok(_) => "success",
-            Err(e) => e.as_str(),
+            Err(e) => e.variant(),
         };
-        relay_statsd::metric!(counter(self.metric) += 1, result = result_msg,);
+        relay_statsd::metric!(counter(self.metric) += 1, result = result_msg);
         self.inner.send(result)
     }
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -966,7 +966,17 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     /// - `item`: what item the decision is taken for (transaction vs span).
     SamplingDecision,
-    /// The number of times an upload of an attachment occurs.
+    /// The number of times an upload location is created through the upload service.
+    ///
+    /// This metric is tagged with:
+    /// - `result`: `success` or the failure reason.
+    UploadCreate,
+    /// The number of times an upload location is created through the upload service.
+    ///
+    /// This metric is tagged with:
+    /// - `result`: `success` or the failure reason.
+    UploadUpload,
+    /// The number of times an objectstore upload of an attachment occurs.
     ///
     /// This metric is tagged with:
     /// - `result`: `success` or the failure reason.
@@ -1047,6 +1057,8 @@ impl CounterMetric for RelayCounters {
             #[cfg(all(sentry, feature = "processing"))]
             RelayCounters::PlaystationProcessing => "processing.playstation",
             RelayCounters::SamplingDecision => "sampling.decision",
+            RelayCounters::UploadCreate => "upload.create",
+            RelayCounters::UploadUpload => "upload.upload",
             #[cfg(feature = "processing")]
             RelayCounters::AttachmentUpload => "attachment.upload",
             RelayCounters::EnvelopeWithLogs => "logs.envelope",


### PR DESCRIPTION
Get better instrumentation about both successful and failed uploads that go through the `Upload` service by emitting a metric in each case.