### PR TITLE
fix(spanv2): Backfill `sentry.transaction`

### DIFF
--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -665,20 +665,22 @@ pub fn write_legacy_attributes(attributes: &mut Annotated<Attributes>) {
     };
 
     // Map of new sentry conventions attributes to legacy SpanV1 attributes
+    #[allow(
+        deprecated,
+        reason = "Writing possibly deprecated legacy attributes is the point of this function."
+    )]
     let current_to_legacy_attributes = [
         // DB attributes
         (DB__QUERY__TEXT, SENTRY__DESCRIPTION),
         (SENTRY__NORMALIZED_DB_QUERY, SENTRY__NORMALIZED_DESCRIPTION),
         (DB__OPERATION__NAME, SENTRY__ACTION),
-        #[allow(
-            deprecated,
-            reason = "Writing possibly deprecated legacy attributes is the point of this function."
-        )]
         (DB__SYSTEM__NAME, DB__SYSTEM),
         // HTTP attributes
         (SERVER__ADDRESS, SENTRY__DOMAIN),
         (HTTP__REQUEST__METHOD, SENTRY__ACTION),
         (HTTP__RESPONSE__STATUS_CODE, SENTRY__STATUS_CODE),
+        // Transaction
+        (SENTRY__SEGMENT__NAME, SENTRY__TRANSACTION),
     ];
 
     for (current_attribute, legacy_attribute) in current_to_legacy_attributes {

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -119,9 +119,6 @@ def lcp_cls_inp_differences(mode):
         attributes = {
             # The legacy pipeline extracts this attribute from `sentry_tags`.
             "sentry.browser.name": {"type": "string", "value": "Chrome"},
-            # Legacy behaviour, new field is `sentry.segment.name`
-            # Maybe this shouldn't exist since parent and segment information is also removed
-            "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
         }
         fields = {}
     else:
@@ -255,6 +252,7 @@ def test_lcp_span(
             },
             "sentry.report_event": {"type": "string", "value": "navigation"},
             "sentry.segment.name": {"type": "string", "value": "/insights/projects/"},
+            "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -450,6 +448,7 @@ def test_cls_span(
             },
             "sentry.report_event": {"type": "string", "value": "navigation"},
             "sentry.segment.name": {"type": "string", "value": "/insights/projects/"},
+            "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -625,6 +624,7 @@ def test_inp_span(
                 "value": "3d76a6311de149b9b3f560827ea0ecf9",
             },
             "sentry.segment.name": {"type": "string", "value": "/insights/projects/"},
+            "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -117,6 +117,7 @@ def test_span_ingestion(
             "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
             "sentry.segment.id": {"type": "string", "value": "f0b809703e783d00"},
             "sentry.segment.name": {"type": "string", "value": "A Proto Span"},
+            "sentry.transaction": {"type": "string", "value": "A Proto Span"},
             "sentry.kind": {"type": "string", "value": "server"},
             "ui.component_name": {"type": "string", "value": "MyComponent"},
         },


### PR DESCRIPTION
This backfills the (deprecated) `sentry.transaction` attribute from `sentry.segment.name` for V2 spans.

ref: INGEST-905