### PR TITLE
feat(upload): Count killswitched requests

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -32,6 +32,7 @@ use crate::services::objectstore;
 use crate::services::projects::cache::Project;
 use crate::services::upload::{self, ByteStream, SignedLocation};
 use crate::services::upstream::UpstreamRequestError;
+use crate::statsd::RelayCounters;
 use crate::utils::{ApiErrorResponse, MeteredStream};
 use crate::utils::{BoundedStream, find_error_source, tus};
 
@@ -271,6 +272,7 @@ fn check_kill_switch(state: &ServiceState) -> Result<(), StatusCode> {
         .options
         .endpoint_fetch_config_enabled
     {
+        relay_statsd::metric!(counter(RelayCounters::UploadKillswitched) += 1);
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
     Ok(())

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -966,6 +966,10 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     /// - `item`: what item the decision is taken for (transaction vs span).
     SamplingDecision,
+    /// How often a call to the upload endpoint was rejected because of the global kill switch.
+    ///
+    /// This is intended as a temporary metric to debug 503 flakiness.
+    UploadKillswitched,
     /// The number of times an upload location is created through the upload service.
     ///
     /// This metric is tagged with:
@@ -1057,6 +1061,7 @@ impl CounterMetric for RelayCounters {
             #[cfg(all(sentry, feature = "processing"))]
             RelayCounters::PlaystationProcessing => "processing.playstation",
             RelayCounters::SamplingDecision => "sampling.decision",
+            RelayCounters::UploadKillswitched => "upload.killswitched",
             RelayCounters::UploadCreate => "upload.create",
             RelayCounters::UploadUpload => "upload.upload",
             #[cfg(feature = "processing")]


### PR DESCRIPTION
We're seeing 503s from processing relays that by exclusion I can only attribute to the global kill switch. Add a metric to verify.

ref: INGEST-910