### PR TITLE
test(asserts): Minimize diffs with assertion helpers

### DIFF
--- a/tests/integration/asserts/__init__.py
+++ b/tests/integration/asserts/__init__.py
@@ -1,8 +1,10 @@
 from typing import Any, Callable
 from .time import time_after, time_within, time_within_delta, time_is
 from .protocol import only_items
+from .utils import PrintLastCompare
 
 __all__ = [
+    "any",
     "matches",
     "only_items",
     "time_after",
@@ -12,7 +14,7 @@ __all__ = [
 ]
 
 
-class _Matches(object):
+class _Matches(PrintLastCompare):
     def __init__(self, compare_with: Callable[[Any], bool]):
         self._compare_with = compare_with
 
@@ -37,3 +39,15 @@ def matches(f: Callable[[Any], bool]):
         }
     """
     return _Matches(f)
+
+
+class _Any(PrintLastCompare):
+    def __eq__(self, other, /):
+        return True
+
+    def __repr__(self):
+        return "<ANY>"
+
+
+def any():
+    return _Any()

--- a/tests/integration/asserts/__init__.py
+++ b/tests/integration/asserts/__init__.py
@@ -45,9 +45,15 @@ class _Any(PrintLastCompare):
     def __eq__(self, other, /):
         return True
 
+    def __ne__(self, other, /):
+        return False
+
     def __repr__(self):
         return "<ANY>"
 
 
 def any():
+    """
+    A helper object that compares equal to everything."
+    """
     return _Any()

--- a/tests/integration/asserts/time.py
+++ b/tests/integration/asserts/time.py
@@ -1,6 +1,8 @@
 from datetime import timedelta, datetime, timezone
 from enum import StrEnum
 
+from .utils import PrintLastCompare
+
 
 class Resolution(StrEnum):
     Seconds = "s"
@@ -79,7 +81,7 @@ def _format_resolution(dt: datetime, resolution):
             return str(int(dt.timestamp() * 1_000_000) * 1_000)
 
 
-class _WithinBounds:
+class _WithinBounds(PrintLastCompare):
     def __init__(
         self,
         lower_bound,

--- a/tests/integration/asserts/utils.py
+++ b/tests/integration/asserts/utils.py
@@ -12,9 +12,9 @@ class PrintLastCompare(object):
         def _wrap_eq(fn):
             @functools.wraps(fn)
             def wrapped(self, value, /):
-                self._last_compare_value = value
-                self._last_compare_is_eq = fn(self, value)
-                return self._last_compare_is_eq
+                self.__last_compare_value = value
+                self.__last_compare_is_eq = fn(self, value)
+                return self.__last_compare_is_eq
 
             return wrapped
 
@@ -24,9 +24,9 @@ class PrintLastCompare(object):
         def _wrap_ne(fn):
             @functools.wraps(fn)
             def wrapped(self, value, /):
-                self._last_compare_value = value
-                self._last_compare_is_eq = not fn(self, value)
-                return not self._last_compare_is_eq
+                self.__last_compare_value = value
+                self.__last_compare_is_eq = not fn(self, value)
+                return not self.__last_compare_is_eq
 
             return wrapped
 
@@ -34,7 +34,7 @@ class PrintLastCompare(object):
             setattr(cls, "__ne__", _wrap_ne(cls.__ne__))
 
         # This depends on pytest internals, should this ever break, a simple alternative is to instead override
-        # repr of `cls` to return `repr(self._last_compare_value)`. This will not work for anything where pytest
+        # repr of `cls` to return `repr(self.__last_compare_value)`. This will not work for anything where pytest
         # has custom formatters, but for all primitives this will work.
         def _dispatch_last_compare(
             printer, obj, stream, indent, allowance, context, level
@@ -42,8 +42,11 @@ class PrintLastCompare(object):
             # Since cls.__repr__ points to this function and we want to delegate to the original
             # repr implementation, we'll have to use a wrapper such as `_NoopRepr` to break the recursion.
             p = _NoopRepr(obj)
-            if getattr(obj, "_last_compare_is_eq", False):
-                p = obj._last_compare_value
+            try:
+                if obj.__last_compare_is_eq:
+                    p = obj.__last_compare_value
+            except AttributeError:
+                pass
             printer._format(p, stream, indent, allowance, context, level)
 
         from _pytest._io.pprint import PrettyPrinter

--- a/tests/integration/asserts/utils.py
+++ b/tests/integration/asserts/utils.py
@@ -1,0 +1,63 @@
+import functools
+
+
+class PrintLastCompare(object):
+    """
+    Meta class which remembers the last comparison result to minimize differences in pytest's diff output.
+    """
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+
+        def _wrap_eq(fn):
+            @functools.wraps(fn)
+            def wrapped(self, value, /):
+                self._last_compare_value = value
+                self._last_compare_is_eq = fn(self, value)
+                return self._last_compare_is_eq
+
+            return wrapped
+
+        if hasattr(cls, "__eq__"):
+            setattr(cls, "__eq__", _wrap_eq(cls.__eq__))
+
+        def _wrap_ne(fn):
+            @functools.wraps(fn)
+            def wrapped(self, value, /):
+                self._last_compare_value = value
+                self._last_compare_is_eq = not fn(self, value)
+                return not self._last_compare_is_eq
+
+            return wrapped
+
+        if hasattr(cls, "__ne__"):
+            setattr(cls, "__ne__", _wrap_ne(cls.__ne__))
+
+        # This depends on pytest internals, should this ever break, a simple alternative is to instead override
+        # repr of `cls` to return `repr(self._last_compare_value)`. This will not work for anything where pytest
+        # has custom formatters, but for all primitives this will work.
+        def _register_any_printer(cls):
+            from _pytest._io.pprint import PrettyPrinter
+
+            def _dispatch_last_compare(
+                printer, obj, stream, indent, allowance, context, level
+            ):
+                if getattr(obj, "_last_compare_is_eq", False):
+                    p = obj._last_compare_value
+                else:
+                    # Since cls.__repr__ points to this function and we want to delegate to the original
+                    # repr implementation, we'll have to use a wrapper such as `_NoopRepr` to break the recursion.
+                    p = _NoopRepr(obj)
+                printer._format(p, stream, indent, allowance, context, level)
+
+            PrettyPrinter._dispatch[cls.__repr__] = _dispatch_last_compare
+
+        _register_any_printer(cls)
+
+
+class _NoopRepr(object):
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    def __repr__(self) -> str:
+        return repr(self.delegate)

--- a/tests/integration/asserts/utils.py
+++ b/tests/integration/asserts/utils.py
@@ -36,23 +36,19 @@ class PrintLastCompare(object):
         # This depends on pytest internals, should this ever break, a simple alternative is to instead override
         # repr of `cls` to return `repr(self._last_compare_value)`. This will not work for anything where pytest
         # has custom formatters, but for all primitives this will work.
-        def _register_any_printer(cls):
-            from _pytest._io.pprint import PrettyPrinter
+        def _dispatch_last_compare(
+            printer, obj, stream, indent, allowance, context, level
+        ):
+            # Since cls.__repr__ points to this function and we want to delegate to the original
+            # repr implementation, we'll have to use a wrapper such as `_NoopRepr` to break the recursion.
+            p = _NoopRepr(obj)
+            if getattr(obj, "_last_compare_is_eq", False):
+                p = obj._last_compare_value
+            printer._format(p, stream, indent, allowance, context, level)
 
-            def _dispatch_last_compare(
-                printer, obj, stream, indent, allowance, context, level
-            ):
-                if getattr(obj, "_last_compare_is_eq", False):
-                    p = obj._last_compare_value
-                else:
-                    # Since cls.__repr__ points to this function and we want to delegate to the original
-                    # repr implementation, we'll have to use a wrapper such as `_NoopRepr` to break the recursion.
-                    p = _NoopRepr(obj)
-                printer._format(p, stream, indent, allowance, context, level)
+        from _pytest._io.pprint import PrettyPrinter
 
-            PrettyPrinter._dispatch[cls.__repr__] = _dispatch_last_compare
-
-        _register_any_printer(cls)
+        PrettyPrinter._dispatch[cls.__repr__] = _dispatch_last_compare
 
 
 class _NoopRepr(object):

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -1,11 +1,10 @@
 from datetime import datetime, timezone
-from unittest import mock
 
 import pytest
 
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta
+from .asserts import any, time_within_delta
 
 
 @pytest.mark.parametrize(
@@ -392,7 +391,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": mock.ANY,
+                    "value": any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.45},
@@ -467,7 +466,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI agent operation",
@@ -483,7 +482,7 @@ def test_ai_spans_example_transaction(
             "trace_id": "a9351cd574f092f6acad48e250981f11",
         },
         {
-            "_meta": mock.ANY,
+            "_meta": any(),
             "attributes": {
                 "gen_ai.conversation.id": {
                     "type": "string",
@@ -491,7 +490,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": mock.ANY,
+                    "value": any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 0.37},
@@ -610,7 +609,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "gen_ai.generate_text",
@@ -690,7 +689,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "POST",
@@ -764,7 +763,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI model operation",
@@ -842,7 +841,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "GET",
@@ -916,7 +915,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI model operation",
@@ -994,7 +993,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "GET",
@@ -1010,7 +1009,7 @@ def test_ai_spans_example_transaction(
             "trace_id": "a9351cd574f092f6acad48e250981f11",
         },
         {
-            "_meta": mock.ANY,
+            "_meta": any(),
             "attributes": {
                 "gen_ai.conversation.id": {
                     "type": "string",
@@ -1018,7 +1017,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": mock.ANY,
+                    "value": any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.08},
@@ -1137,7 +1136,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "gen_ai.generate_text",
@@ -1217,7 +1216,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": False,
             "key_id": 123,
             "name": "POST",
@@ -1271,7 +1270,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": mock.ANY,
+            "event_id": any(),
             "is_segment": True,
             "key_id": 123,
             "name": "main",

--- a/tests/integration/test_attachment_ref.py
+++ b/tests/integration/test_attachment_ref.py
@@ -1,12 +1,12 @@
 import json
 import pytest
 import uuid
-from unittest import mock
 
 from requests.exceptions import HTTPError
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
+from .asserts import any
 from .test_store import make_transaction
 
 
@@ -199,14 +199,14 @@ def test_attachment_ref(
 
     relay.send_envelope(project_id, envelope)
     expected_attachment = {
-        "id": mock.ANY,
+        "id": any(),
         "name": "test.txt",
         "content_type": "text/plain",
         "attachment_type": "event.attachment",
         "size": len(attachment_data),
         "rate_limited": False,
-        "stored_id": mock.ANY,
-        "retention_days": mock.ANY,
+        "stored_id": any(),
+        "retention_days": any(),
     }
 
     if event_type == "event":

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -4,10 +4,10 @@ import pytest
 import uuid
 import json
 
-from unittest import mock
 from requests.exceptions import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
+from .asserts import any
 from .test_store import make_transaction
 
 
@@ -164,7 +164,7 @@ def test_attachments_with_objectstore(
     assert stored == {
         "type": "attachment",
         "attachment": {
-            "id": mock.ANY,
+            "id": any(),
             "name": "foo.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -181,7 +181,7 @@ def test_attachments_with_objectstore(
     assert empty == {
         "type": "attachment",
         "attachment": {
-            "id": mock.ANY,
+            "id": any(),
             "name": "foobar.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -670,7 +670,7 @@ def test_event_with_attachment(
             "attachment_type": "event.attachment",
             "size": len(b"event attachment"),
             "retention_days": 90,
-            **({"stored_id": mock.ANY} if use_objectstore else {"chunks": 1}),
+            **({"stored_id": any()} if use_objectstore else {"chunks": 1}),
         }
     ]
 
@@ -699,7 +699,7 @@ def test_event_with_attachment(
         "size": len(b"transaction attachment"),
         "retention_days": 90,
         **(
-            {"stored_id": mock.ANY}
+            {"stored_id": any()}
             if use_objectstore
             else {"data": b"transaction attachment"}
         ),

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -3,9 +3,8 @@ from collections import Counter
 from datetime import datetime, timezone
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
-from unittest import mock
 
-from .asserts import time_within_delta, time_is
+from .asserts import any, time_within_delta, time_is
 from .test_spansv2 import envelope_with_spans
 
 from .test_dynamic_sampling import add_sampling_config
@@ -153,10 +152,10 @@ def test_standalone_attachment_store(
         "itemType": "TRACE_ITEM_TYPE_ATTACHMENT",
         "organizationId": "1",
         "projectId": "42",
-        "received": mock.ANY,
+        "received": any(),
         "retentionDays": 90,
         "serverSampleRate": 1.0,
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "traceId": attachment_metadata["trace_id"].replace("-", ""),
     }
 
@@ -328,7 +327,7 @@ def test_attachment_with_matching_span(mini_sentry, relay):
             "is_segment": True,
             "start_timestamp": time_is(ts),
             "end_timestamp": time_is(ts.timestamp() + 0.5),
-            "attributes": mock.ANY,
+            "attributes": any(),
         }
     ]
 
@@ -415,10 +414,10 @@ def test_attachment_with_matching_span_store(
         "itemType": "TRACE_ITEM_TYPE_ATTACHMENT",
         "organizationId": "1",
         "projectId": "42",
-        "received": mock.ANY,
+        "received": any(),
         "retentionDays": 90,
         "serverSampleRate": 1.0,
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "traceId": metadata["trace_id"],
     }
 
@@ -527,7 +526,7 @@ def test_two_attachments_mapping_to_same_span(mini_sentry, relay):
             "is_segment": True,
             "start_timestamp": time_is(ts),
             "end_timestamp": time_is(ts.timestamp() + 0.5),
-            "attributes": mock.ANY,
+            "attributes": any(),
         }
     ]
 
@@ -638,7 +637,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
 
     assert mini_sentry.get_metrics() == [
         {
-            "metadata": mock.ANY,
+            "metadata": any(),
             "name": "c:spans/count_per_root_project@none",
             "tags": {
                 "decision": "drop",
@@ -652,7 +651,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
             "width": 1,
         },
         {
-            "metadata": mock.ANY,
+            "metadata": any(),
             "name": "c:spans/usage@none",
             "tags": {
                 "is_segment": "false",
@@ -1305,8 +1304,8 @@ def test_attachment_default_pii_scrubbing_meta(
                 attribute_key: {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                            "len": any(),
+                            "rem": [[rule_type, any(), any(), any()]],
                         }
                     }
                 }
@@ -1398,8 +1397,8 @@ def test_attachment_pii_scrubbing_meta_attribute(
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                            "len": any(),
+                            "rem": [[rule_type, any(), any(), any()]],
                         }
                     }
                 }

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -1,5 +1,4 @@
 import os
-from unittest import mock
 
 from flask import Response
 import msgpack
@@ -14,7 +13,7 @@ from uuid import UUID
 from urllib3.filepost import encode_multipart_formdata
 
 from sentry_relay.consts import DataCategory
-from .asserts import time_within_delta
+from .asserts import any, time_within_delta
 from .test_attachment_ref import upload_and_make_ref
 from .consts import DUMMY_UPLOAD_LOCATION
 
@@ -856,18 +855,18 @@ def test_minidump_placeholder(
                 },
             ],
         },
-        "grouping_config": mock.ANY,
+        "grouping_config": any(),
         "key_id": "123",
         "level": "fatal",
         "logger": "",
         "platform": "native",
         "project": 42,
-        "received": mock.ANY,
+        "received": any(),
         "sdk": {
             "name": "minidump.upload",
             "version": "0.0.0",
         },
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "type": "error",
         "version": "5",
     }
@@ -879,12 +878,12 @@ def test_minidump_placeholder(
     assert attachment == {
         "attachment_type": "event.minidump",
         "content_type": "application/x-dmp",
-        "id": mock.ANY,
+        "id": any(),
         "name": "minidump.dmp",
         "rate_limited": False,
         "retention_days": 90,
         "size": 26,
-        "stored_id": mock.ANY,
+        "stored_id": any(),
     }
 
     # Verify the actual data is retrievable from the objectstore.

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -1,9 +1,8 @@
 import json
 from datetime import datetime, timedelta, timezone
 from time import sleep
-from unittest import mock
 
-from .asserts import time_within_delta
+from .asserts import any, time_within_delta
 
 
 def test_nel_converted_to_logs(mini_sentry, relay):
@@ -24,7 +23,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
         "version": 2,
         "items": [
             {
-                "__header": mock.ANY,
+                "__header": any(),
                 "attributes": {
                     "sentry.origin": {
                         "type": "string",
@@ -75,7 +74,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
                 "body": "The user agent successfully received a response, but it had a 500 status code",
                 "level": "warn",
                 "timestamp": time_within_delta(expected_ts),
-                "trace_id": mock.ANY,
+                "trace_id": any(),
             }
         ],
     }

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -1,9 +1,8 @@
 from datetime import datetime, timezone, timedelta
-from unittest import mock
 
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within, only_items
+from .asserts import any, time_within_delta, time_within, only_items
 
 TEST_CONFIG = {
     "outcomes": {
@@ -130,7 +129,7 @@ def test_otlp_logs_conversion(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": mock.ANY},
+                "sentry.payload_size_bytes": {"intValue": any()},
                 "sentry.severity_text": {"stringValue": "info"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_precise": {
@@ -144,7 +143,7 @@ def test_otlp_logs_conversion(
                 "string.attribute": {"stringValue": "some string"},
             },
             "clientSampleRate": 1.0,
-            "itemId": mock.ANY,
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -239,7 +238,7 @@ def test_otlp_logs_multiple_records(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": mock.ANY},
+                "sentry.payload_size_bytes": {"intValue": any()},
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_precise": {
@@ -252,7 +251,7 @@ def test_otlp_logs_multiple_records(
                 },
             },
             "clientSampleRate": 1.0,
-            "itemId": mock.ANY,
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -270,7 +269,7 @@ def test_otlp_logs_multiple_records(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": mock.ANY},
+                "sentry.payload_size_bytes": {"intValue": any()},
                 "sentry.severity_text": {"stringValue": "debug"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
                 "sentry.timestamp_precise": {
@@ -283,7 +282,7 @@ def test_otlp_logs_multiple_records(
                 },
             },
             "clientSampleRate": 1.0,
-            "itemId": mock.ANY,
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -1,14 +1,13 @@
 import json
 
 from datetime import datetime, timezone, timedelta
-from unittest import mock
 import uuid
 
 from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within, matches
+from .asserts import time_within_delta, time_within, matches, any
 
 import pytest
 
@@ -316,12 +315,12 @@ def test_ourlog_extraction_with_sentry_logs(
                 "browser.name": {"stringValue": "Firefox"},
                 "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "error"},
-                "sentry.payload_size_bytes": {"intValue": mock.ANY},
+                "sentry.payload_size_bytes": {"intValue": any()},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
-            "itemId": mock.ANY,
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -391,7 +390,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 "browser.name": {"stringValue": "Firefox"},
                 "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "info"},
-                "sentry.payload_size_bytes": {"intValue": mock.ANY},
+                "sentry.payload_size_bytes": {"intValue": any()},
                 "http.response_content_length": {"intValue": "17"},
                 "http.response.body.size": {"intValue": "17"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
@@ -405,7 +404,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
-            "itemId": mock.ANY,
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -511,14 +510,14 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": mock.ANY},
+        "__header": {"byte_size": any()},
         "_meta": {
             "attributes": {
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                            "len": any(),
+                            "rem": [[rule_type, any(), any(), any()]],
                         }
                     }
                 }
@@ -621,15 +620,15 @@ def test_ourlog_default_pii_body(
     assert log == {
         **_if_dict(
             non_destructive.scrubs(),
-            {"_meta": {"body": {"": {"len": mock.ANY, "rem": mock.ANY}}}},
+            {"_meta": {"body": {"": {"len": any(), "rem": any()}}}},
         ),
-        "attributes": mock.ANY,
+        "attributes": any(),
         "body": non_destructive.expected_output,
         "level": "info",
         "span_id": "eee19b7ec3c1b174",
         "timestamp": time_within(ts),
         "trace_id": "5b8efff798038103d269b633813fc60c",
-        "__header": mock.ANY,
+        "__header": any(),
     }
 
     if non_destructive.additional_checks:
@@ -696,12 +695,12 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             "sentry.body": {"stringValue": "Test log"},
             "sentry.severity_text": {"stringValue": "info"},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
-            "sentry.payload_size_bytes": mock.ANY,
+            "sentry.payload_size_bytes": any(),
             "browser.name": {"stringValue": "Firefox"},
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": mock.ANY,
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -748,11 +747,11 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
             "browser.name": {"stringValue": "Firefox"},
             "browser.version": {"stringValue": "42.0"},
             "sentry.severity_text": {"stringValue": "warn"},
-            "sentry.payload_size_bytes": {"intValue": mock.ANY},
+            "sentry.payload_size_bytes": {"intValue": any()},
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": mock.ANY,
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -890,12 +889,12 @@ def test_browser_name_version_extraction(
             "browser.name": {"stringValue": expected_browser_name},
             "browser.version": {"stringValue": expected_browser_version},
             "sentry.severity_text": {"stringValue": "error"},
-            "sentry.payload_size_bytes": {"intValue": mock.ANY},
+            "sentry.payload_size_bytes": {"intValue": any()},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": mock.ANY,
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -1030,7 +1029,7 @@ def test_filters_are_applied_to_logs(
             "org_id": 1,
             "outcome": 1,
             "project_id": 42,
-            "quantity": mock.ANY,
+            "quantity": any(),
             "reason": filter_name,
             "timestamp": time_within_delta(ts),
         },
@@ -1089,7 +1088,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": mock.ANY,
+        "attributes": any(),
         "body": "foo",
         "level": "error",
         "span_id": "eee19b7ec3c1b175",
@@ -1186,7 +1185,7 @@ def test_ourlog_container_metadata(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": mock.ANY,
+        "__header": any(),
         "body": "Test log",
         "level": "info",
         "timestamp": time_within(ts),

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from time import sleep
-from unittest import mock
 import pytest
 import os
 import requests
@@ -9,7 +8,7 @@ from functools import cache
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from urllib3 import encode_multipart_formdata
-from .asserts import time_within_delta
+from .asserts import any, time_within_delta
 
 
 @cache
@@ -41,7 +40,7 @@ def playstation_project_config():
 def user_data_event_json(response):
     return {
         "event_id": response.text.replace("-", ""),
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "received": time_within_delta(),
         "level": "error",
         "version": "7",
@@ -76,7 +75,7 @@ def user_data_event_json(response):
         "breadcrumbs": {
             "values": [
                 {
-                    "timestamp": mock.ANY,
+                    "timestamp": any(),
                     "type": "default",
                     "level": "info",
                     "message": "crumb",
@@ -110,20 +109,20 @@ def user_data_event_json(response):
         },
         "key_id": "123",
         "project": 42,
-        "_metrics": mock.ANY,
-        "grouping_config": mock.ANY,
+        "_metrics": any(),
+        "grouping_config": any(),
     }
 
 
-def playstation_event_json(sdk=mock.ANY):
+def playstation_event_json(sdk=any()):
     return {
-        "event_id": mock.ANY,
+        "event_id": any(),
         "level": "fatal",
-        "version": mock.ANY,
+        "version": any(),
         "type": "error",
         "logger": "",
         "platform": "native",
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "received": time_within_delta(),
         "contexts": {
             "app": {"app_version": "", "type": "app"},
@@ -175,17 +174,15 @@ def playstation_event_json(sdk=mock.ANY):
         "sdk": sdk,
         "key_id": "123",
         "project": 42,
-        "grouping_config": mock.ANY,
-        "_metrics": mock.ANY,
+        "grouping_config": any(),
+        "_metrics": any(),
     }
 
 
-def attachments(
-    log_size=mock.ANY, generated_dump_size=mock.ANY, playstation_dump_size=mock.ANY
-):
+def attachments(log_size=any(), generated_dump_size=any(), playstation_dump_size=any()):
     return [
         {
-            "id": mock.ANY,
+            "id": any(),
             "name": "console.log",
             "rate_limited": False,
             "content_type": "text/plain",
@@ -195,7 +192,7 @@ def attachments(
             "chunks": 1,
         },
         {
-            "id": mock.ANY,
+            "id": any(),
             "name": "generated_minidump.dmp",
             "rate_limited": False,
             "content_type": "application/x-dmp",
@@ -205,7 +202,7 @@ def attachments(
             "chunks": 1,
         },
         {
-            "id": mock.ANY,
+            "id": any(),
             "name": "playstation.prosperodmp",
             "rate_limited": False,
             "content_type": "application/octet-stream",
@@ -771,13 +768,13 @@ def test_playstation_attachment_no_feature_flag(
     event, payload = attachments_consumer.get_event_only()
 
     assert payload == {
-        "event_id": mock.ANY,
+        "event_id": any(),
         "level": "error",
         "version": "5",
         "type": "error",
         "logger": "",
         "platform": "other",
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "received": time_within_delta(),
         "exception": {"values": [{"type": "ValueError", "value": "Should not happen"}]},
         "sdk": {"name": "raven-node", "version": "2.6.3"},
@@ -794,7 +791,7 @@ def test_playstation_attachment_no_feature_flag(
 
     assert event["attachments"] == (
         {
-            "id": mock.ANY,
+            "id": any(),
             "name": "playstation.prosperodmp",
             "rate_limited": False,
             "content_type": "application/octet-stream",
@@ -878,7 +875,7 @@ def test_event_merging(
 
     event, payload = attachments_consumer.get_event_only()
     assert payload == {
-        "event_id": mock.ANY,
+        "event_id": any(),
         "level": "fatal",
         "version": "5",
         "type": "error",

--- a/tests/integration/test_sessions_eap.py
+++ b/tests/integration/test_sessions_eap.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
-from unittest import mock
 
-from .asserts import time_within_delta
+from .asserts import time_within_delta, any
 
 
 def test_session_eap_double_write(
@@ -57,8 +56,8 @@ def test_session_eap_double_write(
         {
             "organizationId": "1",
             "projectId": "42",
-            "traceId": mock.ANY,
-            "itemId": mock.ANY,
+            "traceId": any(),
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_USER_SESSION",
             "timestamp": time_within_delta(started, delta=timedelta(seconds=2)),
             "received": time_within_delta(),
@@ -78,8 +77,8 @@ def test_session_eap_double_write(
         {
             "organizationId": "1",
             "projectId": "42",
-            "traceId": mock.ANY,
-            "itemId": mock.ANY,
+            "traceId": any(),
+            "itemId": any(),
             "itemType": "TRACE_ITEM_TYPE_USER_SESSION",
             "timestamp": time_within_delta(started, delta=timedelta(seconds=2)),
             "received": time_within_delta(),

--- a/tests/integration/test_span_links.py
+++ b/tests/integration/test_span_links.py
@@ -1,7 +1,8 @@
 import uuid
-from unittest import mock
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
+
+from .asserts import any
 
 
 def test_event_with_span_link_in_transaction(relay, mini_sentry):
@@ -98,7 +99,7 @@ def test_event_with_span_link_in_transaction(relay, mini_sentry):
             "status": "ok",
             "start_timestamp": 1624366926.0,
             "timestamp": 1624366927.0,
-            "sentry_tags": mock.ANY,
+            "sentry_tags": any(),
             "data": {"sentry.segment.name": "/users"},
             "links": [
                 {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-from unittest import mock
 import uuid
 from collections import Counter
 from datetime import UTC, datetime, timedelta, timezone
@@ -10,6 +9,7 @@ from requests import HTTPError
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
+from .asserts import any
 from .test_store import make_transaction
 
 TEST_CONFIG = {
@@ -1228,7 +1228,7 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 1,
             "reason": "too_large:span",
-            "timestamp": mock.ANY,
+            "timestamp": any(),
         },
         {
             "category": DataCategory.SPAN_INDEXED,
@@ -1238,7 +1238,7 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 1,
             "reason": "too_large:span",
-            "timestamp": mock.ANY,
+            "timestamp": any(),
         },
     ]
 

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timezone, timedelta
-from unittest import mock
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within, time_is
+from .asserts import any, time_within_delta, time_within, time_is
 
 from .test_dynamic_sampling import add_sampling_config
 
@@ -487,7 +486,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
 
     assert mini_sentry.get_metrics() == [
         {
-            "metadata": mock.ANY,
+            "metadata": any(),
             "name": "c:spans/count_per_root_project@none",
             "tags": {
                 "decision": "drop",
@@ -501,7 +500,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
             "width": 1,
         },
         {
-            "metadata": mock.ANY,
+            "metadata": any(),
             "name": "c:spans/usage@none",
             "tags": {
                 "is_segment": "false",
@@ -588,7 +587,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
     if rate_limit == DataCategory.SPAN_INDEXED:
         assert mini_sentry.get_metrics() == [
             {
-                "metadata": mock.ANY,
+                "metadata": any(),
                 "name": "c:spans/count_per_root_project@none",
                 "tags": {
                     "decision": "keep",
@@ -601,7 +600,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
                 "width": 1,
             },
             {
-                "metadata": mock.ANY,
+                "metadata": any(),
                 "name": "c:spans/usage@none",
                 "tags": {
                     "was_transaction": "false",
@@ -1185,8 +1184,8 @@ def test_spanv2_with_string_pii_scrubbing(
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                            "len": any(),
+                            "rem": [[rule_type, any(), any(), any()]],
                         }
                     }
                 }
@@ -1322,8 +1321,8 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                     "value": {
                         "1": {
                             "": {
-                                "len": mock.ANY,
-                                "rem": [["@creditcard", mock.ANY, mock.ANY, mock.ANY]],
+                                "len": any(),
+                                "rem": [["@creditcard", any(), any(), any()]],
                             }
                         }
                     }
@@ -1703,7 +1702,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": mock.ANY,
+        "attributes": any(),
         "status": "ok",
         "is_segment": True,
         "name": "some op",

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -1,12 +1,11 @@
 from datetime import datetime, timezone, timedelta
-from unittest import mock
 import uuid
 
 from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within, only_items, matches
+from .asserts import any, time_within_delta, time_within, only_items, matches
 
 import pytest
 import json
@@ -222,7 +221,7 @@ def test_trace_metric_extraction(
         },
         "clientSampleRate": 0.25,
         "downsampledRetentionDays": 390,
-        "itemId": mock.ANY,
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -482,7 +481,7 @@ def test_trace_metric_pii_scrubbing(
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": mock.ANY,
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -563,14 +562,14 @@ def test_trace_metric_string_pii_scrubbing(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": mock.ANY},
+        "__header": {"byte_size": any()},
         "_meta": {
             "attributes": {
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                            "len": any(),
+                            "rem": [[rule_type, any(), any(), any()]],
                         }
                     }
                 }
@@ -634,14 +633,14 @@ def test_trace_metric_default_pii_scrubbing_attributes(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": mock.ANY},
+        "__header": {"byte_size": any()},
         "_meta": {
             "attributes": {
                 attribute_key: {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [[rule_type, mock.ANY, mock.ANY, mock.ANY]],
+                            "len": any(),
+                            "rem": [[rule_type, any(), any(), any()]],
                         }
                     }
                 }
@@ -713,16 +712,14 @@ def test_trace_metric_default_pii_scrubbing_does_not_scrub_default_attributes(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": mock.ANY},
+        "__header": {"byte_size": any()},
         "_meta": {
             "attributes": {
                 "custom_field": {
                     "value": {
                         "": {
-                            "len": mock.ANY,
-                            "rem": [
-                                ["remove_custom_field", mock.ANY, mock.ANY, mock.ANY]
-                            ],
+                            "len": any(),
+                            "rem": [["remove_custom_field", any(), any(), any()]],
                         }
                     }
                 }
@@ -828,7 +825,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
     envelope = mini_sentry.get_captured_envelope()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     assert item_payload["items"][0] == {
-        "__header": mock.ANY,
+        "__header": any(),
         "_meta": {
             "timestamp": {
                 "": {
@@ -844,7 +841,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": mock.ANY,
+        "attributes": any(),
         "name": "http.request.duration",
         "type": "distribution",
         "value": 123.45,
@@ -942,7 +939,7 @@ def test_trace_metric_container_metadata(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": mock.ANY,
+        "__header": any(),
         "name": "test.metric",
         "type": "counter",
         "value": 1.0,

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timezone
-from unittest import mock
 import json
 
-from .asserts import time_within_delta
+from .asserts import any, time_within_delta
 
 from sentry_relay.consts import DataCategory
 
@@ -60,10 +59,10 @@ EXPECTED_ITEMS = [
     {
         "organizationId": "1",
         "projectId": "42",
-        "traceId": mock.ANY,
-        "itemId": mock.ANY,
+        "traceId": any(),
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "attributes": {
             "vercel.id": {"stringValue": "1573817187330377061717300000"},
             "sentry.origin": {"stringValue": "auto.log_drain.vercel"},
@@ -74,12 +73,12 @@ EXPECTED_ITEMS = [
             "sentry.body": {"stringValue": "Build completed successfully"},
             "vercel.project_name": {"stringValue": "my-app"},
             "sentry.severity_text": {"stringValue": "info"},
-            "sentry.observed_timestamp_nanos": {"stringValue": mock.ANY},
+            "sentry.observed_timestamp_nanos": {"stringValue": any()},
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(expect_resolution="ns")
             },
             "vercel.build_id": {"stringValue": "bld_cotnkcr76"},
-            "sentry.payload_size_bytes": {"intValue": mock.ANY},
+            "sentry.payload_size_bytes": {"intValue": any()},
             "vercel.project_id": {"stringValue": "gdufoJxB6b9b1fEqr1jUtFkyavUU"},
             "sentry._meta.fields.trace_id": {
                 "stringValue": '{"meta":{"":{"rem":[["trace_id.missing","s"]]}}}'
@@ -88,16 +87,16 @@ EXPECTED_ITEMS = [
         "clientSampleRate": 1.0,
         "serverSampleRate": 1.0,
         "retentionDays": 90,
-        "received": mock.ANY,
+        "received": any(),
         "downsampledRetentionDays": 90,
     },
     {
         "organizationId": "1",
         "projectId": "42",
         "traceId": "1b02cd14bb8642fd092bc23f54c7ffcd",
-        "itemId": mock.ANY,
+        "itemId": any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
-        "timestamp": mock.ANY,
+        "timestamp": any(),
         "attributes": {
             "vercel.path": {"stringValue": "/api/users"},
             "vercel.proxy.scheme": {"stringValue": "https"},
@@ -126,17 +125,17 @@ EXPECTED_ITEMS = [
             "vercel.proxy.timestamp": {"intValue": "1573817250172"},
             "sentry.body": {"stringValue": "API request processed"},
             "vercel.proxy.status_code": {"intValue": "200"},
-            "sentry.observed_timestamp_nanos": {"stringValue": mock.ANY},
+            "sentry.observed_timestamp_nanos": {"stringValue": any()},
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(expect_resolution="ns")
             },
-            "sentry.payload_size_bytes": {"intValue": mock.ANY},
+            "sentry.payload_size_bytes": {"intValue": any()},
             "vercel.proxy.region": {"stringValue": "sfo1"},
         },
         "clientSampleRate": 1.0,
         "serverSampleRate": 1.0,
         "retentionDays": 90,
-        "received": mock.ANY,
+        "received": any(),
         "downsampledRetentionDays": 90,
     },
 ]


### PR DESCRIPTION
Minimize diff output for integration test helpers by remembering the last comparison result and outcome.

Before:
```
Full diff:
    {
        'attributes': {
            'browser.name': {
                'stringValue': 'Firefox',
            },
            'browser.version': {
                'stringValue': '42.0',
            },
            'custom_field': {
                'stringValue': '[REDACTED]',
            },
            'sentry._meta.fields.attributes.custom_field': {
                'stringValue': '{"meta":{"value":{"":{"rem":[[["remove_custom_field","s",0,10](https://github.com/getsentry/relay/compare/dav1d/%22remove_custom_field%22,%22s%22,0,10)]],"len":12}}}}',
            },
  -         'sentry.body3': {
  ?                     -
  +         'sentry.body': {
                'stringValue': 'Test log',
            },
            'sentry.observed_timestamp_nanos': {
  -             'stringValue': 2026-05-22 07:02:08.193934+00:00 (1779433328193934000) <= x <= 2026-05-22 07:02:08.378575+00:00 (1779433328378575000),
  +             'stringValue': '1779433328195084000',
            },
  -         'sentry.payload_size_bytes': <ANY>,
  ?                                      ^^^^^^
  +         'sentry.payload_size_bytes': {
  ?                                      ^
  +             'intValue': '32',
  +         },
            'sentry.severity_text': {
                'stringValue': 'info',
            },
            'sentry.span_id': {
                'stringValue': 'eee19b7ec3c1b174',
            },
            'sentry.timestamp_precise': {
  -             'intValue': 2026-05-22 07:02:08.193934+00:00 (1779433328193934000) <= x <= 2026-05-22 07:02:08.193935+00:00 (1779433328193935000),
  +             'intValue': '1779433328193934000',
            },
        },
        'clientSampleRate': 1.0,
        'downsampledRetentionDays': 90,
  -     'itemId': <ANY>,
  +     'itemId': 'EQarNpU5maCCdkHOfU6eAQ==',
        'itemType': 'TRACE_ITEM_TYPE_LOG',
        'organizationId': '1',
        'projectId': '42',
  -     'received': 2026-05-22 07:01:38.378597+00:00 (1779433298.378597) <= x <= 2026-05-22 07:02:38.378598+00:00 (1779433358.378598),
  +     'received': '2026-05-22T07:02:08.195084Z',
        'retentionDays': 90,
        'serverSampleRate': 1.0,
  -     'timestamp': 2026-05-22 07:02:07.193934+00:00 (1779433327193934000) <= x <= 2026-05-22 07:02:09.193935+00:00 (1779433329193935000),
  +     'timestamp': '2026-05-22T07:02:08.193934Z',
        'traceId': '5b8efff798038103d269b633813fc60c',
    }
```

After:
```
Full diff:
    {
        'attributes': {
            'browser.name': {
                'stringValue': 'Firefox',
            },
            'browser.version': {
                'stringValue': '42.0',
            },
            'custom_field': {
                'stringValue': '[REDACTED]',
            },
            'sentry._meta.fields.attributes.custom_field': {
                'stringValue': '{"meta":{"value":{"":{"rem":[[["remove_custom_field","s",0,10](https://github.com/getsentry/relay/compare/dav1d/%22remove_custom_field%22,%22s%22,0,10)]],"len":12}}}}',
            },
  -         'sentry.body3': {
  ?                     -
  +         'sentry.body': {
                'stringValue': 'Test log',
            },
            'sentry.observed_timestamp_nanos': {
                'stringValue': '1779434516909935000',
            },
            'sentry.payload_size_bytes': {
                'intValue': '32',
            },
            'sentry.severity_text': {
                'stringValue': 'info',
            },
            'sentry.span_id': {
                'stringValue': 'eee19b7ec3c1b174',
            },
            'sentry.timestamp_precise': {
                'intValue': '1779434516908811000',
            },
        },
        'clientSampleRate': 1.0,
        'downsampledRetentionDays': 90,
        'itemId': 'gJssFA94uahFfKzxj06eAQ==',
        'itemType': 'TRACE_ITEM_TYPE_LOG',
        'organizationId': '1',
        'projectId': '42',
        'received': '2026-05-22T07:21:56.909935Z',
        'retentionDays': 90,
        'serverSampleRate': 1.0,
        'timestamp': '2026-05-22T07:21:56.908811Z',
        'traceId': '5b8efff798038103d269b633813fc60c',
    }
```