### PR TITLE
fix: Add dsc project id to all spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005))
 - Obtain PII values for `SpanData` fields from `sentry-conventions`. ([#5997](https://github.com/getsentry/relay/pull/5997))
-- Add `sentry.dsc.transaction` and `sentry.dsc.trace_id` to all spans. ([#6001](https://github.com/getsentry/relay/pull/6001), [#6004](https://github.com/getsentry/relay/pull/6004), [#6008](https://github.com/getsentry/relay/pull/6008))
+- Add `sentry.dsc.transaction`, `sentry.dsc.trace_id`, and `sentry.dsc.project_id` to all spans. ([#6001](https://github.com/getsentry/relay/pull/6001), [#6004](https://github.com/getsentry/relay/pull/6004), [#6008](https://github.com/getsentry/relay/pull/6008), [#6011](https://github.com/getsentry/relay/pull/6011))
 
 ## 26.5.0
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -276,6 +276,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         performance_issues_spans: Default::default(),
         derive_trace_id: Default::default(),
         dsc: None,
+        sampling_project_id: None,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -275,7 +275,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         span_op_defaults: Default::default(), // only supported in relay
         performance_issues_spans: Default::default(),
         derive_trace_id: Default::default(),
-        enriched_dsc: None,
+        dsc: None,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -275,7 +275,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         span_op_defaults: Default::default(), // only supported in relay
         performance_issues_spans: Default::default(),
         derive_trace_id: Default::default(),
-        dsc_normalization_props: None,
+        enriched_dsc: None,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -275,8 +275,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         span_op_defaults: Default::default(), // only supported in relay
         performance_issues_spans: Default::default(),
         derive_trace_id: Default::default(),
-        dsc: None,
-        sampling_project_id: None,
+        dsc_normalization_props: None,
     };
     normalize_event(&mut event, &normalization_config);
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -352,11 +352,13 @@ pub fn normalize_user_geo(
 /// If `is_segment` is set to `false`, the function will only add select attributes that are
 /// necessary on every span - both segment and non-segment - for dynamic sampling to work. More
 /// attributes are added when `is_segment` is set to `true`.
+///
+/// `sampling_project_id` is the id of the project where the trace originated.
 pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
     dsc: Option<&DynamicSamplingContext>,
-    project_id: Option<&ProjectId>,
+    sampling_project_id: Option<ProjectId>,
 ) {
     let Some(dsc) = dsc else { return };
 
@@ -371,7 +373,7 @@ pub fn normalize_dsc(
     if let Some(transaction) = &dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
-    if let Some(project_id) = project_id {
+    if let Some(project_id) = sampling_project_id {
         attributes.insert(SENTRY__DSC__PROJECT_ID, project_id.value() as i64);
     }
 
@@ -769,7 +771,7 @@ mod tests {
             &mut attributes,
             &Annotated::new(false),
             Some(&dsc),
-            Some(&ProjectId::new(42)),
+            Some(ProjectId::new(42)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -793,7 +795,7 @@ mod tests {
             &mut attributes,
             &Annotated::new(false),
             Some(&dsc),
-            Some(&ProjectId::new(42)),
+            Some(ProjectId::new(42)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -821,7 +823,7 @@ mod tests {
             &mut attributes,
             &Annotated::new(true),
             Some(&dsc),
-            Some(&ProjectId::new(42)),
+            Some(ProjectId::new(42)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -353,9 +353,9 @@ pub fn normalize_user_geo(
 pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
-    props: &DscNormalizationCommonProps,
+    props: Option<&DscNormalizationCommonProps>,
 ) {
-    let Some(dsc) = props.dsc else { return };
+    let Some(props) = props else { return };
 
     let attributes = attributes.get_or_insert_with(Default::default);
 
@@ -363,27 +363,29 @@ pub fn normalize_dsc(
     if attributes.contains_key(SENTRY__DSC__TRACE_ID) {
         return;
     }
-    attributes.insert(SENTRY__DSC__TRACE_ID, dsc.trace_id.to_string());
+    attributes.insert(SENTRY__DSC__TRACE_ID, props.dsc.trace_id.to_string());
 
-    if let Some(transaction) = &dsc.transaction {
+    if let Some(transaction) = &props.dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
-    if let Some(project_id) = props.sampling_project_id {
-        attributes.insert(SENTRY__DSC__PROJECT_ID, project_id.to_string());
-    }
+
+    attributes.insert(
+        SENTRY__DSC__PROJECT_ID,
+        props.sampling_project_id.to_string(),
+    );
 
     if is_segment.value().is_some_and(|is_segment| *is_segment) {
-        attributes.insert(SENTRY__DSC__PUBLIC_KEY, dsc.public_key.to_string());
-        if let Some(release) = &dsc.release {
+        attributes.insert(SENTRY__DSC__PUBLIC_KEY, props.dsc.public_key.to_string());
+        if let Some(release) = &props.dsc.release {
             attributes.insert(SENTRY__DSC__RELEASE, release.clone());
         }
-        if let Some(environment) = &dsc.environment {
+        if let Some(environment) = &props.dsc.environment {
             attributes.insert(SENTRY__DSC__ENVIRONMENT, environment.clone());
         }
-        if let Some(sample_rate) = dsc.sample_rate {
+        if let Some(sample_rate) = props.dsc.sample_rate {
             attributes.insert(SENTRY__DSC__SAMPLE_RATE, sample_rate);
         }
-        if let Some(sampled) = dsc.sampled {
+        if let Some(sampled) = props.dsc.sampled {
             attributes.insert(SENTRY__DSC__SAMPLED, sampled);
         }
     }
@@ -756,11 +758,7 @@ mod tests {
     #[test]
     fn test_normalize_dsc_child_span_no_dsc() {
         let mut attributes = Annotated::empty();
-        normalize_dsc(
-            &mut attributes,
-            &Annotated::new(false),
-            &DscNormalizationCommonProps::new(None, None),
-        );
+        normalize_dsc(&mut attributes, &Annotated::new(false), None);
         assert!(attributes.value().is_none());
     }
 
@@ -772,7 +770,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            &DscNormalizationCommonProps::new(Some(dsc), Some(sampling_project_id)),
+            Some(&DscNormalizationCommonProps::new(dsc, sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -796,7 +794,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            &DscNormalizationCommonProps::new(Some(dsc), Some(sampling_project_id)),
+            Some(&DscNormalizationCommonProps::new(dsc, sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -824,7 +822,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(true),
-            &DscNormalizationCommonProps::new(Some(dsc), Some(sampling_project_id)),
+            Some(&DscNormalizationCommonProps::new(dsc, sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -353,7 +353,7 @@ pub fn normalize_user_geo(
 pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
-    dsc: Option<&EnrichedDsc>,
+    dsc: Option<EnrichedDsc>,
 ) {
     let Some(dsc) = dsc else {
         return;
@@ -817,7 +817,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&EnrichedDsc {
+            Some(EnrichedDsc {
                 dsc,
                 sampling_project_id,
             }),
@@ -844,7 +844,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&EnrichedDsc {
+            Some(EnrichedDsc {
                 dsc,
                 sampling_project_id,
             }),
@@ -875,7 +875,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(true),
-            Some(&EnrichedDsc {
+            Some(EnrichedDsc {
                 dsc,
                 sampling_project_id,
             }),

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -6,13 +6,11 @@ use std::borrow::Cow;
 use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
-use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
 use relay_conventions::attributes::*;
 use relay_conventions::{AttributeInfo, WriteBehavior};
 use relay_event_schema::protocol::{AttributeType, Attributes, BrowserContext, Geo};
 use relay_protocol::{Annotated, ErrorKind, Meta, Remark, RemarkType, Value};
-use relay_sampling::DynamicSamplingContext;
 use relay_spans::derive_op_for_v2_span;
 
 use crate::span::TABLE_NAME_REGEX;
@@ -21,7 +19,7 @@ use crate::span::tag_extraction::{
     domain_from_scrubbed_http, domain_from_server_address, span_op_to_category,
     sql_action_from_query, sql_tables_from_query,
 };
-use crate::{ClientHints, FromUserAgentInfo as _, RawUserAgentInfo};
+use crate::{ClientHints, DscNormalizationCommonProps, FromUserAgentInfo as _, RawUserAgentInfo};
 
 mod ai;
 mod mobile;
@@ -352,15 +350,12 @@ pub fn normalize_user_geo(
 /// If `is_segment` is set to `false`, the function will only add select attributes that are
 /// necessary on every span - both segment and non-segment - for dynamic sampling to work. More
 /// attributes are added when `is_segment` is set to `true`.
-///
-/// `sampling_project_id` is the id of the project where the trace originated.
 pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
-    dsc: Option<&DynamicSamplingContext>,
-    sampling_project_id: Option<ProjectId>,
+    props: &DscNormalizationCommonProps,
 ) {
-    let Some(dsc) = dsc else { return };
+    let Some(dsc) = props.dsc else { return };
 
     let attributes = attributes.get_or_insert_with(Default::default);
 
@@ -373,7 +368,7 @@ pub fn normalize_dsc(
     if let Some(transaction) = &dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
-    if let Some(project_id) = sampling_project_id {
+    if let Some(project_id) = props.sampling_project_id {
         attributes.insert(SENTRY__DSC__PROJECT_ID, project_id.value() as i64);
     }
 
@@ -737,7 +732,9 @@ pub fn write_legacy_attributes(attributes: &mut Annotated<Attributes>) {
 
 #[cfg(test)]
 mod tests {
+    use relay_base_schema::project::ProjectId;
     use relay_protocol::{Empty, SerializableAnnotated, assert_annotated_snapshot};
+    use relay_sampling::DynamicSamplingContext;
 
     use super::*;
 
@@ -759,19 +756,23 @@ mod tests {
     #[test]
     fn test_normalize_dsc_child_span_no_dsc() {
         let mut attributes = Annotated::empty();
-        normalize_dsc(&mut attributes, &Annotated::new(false), None, None);
+        normalize_dsc(
+            &mut attributes,
+            &Annotated::new(false),
+            &DscNormalizationCommonProps::new(None, None),
+        );
         assert!(attributes.value().is_none());
     }
 
     #[test]
     fn test_normalize_dsc_child_span_no_transaction() {
         let mut attributes = Annotated::empty();
-        let dsc = mock_dsc(None);
+        let dsc = &mock_dsc(None);
+        let sampling_project_id = ProjectId::new(42);
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&dsc),
-            Some(ProjectId::new(42)),
+            &DscNormalizationCommonProps::new(Some(dsc), Some(sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -790,12 +791,12 @@ mod tests {
     #[test]
     fn test_normalize_dsc_child_span() {
         let mut attributes = Annotated::empty();
-        let dsc = mock_dsc(Some("/some/endpoint"));
+        let dsc = &mock_dsc(Some("/some/endpoint"));
+        let sampling_project_id = ProjectId::new(42);
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&dsc),
-            Some(ProjectId::new(42)),
+            &DscNormalizationCommonProps::new(Some(dsc), Some(sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -818,12 +819,12 @@ mod tests {
     #[test]
     fn test_normalize_dsc_segment() {
         let mut attributes = Annotated::empty();
-        let dsc = mock_dsc(Some("/some/endpoint"));
+        let dsc = &mock_dsc(Some("/some/endpoint"));
+        let sampling_project_id = ProjectId::new(42);
         normalize_dsc(
             &mut attributes,
             &Annotated::new(true),
-            Some(&dsc),
-            Some(ProjectId::new(42)),
+            &DscNormalizationCommonProps::new(Some(dsc), Some(sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -353,9 +353,9 @@ pub fn normalize_user_geo(
 pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
-    enriched_dsc: Option<&EnrichedDsc>,
+    dsc: Option<&EnrichedDsc>,
 ) {
-    let Some(enriched_dsc) = enriched_dsc else {
+    let Some(dsc) = dsc else {
         return;
     };
 
@@ -365,32 +365,26 @@ pub fn normalize_dsc(
     if attributes.contains_key(SENTRY__DSC__TRACE_ID) {
         return;
     }
-    attributes.insert(SENTRY__DSC__TRACE_ID, enriched_dsc.dsc.trace_id.to_string());
+    attributes.insert(SENTRY__DSC__TRACE_ID, dsc.dsc.trace_id.to_string());
 
-    if let Some(transaction) = &enriched_dsc.dsc.transaction {
+    if let Some(transaction) = &dsc.dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
 
-    attributes.insert(
-        SENTRY__DSC__PROJECT_ID,
-        enriched_dsc.sampling_project_id.to_string(),
-    );
+    attributes.insert(SENTRY__DSC__PROJECT_ID, dsc.sampling_project_id.to_string());
 
     if is_segment.value().is_some_and(|is_segment| *is_segment) {
-        attributes.insert(
-            SENTRY__DSC__PUBLIC_KEY,
-            enriched_dsc.dsc.public_key.to_string(),
-        );
-        if let Some(release) = &enriched_dsc.dsc.release {
+        attributes.insert(SENTRY__DSC__PUBLIC_KEY, dsc.dsc.public_key.to_string());
+        if let Some(release) = &dsc.dsc.release {
             attributes.insert(SENTRY__DSC__RELEASE, release.clone());
         }
-        if let Some(environment) = &enriched_dsc.dsc.environment {
+        if let Some(environment) = &dsc.dsc.environment {
             attributes.insert(SENTRY__DSC__ENVIRONMENT, environment.clone());
         }
-        if let Some(sample_rate) = enriched_dsc.dsc.sample_rate {
+        if let Some(sample_rate) = dsc.dsc.sample_rate {
             attributes.insert(SENTRY__DSC__SAMPLE_RATE, sample_rate);
         }
-        if let Some(sampled) = enriched_dsc.dsc.sampled {
+        if let Some(sampled) = dsc.dsc.sampled {
             attributes.insert(SENTRY__DSC__SAMPLED, sampled);
         }
     }
@@ -775,7 +769,10 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&EnrichedDsc::new(dsc, sampling_project_id)),
+            Some(&EnrichedDsc {
+                dsc,
+                sampling_project_id,
+            }),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -799,7 +796,10 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&EnrichedDsc::new(dsc, sampling_project_id)),
+            Some(&EnrichedDsc {
+                dsc,
+                sampling_project_id,
+            }),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -827,7 +827,10 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(true),
-            Some(&EnrichedDsc::new(dsc, sampling_project_id)),
+            Some(&EnrichedDsc {
+                dsc,
+                sampling_project_id,
+            }),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -369,7 +369,7 @@ pub fn normalize_dsc(
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
     if let Some(project_id) = props.sampling_project_id {
-        attributes.insert(SENTRY__DSC__PROJECT_ID, project_id.value() as i64);
+        attributes.insert(SENTRY__DSC__PROJECT_ID, project_id.to_string());
     }
 
     if is_segment.value().is_some_and(|is_segment| *is_segment) {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -19,7 +19,7 @@ use crate::span::tag_extraction::{
     domain_from_scrubbed_http, domain_from_server_address, span_op_to_category,
     sql_action_from_query, sql_tables_from_query,
 };
-use crate::{ClientHints, DscNormalizationCommonProps, FromUserAgentInfo as _, RawUserAgentInfo};
+use crate::{ClientHints, EnrichedDsc, FromUserAgentInfo as _, RawUserAgentInfo};
 
 mod ai;
 mod mobile;
@@ -353,9 +353,11 @@ pub fn normalize_user_geo(
 pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
-    props: Option<&DscNormalizationCommonProps>,
+    enriched_dsc: Option<&EnrichedDsc>,
 ) {
-    let Some(props) = props else { return };
+    let Some(enriched_dsc) = enriched_dsc else {
+        return;
+    };
 
     let attributes = attributes.get_or_insert_with(Default::default);
 
@@ -363,29 +365,32 @@ pub fn normalize_dsc(
     if attributes.contains_key(SENTRY__DSC__TRACE_ID) {
         return;
     }
-    attributes.insert(SENTRY__DSC__TRACE_ID, props.dsc.trace_id.to_string());
+    attributes.insert(SENTRY__DSC__TRACE_ID, enriched_dsc.dsc.trace_id.to_string());
 
-    if let Some(transaction) = &props.dsc.transaction {
+    if let Some(transaction) = &enriched_dsc.dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
     }
 
     attributes.insert(
         SENTRY__DSC__PROJECT_ID,
-        props.sampling_project_id.to_string(),
+        enriched_dsc.sampling_project_id.to_string(),
     );
 
     if is_segment.value().is_some_and(|is_segment| *is_segment) {
-        attributes.insert(SENTRY__DSC__PUBLIC_KEY, props.dsc.public_key.to_string());
-        if let Some(release) = &props.dsc.release {
+        attributes.insert(
+            SENTRY__DSC__PUBLIC_KEY,
+            enriched_dsc.dsc.public_key.to_string(),
+        );
+        if let Some(release) = &enriched_dsc.dsc.release {
             attributes.insert(SENTRY__DSC__RELEASE, release.clone());
         }
-        if let Some(environment) = &props.dsc.environment {
+        if let Some(environment) = &enriched_dsc.dsc.environment {
             attributes.insert(SENTRY__DSC__ENVIRONMENT, environment.clone());
         }
-        if let Some(sample_rate) = props.dsc.sample_rate {
+        if let Some(sample_rate) = enriched_dsc.dsc.sample_rate {
             attributes.insert(SENTRY__DSC__SAMPLE_RATE, sample_rate);
         }
-        if let Some(sampled) = props.dsc.sampled {
+        if let Some(sampled) = enriched_dsc.dsc.sampled {
             attributes.insert(SENTRY__DSC__SAMPLED, sampled);
         }
     }
@@ -770,7 +775,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&DscNormalizationCommonProps::new(dsc, sampling_project_id)),
+            Some(&EnrichedDsc::new(dsc, sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -794,7 +799,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(false),
-            Some(&DscNormalizationCommonProps::new(dsc, sampling_project_id)),
+            Some(&EnrichedDsc::new(dsc, sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -822,7 +827,7 @@ mod tests {
         normalize_dsc(
             &mut attributes,
             &Annotated::new(true),
-            Some(&DscNormalizationCommonProps::new(dsc, sampling_project_id)),
+            Some(&EnrichedDsc::new(dsc, sampling_project_id)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -356,7 +356,7 @@ pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
     dsc: Option<&DynamicSamplingContext>,
-    project_id: Option<ProjectId>,
+    project_id: Option<&ProjectId>,
 ) {
     let Some(dsc) = dsc else { return };
 
@@ -769,7 +769,7 @@ mod tests {
             &mut attributes,
             &Annotated::new(false),
             Some(&dsc),
-            Some(ProjectId::new(42)),
+            Some(&ProjectId::new(42)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -793,7 +793,7 @@ mod tests {
             &mut attributes,
             &Annotated::new(false),
             Some(&dsc),
-            Some(ProjectId::new(42)),
+            Some(&ProjectId::new(42)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -821,7 +821,7 @@ mod tests {
             &mut attributes,
             &Annotated::new(true),
             Some(&dsc),
-            Some(ProjectId::new(42)),
+            Some(&ProjectId::new(42)),
         );
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -777,7 +777,7 @@ mod tests {
         assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.dsc.project_id": {
-            "type": "integer",
+            "type": "string",
             "value": 42
           },
           "sentry.dsc.trace_id": {
@@ -801,7 +801,7 @@ mod tests {
         assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.dsc.project_id": {
-            "type": "integer",
+            "type": "string",
             "value": 42
           },
           "sentry.dsc.trace_id": {
@@ -829,7 +829,7 @@ mod tests {
         assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.dsc.project_id": {
-            "type": "integer",
+            "type": "string",
             "value": 42
           },
           "sentry.dsc.public_key": {

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
+use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
 use relay_conventions::attributes::*;
 use relay_conventions::{AttributeInfo, WriteBehavior};
@@ -355,6 +356,7 @@ pub fn normalize_dsc(
     attributes: &mut Annotated<Attributes>,
     is_segment: &Annotated<bool>,
     dsc: Option<&DynamicSamplingContext>,
+    project_id: Option<ProjectId>,
 ) {
     let Some(dsc) = dsc else { return };
 
@@ -368,6 +370,9 @@ pub fn normalize_dsc(
 
     if let Some(transaction) = &dsc.transaction {
         attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
+    }
+    if let Some(project_id) = project_id {
+        attributes.insert(SENTRY__DSC__PROJECT_ID, project_id.value() as i64);
     }
 
     if is_segment.value().is_some_and(|is_segment| *is_segment) {
@@ -752,7 +757,7 @@ mod tests {
     #[test]
     fn test_normalize_dsc_child_span_no_dsc() {
         let mut attributes = Annotated::empty();
-        normalize_dsc(&mut attributes, &Annotated::new(false), None);
+        normalize_dsc(&mut attributes, &Annotated::new(false), None, None);
         assert!(attributes.value().is_none());
     }
 
@@ -760,9 +765,18 @@ mod tests {
     fn test_normalize_dsc_child_span_no_transaction() {
         let mut attributes = Annotated::empty();
         let dsc = mock_dsc(None);
-        normalize_dsc(&mut attributes, &Annotated::new(false), Some(&dsc));
+        normalize_dsc(
+            &mut attributes,
+            &Annotated::new(false),
+            Some(&dsc),
+            Some(ProjectId::new(42)),
+        );
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "sentry.dsc.project_id": {
+            "type": "integer",
+            "value": 42
+          },
           "sentry.dsc.trace_id": {
             "type": "string",
             "value": "67e5504410b1426f9247bb680e5fe0c8"
@@ -775,9 +789,18 @@ mod tests {
     fn test_normalize_dsc_child_span() {
         let mut attributes = Annotated::empty();
         let dsc = mock_dsc(Some("/some/endpoint"));
-        normalize_dsc(&mut attributes, &Annotated::new(false), Some(&dsc));
+        normalize_dsc(
+            &mut attributes,
+            &Annotated::new(false),
+            Some(&dsc),
+            Some(ProjectId::new(42)),
+        );
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "sentry.dsc.project_id": {
+            "type": "integer",
+            "value": 42
+          },
           "sentry.dsc.trace_id": {
             "type": "string",
             "value": "67e5504410b1426f9247bb680e5fe0c8"
@@ -794,9 +817,18 @@ mod tests {
     fn test_normalize_dsc_segment() {
         let mut attributes = Annotated::empty();
         let dsc = mock_dsc(Some("/some/endpoint"));
-        normalize_dsc(&mut attributes, &Annotated::new(true), Some(&dsc));
+        normalize_dsc(
+            &mut attributes,
+            &Annotated::new(true),
+            Some(&dsc),
+            Some(ProjectId::new(42)),
+        );
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "sentry.dsc.project_id": {
+            "type": "integer",
+            "value": 42
+          },
           "sentry.dsc.public_key": {
             "type": "string",
             "value": "12345678901234567890123456789012"

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -778,7 +778,7 @@ mod tests {
         {
           "sentry.dsc.project_id": {
             "type": "string",
-            "value": 42
+            "value": "42"
           },
           "sentry.dsc.trace_id": {
             "type": "string",
@@ -802,7 +802,7 @@ mod tests {
         {
           "sentry.dsc.project_id": {
             "type": "string",
-            "value": 42
+            "value": "42"
           },
           "sentry.dsc.trace_id": {
             "type": "string",
@@ -830,7 +830,7 @@ mod tests {
         {
           "sentry.dsc.project_id": {
             "type": "string",
-            "value": 42
+            "value": "42"
           },
           "sentry.dsc.public_key": {
             "type": "string",

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -43,10 +43,10 @@ use crate::span::ai::enrich_ai_event_data;
 use crate::span::tag_extraction::{extract_segment_name_from_event, extract_span_tags_from_event};
 use crate::utils::{self, MAX_DURATION_MOBILE_MS, get_event_user_tag};
 use crate::{
-    BorrowedSpanOpDefaults, BreakdownsConfig, CombinedMeasurementsConfig, GeoIpLookup, MaxChars,
-    ModelMetadata, PerformanceScoreConfig, RawUserAgentInfo, SpanDescriptionRule,
-    TransactionNameConfig, breakdowns, event_error, legacy, mechanism, remove_other, schema, span,
-    stacktrace, transactions, trimming, user_agent,
+    BorrowedSpanOpDefaults, BreakdownsConfig, CombinedMeasurementsConfig,
+    DscNormalizationCommonProps, GeoIpLookup, MaxChars, ModelMetadata, PerformanceScoreConfig,
+    RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig, breakdowns, event_error, legacy,
+    mechanism, remove_other, schema, span, stacktrace, transactions, trimming, user_agent,
 };
 
 /// Configuration for [`normalize_event`].
@@ -351,8 +351,9 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts, event_id, config);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
+        let dsc_props = DscNormalizationCommonProps::new(config.dsc, config.sampling_project_id);
+        span::normalize_dsc_for_event_spans(event, &dsc_props);
         span::normalize_app_start_spans(event);
-        span::normalize_dsc_for_event_spans(event, config.dsc, config.sampling_project_id);
         span::exclusive_time::compute_span_exclusive_time(event);
     }
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -179,6 +179,9 @@ pub struct NormalizationConfig<'a> {
 
     /// Dynamic sampling context
     pub dsc: Option<&'a DynamicSamplingContext>,
+
+    /// The identifier of the project where the trace originated.
+    pub sampling_project_id: Option<u64>,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -215,6 +218,7 @@ impl Default for NormalizationConfig<'_> {
             performance_issues_spans: Default::default(),
             derive_trace_id: Default::default(),
             dsc: None,
+            sampling_project_id: Default::default(),
         }
     }
 }
@@ -347,7 +351,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
         span::normalize_app_start_spans(event);
-        span::normalize_dsc_for_event_spans(event, config.dsc);
+        span::normalize_dsc_for_event_spans(event, config.dsc, config.sampling_project_id);
         span::exclusive_time::compute_span_exclusive_time(event);
     }
 

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -41,10 +41,10 @@ use crate::span::ai::enrich_ai_event_data;
 use crate::span::tag_extraction::{extract_segment_name_from_event, extract_span_tags_from_event};
 use crate::utils::{self, MAX_DURATION_MOBILE_MS, get_event_user_tag};
 use crate::{
-    BorrowedSpanOpDefaults, BreakdownsConfig, CombinedMeasurementsConfig,
-    DscNormalizationCommonProps, GeoIpLookup, MaxChars, ModelMetadata, PerformanceScoreConfig,
-    RawUserAgentInfo, SpanDescriptionRule, TransactionNameConfig, breakdowns, event_error, legacy,
-    mechanism, remove_other, schema, span, stacktrace, transactions, trimming, user_agent,
+    BorrowedSpanOpDefaults, BreakdownsConfig, CombinedMeasurementsConfig, EnrichedDsc, GeoIpLookup,
+    MaxChars, ModelMetadata, PerformanceScoreConfig, RawUserAgentInfo, SpanDescriptionRule,
+    TransactionNameConfig, breakdowns, event_error, legacy, mechanism, remove_other, schema, span,
+    stacktrace, transactions, trimming, user_agent,
 };
 
 /// Configuration for [`normalize_event`].
@@ -176,8 +176,8 @@ pub struct NormalizationConfig<'a> {
     /// Should add a random trace ID to events that lack one.
     pub derive_trace_id: bool,
 
-    /// Properties used for dsc span normalization.
-    pub dsc_normalization_props: Option<&'a DscNormalizationCommonProps<'a>>,
+    /// Dynamic sampling context and additional attributes used for dsc span normalization.
+    pub enriched_dsc: Option<&'a EnrichedDsc<'a>>,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -213,7 +213,7 @@ impl Default for NormalizationConfig<'_> {
             span_op_defaults: Default::default(),
             performance_issues_spans: Default::default(),
             derive_trace_id: Default::default(),
-            dsc_normalization_props: None,
+            enriched_dsc: None,
         }
     }
 }
@@ -345,7 +345,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts, event_id, config);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
-        span::normalize_dsc_for_event_spans(event, config.dsc_normalization_props);
+        span::normalize_dsc_for_event_spans(event, config.enriched_dsc);
         span::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
     }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -345,7 +345,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts, event_id, config);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
-        span::normalize_dsc_for_event_spans(event, config.dsc.as_ref());
+        span::normalize_dsc_for_event_spans(event, config.dsc);
         span::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
     }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -182,7 +182,7 @@ pub struct NormalizationConfig<'a> {
     pub dsc: Option<&'a DynamicSamplingContext>,
 
     /// The identifier of the project where the trace originated.
-    pub sampling_project_id: Option<&'a ProjectId>,
+    pub sampling_project_id: Option<ProjectId>,
 }
 
 impl Default for NormalizationConfig<'_> {

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -177,7 +177,7 @@ pub struct NormalizationConfig<'a> {
     pub derive_trace_id: bool,
 
     /// Dynamic sampling context and additional attributes used for dsc span normalization.
-    pub enriched_dsc: Option<&'a EnrichedDsc<'a>>,
+    pub dsc: Option<EnrichedDsc<'a>>,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -213,7 +213,7 @@ impl Default for NormalizationConfig<'_> {
             span_op_defaults: Default::default(),
             performance_issues_spans: Default::default(),
             derive_trace_id: Default::default(),
-            enriched_dsc: None,
+            dsc: None,
         }
     }
 }
@@ -345,7 +345,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts, event_id, config);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
-        span::normalize_dsc_for_event_spans(event, config.enriched_dsc);
+        span::normalize_dsc_for_event_spans(event, config.dsc.as_ref());
         span::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
     }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -13,7 +13,6 @@ use regex::Regex;
 use relay_base_schema::metrics::{
     DurationUnit, FractionUnit, MetricUnit, can_be_valid_metric_name,
 };
-use relay_base_schema::project::ProjectId;
 use relay_conventions::attributes::{
     APP__VITALS__START__COLD__VALUE, APP__VITALS__START__SCREEN, APP__VITALS__START__TYPE,
     APP__VITALS__START__VALUE, APP__VITALS__START__WARM__VALUE, SCORE__TOTAL,
@@ -34,7 +33,6 @@ use relay_protocol::{
     Annotated, Empty, Error, ErrorKind, FiniteF64, FromValue, Getter, Meta, Object, Remark,
     RemarkType, TryFromFloatError, Value,
 };
-use relay_sampling::DynamicSamplingContext;
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -178,11 +176,8 @@ pub struct NormalizationConfig<'a> {
     /// Should add a random trace ID to events that lack one.
     pub derive_trace_id: bool,
 
-    /// Dynamic sampling context.
-    pub dsc: Option<&'a DynamicSamplingContext>,
-
-    /// The identifier of the project where the trace originated.
-    pub sampling_project_id: Option<ProjectId>,
+    /// Properties used for dsc span normalization.
+    pub dsc_normalization_props: Option<&'a DscNormalizationCommonProps<'a>>,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -218,8 +213,7 @@ impl Default for NormalizationConfig<'_> {
             span_op_defaults: Default::default(),
             performance_issues_spans: Default::default(),
             derive_trace_id: Default::default(),
-            dsc: None,
-            sampling_project_id: None,
+            dsc_normalization_props: None,
         }
     }
 }
@@ -351,8 +345,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts, event_id, config);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
-        let dsc_props = DscNormalizationCommonProps::new(config.dsc, config.sampling_project_id);
-        span::normalize_dsc_for_event_spans(event, &dsc_props);
+        span::normalize_dsc_for_event_spans(event, config.dsc_normalization_props);
         span::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
     }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -13,6 +13,7 @@ use regex::Regex;
 use relay_base_schema::metrics::{
     DurationUnit, FractionUnit, MetricUnit, can_be_valid_metric_name,
 };
+use relay_base_schema::project::ProjectId;
 use relay_conventions::attributes::{
     APP__VITALS__START__COLD__VALUE, APP__VITALS__START__SCREEN, APP__VITALS__START__TYPE,
     APP__VITALS__START__VALUE, APP__VITALS__START__WARM__VALUE, SCORE__TOTAL,
@@ -141,7 +142,7 @@ pub struct NormalizationConfig<'a> {
     /// This is similar to `transaction_name_config`, but applies to span descriptions.
     pub span_description_rules: Option<&'a Vec<SpanDescriptionRule>>,
 
-    /// Configuration for generating performance score measurements for web vitals
+    /// Configuration for generating performance score measurements for web vitals.
     pub performance_score: Option<&'a PerformanceScoreConfig>,
 
     /// Metadata for AI models including costs and context size.
@@ -165,7 +166,7 @@ pub struct NormalizationConfig<'a> {
     /// It is persisted into the event payload for correlation.
     pub replay_id: Option<Uuid>,
 
-    /// Controls list of hosts to be excluded from scrubbing
+    /// Controls list of hosts to be excluded from scrubbing.
     pub span_allowed_hosts: &'a [String],
 
     /// Rules to infer `span.op` from other span fields.
@@ -177,11 +178,11 @@ pub struct NormalizationConfig<'a> {
     /// Should add a random trace ID to events that lack one.
     pub derive_trace_id: bool,
 
-    /// Dynamic sampling context
+    /// Dynamic sampling context.
     pub dsc: Option<&'a DynamicSamplingContext>,
 
     /// The identifier of the project where the trace originated.
-    pub sampling_project_id: Option<u64>,
+    pub sampling_project_id: Option<&'a ProjectId>,
 }
 
 impl Default for NormalizationConfig<'_> {
@@ -218,7 +219,7 @@ impl Default for NormalizationConfig<'_> {
             performance_issues_spans: Default::default(),
             derive_trace_id: Default::default(),
             dsc: None,
-            sampling_project_id: Default::default(),
+            sampling_project_id: None,
         }
     }
 }

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -366,19 +366,19 @@ pub struct ModelMetadataEntry {
     pub context_size: Option<u64>,
 }
 
-/// Parameters shared across dsc normalization functions.
+/// [`DynamicSamplingContext`] plus additional attributes used for dsc span normalization.
 #[derive(Debug, Clone)]
-pub struct DscNormalizationCommonProps<'a> {
+pub struct EnrichedDsc<'a> {
     /// Dynamic sampling context containing the trace id and root transaction that started the trace.
     pub dsc: &'a DynamicSamplingContext,
-    /// Id of the project where the trace originated.
+    /// ID of the project where the trace originated.
     pub sampling_project_id: ProjectId,
 }
 
-impl<'a> DscNormalizationCommonProps<'a> {
-    /// Creates a new [`DscNormalizationCommonProps`].
+impl<'a> EnrichedDsc<'a> {
+    /// Creates a new [`EnrichedDsc`].
     pub fn new(dsc: &'a DynamicSamplingContext, sampling_project_id: ProjectId) -> Self {
-        DscNormalizationCommonProps {
+        EnrichedDsc {
             dsc,
             sampling_project_id,
         }

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -367,19 +367,17 @@ pub struct ModelMetadataEntry {
 }
 
 /// Parameters shared across dsc normalization functions.
+#[derive(Debug, Clone)]
 pub struct DscNormalizationCommonProps<'a> {
     /// Dynamic sampling context containing the trace id and root transaction that started the trace.
-    pub dsc: Option<&'a DynamicSamplingContext>,
+    pub dsc: &'a DynamicSamplingContext,
     /// Id of the project where the trace originated.
-    pub sampling_project_id: Option<ProjectId>,
+    pub sampling_project_id: ProjectId,
 }
 
 impl<'a> DscNormalizationCommonProps<'a> {
     /// Creates a new [`DscNormalizationCommonProps`].
-    pub fn new(
-        dsc: Option<&'a DynamicSamplingContext>,
-        sampling_project_id: Option<ProjectId>,
-    ) -> Self {
+    pub fn new(dsc: &'a DynamicSamplingContext, sampling_project_id: ProjectId) -> Self {
         DscNormalizationCommonProps {
             dsc,
             sampling_project_id,

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -375,16 +375,6 @@ pub struct EnrichedDsc<'a> {
     pub sampling_project_id: ProjectId,
 }
 
-impl<'a> EnrichedDsc<'a> {
-    /// Creates a new [`EnrichedDsc`].
-    pub fn new(dsc: &'a DynamicSamplingContext, sampling_project_id: ProjectId) -> Self {
-        EnrichedDsc {
-            dsc,
-            sampling_project_id,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -367,7 +367,7 @@ pub struct ModelMetadataEntry {
 }
 
 /// [`DynamicSamplingContext`] plus additional attributes used for dsc span normalization.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct EnrichedDsc<'a> {
     /// Dynamic sampling context containing the trace id and root transaction that started the trace.
     pub dsc: &'a DynamicSamplingContext,

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -3,9 +3,11 @@ use std::{collections::HashMap, sync::LazyLock};
 
 use regex::Regex;
 use relay_base_schema::metrics::MetricUnit;
+use relay_base_schema::project::ProjectId;
 use relay_event_schema::protocol::VALID_PLATFORMS;
 use relay_pattern::Pattern;
 use relay_protocol::{FiniteF64, RuleCondition};
+use relay_sampling::DynamicSamplingContext;
 use serde::{Deserialize, Serialize};
 
 pub mod breakdowns;
@@ -362,6 +364,27 @@ pub struct ModelMetadataEntry {
     /// The context window size in tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_size: Option<u64>,
+}
+
+/// Parameters shared across dsc normalization functions.
+pub struct DscNormalizationCommonProps<'a> {
+    /// Dynamic sampling context containing the trace id and root transaction that started the trace.
+    pub dsc: Option<&'a DynamicSamplingContext>,
+    /// Id of the project where the trace originated.
+    pub sampling_project_id: Option<ProjectId>,
+}
+
+impl<'a> DscNormalizationCommonProps<'a> {
+    /// Creates a new [`DscNormalizationCommonProps`].
+    pub fn new(
+        dsc: Option<&'a DynamicSamplingContext>,
+        sampling_project_id: Option<ProjectId>,
+    ) -> Self {
+        DscNormalizationCommonProps {
+            dsc,
+            sampling_project_id,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -6,7 +6,7 @@ use relay_event_schema::protocol::{Event, SpanData, TraceContext};
 use relay_protocol::{Annotated, Value};
 use std::sync::LazyLock;
 
-use crate::DscNormalizationCommonProps;
+use crate::EnrichedDsc;
 
 pub mod ai;
 pub mod country_subregion;
@@ -62,17 +62,14 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-pub fn normalize_dsc_for_event_spans(
-    event: &mut Event,
-    props: Option<&DscNormalizationCommonProps>,
-) {
+pub fn normalize_dsc_for_event_spans(event: &mut Event, enriched_dsc: Option<&EnrichedDsc>) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
-        normalize_dsc_for_span_data(&mut ctx.data, props);
+        normalize_dsc_for_span_data(&mut ctx.data, enriched_dsc);
     }
     if let Some(spans) = event.spans.value_mut() {
         for span in spans {
             if let Some(span) = span.value_mut() {
-                normalize_dsc_for_span_data(&mut span.data, props);
+                normalize_dsc_for_span_data(&mut span.data, enriched_dsc);
             }
         }
     }
@@ -83,9 +80,11 @@ pub fn normalize_dsc_for_event_spans(
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
-    props: Option<&DscNormalizationCommonProps>,
+    enriched_dsc: Option<&EnrichedDsc>,
 ) {
-    let Some(props) = props else { return };
+    let Some(enriched_dsc) = enriched_dsc else {
+        return;
+    };
 
     let data = span_data.get_or_insert_with(SpanData::default);
     if data.other.contains_key(SENTRY__DSC__TRACE_ID) {
@@ -93,10 +92,10 @@ pub fn normalize_dsc_for_span_data(
     }
     data.other.insert(
         SENTRY__DSC__TRACE_ID.to_owned(),
-        Annotated::new(Value::String(props.dsc.trace_id.to_string())),
+        Annotated::new(Value::String(enriched_dsc.dsc.trace_id.to_string())),
     );
 
-    if let Some(transaction) = &props.dsc.transaction {
+    if let Some(transaction) = &enriched_dsc.dsc.transaction {
         data.other.insert(
             SENTRY__DSC__TRANSACTION.to_owned(),
             Annotated::new(Value::String(transaction.clone())),
@@ -104,6 +103,6 @@ pub fn normalize_dsc_for_span_data(
     }
     data.other.insert(
         SENTRY__DSC__PROJECT_ID.to_owned(),
-        Annotated::new(Value::String(props.sampling_project_id.to_string())),
+        Annotated::new(Value::String(enriched_dsc.sampling_project_id.to_string())),
     );
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,6 +1,7 @@
 //! Span normalization logic.
 
 use regex::Regex;
+use relay_base_schema::project::ProjectId;
 use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Event, SpanData, TraceContext};
 use relay_protocol::{Annotated, Value};
@@ -64,7 +65,7 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 pub fn normalize_dsc_for_event_spans(
     event: &mut Event,
     dsc: Option<&DynamicSamplingContext>,
-    project_id: Option<u64>,
+    project_id: Option<&ProjectId>,
 ) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
         normalize_dsc_for_span_data(&mut ctx.data, dsc, project_id);
@@ -84,7 +85,7 @@ pub fn normalize_dsc_for_event_spans(
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
     dsc: Option<&DynamicSamplingContext>,
-    project_id: Option<u64>,
+    project_id: Option<&ProjectId>,
 ) {
     let Some(dsc) = dsc else { return };
 
@@ -106,7 +107,7 @@ pub fn normalize_dsc_for_span_data(
     if let Some(project_id) = project_id {
         data.other.insert(
             SENTRY__DSC__PROJECT_ID.to_owned(),
-            Annotated::new(Value::U64(project_id)),
+            Annotated::new(Value::U64(project_id.value())),
         );
     }
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,7 +1,7 @@
 //! Span normalization logic.
 
 use regex::Regex;
-use relay_conventions::attributes::{SENTRY__DSC__TRACE_ID, SENTRY__DSC__TRANSACTION};
+use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Event, SpanData, TraceContext};
 use relay_protocol::{Annotated, Value};
 use relay_sampling::DynamicSamplingContext;
@@ -61,14 +61,18 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&DynamicSamplingContext>) {
+pub fn normalize_dsc_for_event_spans(
+    event: &mut Event,
+    dsc: Option<&DynamicSamplingContext>,
+    project_id: Option<u64>,
+) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
-        normalize_dsc_for_span_data(&mut ctx.data, dsc);
+        normalize_dsc_for_span_data(&mut ctx.data, dsc, project_id);
     }
     if let Some(spans) = event.spans.value_mut() {
         for span in spans {
             if let Some(span) = span.value_mut() {
-                normalize_dsc_for_span_data(&mut span.data, dsc);
+                normalize_dsc_for_span_data(&mut span.data, dsc, project_id);
             }
         }
     }
@@ -80,6 +84,7 @@ pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&DynamicSamp
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
     dsc: Option<&DynamicSamplingContext>,
+    project_id: Option<u64>,
 ) {
     let Some(dsc) = dsc else { return };
 
@@ -96,6 +101,12 @@ pub fn normalize_dsc_for_span_data(
         data.other.insert(
             SENTRY__DSC__TRANSACTION.to_owned(),
             Annotated::new(Value::String(transaction.clone())),
+        );
+    }
+    if let Some(project_id) = project_id {
+        data.other.insert(
+            SENTRY__DSC__PROJECT_ID.to_owned(),
+            Annotated::new(Value::U64(project_id)),
         );
     }
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -62,18 +62,20 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
+///
+/// `sampling_project_id` is the id of the project where the trace originated.
 pub fn normalize_dsc_for_event_spans(
     event: &mut Event,
     dsc: Option<&DynamicSamplingContext>,
-    project_id: Option<&ProjectId>,
+    sampling_project_id: Option<ProjectId>,
 ) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
-        normalize_dsc_for_span_data(&mut ctx.data, dsc, project_id);
+        normalize_dsc_for_span_data(&mut ctx.data, dsc, sampling_project_id);
     }
     if let Some(spans) = event.spans.value_mut() {
         for span in spans {
             if let Some(span) = span.value_mut() {
-                normalize_dsc_for_span_data(&mut span.data, dsc, project_id);
+                normalize_dsc_for_span_data(&mut span.data, dsc, sampling_project_id);
             }
         }
     }
@@ -82,10 +84,12 @@ pub fn normalize_dsc_for_event_spans(
 /// Writes DSC attributes needed for dynamic sampling into `span_data`.
 ///
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
+///
+/// `sampling_project_id` is the id of the project where the trace originated.
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
     dsc: Option<&DynamicSamplingContext>,
-    project_id: Option<&ProjectId>,
+    sampling_project_id: Option<ProjectId>,
 ) {
     let Some(dsc) = dsc else { return };
 
@@ -104,7 +108,7 @@ pub fn normalize_dsc_for_span_data(
             Annotated::new(Value::String(transaction.clone())),
         );
     }
-    if let Some(project_id) = project_id {
+    if let Some(project_id) = sampling_project_id {
         data.other.insert(
             SENTRY__DSC__PROJECT_ID.to_owned(),
             Annotated::new(Value::U64(project_id.value())),

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -62,14 +62,14 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-pub fn normalize_dsc_for_event_spans(event: &mut Event, enriched_dsc: Option<&EnrichedDsc>) {
+pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&EnrichedDsc>) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
-        normalize_dsc_for_span_data(&mut ctx.data, enriched_dsc);
+        normalize_dsc_for_span_data(&mut ctx.data, dsc);
     }
     if let Some(spans) = event.spans.value_mut() {
         for span in spans {
             if let Some(span) = span.value_mut() {
-                normalize_dsc_for_span_data(&mut span.data, enriched_dsc);
+                normalize_dsc_for_span_data(&mut span.data, dsc);
             }
         }
     }
@@ -78,11 +78,8 @@ pub fn normalize_dsc_for_event_spans(event: &mut Event, enriched_dsc: Option<&En
 /// Writes DSC attributes needed for dynamic sampling into `span_data`.
 ///
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
-pub fn normalize_dsc_for_span_data(
-    span_data: &mut Annotated<SpanData>,
-    enriched_dsc: Option<&EnrichedDsc>,
-) {
-    let Some(enriched_dsc) = enriched_dsc else {
+pub fn normalize_dsc_for_span_data(span_data: &mut Annotated<SpanData>, dsc: Option<&EnrichedDsc>) {
+    let Some(dsc) = dsc else {
         return;
     };
 
@@ -92,10 +89,10 @@ pub fn normalize_dsc_for_span_data(
     }
     data.other.insert(
         SENTRY__DSC__TRACE_ID.to_owned(),
-        Annotated::new(Value::String(enriched_dsc.dsc.trace_id.to_string())),
+        Annotated::new(Value::String(dsc.dsc.trace_id.to_string())),
     );
 
-    if let Some(transaction) = &enriched_dsc.dsc.transaction {
+    if let Some(transaction) = &dsc.dsc.transaction {
         data.other.insert(
             SENTRY__DSC__TRANSACTION.to_owned(),
             Annotated::new(Value::String(transaction.clone())),
@@ -103,6 +100,6 @@ pub fn normalize_dsc_for_span_data(
     }
     data.other.insert(
         SENTRY__DSC__PROJECT_ID.to_owned(),
-        Annotated::new(Value::String(enriched_dsc.sampling_project_id.to_string())),
+        Annotated::new(Value::String(dsc.sampling_project_id.to_string())),
     );
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -62,7 +62,10 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-pub fn normalize_dsc_for_event_spans(event: &mut Event, props: &DscNormalizationCommonProps) {
+pub fn normalize_dsc_for_event_spans(
+    event: &mut Event,
+    props: Option<&DscNormalizationCommonProps>,
+) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
         normalize_dsc_for_span_data(&mut ctx.data, props);
     }
@@ -80,9 +83,9 @@ pub fn normalize_dsc_for_event_spans(event: &mut Event, props: &DscNormalization
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
-    props: &DscNormalizationCommonProps,
+    props: Option<&DscNormalizationCommonProps>,
 ) {
-    let Some(dsc) = props.dsc else { return };
+    let Some(props) = props else { return };
 
     let data = span_data.get_or_insert_with(SpanData::default);
     if data.other.contains_key(SENTRY__DSC__TRACE_ID) {
@@ -90,19 +93,17 @@ pub fn normalize_dsc_for_span_data(
     }
     data.other.insert(
         SENTRY__DSC__TRACE_ID.to_owned(),
-        Annotated::new(Value::String(dsc.trace_id.to_string())),
+        Annotated::new(Value::String(props.dsc.trace_id.to_string())),
     );
 
-    if let Some(transaction) = &dsc.transaction {
+    if let Some(transaction) = &props.dsc.transaction {
         data.other.insert(
             SENTRY__DSC__TRANSACTION.to_owned(),
             Annotated::new(Value::String(transaction.clone())),
         );
     }
-    if let Some(project_id) = props.sampling_project_id {
-        data.other.insert(
-            SENTRY__DSC__PROJECT_ID.to_owned(),
-            Annotated::new(Value::String(project_id.to_string())),
-        );
-    }
+    data.other.insert(
+        SENTRY__DSC__PROJECT_ID.to_owned(),
+        Annotated::new(Value::String(props.sampling_project_id.to_string())),
+    );
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -62,7 +62,7 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&EnrichedDsc>) {
+pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<EnrichedDsc>) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
         normalize_dsc_for_span_data(&mut ctx.data, dsc);
     }
@@ -78,7 +78,7 @@ pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&EnrichedDsc
 /// Writes DSC attributes needed for dynamic sampling into `span_data`.
 ///
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
-pub fn normalize_dsc_for_span_data(span_data: &mut Annotated<SpanData>, dsc: Option<&EnrichedDsc>) {
+pub fn normalize_dsc_for_span_data(span_data: &mut Annotated<SpanData>, dsc: Option<EnrichedDsc>) {
     let Some(dsc) = dsc else {
         return;
     };

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,12 +1,12 @@
 //! Span normalization logic.
 
 use regex::Regex;
-use relay_base_schema::project::ProjectId;
 use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Event, SpanData, TraceContext};
 use relay_protocol::{Annotated, Value};
-use relay_sampling::DynamicSamplingContext;
 use std::sync::LazyLock;
+
+use crate::DscNormalizationCommonProps;
 
 pub mod ai;
 pub mod country_subregion;
@@ -62,20 +62,14 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-///
-/// `sampling_project_id` is the id of the project where the trace originated.
-pub fn normalize_dsc_for_event_spans(
-    event: &mut Event,
-    dsc: Option<&DynamicSamplingContext>,
-    sampling_project_id: Option<ProjectId>,
-) {
+pub fn normalize_dsc_for_event_spans(event: &mut Event, props: &DscNormalizationCommonProps) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
-        normalize_dsc_for_span_data(&mut ctx.data, dsc, sampling_project_id);
+        normalize_dsc_for_span_data(&mut ctx.data, props);
     }
     if let Some(spans) = event.spans.value_mut() {
         for span in spans {
             if let Some(span) = span.value_mut() {
-                normalize_dsc_for_span_data(&mut span.data, dsc, sampling_project_id);
+                normalize_dsc_for_span_data(&mut span.data, props);
             }
         }
     }
@@ -84,14 +78,11 @@ pub fn normalize_dsc_for_event_spans(
 /// Writes DSC attributes needed for dynamic sampling into `span_data`.
 ///
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
-///
-/// `sampling_project_id` is the id of the project where the trace originated.
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
-    dsc: Option<&DynamicSamplingContext>,
-    sampling_project_id: Option<ProjectId>,
+    props: &DscNormalizationCommonProps,
 ) {
-    let Some(dsc) = dsc else { return };
+    let Some(dsc) = props.dsc else { return };
 
     let data = span_data.get_or_insert_with(SpanData::default);
     if data.other.contains_key(SENTRY__DSC__TRACE_ID) {
@@ -108,7 +99,7 @@ pub fn normalize_dsc_for_span_data(
             Annotated::new(Value::String(transaction.clone())),
         );
     }
-    if let Some(project_id) = sampling_project_id {
+    if let Some(project_id) = props.sampling_project_id {
         data.other.insert(
             SENTRY__DSC__PROJECT_ID.to_owned(),
             Annotated::new(Value::U64(project_id.value())),

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -2,7 +2,6 @@
 
 use crate::services::processor::ProcessingError;
 use chrono::{DateTime, Utc};
-use relay_base_schema::project::ProjectId;
 use relay_event_normalization::DscNormalizationCommonProps;
 use relay_event_normalization::span::{self, ai};
 use relay_event_normalization::{
@@ -16,7 +15,6 @@ use relay_event_schema::processor::{ProcessingState, process_value};
 use relay_event_schema::protocol::{BrowserContext, EventId, IpAddr, Span, SpanData};
 use relay_metrics::UnixTimestamp;
 use relay_protocol::{Annotated, Empty, Value};
-use relay_sampling::DynamicSamplingContext;
 
 /// Config needed to normalize a standalone span.
 #[derive(Clone, Debug)]
@@ -58,10 +56,8 @@ pub struct NormalizeSpanConfig<'a> {
     /// An initialized GeoIP lookup.
     pub geo_lookup: &'a GeoIpLookup,
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
-    /// Dynamic sampling context from the envelope headers.
-    pub dsc: Option<&'a DynamicSamplingContext>,
-    /// Project ID of the project that started the trace.
-    pub sampling_project_id: Option<ProjectId>,
+    /// Properties used for dsc span normalization.
+    pub dsc_normalization_props: Option<&'a DscNormalizationCommonProps<'a>>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -115,8 +111,7 @@ pub fn normalize(
         client_ip,
         geo_lookup,
         span_op_defaults,
-        dsc,
-        sampling_project_id,
+        dsc_normalization_props,
     } = config;
 
     set_segment_attributes(annotated_span);
@@ -216,8 +211,7 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    let dsc_normalization_props = &DscNormalizationCommonProps::new(*dsc, *sampling_project_id);
-    span::normalize_dsc_for_span_data(&mut span.data, dsc_normalization_props);
+    span::normalize_dsc_for_span_data(&mut span.data, *dsc_normalization_props);
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 
@@ -560,8 +554,7 @@ mod tests {
             client_ip: Some(IpAddr("2.125.160.216".to_owned())),
             geo_lookup: &GEO_LOOKUP,
             span_op_defaults: Default::default(),
-            dsc: None,
-            sampling_project_id: None,
+            dsc_normalization_props: None,
         }
     }
 

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -60,7 +60,7 @@ pub struct NormalizeSpanConfig<'a> {
     /// Dynamic sampling context from the envelope headers.
     pub dsc: Option<&'a DynamicSamplingContext>,
     /// Project ID of the project that started the trace.
-    pub sampling_project_id: Option<ProjectId>,
+    pub sampling_project_id: Option<&'a ProjectId>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -215,7 +215,7 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    span::normalize_dsc_for_span_data(&mut span.data, *dsc, sampling_project_id.map(|p| p.value()));
+    span::normalize_dsc_for_span_data(&mut span.data, *dsc, *sampling_project_id);
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -57,7 +57,7 @@ pub struct NormalizeSpanConfig<'a> {
     pub geo_lookup: &'a GeoIpLookup,
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
     /// Dynamic sampling context plus additional attributes used for dsc span normalization.
-    pub enriched_dsc: Option<&'a EnrichedDsc<'a>>,
+    pub dsc: Option<EnrichedDsc<'a>>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -111,7 +111,7 @@ pub fn normalize(
         client_ip,
         geo_lookup,
         span_op_defaults,
-        enriched_dsc,
+        dsc,
     } = config;
 
     set_segment_attributes(annotated_span);
@@ -211,7 +211,7 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    span::normalize_dsc_for_span_data(&mut span.data, *enriched_dsc);
+    span::normalize_dsc_for_span_data(&mut span.data, dsc.as_ref());
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 
@@ -554,7 +554,7 @@ mod tests {
             client_ip: Some(IpAddr("2.125.160.216".to_owned())),
             geo_lookup: &GEO_LOOKUP,
             span_op_defaults: Default::default(),
-            enriched_dsc: None,
+            dsc: None,
         }
     }
 

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -211,7 +211,7 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    span::normalize_dsc_for_span_data(&mut span.data, dsc.as_ref());
+    span::normalize_dsc_for_span_data(&mut span.data, *dsc);
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -3,6 +3,7 @@
 use crate::services::processor::ProcessingError;
 use chrono::{DateTime, Utc};
 use relay_base_schema::project::ProjectId;
+use relay_event_normalization::DscNormalizationCommonProps;
 use relay_event_normalization::span::{self, ai};
 use relay_event_normalization::{
     BorrowedSpanOpDefaults, ClientHints, CombinedMeasurementsConfig, FromUserAgentInfo,
@@ -215,7 +216,8 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    span::normalize_dsc_for_span_data(&mut span.data, *dsc, *sampling_project_id);
+    let dsc_normalization_props = &DscNormalizationCommonProps::new(*dsc, *sampling_project_id);
+    span::normalize_dsc_for_span_data(&mut span.data, dsc_normalization_props);
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -2,7 +2,7 @@
 
 use crate::services::processor::ProcessingError;
 use chrono::{DateTime, Utc};
-use relay_event_normalization::DscNormalizationCommonProps;
+use relay_event_normalization::EnrichedDsc;
 use relay_event_normalization::span::{self, ai};
 use relay_event_normalization::{
     BorrowedSpanOpDefaults, ClientHints, CombinedMeasurementsConfig, FromUserAgentInfo,
@@ -56,8 +56,8 @@ pub struct NormalizeSpanConfig<'a> {
     /// An initialized GeoIP lookup.
     pub geo_lookup: &'a GeoIpLookup,
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
-    /// Properties used for dsc span normalization.
-    pub dsc_normalization_props: Option<&'a DscNormalizationCommonProps<'a>>,
+    /// Dynamic sampling context plus additional attributes used for dsc span normalization.
+    pub enriched_dsc: Option<&'a EnrichedDsc<'a>>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -111,7 +111,7 @@ pub fn normalize(
         client_ip,
         geo_lookup,
         span_op_defaults,
-        dsc_normalization_props,
+        enriched_dsc,
     } = config;
 
     set_segment_attributes(annotated_span);
@@ -211,7 +211,7 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    span::normalize_dsc_for_span_data(&mut span.data, *dsc_normalization_props);
+    span::normalize_dsc_for_span_data(&mut span.data, *enriched_dsc);
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 
@@ -554,7 +554,7 @@ mod tests {
             client_ip: Some(IpAddr("2.125.160.216".to_owned())),
             geo_lookup: &GEO_LOOKUP,
             span_op_defaults: Default::default(),
-            dsc_normalization_props: None,
+            enriched_dsc: None,
         }
     }
 

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -60,7 +60,7 @@ pub struct NormalizeSpanConfig<'a> {
     /// Dynamic sampling context from the envelope headers.
     pub dsc: Option<&'a DynamicSamplingContext>,
     /// Project ID of the project that started the trace.
-    pub sampling_project_id: Option<&'a ProjectId>,
+    pub sampling_project_id: Option<ProjectId>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -2,6 +2,7 @@
 
 use crate::services::processor::ProcessingError;
 use chrono::{DateTime, Utc};
+use relay_base_schema::project::ProjectId;
 use relay_event_normalization::span::{self, ai};
 use relay_event_normalization::{
     BorrowedSpanOpDefaults, ClientHints, CombinedMeasurementsConfig, FromUserAgentInfo,
@@ -58,6 +59,8 @@ pub struct NormalizeSpanConfig<'a> {
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
     /// Dynamic sampling context from the envelope headers.
     pub dsc: Option<&'a DynamicSamplingContext>,
+    /// Project ID of the project that started the trace.
+    pub sampling_project_id: Option<ProjectId>,
 }
 
 fn set_segment_attributes(span: &mut Annotated<Span>) {
@@ -112,6 +115,7 @@ pub fn normalize(
         geo_lookup,
         span_op_defaults,
         dsc,
+        sampling_project_id,
     } = config;
 
     set_segment_attributes(annotated_span);
@@ -211,7 +215,7 @@ pub fn normalize(
 
     normalize_performance_score(span, *performance_score);
 
-    span::normalize_dsc_for_span_data(&mut span.data, *dsc);
+    span::normalize_dsc_for_span_data(&mut span.data, *dsc, sampling_project_id.map(|p| p.value()));
 
     ai::enrich_ai_span(span, *ai_model_metadata);
 
@@ -555,6 +559,7 @@ mod tests {
             geo_lookup: &GEO_LOOKUP,
             span_op_defaults: Default::default(),
             dsc: None,
+            sampling_project_id: None,
         }
     }
 

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -46,8 +46,11 @@ pub fn normalize(
 ) {
     let aggregator_config = ctx.config.aggregator_config_for(MetricNamespace::Spans);
     let model_data = ctx.global_config.ai_model_metadata();
+    let sampling_project_id = ctx
+        .sampling_project_info
+        .and_then(|p| p.project_id)
+        .or(ctx.project_info.project_id);
     let dsc = spans.headers.dsc().cloned();
-    let sampling_project_id = ctx.sampling_project_info.and_then(|p| p.project_id);
     let dsc = dsc
         .as_ref()
         .zip(sampling_project_id)

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -47,11 +47,14 @@ pub fn normalize(
     let aggregator_config = ctx.config.aggregator_config_for(MetricNamespace::Spans);
     let model_data = ctx.global_config.ai_model_metadata();
     let dsc = spans.headers.dsc().cloned();
-    let dsc = dsc.as_ref();
     let sampling_project_id = ctx.sampling_project_info.and_then(|p| p.project_id);
-    let enriched_dsc = dsc
+    let dsc = dsc
+        .as_ref()
         .zip(sampling_project_id)
-        .map(|(d, s)| EnrichedDsc::new(d, s));
+        .map(|(dsc, sampling_project_id)| EnrichedDsc {
+            dsc,
+            sampling_project_id,
+        });
     let norm = normalize::NormalizeSpanConfig {
         received_at: spans.received_at(),
         timestamp_range: aggregator_config.timestamp_range(),
@@ -73,7 +76,7 @@ pub fn normalize(
         client_ip: spans.headers.meta().client_addr().map(Into::into),
         geo_lookup,
         span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
-        enriched_dsc: enriched_dsc.as_ref(),
+        dsc,
     };
 
     spans.retain(

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -67,9 +67,7 @@ pub fn normalize(
         geo_lookup,
         span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
         dsc: dsc.as_ref(),
-        sampling_project_id: ctx
-            .sampling_project_info
-            .and_then(|p| p.project_id.as_ref()),
+        sampling_project_id: ctx.sampling_project_info.and_then(|p| p.project_id),
     };
 
     spans.retain(

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -67,7 +67,9 @@ pub fn normalize(
         geo_lookup,
         span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
         dsc: dsc.as_ref(),
-        sampling_project_id: ctx.sampling_project_info.and_then(|p| p.project_id),
+        sampling_project_id: ctx
+            .sampling_project_info
+            .and_then(|p| p.project_id.as_ref()),
     };
 
     spans.retain(

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -67,6 +67,7 @@ pub fn normalize(
         geo_lookup,
         span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
         dsc: dsc.as_ref(),
+        sampling_project_id: ctx.sampling_project_info.and_then(|p| p.project_id),
     };
 
     spans.retain(

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -1,5 +1,5 @@
 use relay_event_normalization::{
-    CombinedMeasurementsConfig, DscNormalizationCommonProps, GeoIpLookup, MeasurementsConfig,
+    CombinedMeasurementsConfig, EnrichedDsc, GeoIpLookup, MeasurementsConfig,
 };
 use relay_event_schema::processor::{ProcessingAction, ProcessingState, process_value};
 use relay_event_schema::protocol::Span;
@@ -49,9 +49,9 @@ pub fn normalize(
     let dsc = spans.headers.dsc().cloned();
     let dsc = dsc.as_ref();
     let sampling_project_id = ctx.sampling_project_info.and_then(|p| p.project_id);
-    let dsc_normalization_props = dsc
+    let enriched_dsc = dsc
         .zip(sampling_project_id)
-        .map(|(d, s)| DscNormalizationCommonProps::new(d, s));
+        .map(|(d, s)| EnrichedDsc::new(d, s));
     let norm = normalize::NormalizeSpanConfig {
         received_at: spans.received_at(),
         timestamp_range: aggregator_config.timestamp_range(),
@@ -73,7 +73,7 @@ pub fn normalize(
         client_ip: spans.headers.meta().client_addr().map(Into::into),
         geo_lookup,
         span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
-        dsc_normalization_props: dsc_normalization_props.as_ref(),
+        enriched_dsc: enriched_dsc.as_ref(),
     };
 
     spans.retain(

--- a/relay-server/src/processing/legacy_spans/process.rs
+++ b/relay-server/src/processing/legacy_spans/process.rs
@@ -1,4 +1,6 @@
-use relay_event_normalization::{CombinedMeasurementsConfig, GeoIpLookup, MeasurementsConfig};
+use relay_event_normalization::{
+    CombinedMeasurementsConfig, DscNormalizationCommonProps, GeoIpLookup, MeasurementsConfig,
+};
 use relay_event_schema::processor::{ProcessingAction, ProcessingState, process_value};
 use relay_event_schema::protocol::Span;
 use relay_metrics::MetricNamespace;
@@ -45,6 +47,11 @@ pub fn normalize(
     let aggregator_config = ctx.config.aggregator_config_for(MetricNamespace::Spans);
     let model_data = ctx.global_config.ai_model_metadata();
     let dsc = spans.headers.dsc().cloned();
+    let dsc = dsc.as_ref();
+    let sampling_project_id = ctx.sampling_project_info.and_then(|p| p.project_id);
+    let dsc_normalization_props = dsc
+        .zip(sampling_project_id)
+        .map(|(d, s)| DscNormalizationCommonProps::new(d, s));
     let norm = normalize::NormalizeSpanConfig {
         received_at: spans.received_at(),
         timestamp_range: aggregator_config.timestamp_range(),
@@ -66,8 +73,7 @@ pub fn normalize(
         client_ip: spans.headers.meta().client_addr().map(Into::into),
         geo_lookup,
         span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
-        dsc: dsc.as_ref(),
-        sampling_project_id: ctx.sampling_project_info.and_then(|p| p.project_id),
+        dsc_normalization_props: dsc_normalization_props.as_ref(),
     };
 
     spans.retain(

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -225,7 +225,12 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(&mut span.attributes, &span.is_segment, dsc);
+        eap::normalize_dsc(
+            &mut span.attributes,
+            &span.is_segment,
+            dsc,
+            ctx.sampling_project_info.and_then(|p| p.project_id),
+        );
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -229,7 +229,8 @@ fn normalize_span(
             &mut span.attributes,
             &span.is_segment,
             dsc,
-            ctx.sampling_project_info.and_then(|p| p.project_id),
+            ctx.sampling_project_info
+                .and_then(|p| p.project_id.as_ref()),
         );
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use relay_event_normalization::eap::ClientUserAgentInfo;
-use relay_event_normalization::{GeoIpLookup, RequiredMode, SchemaProcessor, eap};
+use relay_event_normalization::{
+    DscNormalizationCommonProps, GeoIpLookup, RequiredMode, SchemaProcessor, eap,
+};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
 use relay_event_schema::protocol::{Span, SpanId, SpanV2};
 use relay_protocol::Annotated;
@@ -199,7 +201,10 @@ fn normalize_span(
     );
 
     if let Some(span) = span.value_mut() {
-        let dsc = headers.dsc();
+        let dsc_props = DscNormalizationCommonProps::new(
+            headers.dsc(),
+            ctx.sampling_project_info.and_then(|p| p.project_id),
+        );
         let duration = span_duration(span);
         let allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
         let model_metdata = ctx.global_config.ai_model_metadata();
@@ -225,12 +230,7 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(
-            &mut span.attributes,
-            &span.is_segment,
-            dsc,
-            ctx.sampling_project_info.and_then(|p| p.project_id),
-        );
+        eap::normalize_dsc(&mut span.attributes, &span.is_segment, &dsc_props);
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -211,6 +211,7 @@ fn normalize_span(
             .dsc()
             .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
             .map(|(d, s)| EnrichedDsc::new(d, s));
+        let enriched_dsc = enriched_dsc.as_ref();
         let duration = span_duration(span);
         let allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
         let model_metdata = ctx.global_config.ai_model_metadata();
@@ -236,11 +237,7 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(
-            &mut span.attributes,
-            &span.is_segment,
-            enriched_dsc.as_ref(),
-        );
+        eap::normalize_dsc(&mut span.attributes, &span.is_segment, enriched_dsc);
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 
 use relay_dynamic_config::Feature;
 use relay_event_normalization::eap::ClientUserAgentInfo;
-use relay_event_normalization::{
-    DscNormalizationCommonProps, GeoIpLookup, RequiredMode, SchemaProcessor, eap,
-};
+use relay_event_normalization::{EnrichedDsc, GeoIpLookup, RequiredMode, SchemaProcessor, eap};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
 use relay_event_schema::protocol::{Span, SpanId, SpanV2};
 use relay_protocol::Annotated;
@@ -209,10 +207,10 @@ fn normalize_span(
     );
 
     if let Some(span) = span.value_mut() {
-        let dsc_props = headers
+        let enriched_dsc = headers
             .dsc()
             .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
-            .map(|(d, s)| DscNormalizationCommonProps::new(d, s));
+            .map(|(d, s)| EnrichedDsc::new(d, s));
         let duration = span_duration(span);
         let allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
         let model_metdata = ctx.global_config.ai_model_metadata();
@@ -238,7 +236,11 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(&mut span.attributes, &span.is_segment, dsc_props.as_ref());
+        eap::normalize_dsc(
+            &mut span.attributes,
+            &span.is_segment,
+            enriched_dsc.as_ref(),
+        );
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -207,11 +207,13 @@ fn normalize_span(
     );
 
     if let Some(span) = span.value_mut() {
-        let enriched_dsc = headers
+        let dsc = headers
             .dsc()
             .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
-            .map(|(d, s)| EnrichedDsc::new(d, s));
-        let enriched_dsc = enriched_dsc.as_ref();
+            .map(|(dsc, sampling_project_id)| EnrichedDsc {
+                dsc,
+                sampling_project_id,
+            });
         let duration = span_duration(span);
         let allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
         let model_metdata = ctx.global_config.ai_model_metadata();
@@ -237,7 +239,7 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(&mut span.attributes, &span.is_segment, enriched_dsc);
+        eap::normalize_dsc(&mut span.attributes, &span.is_segment, dsc.as_ref());
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -229,8 +229,7 @@ fn normalize_span(
             &mut span.attributes,
             &span.is_segment,
             dsc,
-            ctx.sampling_project_info
-                .and_then(|p| p.project_id.as_ref()),
+            ctx.sampling_project_info.and_then(|p| p.project_id),
         );
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -243,7 +243,7 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(&mut span.attributes, &span.is_segment, dsc.as_ref());
+        eap::normalize_dsc(&mut span.attributes, &span.is_segment, dsc);
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -209,10 +209,10 @@ fn normalize_span(
     );
 
     if let Some(span) = span.value_mut() {
-        let dsc_props = DscNormalizationCommonProps::new(
-            headers.dsc(),
-            ctx.sampling_project_info.and_then(|p| p.project_id),
-        );
+        let dsc_props = headers
+            .dsc()
+            .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
+            .map(|(d, s)| DscNormalizationCommonProps::new(d, s));
         let duration = span_duration(span);
         let allowed_hosts = ctx.global_config.options.http_span_allowed_hosts.as_slice();
         let model_metdata = ctx.global_config.ai_model_metadata();
@@ -238,7 +238,7 @@ fn normalize_span(
         }
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
-        eap::normalize_dsc(&mut span.attributes, &span.is_segment, &dsc_props);
+        eap::normalize_dsc(&mut span.attributes, &span.is_segment, dsc_props.as_ref());
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -207,9 +207,13 @@ fn normalize_span(
     );
 
     if let Some(span) = span.value_mut() {
+        let sampling_project_id = ctx
+            .sampling_project_info
+            .and_then(|p| p.project_id)
+            .or(ctx.project_info.project_id);
         let dsc = headers
             .dsc()
-            .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
+            .zip(sampling_project_id)
             .map(|(dsc, sampling_project_id)| EnrichedDsc {
                 dsc,
                 sampling_project_id,

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -251,9 +251,13 @@ pub fn normalize(
             );
         }
 
+        let sampling_project_id = ctx
+            .sampling_project_info
+            .and_then(|p| p.project_id)
+            .or(ctx.project_info.project_id);
         let dsc = headers
             .dsc()
-            .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
+            .zip(sampling_project_id)
             .map(|(dsc, sampling_project_id)| EnrichedDsc {
                 dsc,
                 sampling_project_id,

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -303,9 +303,7 @@ pub fn normalize(
                 .has_feature(Feature::PerformanceIssuesSpans),
             derive_trace_id: project_info.has_feature(Feature::AddDefaultTraceID),
             dsc: headers.dsc(),
-            sampling_project_id: ctx
-                .sampling_project_info
-                .and_then(|p| p.project_id.as_ref()),
+            sampling_project_id: ctx.sampling_project_info.and_then(|p| p.project_id),
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -251,10 +251,13 @@ pub fn normalize(
             );
         }
 
-        let enriched_dsc = headers
+        let dsc = headers
             .dsc()
             .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
-            .map(|(d, s)| EnrichedDsc::new(d, s));
+            .map(|(dsc, sampling_project_id)| EnrichedDsc {
+                dsc,
+                sampling_project_id,
+            });
 
         let normalization_config = NormalizationConfig {
             project_id: Some(project_id.value()),
@@ -308,7 +311,7 @@ pub fn normalize(
                 .project_info
                 .has_feature(Feature::PerformanceIssuesSpans),
             derive_trace_id: project_info.has_feature(Feature::AddDefaultTraceID),
-            enriched_dsc: enriched_dsc.as_ref(),
+            dsc,
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -12,6 +12,7 @@ use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_config::NormalizationLevel;
 use relay_dynamic_config::Feature;
+use relay_event_normalization::DscNormalizationCommonProps;
 use relay_event_normalization::GeoIpLookup;
 use relay_event_normalization::{
     ClockDriftProcessor, normalize_event as normalize_event_inner, validate_event,
@@ -250,6 +251,11 @@ pub fn normalize(
             );
         }
 
+        let dsc_props = headers
+            .dsc()
+            .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
+            .map(|(d, s)| DscNormalizationCommonProps::new(d, s));
+
         let normalization_config = NormalizationConfig {
             project_id: Some(project_id.value()),
             client: request_meta.client().map(str::to_owned),
@@ -302,8 +308,7 @@ pub fn normalize(
                 .project_info
                 .has_feature(Feature::PerformanceIssuesSpans),
             derive_trace_id: project_info.has_feature(Feature::AddDefaultTraceID),
-            dsc: headers.dsc(),
-            sampling_project_id: ctx.sampling_project_info.and_then(|p| p.project_id),
+            dsc_normalization_props: dsc_props.as_ref(),
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -303,6 +303,9 @@ pub fn normalize(
                 .has_feature(Feature::PerformanceIssuesSpans),
             derive_trace_id: project_info.has_feature(Feature::AddDefaultTraceID),
             dsc: headers.dsc(),
+            sampling_project_id: ctx
+                .sampling_project_info
+                .and_then(|p| p.project_id.map(|p| p.value())),
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -12,7 +12,7 @@ use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_config::NormalizationLevel;
 use relay_dynamic_config::Feature;
-use relay_event_normalization::DscNormalizationCommonProps;
+use relay_event_normalization::EnrichedDsc;
 use relay_event_normalization::GeoIpLookup;
 use relay_event_normalization::{
     ClockDriftProcessor, normalize_event as normalize_event_inner, validate_event,
@@ -251,10 +251,10 @@ pub fn normalize(
             );
         }
 
-        let dsc_props = headers
+        let enriched_dsc = headers
             .dsc()
             .zip(ctx.sampling_project_info.and_then(|p| p.project_id))
-            .map(|(d, s)| DscNormalizationCommonProps::new(d, s));
+            .map(|(d, s)| EnrichedDsc::new(d, s));
 
         let normalization_config = NormalizationConfig {
             project_id: Some(project_id.value()),
@@ -308,7 +308,7 @@ pub fn normalize(
                 .project_info
                 .has_feature(Feature::PerformanceIssuesSpans),
             derive_trace_id: project_info.has_feature(Feature::AddDefaultTraceID),
-            dsc_normalization_props: dsc_props.as_ref(),
+            enriched_dsc: enriched_dsc.as_ref(),
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -305,7 +305,7 @@ pub fn normalize(
             dsc: headers.dsc(),
             sampling_project_id: ctx
                 .sampling_project_info
-                .and_then(|p| p.project_id.map(|p| p.value())),
+                .and_then(|p| p.project_id.as_ref()),
         };
 
         metric!(timer(RelayTimers::EventProcessingNormalization), {

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -420,6 +420,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generateText weather-chat",
                 },
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -539,6 +540,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generate_text gpt-4o",
                 },
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -639,6 +641,7 @@ def test_ai_spans_example_transaction(
                     "value": "POST " "https://api.openai.com/v1/responses",
                 },
                 "sentry.domain": {"type": "string", "value": "*.openai.com"},
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -735,6 +738,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "execute_tool getWeather",
                 },
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -798,6 +802,7 @@ def test_ai_spans_example_transaction(
                     "value": "GET " "https://wttr.in/San%20Francisco",
                 },
                 "sentry.domain": {"type": "string", "value": "wttr.in"},
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -887,6 +892,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "execute_tool getWeather",
                 },
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -950,6 +956,7 @@ def test_ai_spans_example_transaction(
                     "value": "GET https://wttr.in/London",
                 },
                 "sentry.domain": {"type": "string", "value": "wttr.in"},
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -1069,6 +1076,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generate_text gpt-4o",
                 },
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -1166,6 +1174,7 @@ def test_ai_spans_example_transaction(
                     "value": "POST " "https://api.openai.com/v1/responses",
                 },
                 "sentry.domain": {"type": "string", "value": "*.openai.com"},
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -1244,6 +1253,7 @@ def test_ai_spans_example_transaction(
                 "gen_ai.usage.output_tokens": {"type": "integer", "value": 65},
                 "gen_ai.usage.total_tokens": {"type": "double", "value": 310.0},
                 "sentry.description": {"type": "string", "value": "main"},
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -420,7 +420,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generateText weather-chat",
                 },
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -540,7 +540,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generate_text gpt-4o",
                 },
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -641,7 +641,7 @@ def test_ai_spans_example_transaction(
                     "value": "POST " "https://api.openai.com/v1/responses",
                 },
                 "sentry.domain": {"type": "string", "value": "*.openai.com"},
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -738,7 +738,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "execute_tool getWeather",
                 },
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -802,7 +802,7 @@ def test_ai_spans_example_transaction(
                     "value": "GET " "https://wttr.in/San%20Francisco",
                 },
                 "sentry.domain": {"type": "string", "value": "wttr.in"},
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -892,7 +892,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "execute_tool getWeather",
                 },
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -956,7 +956,7 @@ def test_ai_spans_example_transaction(
                     "value": "GET https://wttr.in/London",
                 },
                 "sentry.domain": {"type": "string", "value": "wttr.in"},
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -1076,7 +1076,7 @@ def test_ai_spans_example_transaction(
                     "type": "string",
                     "value": "generate_text gpt-4o",
                 },
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -1174,7 +1174,7 @@ def test_ai_spans_example_transaction(
                     "value": "POST " "https://api.openai.com/v1/responses",
                 },
                 "sentry.domain": {"type": "string", "value": "*.openai.com"},
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",
@@ -1253,7 +1253,7 @@ def test_ai_spans_example_transaction(
                 "gen_ai.usage.output_tokens": {"type": "integer", "value": 65},
                 "gen_ai.usage.total_tokens": {"type": "double", "value": 310.0},
                 "sentry.description": {"type": "string", "value": "main"},
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
+                "sentry.dsc.project_id": {"type": "string", "value": "42"},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "a9351cd574f092f6acad48e250981f11",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -156,6 +156,7 @@ def test_span_extraction(
             },
             "sentry.is_remote": {"type": "boolean", "value": False},
             "sentry.segment.id": {"type": "string", "value": "968cff94913ebb07"},
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "a0fa8803753e40fd8124b21eeb2986b5",
@@ -232,6 +233,7 @@ def test_span_extraction(
             "sentry.user.id": {"type": "string", "value": user_id},
             "sentry.user.ip": {"type": "string", "value": "192.168.0.1"},
             "sentry.user": {"type": "string", "value": f"id:{user_id}"},
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "a0fa8803753e40fd8124b21eeb2986b5",

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1246,6 +1246,7 @@ def test_spans_dsc_normalization(
             "data": {
                 "sentry.dsc.trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
                 "sentry.dsc.transaction": "/transaction/already/exists",
+                "sentry.dsc.project_id": 41,
             },
         },
     ]
@@ -1256,9 +1257,21 @@ def test_spans_dsc_normalization(
     def get_transaction(span_id: str):
         return spans[span_id]["attributes"]["sentry.dsc.transaction"]["value"]
 
+    def get_project_id(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.project_id"]["value"]
+
+    def get_trace_id(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.trace_id"]["value"]
+
     assert spans["968cff94913ebb07"]["is_segment"] is True
     assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
     assert spans["cccccccccccccccc"]["is_segment"] is False
     assert get_transaction("968cff94913ebb07") == "hi"
     assert get_transaction("bbbbbbbbbbbbbbbb") == "hi"
     assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
+    assert get_project_id("968cff94913ebb07") == 42
+    assert get_project_id("bbbbbbbbbbbbbbbb") == 42
+    assert get_project_id("cccccccccccccccc") == 41
+    assert get_trace_id("968cff94913ebb07") == "a0fa8803753e40fd8124b21eeb2986b5"
+    assert get_trace_id("bbbbbbbbbbbbbbbb") == "a0fa8803753e40fd8124b21eeb2986b5"
+    assert get_trace_id("cccccccccccccccc") == "a0fa8803753e40fd8124b21eeb2986b5"

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -156,7 +156,7 @@ def test_span_extraction(
             },
             "sentry.is_remote": {"type": "boolean", "value": False},
             "sentry.segment.id": {"type": "string", "value": "968cff94913ebb07"},
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "a0fa8803753e40fd8124b21eeb2986b5",
@@ -233,7 +233,7 @@ def test_span_extraction(
             "sentry.user.id": {"type": "string", "value": user_id},
             "sentry.user.ip": {"type": "string", "value": "192.168.0.1"},
             "sentry.user": {"type": "string", "value": f"id:{user_id}"},
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "a0fa8803753e40fd8124b21eeb2986b5",
@@ -1271,7 +1271,7 @@ def test_spans_dsc_normalization(
             "data": {
                 "sentry.dsc.trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
                 "sentry.dsc.transaction": "/transaction/already/exists",
-                "sentry.dsc.project_id": 41,
+                "sentry.dsc.project_id": "41",
             },
         },
     ]
@@ -1294,9 +1294,9 @@ def test_spans_dsc_normalization(
     assert get_transaction("968cff94913ebb07") == "hi"
     assert get_transaction("bbbbbbbbbbbbbbbb") == "hi"
     assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
-    assert get_project_id("968cff94913ebb07") == 42
-    assert get_project_id("bbbbbbbbbbbbbbbb") == 42
-    assert get_project_id("cccccccccccccccc") == 41
+    assert get_project_id("968cff94913ebb07") == "42"
+    assert get_project_id("bbbbbbbbbbbbbbbb") == "42"
+    assert get_project_id("cccccccccccccccc") == "41"
     assert get_trace_id("968cff94913ebb07") == "a0fa8803753e40fd8124b21eeb2986b5"
     assert get_trace_id("bbbbbbbbbbbbbbbb") == "a0fa8803753e40fd8124b21eeb2986b5"
     assert get_trace_id("cccccccccccccccc") == "a0fa8803753e40fd8124b21eeb2986b5"

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -241,6 +241,7 @@ def test_lcp_span(
                 "type": "string",
                 "value": "/insights/projects/",
             },
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",
@@ -445,6 +446,7 @@ def test_cls_span(
                 "type": "string",
                 "value": "/insights/projects/",
             },
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",
@@ -631,6 +633,7 @@ def test_inp_span(
                 "type": "string",
                 "value": "/insights/projects/",
             },
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -762,6 +762,7 @@ def test_spans_standalone_dsc_normalization(
             "data": {
                 "sentry.dsc.trace_id": "5b8efff798038103d269b633813fc60c",
                 "sentry.dsc.transaction": "/transaction/already/exists",
+                "sentry.dsc.project_id": 41,
             },
         },
         trace_info={
@@ -777,9 +778,21 @@ def test_spans_standalone_dsc_normalization(
     def get_transaction(span_id: str):
         return spans[span_id]["attributes"]["sentry.dsc.transaction"]["value"]
 
+    def get_project_id(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.project_id"]["value"]
+
+    def get_trace_id(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.trace_id"]["value"]
+
     assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
     assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
     assert spans["cccccccccccccccc"]["is_segment"] is False
     assert get_transaction("aaaaaaaaaaaaaaaa") == "/my/fancy/endpoint"
     assert get_transaction("bbbbbbbbbbbbbbbb") == "/my/fancy/endpoint"
     assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
+    assert get_project_id("aaaaaaaaaaaaaaaa") == 42
+    assert get_project_id("bbbbbbbbbbbbbbbb") == 42
+    assert get_project_id("cccccccccccccccc") == 41
+    assert get_trace_id("aaaaaaaaaaaaaaaa") == "5b8efff798038103d269b633813fc60c"
+    assert get_trace_id("bbbbbbbbbbbbbbbb") == "5b8efff798038103d269b633813fc60c"
+    assert get_trace_id("cccccccccccccccc") == "5b8efff798038103d269b633813fc60c"

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -259,7 +259,7 @@ def test_lcp_span(
                 "type": "string",
                 "value": "/insights/projects/",
             },
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",
@@ -482,7 +482,7 @@ def test_cls_span(
                 "type": "string",
                 "value": "/insights/projects/",
             },
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",
@@ -687,7 +687,7 @@ def test_inp_span(
                 "type": "string",
                 "value": "/insights/projects/",
             },
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",
@@ -816,7 +816,7 @@ def test_spans_standalone_dsc_normalization(
             "data": {
                 "sentry.dsc.trace_id": "5b8efff798038103d269b633813fc60c",
                 "sentry.dsc.transaction": "/transaction/already/exists",
-                "sentry.dsc.project_id": 41,
+                "sentry.dsc.project_id": "41",
             },
         },
         trace_info={
@@ -844,9 +844,9 @@ def test_spans_standalone_dsc_normalization(
     assert get_transaction("aaaaaaaaaaaaaaaa") == "/my/fancy/endpoint"
     assert get_transaction("bbbbbbbbbbbbbbbb") == "/my/fancy/endpoint"
     assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
-    assert get_project_id("aaaaaaaaaaaaaaaa") == 42
-    assert get_project_id("bbbbbbbbbbbbbbbb") == 42
-    assert get_project_id("cccccccccccccccc") == 41
+    assert get_project_id("aaaaaaaaaaaaaaaa") == "42"
+    assert get_project_id("bbbbbbbbbbbbbbbb") == "42"
+    assert get_project_id("cccccccccccccccc") == "41"
     assert get_trace_id("aaaaaaaaaaaaaaaa") == "5b8efff798038103d269b633813fc60c"
     assert get_trace_id("bbbbbbbbbbbbbbbb") == "5b8efff798038103d269b633813fc60c"
     assert get_trace_id("cccccccccccccccc") == "5b8efff798038103d269b633813fc60c"

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -239,7 +239,7 @@ def test_spansv2_trimming_basic(
             # This is sufficient for all builtin attributes not
             # to be trimmed. The span fields that aren't trimmed
             # also still count for the size limit.
-            "trimming": {"span": {"maxSize": 460}},
+            "trimming": {"span": {"maxSize": 454}},
         }
     )
 
@@ -336,7 +336,7 @@ def test_spansv2_trimming_basic(
         },
         "_meta": {
             "attributes": {
-                "": {"len": 512},
+                "": {"len": 506},
                 "custom.array.attribute": {
                     "value": {
                         "2": {

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -130,7 +130,7 @@ def test_spansv2_basic(
             },
             "sentry.dsc.release": {"type": "string", "value": "foo@1.0"},
             "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -323,7 +323,7 @@ def test_spansv2_trimming_basic(
             },
             "sentry.dsc.release": {"type": "string", "value": "foo@1.0"},
             "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1171,7 +1171,7 @@ def test_spanv2_with_string_pii_scrubbing(
         "trace_id": "5b8efff798038103d269b633813fc60c",
         "span_id": "eee19b7ec3c1b174",
         "attributes": {
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1309,7 +1309,7 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                 "type": "array",
                 "value": ["normal", "[creditcard]", "other"],
             },
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1457,7 +1457,7 @@ def test_spansv2_attribute_normalization(
                 "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
             },
             "sentry.domain": {"type": "string", "value": ",users,"},
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1509,7 +1509,7 @@ def test_spansv2_attribute_normalization(
             "sentry.action": {"type": "string", "value": "GET"},
             "server.address": {"type": "string", "value": "*.service.io"},
             "sentry.domain": {"type": "string", "value": "*.service.io"},
-            "sentry.dsc.project_id": {"type": "integer", "value": 42},
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1929,7 +1929,7 @@ def test_spansv2_dsc_normalization(
                     "type": "string",
                     "value": "/transaction/already/exists",
                 },
-                "sentry.dsc.project_id": {"type": "integer", "value": 41},
+                "sentry.dsc.project_id": {"type": "string", "value": "41"},
             },
         },
         trace_info={
@@ -1957,9 +1957,9 @@ def test_spansv2_dsc_normalization(
     assert get_transaction("aaaaaaaaaaaaaaaa") == "/my/fancy/endpoint"
     assert get_transaction("bbbbbbbbbbbbbbbb") == "/my/fancy/endpoint"
     assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
-    assert get_project_id("aaaaaaaaaaaaaaaa") == 42
-    assert get_project_id("bbbbbbbbbbbbbbbb") == 42
-    assert get_project_id("cccccccccccccccc") == 41
+    assert get_project_id("aaaaaaaaaaaaaaaa") == "42"
+    assert get_project_id("bbbbbbbbbbbbbbbb") == "42"
+    assert get_project_id("cccccccccccccccc") == "41"
     assert get_trace_id("aaaaaaaaaaaaaaaa") == "5b8efff798038103d269b633813fc60c"
     assert get_trace_id("bbbbbbbbbbbbbbbb") == "5b8efff798038103d269b633813fc60c"
     assert get_trace_id("cccccccccccccccc") == "5b8efff798038103d269b633813fc60c"

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -644,6 +644,8 @@ def test_spansv2_ds_sampled(
     sampling_config["organizationId"] = project_config["organizationId"]
     add_sampling_config(sampling_config, sample_rate=0.9, rule_type="trace")
 
+    trace_id = "5b8efff798038103d269b633813fc60c"
+
     relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
 
     ts = datetime.now(timezone.utc)
@@ -651,7 +653,7 @@ def test_spansv2_ds_sampled(
         {
             "start_timestamp": ts.timestamp(),
             "end_timestamp": ts.timestamp() + 0.5,
-            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "trace_id": trace_id,
             "span_id": "aaaaaaaaaaaaaaaa",
             "is_segment": False,
             "name": "some op",
@@ -661,14 +663,14 @@ def test_spansv2_ds_sampled(
         {
             "start_timestamp": ts.timestamp(),
             "end_timestamp": ts.timestamp() + 0.5,
-            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "trace_id": trace_id,
             "span_id": "bbbbbbbbbbbbbbbb",
             "is_segment": True,
             "name": "some other op",
             "status": "ok",
         },
         trace_info={
-            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "trace_id": trace_id,
             "public_key": sampling_config["publicKeys"][0]["publicKey"],
             "transaction": "tx_from_root",
         },
@@ -676,9 +678,12 @@ def test_spansv2_ds_sampled(
 
     relay.send_envelope(project_id, envelope)
 
-    for span in spans_consumer.get_spans(n=2):
+    for span in spans_consumer.get_spans():
         assert span["span_id"] in ("aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb")
         assert span["attributes"]["sentry.server_sample_rate"]["value"] == 0.9
+        assert span["attributes"]["sentry.dsc.trace_id"]["value"] == trace_id
+        assert span["attributes"]["sentry.dsc.transaction"]["value"] == "tx_from_root"
+        assert span["attributes"]["sentry.dsc.project_id"]["value"] == "43"
 
     assert metrics_consumer.get_metrics(n=4, with_headers=False) == [
         {

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1913,35 +1913,14 @@ def test_spansv2_dsc_normalization(
         },
         {
             "start_timestamp": ts.timestamp(),
-            "end_timestamp": ts.timestamp() + 0.5,
-            "trace_id": "5b8efff798038103d269b633813fc60c",
-            "span_id": "cccccccccccccccc",
-            "is_segment": True,
-            "name": "root",
-            "status": "ok",
-            "attributes": {
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
-                "sentry.dsc.trace_id": {
-                    "type": "string",
-                    "value": "5b8efff798038103d269b633813fc60c",
-                },
-                "sentry.dsc.transaction": {
-                    "type": "string",
-                    "value": "/transaction/already/exists",
-                },
-            },
-        },
-        {
-            "start_timestamp": ts.timestamp(),
             "end_timestamp": ts.timestamp() + 0.3,
             "trace_id": "5b8efff798038103d269b633813fc60c",
-            "span_id": "dddddddddddddddd",
-            "parent_span_id": "cccccccccccccccc",
+            "span_id": "cccccccccccccccc",
+            "parent_span_id": "aaaaaaaaaaaaaaaa",
             "is_segment": False,
             "name": "child",
             "status": "ok",
             "attributes": {
-                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "5b8efff798038103d269b633813fc60c",
@@ -1950,6 +1929,7 @@ def test_spansv2_dsc_normalization(
                     "type": "string",
                     "value": "/transaction/already/exists",
                 },
+                "sentry.dsc.project_id": {"type": "integer", "value": 41},
             },
         },
         trace_info={
@@ -1961,21 +1941,25 @@ def test_spansv2_dsc_normalization(
 
     relay.send_envelope(project_id, envelope)
 
+    def get_transaction(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.transaction"]["value"]
+
+    def get_project_id(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.project_id"]["value"]
+
+    def get_trace_id(span_id: str):
+        return spans[span_id]["attributes"]["sentry.dsc.trace_id"]["value"]
+
     spans = {s["span_id"]: s for s in spans_consumer.get_spans()}
     assert spans["aaaaaaaaaaaaaaaa"]["is_segment"] is True
     assert spans["bbbbbbbbbbbbbbbb"]["is_segment"] is False
-    assert spans["cccccccccccccccc"]["is_segment"] is True
-    assert spans["dddddddddddddddd"]["is_segment"] is False
-    for span_id in [
-        "aaaaaaaaaaaaaaaa",
-        "bbbbbbbbbbbbbbbb",
-        "cccccccccccccccc",
-        "dddddddddddddddd",
-    ]:
-        expected = (
-            "/my/fancy/endpoint"
-            if span_id in ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]
-            else "/transaction/already/exists"
-        )
-        actual = spans[span_id]["attributes"]["sentry.dsc.transaction"]["value"]
-        assert actual == expected
+    assert spans["cccccccccccccccc"]["is_segment"] is False
+    assert get_transaction("aaaaaaaaaaaaaaaa") == "/my/fancy/endpoint"
+    assert get_transaction("bbbbbbbbbbbbbbbb") == "/my/fancy/endpoint"
+    assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
+    assert get_project_id("aaaaaaaaaaaaaaaa") == 42
+    assert get_project_id("bbbbbbbbbbbbbbbb") == 42
+    assert get_project_id("cccccccccccccccc") == 41
+    assert get_trace_id("aaaaaaaaaaaaaaaa") == "5b8efff798038103d269b633813fc60c"
+    assert get_trace_id("bbbbbbbbbbbbbbbb") == "5b8efff798038103d269b633813fc60c"
+    assert get_trace_id("cccccccccccccccc") == "5b8efff798038103d269b633813fc60c"

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -130,6 +130,7 @@ def test_spansv2_basic(
             },
             "sentry.dsc.release": {"type": "string", "value": "foo@1.0"},
             "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -238,7 +239,7 @@ def test_spansv2_trimming_basic(
             # This is sufficient for all builtin attributes not
             # to be trimmed. The span fields that aren't trimmed
             # also still count for the size limit.
-            "trimming": {"span": {"maxSize": 431}},
+            "trimming": {"span": {"maxSize": 460}},
         }
     )
 
@@ -322,6 +323,7 @@ def test_spansv2_trimming_basic(
             },
             "sentry.dsc.release": {"type": "string", "value": "foo@1.0"},
             "sentry.dsc.transaction": {"type": "string", "value": "/my/fancy/endpoint"},
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -334,7 +336,7 @@ def test_spansv2_trimming_basic(
         },
         "_meta": {
             "attributes": {
-                "": {"len": 483},
+                "": {"len": 512},
                 "custom.array.attribute": {
                     "value": {
                         "2": {
@@ -1169,6 +1171,7 @@ def test_spanv2_with_string_pii_scrubbing(
         "trace_id": "5b8efff798038103d269b633813fc60c",
         "span_id": "eee19b7ec3c1b174",
         "attributes": {
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1306,6 +1309,7 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                 "type": "array",
                 "value": ["normal", "[creditcard]", "other"],
             },
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1453,6 +1457,7 @@ def test_spansv2_attribute_normalization(
                 "value": "SELECT id FROM users WHERE id = 1 AND name = 'Test'",
             },
             "sentry.domain": {"type": "string", "value": ",users,"},
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1504,6 +1509,7 @@ def test_spansv2_attribute_normalization(
             "sentry.action": {"type": "string", "value": "GET"},
             "server.address": {"type": "string", "value": "*.service.io"},
             "sentry.domain": {"type": "string", "value": "*.service.io"},
+            "sentry.dsc.project_id": {"type": "integer", "value": 42},
             "sentry.dsc.trace_id": {
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
@@ -1914,6 +1920,7 @@ def test_spansv2_dsc_normalization(
             "name": "root",
             "status": "ok",
             "attributes": {
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "5b8efff798038103d269b633813fc60c",
@@ -1934,6 +1941,7 @@ def test_spansv2_dsc_normalization(
             "name": "child",
             "status": "ok",
             "attributes": {
+                "sentry.dsc.project_id": {"type": "integer", "value": 42},
                 "sentry.dsc.trace_id": {
                     "type": "string",
                     "value": "5b8efff798038103d269b633813fc60c",


### PR DESCRIPTION
Needed for the new dynamic sampling pipeline.

Fixes: https://linear.app/getsentry/issue/RELAY-239/add-dsc-attributes-trace-root-project-onto-every-span
Fixes: https://linear.app/getsentry/issue/RELAY-244/add-project-id-to-transaction-spans
Fixes: https://linear.app/getsentry/issue/RELAY-245/add-project-id-to-v2-spans
Fixes: https://linear.app/getsentry/issue/RELAY-243/add-project-id-to-v1-spans