### PR TITLE
fix: Add root transaction to v2 spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**:
 
-- Add missing `sentry.dsc.transaction` to non-segment v2 spans. ([#6001](https://github.com/getsentry/relay/pull/6001))
+- Add `sentry.dsc.transaction` and `sentry.dsc.trace_id` to all v2 spans. ([#6001](https://github.com/getsentry/relay/pull/6001))
 
 ## 26.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Add missing `sentry.dsc.transaction` to non-segment v2 spans. ([#6001](https://github.com/getsentry/relay/pull/6001))
+
 ## 26.5.0
 
 **Features**:

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -346,25 +346,16 @@ pub fn normalize_user_geo(
     attributes.insert_if_missing(USER__GEO__REGION, || geo.region);
 }
 
-/// Add `sentry.dsc.transaction` to [`Attributes`].
+/// Normalizes the [DSC](DynamicSamplingContext) into [`Attributes`].
 ///
-/// `sentry.dsc.transaction` is the root transaction/segment that initiated the trace and needs to
-/// be added to every span in order for dynamic sampling to work.
-pub fn ensure_dsc_transaction(
+/// If `is_segment` is set to `false`, the function will only add select attributes that are
+/// necessary on every span - both segment and non-segment - for dynamic sampling to work. More
+/// attributes are added when `is_segment` is set to `true`.
+pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     dsc: Option<&DynamicSamplingContext>,
+    is_segment: bool,
 ) {
-    if let Some(dsc) = dsc
-        && let Some(transaction) = &dsc.transaction
-    {
-        attributes
-            .get_or_insert_with(Default::default)
-            .insert(SENTRY__DSC__TRANSACTION, transaction.clone());
-    }
-}
-
-/// Normalizes the [DSC](DynamicSamplingContext) into [`Attributes`].
-pub fn normalize_dsc(attributes: &mut Annotated<Attributes>, dsc: Option<&DynamicSamplingContext>) {
     let Some(dsc) = dsc else { return };
 
     let attributes = attributes.get_or_insert_with(Default::default);
@@ -373,23 +364,26 @@ pub fn normalize_dsc(attributes: &mut Annotated<Attributes>, dsc: Option<&Dynami
     if attributes.contains_key(SENTRY__DSC__TRACE_ID) {
         return;
     }
-
     attributes.insert(SENTRY__DSC__TRACE_ID, dsc.trace_id.to_string());
-    attributes.insert(SENTRY__DSC__PUBLIC_KEY, dsc.public_key.to_string());
-    if let Some(release) = &dsc.release {
-        attributes.insert(SENTRY__DSC__RELEASE, release.clone());
-    }
-    if let Some(environment) = &dsc.environment {
-        attributes.insert(SENTRY__DSC__ENVIRONMENT, environment.clone());
-    }
+
     if let Some(transaction) = &dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
-    if let Some(sample_rate) = dsc.sample_rate {
-        attributes.insert(SENTRY__DSC__SAMPLE_RATE, sample_rate);
-    }
-    if let Some(sampled) = dsc.sampled {
-        attributes.insert(SENTRY__DSC__SAMPLED, sampled);
+
+    if is_segment {
+        attributes.insert(SENTRY__DSC__PUBLIC_KEY, dsc.public_key.to_string());
+        if let Some(release) = &dsc.release {
+            attributes.insert(SENTRY__DSC__RELEASE, release.clone());
+        }
+        if let Some(environment) = &dsc.environment {
+            attributes.insert(SENTRY__DSC__ENVIRONMENT, environment.clone());
+        }
+        if let Some(sample_rate) = dsc.sample_rate {
+            attributes.insert(SENTRY__DSC__SAMPLE_RATE, sample_rate);
+        }
+        if let Some(sampled) = dsc.sampled {
+            attributes.insert(SENTRY__DSC__SAMPLED, sampled);
+        }
     }
 }
 
@@ -736,7 +730,7 @@ pub fn write_legacy_attributes(attributes: &mut Annotated<Attributes>) {
 
 #[cfg(test)]
 mod tests {
-    use relay_protocol::{Empty, SerializableAnnotated};
+    use relay_protocol::{Empty, SerializableAnnotated, assert_annotated_snapshot};
 
     use super::*;
 
@@ -756,30 +750,64 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_dsc_transaction_none_dsc() {
+    fn test_normalize_dsc_child_span_no_dsc() {
         let mut attributes = Annotated::empty();
-        ensure_dsc_transaction(&mut attributes, None);
+        normalize_dsc(&mut attributes, None, false);
         assert!(attributes.value().is_none());
     }
 
     #[test]
-    fn test_ensure_dsc_transaction_none_transaction() {
+    fn test_normalize_dsc_child_span_no_transaction() {
         let mut attributes = Annotated::empty();
         let dsc = mock_dsc(None);
-        ensure_dsc_transaction(&mut attributes, Some(&dsc));
-        assert!(attributes.value().is_none());
+        normalize_dsc(&mut attributes, Some(&dsc), false);
+        assert_annotated_snapshot!(attributes, @r#"
+        {
+          "sentry.dsc.trace_id": {
+            "type": "string",
+            "value": "67e5504410b1426f9247bb680e5fe0c8"
+          }
+        }
+        "#);
     }
 
     #[test]
-    fn test_ensure_dsc_transaction_stamps_value() {
+    fn test_normalize_dsc_child_span() {
         let mut attributes = Annotated::empty();
-        let dsc = mock_dsc(Some("some/endpoint"));
-        ensure_dsc_transaction(&mut attributes, Some(&dsc));
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        let dsc = mock_dsc(Some("/some/endpoint"));
+        normalize_dsc(&mut attributes, Some(&dsc), false);
+        assert_annotated_snapshot!(attributes, @r#"
         {
+          "sentry.dsc.trace_id": {
+            "type": "string",
+            "value": "67e5504410b1426f9247bb680e5fe0c8"
+          },
           "sentry.dsc.transaction": {
             "type": "string",
-            "value": "some/endpoint"
+            "value": "/some/endpoint"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_dsc_segment() {
+        let mut attributes = Annotated::empty();
+        let dsc = mock_dsc(Some("/some/endpoint"));
+        normalize_dsc(&mut attributes, Some(&dsc), true);
+        assert_annotated_snapshot!(attributes, @r#"
+        {
+          "sentry.dsc.public_key": {
+            "type": "string",
+            "value": "12345678901234567890123456789012"
+          },
+          "sentry.dsc.trace_id": {
+            "type": "string",
+            "value": "67e5504410b1426f9247bb680e5fe0c8"
+          },
+          "sentry.dsc.transaction": {
+            "type": "string",
+            "value": "/some/endpoint"
           }
         }
         "#);
@@ -794,7 +822,7 @@ mod tests {
             DateTime::from_timestamp_nanos(1_234_201_337),
         );
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.observed_timestamp_nanos": {
             "type": "string",
@@ -821,7 +849,7 @@ mod tests {
             DateTime::from_timestamp_nanos(1_234_201_337),
         );
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r###"
+        assert_annotated_snapshot!(attributes, @r###"
         {
           "sentry.observed_timestamp_nanos": {
             "type": "string",
@@ -918,7 +946,7 @@ mod tests {
         let mut attributes = Annotated::<Attributes>::from_json(json).unwrap();
         normalize_attribute_types(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "double_with_i64": {
             "type": "double",
@@ -1090,7 +1118,7 @@ mod tests {
             }),
         );
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "browser.name": {
             "type": "string",
@@ -1130,7 +1158,7 @@ mod tests {
             }),
         );
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "browser.name": {
             "type": "string",
@@ -1141,7 +1169,7 @@ mod tests {
             "value": "13.3.7"
           }
         }
-        "#,
+        "#
         );
     }
 
@@ -1167,7 +1195,7 @@ mod tests {
             })
         });
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -1207,7 +1235,7 @@ mod tests {
 
         normalize_user_geo(&mut attributes, |_| unreachable!());
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -1218,7 +1246,7 @@ mod tests {
             "value": "Foo Hausen"
           }
         }
-        "#,
+        "#
         );
     }
 
@@ -1281,7 +1309,7 @@ mod tests {
 
         normalize_attribute_names_inner(&mut attributes, mock_attribute_info);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r###"
+        assert_annotated_snapshot!(attributes, @r###"
         {
           "backfill.empty": {
             "type": "string",
@@ -1354,7 +1382,7 @@ mod tests {
 
         normalize_sentry_op(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "db.operation.name": {
             "type": "string",
@@ -1400,7 +1428,7 @@ mod tests {
 
         normalize_db_attributes(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "db.operation.name": {
             "type": "string",
@@ -1466,7 +1494,7 @@ mod tests {
 
         normalize_db_attributes(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "db.collection.name": {
             "type": "string",
@@ -1592,7 +1620,7 @@ mod tests {
 
         normalize_db_attributes(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -1638,7 +1666,7 @@ mod tests {
 
         normalize_http_attributes(&mut attributes, &[]);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -1696,7 +1724,7 @@ mod tests {
 
         normalize_http_attributes(&mut attributes, &[]);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -1757,7 +1785,7 @@ mod tests {
             &["application.www.xn--85x722f.xn--55qx5d.cn".to_owned()],
         );
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -1815,7 +1843,7 @@ mod tests {
 
         normalize_db_attributes(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "db.collection.name": {
             "type": "string",
@@ -1874,7 +1902,7 @@ mod tests {
         normalize_attribute_names(&mut attributes);
         normalize_http_attributes(&mut attributes, &[]);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -1920,7 +1948,7 @@ mod tests {
 
         normalize_http_attributes(&mut attributes, &[]);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -1990,7 +2018,7 @@ mod tests {
 
         write_legacy_attributes(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "db.collection.name": {
             "type": "string",
@@ -2063,7 +2091,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.category": {
             "type": "string",
@@ -2091,7 +2119,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.category": {
             "type": "string",
@@ -2119,7 +2147,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.category": {
             "type": "string",
@@ -2147,7 +2175,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.category": {
             "type": "string",
@@ -2176,7 +2204,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "db.system.name": {
             "type": "string",
@@ -2205,7 +2233,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "http.request.method": {
             "type": "string",
@@ -2234,7 +2262,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.category": {
             "type": "string",
@@ -2263,7 +2291,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "resource.render_blocking_status": {
             "type": "string",
@@ -2292,7 +2320,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.category": {
             "type": "string",
@@ -2320,7 +2348,7 @@ mod tests {
 
         normalize_client_address(&mut attributes, Some("192.168.1.1".parse().unwrap()));
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -2344,7 +2372,7 @@ mod tests {
 
         normalize_client_address(&mut attributes, None);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {}
         "#);
     }
@@ -2363,7 +2391,7 @@ mod tests {
 
         normalize_client_address(&mut attributes, Some("192.168.1.1".parse().unwrap()));
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -2396,7 +2424,7 @@ mod tests {
 
         normalize_client_address(&mut attributes, Some("2001:db8::1".parse().unwrap()));
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -2412,7 +2440,7 @@ mod tests {
 
         normalize_inject_client_address(&mut attributes, Some("192.168.1.1".parse().unwrap()));
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -2436,7 +2464,7 @@ mod tests {
 
         normalize_inject_client_address(&mut attributes, Some("192.168.1.1".parse().unwrap()));
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -2452,7 +2480,7 @@ mod tests {
 
         normalize_inject_client_address(&mut attributes, None);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {}
         "#);
     }
@@ -2463,7 +2491,7 @@ mod tests {
 
         normalize_inject_client_address(&mut attributes, Some("2001:db8::1".parse().unwrap()));
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "client.address": {
             "type": "string",
@@ -2488,7 +2516,7 @@ mod tests {
 
         normalize_span_category(&mut attributes);
 
-        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "some.other.attribute": {
             "type": "string",

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -346,6 +346,23 @@ pub fn normalize_user_geo(
     attributes.insert_if_missing(USER__GEO__REGION, || geo.region);
 }
 
+/// Add `sentry.dsc.transaction` to [`Attributes`].
+///
+/// `sentry.dsc.transaction` is the root transaction/segment that initiated the trace and needs to
+/// be added to every span in order for dynamic sampling to work.
+pub fn ensure_dsc_transaction(
+    attributes: &mut Annotated<Attributes>,
+    dsc: Option<&DynamicSamplingContext>,
+) {
+    if let Some(dsc) = dsc
+        && let Some(transaction) = &dsc.transaction
+    {
+        attributes
+            .get_or_insert_with(Default::default)
+            .insert(SENTRY__DSC__TRANSACTION, transaction.clone());
+    }
+}
+
 /// Normalizes the [DSC](DynamicSamplingContext) into [`Attributes`].
 pub fn normalize_dsc(attributes: &mut Annotated<Attributes>, dsc: Option<&DynamicSamplingContext>) {
     let Some(dsc) = dsc else { return };
@@ -722,6 +739,51 @@ mod tests {
     use relay_protocol::{Empty, SerializableAnnotated};
 
     use super::*;
+
+    fn mock_dsc(transaction: Option<&str>) -> DynamicSamplingContext {
+        DynamicSamplingContext {
+            trace_id: "67e5504410b1426f9247bb680e5fe0c8".parse().unwrap(),
+            public_key: "12345678901234567890123456789012".parse().unwrap(),
+            release: None,
+            environment: None,
+            transaction: transaction.map(str::to_owned),
+            sample_rate: None,
+            user: Default::default(),
+            replay_id: None,
+            sampled: None,
+            other: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_ensure_dsc_transaction_none_dsc() {
+        let mut attributes = Annotated::empty();
+        ensure_dsc_transaction(&mut attributes, None);
+        assert!(attributes.value().is_none());
+    }
+
+    #[test]
+    fn test_ensure_dsc_transaction_none_transaction() {
+        let mut attributes = Annotated::empty();
+        let dsc = mock_dsc(None);
+        ensure_dsc_transaction(&mut attributes, Some(&dsc));
+        assert!(attributes.value().is_none());
+    }
+
+    #[test]
+    fn test_ensure_dsc_transaction_stamps_value() {
+        let mut attributes = Annotated::empty();
+        let dsc = mock_dsc(Some("some/endpoint"));
+        ensure_dsc_transaction(&mut attributes, Some(&dsc));
+        insta::assert_json_snapshot!(SerializableAnnotated(&attributes), @r#"
+        {
+          "sentry.dsc.transaction": {
+            "type": "string",
+            "value": "some/endpoint"
+          }
+        }
+        "#);
+    }
 
     #[test]
     fn test_normalize_received_none() {

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -227,6 +227,8 @@ fn normalize_span(
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
         if matches!(span.is_segment.value(), Some(true)) {
             eap::normalize_dsc(&mut span.attributes, dsc);
+        } else {
+            eap::ensure_dsc_transaction(&mut span.attributes, dsc);
         }
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -225,11 +225,11 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        if matches!(span.is_segment.value(), Some(true)) {
-            eap::normalize_dsc(&mut span.attributes, dsc);
-        } else {
-            eap::ensure_dsc_transaction(&mut span.attributes, dsc);
-        }
+        eap::normalize_dsc(
+            &mut span.attributes,
+            dsc,
+            *span.is_segment.value().unwrap_or(&false),
+        );
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -132,6 +132,15 @@ def lcp_cls_inp_differences(mode):
             },
             # Maybe should not exist. Segment information in legacy processing is removed.
             "sentry.segment.id": {"type": "string", "value": "8a6626cc9bdd5d9b"},
+            # Needed for dynamic sampling; will be added for legacy later.
+            "sentry.dsc.transaction": {
+                "type": "string",
+                "value": "/insights/projects/",
+            },
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "d3d20f000885466b8c8f947c9b92b8d3",
+            },
         }
         fields = {
             # See `set_segment_attributes` which removes segment information on LCP and CLS spans.
@@ -224,8 +233,7 @@ def test_lcp_span(
             },
         }
 
-    actual = spans_consumer.get_span()
-    expected = {
+    assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "lcp": {"type": "double", "value": 548.0},
@@ -307,13 +315,6 @@ def test_lcp_span(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
-    if mode == "v2":
-        expected["attributes"]["sentry.dsc.transaction"] = {
-            "type": "string",
-            "value": "/insights/projects/",
-        }
-
-    assert actual == expected
 
     assert metrics_consumer.get_metrics(with_headers=False) == [
         {
@@ -423,8 +424,7 @@ def test_cls_span(
             },
         }
 
-    actual = spans_consumer.get_span()
-    expected = {
+    assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "cls": {"type": "double", "value": 0.1},
@@ -511,13 +511,6 @@ def test_cls_span(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
-    if mode == "v2":
-        expected["attributes"]["sentry.dsc.transaction"] = {
-            "type": "string",
-            "value": "/insights/projects/",
-        }
-
-    assert actual == expected
 
     assert metrics_consumer.get_metrics(with_headers=False) == [
         {
@@ -618,8 +611,7 @@ def test_inp_span(
             "browser.web_vital.inp.value": {"type": "double", "value": 104.0},
         }
 
-    actual = spans_consumer.get_span()
-    expected = {
+    assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "inp": {"type": "double", "value": 104.0},
@@ -683,13 +675,6 @@ def test_inp_span(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
-    if mode == "v2":
-        expected["attributes"]["sentry.dsc.transaction"] = {
-            "type": "string",
-            "value": "/insights/projects/",
-        }
-
-    assert actual == expected
 
     assert metrics_consumer.get_metrics(with_headers=False) == [
         {

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -224,7 +224,8 @@ def test_lcp_span(
             },
         }
 
-    assert spans_consumer.get_span() == {
+    actual = spans_consumer.get_span()
+    expected = {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "lcp": {"type": "double", "value": 548.0},
@@ -306,6 +307,13 @@ def test_lcp_span(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
+    if mode == "v2":
+        expected["attributes"]["sentry.dsc.transaction"] = {
+            "type": "string",
+            "value": "/insights/projects/",
+        }
+
+    assert actual == expected
 
     assert metrics_consumer.get_metrics(with_headers=False) == [
         {
@@ -415,7 +423,8 @@ def test_cls_span(
             },
         }
 
-    assert spans_consumer.get_span() == {
+    actual = spans_consumer.get_span()
+    expected = {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "cls": {"type": "double", "value": 0.1},
@@ -502,6 +511,13 @@ def test_cls_span(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
+    if mode == "v2":
+        expected["attributes"]["sentry.dsc.transaction"] = {
+            "type": "string",
+            "value": "/insights/projects/",
+        }
+
+    assert actual == expected
 
     assert metrics_consumer.get_metrics(with_headers=False) == [
         {
@@ -602,7 +618,8 @@ def test_inp_span(
             "browser.web_vital.inp.value": {"type": "double", "value": 104.0},
         }
 
-    assert spans_consumer.get_span() == {
+    actual = spans_consumer.get_span()
+    expected = {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "inp": {"type": "double", "value": 104.0},
@@ -666,6 +683,13 @@ def test_inp_span(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
+    if mode == "v2":
+        expected["attributes"]["sentry.dsc.transaction"] = {
+            "type": "string",
+            "value": "/insights/projects/",
+        }
+
+    assert actual == expected
 
     assert metrics_consumer.get_metrics(with_headers=False) == [
         {

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -64,12 +64,7 @@ def test_spansv2_basic(
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"].update(
-        {
-            "features": [
-                "projects:span-v2-experimental-processing",
-            ],
-            "retentions": {"span": {"standard": 42, "downsampled": 1337}},
-        }
+        {"retentions": {"span": {"standard": 42, "downsampled": 1337}}}
     )
 
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
@@ -239,9 +234,6 @@ def test_spansv2_trimming_basic(
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"].update(
         {
-            "features": [
-                "projects:span-v2-experimental-processing",
-            ],
             "retentions": {"span": {"standard": 42, "downsampled": 1337}},
             # This is sufficient for all builtin attributes not
             # to be trimmed. The span fields that aren't trimmed
@@ -431,9 +423,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
     """
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
+    project_config["config"]["features"] = ["projects:span-v2-experimental-processing"]
     # A transaction rule should never apply.
     add_sampling_config(project_config, sample_rate=1, rule_type="transaction")
     # Setup the actual rule we want to test against.
@@ -535,9 +525,6 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
     """
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
 
     ts = datetime.now(timezone.utc)
 
@@ -649,9 +636,6 @@ def test_spansv2_ds_sampled(
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
     add_sampling_config(project_config, sample_rate=0.0, rule_type="trace")
 
     sampling_project_id = 43
@@ -788,9 +772,6 @@ def test_spansv2_ds_root_in_different_org(
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
     add_sampling_config(project_config, sample_rate=0.0, rule_type="trace")
 
     sampling_project_id = 43
@@ -926,9 +907,6 @@ def test_spanv2_inbound_filters(
 ):
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
 
     if filter_name.startswith("gen_"):
         filter_config = {
@@ -1014,10 +992,7 @@ def test_spans_v2_multiple_containers_not_allowed(
     relay,
 ):
     project_id = 42
-    project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
+    mini_sentry.add_full_project_config(project_id)
 
     relay = relay(mini_sentry, options=TEST_CONFIG)
     start = datetime.now(timezone.utc)
@@ -1090,9 +1065,6 @@ def test_spans_v2_dsc_validations(
     """
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
 
     relay = relay(mini_sentry, options=TEST_CONFIG)
 
@@ -1162,9 +1134,6 @@ def test_spanv2_with_string_pii_scrubbing(
     rule_type, test_value, expected_scrubbed = scrubbing_rule
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
 
     project_config["config"]["piiConfig"]["applications"] = {"$string": [rule_type]}
 
@@ -1200,6 +1169,10 @@ def test_spanv2_with_string_pii_scrubbing(
         "trace_id": "5b8efff798038103d269b633813fc60c",
         "span_id": "eee19b7ec3c1b174",
         "attributes": {
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "5b8efff798038103d269b633813fc60c",
+            },
             "test_pii": {"type": "string", "value": expected_scrubbed},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -1235,9 +1208,6 @@ def test_spanv2_default_pii_scrubbing_attributes(
     attribute_key, attribute_value, expected_value, rule_type = secret_attribute
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
     project_config["config"].setdefault(
         "datascrubbingSettings",
         {
@@ -1292,9 +1262,6 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
     """
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
     project_config["config"]["datascrubbingSettings"] = {
         "scrubData": True,
         "scrubDefaults": True,
@@ -1339,6 +1306,10 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                 "type": "array",
                 "value": ["normal", "[creditcard]", "other"],
             },
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "5b8efff798038103d269b633813fc60c",
+            },
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),
@@ -1381,12 +1352,7 @@ def test_spansv2_attribute_normalization(
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"].update(
-        {
-            "features": [
-                "projects:span-v2-experimental-processing",
-            ],
-            "retentions": {"span": {"standard": 42, "downsampled": 1337}},
-        }
+        {"retentions": {"span": {"standard": 42, "downsampled": 1337}}}
     )
 
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
@@ -1487,6 +1453,10 @@ def test_spansv2_attribute_normalization(
                 "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
             },
             "sentry.domain": {"type": "string", "value": ",users,"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "5b8efff798038103d269b633813fc60c",
+            },
             "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
             "sentry.normalized_db_query": {
                 "type": "string",
@@ -1527,6 +1497,10 @@ def test_spansv2_attribute_normalization(
             "sentry.action": {"type": "string", "value": "GET"},
             "server.address": {"type": "string", "value": "*.service.io"},
             "sentry.domain": {"type": "string", "value": "*.service.io"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "5b8efff798038103d269b633813fc60c",
+            },
             "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
             "url.full": {
                 "type": "string",
@@ -1551,9 +1525,6 @@ def test_invalid_spans(mini_sentry, relay):
     """
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
 
     relay = relay(mini_sentry, options=TEST_CONFIG)
 
@@ -1681,9 +1652,6 @@ def test_invalid_spans(mini_sentry, relay):
 def test_time_corrections(mini_sentry, relay, delta, error):
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
     project_config["config"]["retentions"] = {
         "span": {"standard": 1, "downsampled": 100},
     }
@@ -1749,7 +1717,6 @@ def test_spansv2_ingestion_with_performance_scores(
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = ["projects:span-v2-experimental-processing"]
     project_config["config"]["performanceScore"] = {
         "profiles": [
             {
@@ -1903,17 +1870,14 @@ def test_spansv2_ingestion_with_performance_scores(
             assert span["attributes"][key]["value"] == score
 
 
-def test_spansv2_dsc_transaction_on_segment_and_non_segment_span(
+def test_spansv2_dsc_normalization_on_segment_and_non_segment_span(
     mini_sentry, relay, relay_with_processing, spans_consumer
 ):
-    """Test that `sentry.dsc.transaction` is stamped on both segment and non-segment spans."""
+    """Test that specific dsc attributes are stamped on both segment and non-segment spans."""
 
     spans_consumer = spans_consumer()
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"]["features"] = [
-        "projects:span-v2-experimental-processing",
-    ]
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
     ts = datetime.now(timezone.utc) - timedelta(seconds=1)
     envelope = envelope_with_spans(
@@ -1939,7 +1903,7 @@ def test_spansv2_dsc_transaction_on_segment_and_non_segment_span(
         trace_info={
             "trace_id": "5b8efff798038103d269b633813fc60c",
             "public_key": project_config["publicKeys"][0]["publicKey"],
-            "transaction": "my/fancy/endpoint",
+            "transaction": "/my/fancy/endpoint",
         },
     )
 
@@ -1949,10 +1913,80 @@ def test_spansv2_dsc_transaction_on_segment_and_non_segment_span(
     assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
     assert (
         spans["aaaaaaaaaaaaaaaa"]["attributes"]["sentry.dsc.transaction"]["value"]
-        == "my/fancy/endpoint"
+        == "/my/fancy/endpoint"
     )
     assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
     assert (
         spans["bbbbbbbbbbbbbbbb"]["attributes"]["sentry.dsc.transaction"]["value"]
-        == "my/fancy/endpoint"
+        == "/my/fancy/endpoint"
+    )
+
+
+def test_spansv2_dsc_attributes_already_exist(
+    mini_sentry, relay, relay_with_processing, spans_consumer
+):
+    spans_consumer = spans_consumer()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+    ts = datetime.now(timezone.utc) - timedelta(seconds=1)
+    envelope = envelope_with_spans(
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.5,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "aaaaaaaaaaaaaaaa",
+            "is_segment": True,
+            "name": "root",
+            "status": "ok",
+            "attributes": {
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "5b8efff798038103d269b633813fc60c",
+                },
+                "sentry.dsc.transaction": {
+                    "type": "string",
+                    "value": "/transaction/already/exists",
+                },
+            },
+        },
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.3,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "bbbbbbbbbbbbbbbb",
+            "parent_span_id": "aaaaaaaaaaaaaaaa",
+            "is_segment": False,
+            "name": "child",
+            "status": "ok",
+            "attributes": {
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "5b8efff798038103d269b633813fc60c",
+                },
+                "sentry.dsc.transaction": {
+                    "type": "string",
+                    "value": "/transaction/already/exists",
+                },
+            },
+        },
+        trace_info={
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "public_key": project_config["publicKeys"][0]["publicKey"],
+            "transaction": "/my/fancy/endpoint",
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    spans = {s["span_id"]: s for s in spans_consumer.get_spans()}
+    assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
+    assert (
+        spans["aaaaaaaaaaaaaaaa"]["attributes"]["sentry.dsc.transaction"]["value"]
+        == "/transaction/already/exists"
+    )
+    assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
+    assert (
+        spans["bbbbbbbbbbbbbbbb"]["attributes"]["sentry.dsc.transaction"]["value"]
+        == "/transaction/already/exists"
     )

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1870,11 +1870,9 @@ def test_spansv2_ingestion_with_performance_scores(
             assert span["attributes"][key]["value"] == score
 
 
-def test_spansv2_dsc_normalization_on_segment_and_non_segment_span(
+def test_spansv2_dsc_normalization(
     mini_sentry, relay, relay_with_processing, spans_consumer
 ):
-    """Test that specific dsc attributes are stamped on both segment and non-segment spans."""
-
     spans_consumer = spans_consumer()
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -1900,42 +1898,11 @@ def test_spansv2_dsc_normalization_on_segment_and_non_segment_span(
             "name": "child",
             "status": "ok",
         },
-        trace_info={
-            "trace_id": "5b8efff798038103d269b633813fc60c",
-            "public_key": project_config["publicKeys"][0]["publicKey"],
-            "transaction": "/my/fancy/endpoint",
-        },
-    )
-
-    relay.send_envelope(project_id, envelope)
-
-    spans = {s["span_id"]: s for s in spans_consumer.get_spans()}
-    assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
-    assert (
-        spans["aaaaaaaaaaaaaaaa"]["attributes"]["sentry.dsc.transaction"]["value"]
-        == "/my/fancy/endpoint"
-    )
-    assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
-    assert (
-        spans["bbbbbbbbbbbbbbbb"]["attributes"]["sentry.dsc.transaction"]["value"]
-        == "/my/fancy/endpoint"
-    )
-
-
-def test_spansv2_dsc_attributes_already_exist(
-    mini_sentry, relay, relay_with_processing, spans_consumer
-):
-    spans_consumer = spans_consumer()
-    project_id = 42
-    project_config = mini_sentry.add_full_project_config(project_id)
-    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
-    ts = datetime.now(timezone.utc) - timedelta(seconds=1)
-    envelope = envelope_with_spans(
         {
             "start_timestamp": ts.timestamp(),
             "end_timestamp": ts.timestamp() + 0.5,
             "trace_id": "5b8efff798038103d269b633813fc60c",
-            "span_id": "aaaaaaaaaaaaaaaa",
+            "span_id": "cccccccccccccccc",
             "is_segment": True,
             "name": "root",
             "status": "ok",
@@ -1954,8 +1921,8 @@ def test_spansv2_dsc_attributes_already_exist(
             "start_timestamp": ts.timestamp(),
             "end_timestamp": ts.timestamp() + 0.3,
             "trace_id": "5b8efff798038103d269b633813fc60c",
-            "span_id": "bbbbbbbbbbbbbbbb",
-            "parent_span_id": "aaaaaaaaaaaaaaaa",
+            "span_id": "dddddddddddddddd",
+            "parent_span_id": "cccccccccccccccc",
             "is_segment": False,
             "name": "child",
             "status": "ok",
@@ -1981,12 +1948,19 @@ def test_spansv2_dsc_attributes_already_exist(
 
     spans = {s["span_id"]: s for s in spans_consumer.get_spans()}
     assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
-    assert (
-        spans["aaaaaaaaaaaaaaaa"]["attributes"]["sentry.dsc.transaction"]["value"]
-        == "/transaction/already/exists"
-    )
     assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
-    assert (
-        spans["bbbbbbbbbbbbbbbb"]["attributes"]["sentry.dsc.transaction"]["value"]
-        == "/transaction/already/exists"
-    )
+    assert spans["cccccccccccccccc"]["is_segment"] is True
+    assert spans["dddddddddddddddd"]["is_segment"] is False
+    for span_id in [
+        "aaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbb",
+        "cccccccccccccccc",
+        "dddddddddddddddd",
+    ]:
+        expected = (
+            "/my/fancy/endpoint"
+            if span_id in ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]
+            else "/transaction/already/exists"
+        )
+        actual = spans[span_id]["attributes"]["sentry.dsc.transaction"]["value"]
+        assert actual == expected

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1487,6 +1487,7 @@ def test_spansv2_attribute_normalization(
                 "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
             },
             "sentry.domain": {"type": "string", "value": ",users,"},
+            "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
             "sentry.normalized_db_query": {
                 "type": "string",
                 "value": "SELECT id FROM users WHERE id = %s AND name = %s",
@@ -1526,6 +1527,7 @@ def test_spansv2_attribute_normalization(
             "sentry.action": {"type": "string", "value": "GET"},
             "server.address": {"type": "string", "value": "*.service.io"},
             "sentry.domain": {"type": "string", "value": "*.service.io"},
+            "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
             "url.full": {
                 "type": "string",
                 "value": "https://www.service.io/users/01234-qwerty/settings/98765-adfghj",
@@ -1899,3 +1901,58 @@ def test_spansv2_ingestion_with_performance_scores(
     for span, scores in zip(spans, expected_scores):
         for key, score in scores.items():
             assert span["attributes"][key]["value"] == score
+
+
+def test_spansv2_dsc_transaction_on_segment_and_non_segment_span(
+    mini_sentry, relay, relay_with_processing, spans_consumer
+):
+    """Test that `sentry.dsc.transaction` is stamped on both segment and non-segment spans."""
+
+    spans_consumer = spans_consumer()
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "projects:span-v2-experimental-processing",
+    ]
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+    ts = datetime.now(timezone.utc) - timedelta(seconds=1)
+    envelope = envelope_with_spans(
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.5,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "aaaaaaaaaaaaaaaa",
+            "is_segment": True,
+            "name": "root",
+            "status": "ok",
+        },
+        {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.3,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "bbbbbbbbbbbbbbbb",
+            "parent_span_id": "aaaaaaaaaaaaaaaa",
+            "is_segment": False,
+            "name": "child",
+            "status": "ok",
+        },
+        trace_info={
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "public_key": project_config["publicKeys"][0]["publicKey"],
+            "transaction": "my/fancy/endpoint",
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    spans = {s["span_id"]: s for s in spans_consumer.get_spans()}
+    assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
+    assert (
+        spans["aaaaaaaaaaaaaaaa"]["attributes"]["sentry.dsc.transaction"]["value"]
+        == "my/fancy/endpoint"
+    )
+    assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
+    assert (
+        spans["bbbbbbbbbbbbbbbb"]["attributes"]["sentry.dsc.transaction"]["value"]
+        == "my/fancy/endpoint"
+    )


### PR DESCRIPTION
Add root transaction/segment name and trace id as `sentry.dsc.x` attributes to all v2 spans, not only the segment/root transaction span itself.

Fixes https://linear.app/getsentry/issue/RELAY-247/add-root-transactionsegment-name-to-v2-spans
Ref https://linear.app/getsentry/issue/RELAY-239/add-dsc-attributes-trace-root-project-onto-every-span