### PR TITLE
fix: Add dsc transaction to transaction spans

### DIFF
--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -275,6 +275,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         span_op_defaults: Default::default(), // only supported in relay
         performance_issues_spans: Default::default(),
         derive_trace_id: Default::default(),
+        dsc: None,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -29,6 +29,7 @@ use relay_protocol::{
     Annotated, Empty, Error, ErrorKind, FiniteF64, FromValue, Getter, Meta, Object, Remark,
     RemarkType, TryFromFloatError, Value,
 };
+use relay_sampling::DynamicSamplingContext;
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -171,6 +172,9 @@ pub struct NormalizationConfig<'a> {
 
     /// Should add a random trace ID to events that lack one.
     pub derive_trace_id: bool,
+
+    /// Dynamic sampling context
+    pub dsc: Option<&'a DynamicSamplingContext>,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -206,6 +210,7 @@ impl Default for NormalizationConfig<'_> {
             span_op_defaults: Default::default(),
             performance_issues_spans: Default::default(),
             derive_trace_id: Default::default(),
+            dsc: None,
         }
     }
 }
@@ -337,7 +342,8 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts, event_id, config);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
-        crate::normalize::normalize_app_start_spans(event);
+        span::normalize_app_start_spans(event);
+        span::normalize_dsc_for_event_spans(event, config.dsc);
         span::exclusive_time::compute_span_exclusive_time(event);
     }
 

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::LazyLock};
 
 use regex::Regex;
 use relay_base_schema::metrics::MetricUnit;
-use relay_event_schema::protocol::{Event, VALID_PLATFORMS};
+use relay_event_schema::protocol::VALID_PLATFORMS;
 use relay_pattern::Pattern;
 use relay_protocol::{FiniteF64, RuleCondition};
 use serde::{Deserialize, Serialize};
