### PR TITLE
fix(spans): Clamp span timestamps instead of rejecting transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bug Fixes**:
 
-- Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005), [#6013](https://github.com/getsentry/relay/pull/6013))
+- Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005), [#6013](https://github.com/getsentry/relay/pull/6013), [#6015](https://github.com/getsentry/relay/pull/6015))
 - Obtain PII values for `SpanData` fields from `sentry-conventions`. ([#5997](https://github.com/getsentry/relay/pull/5997))
 - Add `sentry.dsc.transaction` and `sentry.dsc.trace_id` to all spans. ([#6001](https://github.com/getsentry/relay/pull/6001), [#6004](https://github.com/getsentry/relay/pull/6004), [#6008](https://github.com/getsentry/relay/pull/6008))
 

--- a/relay-event-normalization/src/lib.rs
+++ b/relay-event-normalization/src/lib.rs
@@ -25,7 +25,7 @@ mod transactions;
 mod trimming;
 mod validation;
 
-pub use validation::{EventValidationConfig, validate_event, validate_span};
+pub use validation::{EventValidationConfig, validate_event, validate_standalone_span};
 pub mod replay;
 pub use event::{
     NormalizationConfig, normalize_event, normalize_measurements, normalize_performance_score,

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -242,7 +242,7 @@ fn end_all_spans(event: &mut Event) {
 /// Validates the spans in the transaction.
 ///
 /// A [`ProcessingResult`] error is returned if there's an invalid span. For
-/// span validity, see [`validate_span`].
+/// span validity, see [`validate_transaction_span`].
 fn validate_spans(
     transaction: &mut Event,
     timestamp_range: Option<&Range<UnixTimestamp>>,

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -251,16 +251,26 @@ fn end_all_spans(event: &mut Event) {
 /// A [`ProcessingResult`] error is returned if there's an invalid span. For
 /// span validity, see [`validate_span`].
 fn validate_spans(
-    transaction: &Event,
+    transaction: &mut Event,
     timestamp_range: Option<&Range<UnixTimestamp>>,
 ) -> ProcessingResult {
-    let Some(spans) = transaction.spans.value() else {
+    let (Some(transaction_start), Some(transaction_end)) = (
+        transaction.start_timestamp.value().copied(),
+        transaction.timestamp.value().copied(),
+    ) else {
+        // Should never run into this since it is already validated earlier.
+        return Err(ProcessingAction::InvalidTransaction(
+            "timestamps hard-required for transaction events",
+        ));
+    };
+
+    let Some(spans) = transaction.spans.value_mut() else {
         return Ok(());
     };
 
     for span in spans {
-        if let Some(span) = span.value() {
-            validate_span(span, timestamp_range)?;
+        if let Some(span) = span.value_mut() {
+            validate_transaction_span(span, transaction_start, transaction_end, timestamp_range)?;
         } else {
             return Err(ProcessingAction::InvalidTransaction(
                 "spans must be valid in transaction event",
@@ -271,16 +281,72 @@ fn validate_spans(
     Ok(())
 }
 
-/// Validates a span.
+/// Ensures that `timestamp` is within `range`, otherwise replacing it with `fallback`.
+///
+/// Returns an error if `timestamp` has no value or cannot be parsed to [`UnixTimestamp`].
+fn clamp_timestamp(
+    timestamp: &mut Annotated<Timestamp>,
+    fallback: Timestamp,
+    range: Option<&Range<UnixTimestamp>>,
+) -> ProcessingResult {
+    let Annotated(Some(ts), meta) = timestamp else {
+        return Err(ProcessingAction::InvalidTransaction(
+            "span is missing timestamp",
+        ));
+    };
+
+    let Some(uts) = UnixTimestamp::from_datetime(ts.into_inner()) else {
+        return Err(ProcessingAction::InvalidTransaction(
+            "invalid unix timestamp",
+        ));
+    };
+
+    if let Some(range) = range {
+        if uts < range.start || range.end <= uts {
+            meta.set_original_value(Some(ts.to_string()));
+            meta.add_error(ErrorKind::ClockDrift);
+            *ts = fallback;
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates a transaction span.
+///
+/// Similar to [`validate_standalone_span`] but will replace timestamps outside `range` with the
+/// timestamps of the transaction.
+fn validate_transaction_span(
+    span: &mut Span,
+    transaction_start: Timestamp,
+    transaction_end: Timestamp,
+    range: Option<&Range<UnixTimestamp>>,
+) -> ProcessingResult {
+    clamp_timestamp(&mut span.start_timestamp, transaction_start, range)?;
+    clamp_timestamp(&mut span.timestamp, transaction_end, range)?;
+
+    if let (Some(start), Some(end)) = (span.start_timestamp.value(), span.timestamp.value())
+        && end < start
+    {
+        return Err(ProcessingAction::InvalidTransaction(
+            "end timestamp is smaller than start timestamp",
+        ));
+    }
+
+    validate_span_ids(span)
+}
+
+/// Validates a standalone span.
 ///
 /// A [`ProcessingResult`] error is returned when the span is invalid. A span is
 /// valid if all the following conditions are met:
 /// - A start timestamp exists.
 /// - An end timestamp exists.
 /// - Start timestamp must be no later than end timestamp.
+/// - Both start and end timestamps must be within `timestamp_range`.
 /// - A trace id exists.
 /// - A span id exists.
-pub fn validate_span(
+pub fn validate_standalone_span(
     span: &Span,
     timestamp_range: Option<&Range<UnixTimestamp>>,
 ) -> ProcessingResult {
@@ -302,6 +368,11 @@ pub fn validate_span(
         }
     }
 
+    validate_span_ids(span)
+}
+
+/// Validates that the span has a `trace_id` and `span_id`.
+fn validate_span_ids(span: &Span) -> ProcessingResult {
     if span.trace_id.value().is_none() {
         return Err(ProcessingAction::InvalidTransaction(
             "span is missing trace_id",
@@ -596,7 +667,7 @@ mod tests {
         assert_eq!(
             validate_event(&mut event, &EventValidationConfig::default()),
             Err(ProcessingAction::InvalidTransaction(
-                "span is missing start_timestamp"
+                "span is missing timestamp"
             ))
         );
     }

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -294,12 +294,12 @@ fn clamp_timestamp(
         ));
     };
 
-    if let Some(range) = range {
-        if uts < range.start || range.end <= uts {
-            meta.set_original_value(Some(ts.to_string()));
-            meta.add_error(ErrorKind::ClockDrift);
-            *ts = fallback;
-        }
+    if let Some(range) = range
+        && (uts < range.start || range.end <= uts)
+    {
+        meta.set_original_value(Some(ts.to_string()));
+        meta.add_error(ErrorKind::ClockDrift);
+        *ts = fallback;
     }
 
     Ok(())

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -298,7 +298,7 @@ fn clamp_timestamp(
         && (uts < range.start || range.end <= uts)
     {
         meta.set_original_value(Some(ts.to_string()));
-        meta.add_error(ErrorKind::ClockDrift);
+        meta.add_error(ErrorKind::InvalidData);
         *ts = fallback;
     }
 

--- a/relay-event-normalization/src/validation.rs
+++ b/relay-event-normalization/src/validation.rs
@@ -277,7 +277,7 @@ fn validate_spans(
 /// Ensures that `timestamp` is within `range`, otherwise replacing it with `fallback`.
 ///
 /// Returns an error if `timestamp` has no value or cannot be parsed to [`UnixTimestamp`].
-fn clamp_timestamp(
+fn enforce_timestamp_in_range(
     timestamp: &mut Annotated<Timestamp>,
     fallback: Timestamp,
     range: Option<&Range<UnixTimestamp>>,
@@ -315,8 +315,8 @@ fn validate_transaction_span(
     transaction_end: Timestamp,
     range: Option<&Range<UnixTimestamp>>,
 ) -> ProcessingResult {
-    clamp_timestamp(&mut span.start_timestamp, transaction_start, range)?;
-    clamp_timestamp(&mut span.timestamp, transaction_end, range)?;
+    enforce_timestamp_in_range(&mut span.start_timestamp, transaction_start, range)?;
+    enforce_timestamp_in_range(&mut span.timestamp, transaction_end, range)?;
 
     if let (Some(start), Some(end)) = (span.start_timestamp.value(), span.timestamp.value())
         && end < start

--- a/relay-server/src/processing/legacy_spans/normalize.rs
+++ b/relay-server/src/processing/legacy_spans/normalize.rs
@@ -8,7 +8,7 @@ use relay_event_normalization::{
     GeoIpLookup, ModelMetadata, PerformanceScoreConfig, RawUserAgentInfo, SchemaProcessor,
     TimestampProcessor, TransactionNameRule, TransactionsProcessor, TrimmingProcessor,
     normalize_measurements, normalize_performance_score, normalize_transaction_name,
-    span::tag_extraction, validate_span,
+    span::tag_extraction, validate_standalone_span,
 };
 use relay_event_schema::processor::{ProcessingState, process_value};
 use relay_event_schema::protocol::{BrowserContext, EventId, IpAddr, Span, SpanData};
@@ -131,7 +131,7 @@ pub fn normalize(
     )?;
 
     if let Some(span) = annotated_span.value() {
-        validate_span(span, Some(timestamp_range))?;
+        validate_standalone_span(span, Some(timestamp_range))?;
     }
     process_value(
         annotated_span,

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -406,9 +406,36 @@ def test_transaction_with_invalid_span_timestamps(mini_sentry, relay, offset):
     assert span["start_timestamp"] == transaction["start_timestamp"]
     assert span["timestamp"] == transaction["timestamp"]
 
-    assert transaction["_meta"]["spans"]["0"] == {
-        "start_timestamp": {"": {"err": ["clock_drift"], "val": mock.ANY}},
-        "timestamp": {"": {"err": ["clock_drift"], "val": mock.ANY}},
+    assert transaction["_meta"] == {
+        "spans": {
+            "0": {
+                "start_timestamp": {
+                    "": {
+                        "err": ["invalid_data"],
+                        "val": mock.ANY,
+                    }
+                },
+                "timestamp": {
+                    "": {
+                        "err": ["invalid_data"],
+                        "val": mock.ANY,
+                    }
+                },
+            }
+        },
+        "timestamp": {
+            "": {
+                "err": [
+                    [
+                        "past_timestamp",
+                        {
+                            "sdk_time": mock.ANY,
+                            "server_time": mock.ANY,
+                        },
+                    ]
+                ]
+            }
+        },
     }
 
 

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -1,8 +1,8 @@
 import pytest
 import queue
+from unittest import mock
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
-from sentry_relay.consts import DataCategory
 
 
 def test_envelope(mini_sentry, relay_chain):
@@ -399,41 +399,17 @@ def test_transaction_with_invalid_span_timestamps(mini_sentry, relay, offset):
     envelope.add_transaction(transaction_item)
     relay.send_envelope(42, envelope)
 
-    assert mini_sentry.get_aggregated_outcomes() == [
-        {
-            "category": DataCategory.TRANSACTION.value,
-            "key_id": 123,
-            "outcome": 3,
-            "project_id": 42,
-            "quantity": 1,
-            "reason": "invalid_transaction",
-        },
-        {
-            "category": DataCategory.TRANSACTION_INDEXED.value,
-            "key_id": 123,
-            "outcome": 3,
-            "project_id": 42,
-            "quantity": 1,
-            "reason": "invalid_transaction",
-        },
-        {
-            "category": DataCategory.SPAN.value,
-            "key_id": 123,
-            "outcome": 3,
-            "project_id": 42,
-            "quantity": 2,
-            "reason": "invalid_transaction",
-        },
-        {
-            "category": DataCategory.SPAN_INDEXED.value,
-            "key_id": 123,
-            "outcome": 3,
-            "project_id": 42,
-            "quantity": 2,
-            "reason": "invalid_transaction",
-        },
-    ]
-    assert mini_sentry.captured_envelopes.empty()
+    transaction = mini_sentry.get_captured_envelope().get_transaction_event()
+    assert transaction is not None
+
+    span = transaction["spans"][0]
+    assert span["start_timestamp"] == transaction["start_timestamp"]
+    assert span["timestamp"] == transaction["timestamp"]
+
+    assert transaction["_meta"]["spans"]["0"] == {
+        "start_timestamp": {"": {"err": ["clock_drift"], "val": mock.ANY}},
+        "timestamp": {"": {"err": ["clock_drift"], "val": mock.ANY}},
+    }
 
 
 def test_span_exclusive_time(mini_sentry, relay_with_processing, transactions_consumer):


### PR DESCRIPTION
Follow up to #6013 this adds the logic to clamp the span timestamps outside of the valid range to that of the transaction (which are already validated) rather than rejecting the entire transaction.