### PR TITLE
feat(conventions): Add measurements

### DIFF
--- a/relay-conventions/build/attributes.rs
+++ b/relay-conventions/build/attributes.rs
@@ -54,7 +54,7 @@ pub struct Deprecation {
 
 /// An attribute, according to the `sentry-conventions` schema.
 ///
-/// Omitted fields: `brief`, `has_dynamic_suffix`, `is_in_otel`, `example`, `sdks`, `ty`.
+/// Omitted fields: `has_dynamic_suffix`, `is_in_otel`, `example`, `sdks`, `ty`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Attribute {
     /// The attribute's name.
@@ -196,7 +196,7 @@ pub fn format_interpolating_fn(attribute: &Attribute) -> Option<String> {
     writeln!(
         &mut out,
         r#"/// Instantiates the `<key>` placeholder in the attribute
-/// [`{constant_name}`](crate::consts::{constant_name}) (`{key}`) with a concrete value.
+/// [`{constant_name}`](crate::attributes::{constant_name}) (`{key}`) with a concrete value.
 /// # Example
 /// ```
 /// use relay_conventions::interpolate::{fn_name};
@@ -227,7 +227,7 @@ fn write_deprecation_annotation(out: &mut impl Write, deprecation: &Deprecation)
         let replacement_name = name_constant(replacement);
         write!(
             out,
-            r#"(note="Use [`{replacement_name}`](crate::consts::{replacement_name}) (`{replacement}`) instead.")"#
+            r#"(note="Use [`{replacement_name}`](crate::attributes::{replacement_name}) (`{replacement}`) instead.")"#
         )
         .unwrap();
     }
@@ -235,7 +235,7 @@ fn write_deprecation_annotation(out: &mut impl Write, deprecation: &Deprecation)
 }
 
 /// Formats an attributes name as a constant identifier.
-fn name_constant(name: &str) -> String {
+pub fn name_constant(name: &str) -> String {
     name_fn(name).to_ascii_uppercase()
 }
 
@@ -289,7 +289,7 @@ pub fn write_canonical_fn(
 /// * If the attribute is not defined in `sentry-conventions`, `None` is returned.
 #[allow(deprecated)]
 pub fn canonical(key: &str) -> Option<&'static str> {{
-    use crate::consts::*;
+    use crate::attributes::*;
     match key {{"#
     )
     .unwrap();

--- a/relay-conventions/build/build.rs
+++ b/relay-conventions/build/build.rs
@@ -1,4 +1,5 @@
 mod attributes;
+mod measurements;
 mod name;
 
 use std::collections::BTreeMap;
@@ -10,12 +11,14 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 const ATTRIBUTE_DIR: &str = "sentry-conventions/model/attributes";
+const MEASUREMENT_DIR: &str = "sentry-conventions/model/measurements";
 const NAME_DIR: &str = "sentry-conventions/model/name";
 
 fn main() {
     let crate_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
 
     write_attribute_rs(&crate_dir);
+    write_measurement_rs(&crate_dir);
     write_name_rs(&crate_dir);
 
     // Ideally this would only run when compiling for tests, but #[cfg(test)] doesn't seem to work
@@ -124,6 +127,47 @@ fn write_name_rs(crate_dir: &Path) {
     let output = name::name_file_output(names);
 
     writeln!(&mut out_file, "{}", output).unwrap();
+}
+
+fn write_measurement_rs(crate_dir: &Path) {
+    use measurements::{
+        Measurement, format_constant, measurement_attribute_pair, write_replacement_fn,
+    };
+
+    let measurement_consts_path =
+        Path::new(&env::var("OUT_DIR").unwrap()).join("measurement_consts.rs");
+    let mut measurement_consts_file =
+        BufWriter::new(File::create(&measurement_consts_path).unwrap());
+
+    let mut measurement_replacement_map = BTreeMap::new();
+
+    for file in WalkDir::new(crate_dir.join(MEASUREMENT_DIR)) {
+        let file = file.unwrap();
+        if file.file_type().is_file()
+            && let Some(ext) = file.path().extension()
+            && ext.to_str() == Some("json")
+        {
+            let contents = std::fs::read_to_string(file.path()).unwrap();
+            let attr: Measurement = serde_json::from_str(&contents).unwrap();
+
+            // Write measurment constant
+            writeln!(&mut measurement_consts_file, "{}\n", format_constant(&attr)).unwrap();
+
+            // Insert measurement -> attribute into map
+            if let Some((old, new)) = measurement_attribute_pair(&attr) {
+                measurement_replacement_map.insert(old, new);
+            }
+        }
+    }
+
+    let replacement_fn_path =
+        Path::new(&env::var("OUT_DIR").unwrap()).join("measurement_replacement_fn.rs");
+    let mut replacement_fn_file = BufWriter::new(File::create(&replacement_fn_path).unwrap());
+
+    write_replacement_fn(
+        &mut replacement_fn_file,
+        measurement_replacement_map.into_iter(),
+    );
 }
 
 /// Writes a canned version of the `name_for_op_and_attributes` function exclusively for tests.

--- a/relay-conventions/build/measurements.rs
+++ b/relay-conventions/build/measurements.rs
@@ -1,0 +1,102 @@
+//! Contains type definitions for deserializing measurement definitions from JSON files in `sentry-conventions/model`.
+
+use std::fmt::Write;
+
+use serde::Deserialize;
+
+use crate::attributes;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Measurement {
+    pub key: String,
+    #[serde(default)]
+    pub brief: String,
+    pub attribute: Option<String>,
+}
+
+/// Formats a measurement as a constant definition.
+pub fn format_constant(attr: &Measurement) -> String {
+    let Measurement {
+        key,
+        brief,
+        attribute,
+    } = attr;
+
+    let name = name_constant(key);
+
+    let mut out = String::new();
+
+    if !brief.is_empty() {
+        write!(&mut out, "/// {brief}").unwrap();
+
+        if !brief.ends_with('.') {
+            write!(&mut out, ".").unwrap();
+        }
+
+        writeln!(&mut out).unwrap();
+    }
+
+    if let Some(attribute) = attribute {
+        writeln!(
+            &mut out,
+            "///\n/// Replacement attribute: [`{}`]",
+            attributes::name_constant(attribute)
+        )
+        .unwrap();
+    }
+
+    writeln!(&mut out, r#"pub const {name}: &str = "{key}";"#).unwrap();
+
+    out
+}
+
+/// Formats a measurement's name as a constant identifier.
+fn name_constant(name: &str) -> String {
+    name.replace(['<', '>'], "")
+        .replace('.', "__")
+        .replace('-', "_")
+        .to_ascii_uppercase()
+}
+
+/// Returns `Some((measurement, replacement))` if `measurement`'s `attribute` field is
+/// set to `replacement`, otherwise returns `None`.
+pub fn measurement_attribute_pair(measurement: &Measurement) -> Option<(String, String)> {
+    let Measurement {
+        key,
+        brief: _,
+        attribute,
+    } = measurement;
+
+    let attribute = attribute.as_ref()?;
+
+    Some((name_constant(key), attributes::name_constant(attribute)))
+}
+
+pub fn write_replacement_fn(
+    out: &mut impl std::io::Write,
+    constants: impl Iterator<Item = (String, String)>,
+) {
+    writeln!(
+        out,
+        r#"/// Returns the attribute replacing a measurement.
+pub fn measurement_to_attribute(key: &str) -> Option<&'static str> {{
+    match key {{"#
+    )
+    .unwrap();
+
+    for (old, new) in constants {
+        writeln!(
+            out,
+            r#"        crate::measurements::{old} => Some(crate::attributes::{new}),"#
+        )
+        .unwrap();
+    }
+
+    writeln!(
+        out,
+        r#"        _ => None,
+    }}
+}}"#
+    )
+    .unwrap();
+}

--- a/relay-conventions/build/measurements.rs
+++ b/relay-conventions/build/measurements.rs
@@ -37,10 +37,10 @@ pub fn format_constant(attr: &Measurement) -> String {
     }
 
     if let Some(attribute) = attribute {
+        let attribute_name = attributes::name_constant(attribute);
         writeln!(
             &mut out,
-            "///\n/// Replacement attribute: [`{}`]",
-            attributes::name_constant(attribute)
+            "///\n/// Replacement attribute: [`{attribute_name}`](crate::attributes::{attribute_name})",
         )
         .unwrap();
     }

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! ### I want to reference an attribute in Relay but it's not defined in `sentry-conventions`, what should I do?
 //! **Always** define it in `sentry-conventions` before using it in Relay. This makes sure we have proper
-pub mod consts {
+pub mod attributes {
     //! Attribute constant definitions.
     #![allow(rustdoc::bare_urls)]
     #![allow(non_upper_case_globals)]
@@ -73,6 +73,12 @@ pub mod consts {
     pub use self::not_yet_defined::*;
 }
 
+pub mod measurements {
+    //! Measurement constant definitions.
+    #![allow(non_upper_case_globals)]
+    include!(concat!(env!("OUT_DIR"), "/measurement_consts.rs"));
+}
+
 pub mod interpolate {
     //! Functions for interpolating attribute keys with placeholders.
     #![allow(non_snake_case)]
@@ -82,6 +88,7 @@ pub mod interpolate {
 include!(concat!(env!("OUT_DIR"), "/attribute_map.rs"));
 include!(concat!(env!("OUT_DIR"), "/canonical_fn.rs"));
 include!(concat!(env!("OUT_DIR"), "/name_fn.rs"));
+include!(concat!(env!("OUT_DIR"), "/measurement_replacement_fn.rs"));
 
 /// Whether an attribute should be PII-strippable/should be subject to datascrubbers
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_event_schema::protocol::Attributes;
 use relay_protocol::Annotated;
 

--- a/relay-event-normalization/src/eap/mobile.rs
+++ b/relay-event-normalization/src/eap/mobile.rs
@@ -1,6 +1,6 @@
 //! Mobile-specific normalizations for SpanV2 attributes.
 
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Attributes, DeviceClass};
 use relay_protocol::Annotated;
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -7,7 +7,7 @@ use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
 use relay_common::time::UnixTimestamp;
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_conventions::{AttributeInfo, WriteBehavior};
 use relay_event_schema::protocol::{AttributeType, Attributes, BrowserContext, Geo};
 use relay_protocol::{Annotated, ErrorKind, Meta, Remark, RemarkType, Value};

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -18,6 +18,10 @@ use relay_conventions::attributes::{
     APP__VITALS__START__VALUE, APP__VITALS__START__WARM__VALUE, SCORE__TOTAL,
 };
 use relay_conventions::interpolate;
+use relay_conventions::measurements::{
+    APP_START_COLD, APP_START_WARM, FRAMES_FROZEN, FRAMES_FROZEN_RATE, FRAMES_SLOW,
+    FRAMES_SLOW_RATE, FRAMES_TOTAL, STALL_PERCENTAGE,
+};
 use relay_event_schema::processor::{self, ProcessingAction, ProcessingState, Processor};
 use relay_event_schema::protocol::{
     AsPair, Attributes, AutoInferSetting, ClientSdkInfo, Context, ContextInner, Contexts,
@@ -1104,22 +1108,22 @@ fn compute_measurements(
     transaction_duration_ms: Option<FiniteF64>,
     measurements: &mut Measurements,
 ) {
-    if let Some(frames_total) = measurements.get_value("frames_total")
+    if let Some(frames_total) = measurements.get_value(FRAMES_TOTAL)
         && frames_total > 0.0
     {
-        if let Some(frames_frozen) = measurements.get_value("frames_frozen") {
+        if let Some(frames_frozen) = measurements.get_value(FRAMES_FROZEN) {
             let frames_frozen_rate = Measurement {
                 value: (frames_frozen / frames_total).into(),
                 unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
             };
-            measurements.insert("frames_frozen_rate".to_owned(), frames_frozen_rate.into());
+            measurements.insert(FRAMES_FROZEN_RATE.to_owned(), frames_frozen_rate.into());
         }
-        if let Some(frames_slow) = measurements.get_value("frames_slow") {
+        if let Some(frames_slow) = measurements.get_value(FRAMES_SLOW) {
             let frames_slow_rate = Measurement {
                 value: (frames_slow / frames_total).into(),
                 unit: MetricUnit::Fraction(FractionUnit::Ratio).into(),
             };
-            measurements.insert("frames_slow_rate".to_owned(), frames_slow_rate.into());
+            measurements.insert(FRAMES_SLOW_RATE.to_owned(), frames_slow_rate.into());
         }
     }
 
@@ -1140,7 +1144,7 @@ fn compute_measurements(
             value: (stall_total_time / transaction_duration_ms).into(),
             unit: (MetricUnit::Fraction(FractionUnit::Ratio)).into(),
         };
-        measurements.insert("stall_percentage".to_owned(), stall_percentage.into());
+        measurements.insert(STALL_PERCENTAGE.to_owned(), stall_percentage.into());
     }
 }
 
@@ -1396,8 +1400,9 @@ fn normalize_contexts(
 /// Drop those outlier measurements for older SDKs.
 fn filter_mobile_outliers(measurements: &mut Measurements) {
     for key in [
-        "app_start_cold",
-        "app_start_warm",
+        APP_START_COLD,
+        APP_START_WARM,
+        // TODO: Regrettably, these measurements are not defined in conventions.
         "time_to_initial_display",
         "time_to_full_display",
     ] {
@@ -1642,6 +1647,8 @@ fn remove_invalid_measurements(
 /// For known measurements, this returns `Some(MetricUnit)`, which can also include
 /// `Some(MetricUnit::None)`. For unknown measurement names, this returns `None`.
 fn get_metric_measurement_unit(measurement_name: &str) -> Option<MetricUnit> {
+    // TODO: Might be neat to resolve this via conventions, but might also not
+    // be worth the trouble.
     match measurement_name {
         // Web
         "fcp" => Some(MetricUnit::Duration(DurationUnit::MilliSecond)),
@@ -1680,11 +1687,12 @@ fn get_metric_measurement_unit(measurement_name: &str) -> Option<MetricUnit> {
 /// The dot.case app start measurements keys are treated as custom measurements.
 /// The snake_case is the key expected by the Sentry UI to aggregate and display in graphs.
 fn normalize_app_start_measurements(measurements: &mut Measurements) {
+    use relay_conventions::measurements::{APP_START_COLD, APP_START_WARM};
     if let Some(app_start_cold_value) = measurements.remove("app.start.cold") {
-        measurements.insert("app_start_cold".to_owned(), app_start_cold_value);
+        measurements.insert(APP_START_COLD.to_owned(), app_start_cold_value);
     }
     if let Some(app_start_warm_value) = measurements.remove("app.start.warm") {
-        measurements.insert("app_start_warm".to_owned(), app_start_warm_value);
+        measurements.insert(APP_START_WARM.to_owned(), app_start_warm_value);
     }
 }
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use relay_base_schema::metrics::{
     DurationUnit, FractionUnit, MetricUnit, can_be_valid_metric_name,
 };
-use relay_conventions::consts::{
+use relay_conventions::attributes::{
     APP__VITALS__START__COLD__VALUE, APP__VITALS__START__SCREEN, APP__VITALS__START__TYPE,
     APP__VITALS__START__VALUE, APP__VITALS__START__WARM__VALUE, SCORE__TOTAL,
 };

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -131,7 +131,7 @@ pub fn calculate_costs(
     Some(CalculatedCost { input, output })
 }
 
-/// Default AI operation stored in [`GEN_AI__OPERATION__TYPE`](relay_conventions::consts::GEN_AI__OPERATION__TYPE)
+/// Default AI operation stored in [`GEN_AI__OPERATION__TYPE`](relay_conventions::attributes::GEN_AI__OPERATION__TYPE)
 /// for AI spans without a well known AI span op.
 ///
 /// See also: [`infer_ai_operation_type`].
@@ -140,11 +140,11 @@ pub const DEFAULT_AI_OPERATION: &str = "ai_client";
 /// Infers the AI operation from an AI operation name.
 ///
 /// The operation name is usually inferred from the
-/// [`GEN_AI__OPERATION__NAME`](relay_conventions::consts::GEN_AI__OPERATION__NAME) span attribute and the span
+/// [`GEN_AI__OPERATION__NAME`](relay_conventions::attributes::GEN_AI__OPERATION__NAME) span attribute and the span
 /// operation.
 ///
 /// Sentry expects the operation type in the
-/// [`GEN_AI__OPERATION__TYPE`](relay_conventions::consts::GEN_AI__OPERATION__TYPE) attribute.
+/// [`GEN_AI__OPERATION__TYPE`](relay_conventions::attributes::GEN_AI__OPERATION__TYPE) attribute.
 ///
 /// The function returns `None` when the op is not a well known AI operation, callers likely want to default
 /// the value to [`DEFAULT_AI_OPERATION`] for AI spans.

--- a/relay-event-schema/src/protocol/device_class.rs
+++ b/relay-event-schema/src/protocol/device_class.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_protocol::{Annotated, Empty, FromValue, IntoValue};
 
 use crate::protocol::{Attributes, Contexts, DeviceContext};

--- a/relay-event-schema/src/protocol/measurements.rs
+++ b/relay-event-schema/src/protocol/measurements.rs
@@ -98,6 +98,7 @@ fn is_valid_measurement_name(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use relay_base_schema::metrics::DurationUnit;
+    use relay_conventions::measurements::*;
     use similar_asserts::assert_eq;
 
     use super::*;
@@ -198,35 +199,35 @@ mod tests {
         let mut measurements = Annotated::new(Measurements({
             let mut measurements = Object::new();
             measurements.insert(
-                "cls".to_owned(),
+                CLS.to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::empty(),
                     unit: Annotated::empty(),
                 }),
             );
             measurements.insert(
-                "lcp".to_owned(),
+                LCP.to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::new(420.69.try_into().unwrap()),
                     unit: Annotated::new(MetricUnit::Duration(DurationUnit::MilliSecond)),
                 }),
             );
             measurements.insert(
-                "fid".to_owned(),
+                FID.to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::new(2020f64.try_into().unwrap()),
                     unit: Annotated::empty(),
                 }),
             );
             measurements.insert(
-                "inp".to_owned(),
+                INP.to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::new(100.14.try_into().unwrap()),
                     unit: Annotated::empty(),
                 }),
             );
             measurements.insert(
-                "fp".to_owned(),
+                FP.to_owned(),
                 Annotated::new(Measurement {
                     value: Annotated::from_error(
                         Error::expected("a finite floating point number"),

--- a/relay-filter/src/interface.rs
+++ b/relay-filter/src/interface.rs
@@ -1,6 +1,6 @@
 //! This module contains the trait for items that can be filtered by Inbound Filters, plus
 //! the implementation for [`Event`].
-use relay_conventions::consts::{
+use relay_conventions::attributes::{
     BROWSER__NAME, BROWSER__VERSION, SENTRY__RELEASE, SENTRY__SEGMENT__NAME, USER_AGENT__ORIGINAL,
 };
 use url::Url;

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -9,7 +9,7 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
 use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLogRecord;
 
 use opentelemetry_proto::tonic::resource::v1::Resource;
-use relay_conventions::consts::{EVENT__NAME, SENTRY__ORIGIN, SENTRY__PLATFORM};
+use relay_conventions::attributes::{EVENT__NAME, SENTRY__ORIGIN, SENTRY__PLATFORM};
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
 use relay_otel::{otel_resource_to_platform, otel_value_to_attribute};
 use relay_protocol::{Annotated, Object};

--- a/relay-ourlogs/src/vercel_to_sentry.rs
+++ b/relay-ourlogs/src/vercel_to_sentry.rs
@@ -3,7 +3,7 @@
 use std::str::FromStr;
 
 use chrono::{TimeZone, Utc};
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
 use relay_protocol::{Annotated, Meta, Remark, RemarkType};
 use serde::{Deserialize, Deserializer};

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -338,7 +338,7 @@ fn span_duration(span: &SpanV2) -> Option<Duration> {
 mod tests {
     use chrono::DateTime;
 
-    use relay_conventions::consts::*;
+    use relay_conventions::attributes::*;
     use relay_event_schema::protocol::{Attributes, EventId, SpanKind};
     use relay_pii::PiiConfig;
     use relay_protocol::SerializableAnnotated;

--- a/relay-server/src/processing/utils/store.rs
+++ b/relay-server/src/processing/utils/store.rs
@@ -2,7 +2,7 @@ use std::array::TryFromSliceError;
 use std::collections::HashMap;
 
 use chrono::Utc;
-use relay_conventions::consts::SENTRY__CLIENT_SAMPLE_RATE;
+use relay_conventions::attributes::SENTRY__CLIENT_SAMPLE_RATE;
 use relay_event_schema::protocol::Attributes;
 use relay_protocol::{Annotated, IntoValue, MetaTree, Value};
 

--- a/relay-spans/src/name.rs
+++ b/relay-spans/src/name.rs
@@ -1,4 +1,4 @@
-use relay_conventions::consts::SENTRY__OP;
+use relay_conventions::attributes::SENTRY__OP;
 use relay_conventions::name_for_op_and_attributes;
 use relay_event_schema::protocol::{Attributes, Span};
 use relay_protocol::{Getter, GetterIter, Val};

--- a/relay-spans/src/op.rs
+++ b/relay-spans/src/op.rs
@@ -1,4 +1,4 @@
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Attributes, SpanKind};
 use relay_protocol::Annotated;
 

--- a/relay-spans/src/otel_to_sentry_v2.rs
+++ b/relay-spans/src/otel_to_sentry_v2.rs
@@ -3,7 +3,7 @@ use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::span::Link as OtelLink;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind as OtelSpanKind;
-use relay_conventions::consts::{
+use relay_conventions::attributes::{
     SENTRY__IS_REMOTE, SENTRY__KIND, SENTRY__ORIGIN, SENTRY__PLATFORM, SENTRY__SEGMENT__ID,
     SENTRY__SEGMENT__NAME, SENTRY__STATUS__MESSAGE,
 };

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use relay_conventions::consts::*;
+use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{
     Attribute, AttributeType, AttributeValue, Attributes, JsonLenientString, Span as SpanV1,
     SpanData, SpanLink, SpanStatus as SpanV1Status, SpanV2, SpanV2Link, SpanV2Status,


### PR DESCRIPTION
This adds measurements functionality to `relay-conventions`. Similarly to attributes, there is now a constant for each defined measurement. Moreover, there is a function `measurement_to_attribute` that maps a measurement to its replacement attribute (if defined). However, this function isn't used yet in this PR.

This PR contains no functional changes, it just lays the groundwork for a future change that will use `measurement_to_attribute`. The new measurement constants are used everywhere I could find that it would make sense. The lion's share of changed files in this PR is due to the `relay_conventions::consts` attribute being renamed to `relay_conventions::attributes` (just calling it `consts` would be ambiguous, now that there are also constants for measurements).

ref: INGEST-909