@@ -79,38 +79,6 @@ impl MeasurementsConfig {
 /// See [`VALID_PLATFORMS`] for a list of all known platforms.
 pub fn is_valid_platform(platform: &str) -> bool {
     VALID_PLATFORMS.contains(&platform)
-}
-
-/// Replaces snake_case app start spans op with dot.case op.
-///
-/// This is done for the affected React Native SDK versions (from 3 to 4.4).
-pub fn normalize_app_start_spans(event: &mut Event) {
-    if !event.sdk_name().eq("sentry.javascript.react-native")
-        || !(event.sdk_version().starts_with("4.4")
-            || event.sdk_version().starts_with("4.3")
-            || event.sdk_version().starts_with("4.2")
-            || event.sdk_version().starts_with("4.1")
-            || event.sdk_version().starts_with("4.0")
-            || event.sdk_version().starts_with('3'))
-    {
-        return;
-    }
-
-    if let Some(spans) = event.spans.value_mut() {
-        for span in spans {
-            if let Some(span) = span.value_mut()
-                && let Some(op) = span.op.value()
-            {
-                if op == "app_start_cold" {
-                    span.op.set_value(Some("app.start.cold".to_owned()));
-                    break;
-                } else if op == "app_start_warm" {
-                    span.op.set_value(Some("app.start.warm".to_owned()));
-                    break;
-                }
-            }
-        }
-    }
 }
 
 /// Container for global and project level [`MeasurementsConfig`]. The purpose is to handle
@@ -405,9 +373,9 @@ mod tests {
     use relay_base_schema::metrics::DurationUnit;
     use relay_base_schema::spans::SpanStatus;
     use relay_event_schema::protocol::{
-        ClientSdkInfo, Context, ContextInner, Contexts, DebugImage, DebugMeta, EventId, Exception,
-        Frame, Geo, IpAddr, LenientString, Level, LogEntry, PairList, RawStacktrace, ReplayContext,
-        Request, Span, Stacktrace, TagEntry, Tags, TraceContext, User, Values,
+        ClientSdkInfo, Context, ContextInner, Contexts, DebugImage, DebugMeta, Event, EventId,
+        Exception, Frame, Geo, IpAddr, LenientString, Level, LogEntry, PairList, RawStacktrace,
+        ReplayContext, Request, Span, Stacktrace, TagEntry, Tags, TraceContext, User, Values,
     };
     use relay_protocol::{
         Annotated, Error, ErrorKind, FromValue, Object, SerializableAnnotated, Value,
@@ -1869,7 +1837,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        normalize_app_start_spans(&mut event);
+        span::normalize_app_start_spans(&mut event);
         assert_debug_snapshot!(event.spans, @r###"
         [
             Span {
@@ -1917,7 +1885,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        normalize_app_start_spans(&mut event);
+        span::normalize_app_start_spans(&mut event);
         assert_debug_snapshot!(event.spans, @r###"
         [
             Span {
@@ -1965,7 +1933,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        normalize_app_start_spans(&mut event);
+        span::normalize_app_start_spans(&mut event);
         assert_debug_snapshot!(event.spans, @r###"
         [
             Span {

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,7 +1,7 @@
 //! Span normalization logic.
 
 use regex::Regex;
-use relay_conventions::consts::{SENTRY__DSC__TRACE_ID, SENTRY__DSC__TRANSACTION};
+use relay_conventions::attributes::{SENTRY__DSC__TRACE_ID, SENTRY__DSC__TRANSACTION};
 use relay_event_schema::protocol::{Event, SpanData, TraceContext};
 use relay_protocol::{Annotated, Value};
 use relay_sampling::DynamicSamplingContext;

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,6 +1,10 @@
 //! Span normalization logic.
 
 use regex::Regex;
+use relay_conventions::consts::{SENTRY__DSC__TRACE_ID, SENTRY__DSC__TRANSACTION};
+use relay_event_schema::protocol::{Event, SpanData, TraceContext};
+use relay_protocol::{Annotated, Value};
+use relay_sampling::DynamicSamplingContext;
 use std::sync::LazyLock;
 
 pub mod ai;
@@ -20,3 +24,78 @@ pub static TABLE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+
+/// Replaces snake_case app start spans op with dot.case op.
+///
+/// This is done for the affected React Native SDK versions (from 3 to 4.4).
+pub fn normalize_app_start_spans(event: &mut Event) {
+    if !event.sdk_name().eq("sentry.javascript.react-native")
+        || !(event.sdk_version().starts_with("4.4")
+            || event.sdk_version().starts_with("4.3")
+            || event.sdk_version().starts_with("4.2")
+            || event.sdk_version().starts_with("4.1")
+            || event.sdk_version().starts_with("4.0")
+            || event.sdk_version().starts_with('3'))
+    {
+        return;
+    }
+
+    if let Some(spans) = event.spans.value_mut() {
+        for span in spans {
+            if let Some(span) = span.value_mut()
+                && let Some(op) = span.op.value()
+            {
+                if op == "app_start_cold" {
+                    span.op.set_value(Some("app.start.cold".to_owned()));
+                    break;
+                } else if op == "app_start_warm" {
+                    span.op.set_value(Some("app.start.warm".to_owned()));
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Writes DSC attributes needed for dynamic sampling into the spans' `data`.
+///
+/// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
+/// that span.
+pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&DynamicSamplingContext>) {
+    if let Some(ctx) = event.context_mut::<TraceContext>() {
+        normalize_dsc_for_span_data(&mut ctx.data, dsc);
+    }
+    if let Some(spans) = event.spans.value_mut() {
+        for span in spans {
+            if let Some(span) = span.value_mut() {
+                normalize_dsc_for_span_data(&mut span.data, dsc);
+            }
+        }
+    }
+}
+
+/// Writes DSC attributes needed for dynamic sampling into `span_data`.
+///
+/// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
+pub fn normalize_dsc_for_span_data(
+    span_data: &mut Annotated<SpanData>,
+    dsc: Option<&DynamicSamplingContext>,
+) {
+    let Some(dsc) = dsc else { return };
+
+    let data = span_data.get_or_insert_with(SpanData::default);
+    if data.other.contains_key(SENTRY__DSC__TRACE_ID) {
+        return;
+    }
+    data.other.insert(
+        SENTRY__DSC__TRACE_ID.to_owned(),
+        Annotated::new(Value::String(dsc.trace_id.to_string())),
+    );
+
+    if let Some(transaction) = &dsc.transaction {
+        data.other.insert(
+            SENTRY__DSC__TRANSACTION.to_owned(),
+            Annotated::new(Value::String(transaction.clone())),
+        );
+    }
+}

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -2,8 +2,7 @@
 
 use crate::services::processor::ProcessingError;
 use chrono::{DateTime, Utc};
-use relay_conventions::consts::*;
-use relay_event_normalization::span::ai::enrich_ai_span;
+use relay_event_normalization::span::{self, ai};
 use relay_event_normalization::{
     BorrowedSpanOpDefaults, ClientHints, CombinedMeasurementsConfig, FromUserAgentInfo,
     GeoIpLookup, ModelMetadata, PerformanceScoreConfig, RawUserAgentInfo, SchemaProcessor,
@@ -59,29 +58,6 @@ pub struct NormalizeSpanConfig<'a> {
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
     /// Dynamic sampling context from the envelope headers.
     pub dsc: Option<&'a DynamicSamplingContext>,
-}
-
-/// Writes DSC attributes needed for dynamic sampling into the span's `data`.
-///
-/// If `sentry.dsc.trace_id` is already present in `span.data`, the function does nothing.
-fn normalize_dsc(span: &mut Span, dsc: Option<&DynamicSamplingContext>) {
-    let Some(dsc) = dsc else { return };
-
-    let data = span.data.get_or_insert_with(SpanData::default);
-    if data.other.contains_key(SENTRY__DSC__TRACE_ID) {
-        return;
-    }
-    data.other.insert(
-        SENTRY__DSC__TRACE_ID.to_owned(),
-        Annotated::new(Value::String(dsc.trace_id.to_string())),
-    );
-
-    if let Some(transaction) = &dsc.transaction {
-        data.other.insert(
-            SENTRY__DSC__TRANSACTION.to_owned(),
-            Annotated::new(Value::String(transaction.clone())),
-        );
-    }
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -235,9 +211,9 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    normalize_dsc(span, *dsc);
+    span::normalize_dsc_for_span_data(&mut span.data, *dsc);
 
-    enrich_ai_span(span, *ai_model_metadata);
+    ai::enrich_ai_span(span, *ai_model_metadata);
 
     tag_extraction::extract_measurements(span, is_mobile);
 

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -302,6 +302,7 @@ pub fn normalize(
                 .project_info
                 .has_feature(Feature::PerformanceIssuesSpans),
             derive_trace_id: project_info.has_feature(Feature::AddDefaultTraceID),
+            dsc: headers.dsc(),
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -8,7 +8,6 @@ from sentry_relay.consts import DataCategory
 from .asserts import time_within_delta
 
 
-# KOLLA VARFÖR VI INTE FÅ TRANSACTION OCKSÅ
 @pytest.mark.parametrize(
     "eap_span_outcomes_rollout_rate",
     [

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -8,6 +8,7 @@ from sentry_relay.consts import DataCategory
 from .asserts import time_within_delta
 
 
+# KOLLA VARFÖR VI INTE FÅ TRANSACTION OCKSÅ
 @pytest.mark.parametrize(
     "eap_span_outcomes_rollout_rate",
     [
@@ -420,6 +421,10 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generateText weather-chat",
                 },
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 0.0},
                 "sentry.is_remote": {"type": "boolean", "value": False},
@@ -535,6 +540,10 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generate_text gpt-4o",
                 },
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 0.0},
                 "sentry.is_remote": {"type": "boolean", "value": False},
@@ -631,6 +640,10 @@ def test_ai_spans_example_transaction(
                     "value": "POST " "https://api.openai.com/v1/responses",
                 },
                 "sentry.domain": {"type": "string", "value": "*.openai.com"},
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.group": {"type": "string", "value": "483aa47139350517"},
@@ -723,6 +736,10 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "execute_tool getWeather",
                 },
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 0.0},
                 "sentry.is_remote": {"type": "boolean", "value": False},
@@ -782,6 +799,10 @@ def test_ai_spans_example_transaction(
                     "value": "GET " "https://wttr.in/San%20Francisco",
                 },
                 "sentry.domain": {"type": "string", "value": "wttr.in"},
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.group": {"type": "string", "value": "2cdcd1b2278e1dd3"},
@@ -867,6 +888,10 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "execute_tool getWeather",
                 },
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 0.0},
                 "sentry.is_remote": {"type": "boolean", "value": False},
@@ -926,6 +951,10 @@ def test_ai_spans_example_transaction(
                     "value": "GET https://wttr.in/London",
                 },
                 "sentry.domain": {"type": "string", "value": "wttr.in"},
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.group": {"type": "string", "value": "2cdcd1b2278e1dd3"},
@@ -1041,6 +1070,10 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generate_text gpt-4o",
                 },
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 0.0},
                 "sentry.is_remote": {"type": "boolean", "value": False},
@@ -1134,6 +1167,10 @@ def test_ai_spans_example_transaction(
                     "value": "POST " "https://api.openai.com/v1/responses",
                 },
                 "sentry.domain": {"type": "string", "value": "*.openai.com"},
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 500.0},
                 "sentry.group": {"type": "string", "value": "483aa47139350517"},
@@ -1208,6 +1245,10 @@ def test_ai_spans_example_transaction(
                 "gen_ai.usage.output_tokens": {"type": "integer", "value": 65},
                 "gen_ai.usage.total_tokens": {"type": "double", "value": 310.0},
                 "sentry.description": {"type": "string", "value": "main"},
+                "sentry.dsc.trace_id": {
+                    "type": "string",
+                    "value": "a9351cd574f092f6acad48e250981f11",
+                },
                 "sentry.environment": {"type": "string", "value": "production"},
                 "sentry.exclusive_time": {"type": "double", "value": 0.0},
                 "sentry.is_remote": {"type": "boolean", "value": True},

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -156,6 +156,11 @@ def test_span_extraction(
             },
             "sentry.is_remote": {"type": "boolean", "value": False},
             "sentry.segment.id": {"type": "string", "value": "968cff94913ebb07"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "a0fa8803753e40fd8124b21eeb2986b5",
+            },
+            "sentry.dsc.transaction": {"type": "string", "value": "hi"},
         },
         "downsampled_retention_days": 90,
         "end_timestamp": end.timestamp(),
@@ -227,6 +232,11 @@ def test_span_extraction(
             "sentry.user.id": {"type": "string", "value": user_id},
             "sentry.user.ip": {"type": "string", "value": "192.168.0.1"},
             "sentry.user": {"type": "string", "value": f"id:{user_id}"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "a0fa8803753e40fd8124b21eeb2986b5",
+            },
+            "sentry.dsc.transaction": {"type": "string", "value": "hi"},
         },
         "downsampled_retention_days": 90,
         "end_timestamp": end_timestamp.timestamp(),
@@ -1206,3 +1216,47 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "timestamp": mock.ANY,
         },
     ]
+
+
+def test_spans_dsc_normalization(
+    mini_sentry, relay, relay_with_processing, spans_consumer
+):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(relay_with_processing())
+    spans_consumer = spans_consumer()
+    ts = datetime.now(timezone.utc)
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    event["spans"] = [
+        {
+            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+            "span_id": "bbbbbbbbbbbbbbbb",
+            "parent_span_id": "968cff94913ebb07",
+            "start_timestamp": ts.timestamp(),
+            "timestamp": ts.timestamp() + 0.3,
+        },
+        {
+            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+            "span_id": "cccccccccccccccc",
+            "parent_span_id": "968cff94913ebb07",
+            "start_timestamp": ts.timestamp(),
+            "timestamp": ts.timestamp() + 0.3,
+            "data": {
+                "sentry.dsc.trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                "sentry.dsc.transaction": "/transaction/already/exists",
+            },
+        },
+    ]
+
+    relay.send_event(project_id, event)
+    spans = {s["span_id"]: s for s in spans_consumer.get_spans()}
+
+    def get_transaction(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.transaction"]["value"]
+
+    assert spans["968cff94913ebb07"]["is_segment"] is True
+    assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
+    assert spans["cccccccccccccccc"]["is_segment"] is False
+    assert get_transaction("968cff94913ebb07") == "hi"
+    assert get_transaction("bbbbbbbbbbbbbbbb") == "hi"
+    assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"


### PR DESCRIPTION
Add root transaction/segment name and trace id as sentry.dsc.x attributes to all tranasction spans. Needed for the new dynamic sampling pipeline to work.

Fixes https://linear.app/getsentry/issue/RELAY-248/add-root-transactionsegment-name-to-transaction-spans
Ref https://linear.app/getsentry/issue/RELAY-239/add-dsc-attributes-trace-root-project-onto-every-span

