### PR TITLE
fix(spans): Validate individual span timestamps on transaction spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**:
 
+- Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005))
 - Add `sentry.dsc.transaction` and `sentry.dsc.trace_id` to all v2 spans. ([#6001](https://github.com/getsentry/relay/pull/6001))
 
 ## 26.5.0

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -79,7 +79,23 @@ pub fn validate_event(
         // There are no timestamp range requirements for span timestamps.
         // Transaction will be rejected only if either end or start timestamp is missing.
         end_all_spans(event);
-        validate_spans(event, None)?;
+
+        let range = {
+            let now = config.received_at.unwrap_or_else(Utc::now).timestamp();
+            let min_timestamp = config
+                .max_secs_in_past
+                .map(|s| now.saturating_sub(s))
+                .and_then(|s| s.try_into().ok())
+                .unwrap_or(0);
+            let max_timestamp = config
+                .max_secs_in_past
+                .map(|s| now.saturating_add(s))
+                .and_then(|s| s.try_into().ok())
+                .unwrap_or(u64::MAX);
+            UnixTimestamp::from_secs(min_timestamp)..UnixTimestamp::from_secs(max_timestamp)
+        };
+
+        validate_spans(event, Some(&range))?;
     }
 
     Ok(())

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -88,7 +88,7 @@ pub fn validate_event(
                 .and_then(|s| s.try_into().ok())
                 .unwrap_or(0);
             let max_timestamp = config
-                .max_secs_in_past
+                .max_secs_in_future
                 .map(|s| now.saturating_add(s))
                 .and_then(|s| s.try_into().ok())
                 .unwrap_or(u64::MAX);

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -372,7 +372,7 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
     }
 
 
-@pytest.mark.parametrize("offset", (320000000, -320000000))
+@pytest.mark.parametrize("offset", (900, -320000000))
 def test_transaction_with_invalid_span_timestamps(mini_sentry, relay, offset):
     relay = relay(mini_sentry, options={"outcomes": {"emit_outcomes": True}})
     mini_sentry.add_basic_project_config(42)

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -2,6 +2,7 @@ import pytest
 import queue
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
+from sentry_relay.consts import DataCategory
 
 
 def test_envelope(mini_sentry, relay_chain):
@@ -297,6 +298,8 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
     transaction_item = generate_transaction_item()
     transaction_item.update(
         {
+            "start_timestamp": 0,
+            "timestamp": 4000,
             "spans": [
                 {
                     "description": "GET /api/0/organizations/?member=1",
@@ -367,6 +370,70 @@ def test_ops_breakdowns(mini_sentry, relay_with_processing, transactions_consume
             "total.time": {"value": 2200001.003, "unit": "millisecond"},
         },
     }
+
+
+@pytest.mark.parametrize("offset", (320000000, -320000000))
+def test_transaction_with_invalid_span_timestamps(mini_sentry, relay, offset):
+    relay = relay(mini_sentry, options={"outcomes": {"emit_outcomes": True}})
+    mini_sentry.add_basic_project_config(42)
+
+    transaction_item = generate_transaction_item()
+    transaction_item.update(
+        {
+            "spans": [
+                {
+                    "description": "GET /api/0/organizations/?member=1",
+                    "op": "http",
+                    "parent_span_id": "aaaaaaaaaaaaaaaa",
+                    "span_id": "bbbbbbbbbbbbbbbb",
+                    "start_timestamp": transaction_item["start_timestamp"] + offset,
+                    "timestamp": transaction_item["timestamp"] + offset,
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                },
+            ],
+        }
+    )
+    transaction_item["contexts"]["trace"].update({"span_id": "aaaaaaaaaaaaaaaa"})
+
+    envelope = Envelope()
+    envelope.add_transaction(transaction_item)
+    relay.send_envelope(42, envelope)
+
+    assert mini_sentry.get_aggregated_outcomes() == [
+        {
+            "category": DataCategory.TRANSACTION.value,
+            "key_id": 123,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "invalid_transaction",
+        },
+        {
+            "category": DataCategory.TRANSACTION_INDEXED.value,
+            "key_id": 123,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "invalid_transaction",
+        },
+        {
+            "category": DataCategory.SPAN.value,
+            "key_id": 123,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 2,
+            "reason": "invalid_transaction",
+        },
+        {
+            "category": DataCategory.SPAN_INDEXED.value,
+            "key_id": 123,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 2,
+            "reason": "invalid_transaction",
+        },
+    ]
+    assert mini_sentry.captured_envelopes.empty()
 
 
 def test_span_exclusive_time(mini_sentry, relay_with_processing, transactions_consumer):


### PR DESCRIPTION
Refs: INGEST-900

Individual spans on transaction can have completely bogus timestamps, we already do some validations on them, like the start timestamp needs to be before the end timestamp. This adds an additional validation that the span timestamps also need to be in a certain maximum timeframe. This validation is already applied to transactions via clock drift correction and this PR fixes a gap where it was not applied to spans.

This is a crude fix for something that causes problems in clickhouse, we'll look into a better solution with INGEST-900.