### PR TITLE
fix(replay): Add clock drift correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**:
 
+- Apply timestamp validation to replays. ([#6018](https://github.com/getsentry/relay/pull/6018))
 - Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005), [#6013](https://github.com/getsentry/relay/pull/6013))
 - Obtain PII values for `SpanData` fields from `sentry-conventions`. ([#5997](https://github.com/getsentry/relay/pull/5997))
 - Add `sentry.dsc.transaction` and `sentry.dsc.trace_id` to all spans. ([#6001](https://github.com/getsentry/relay/pull/6001), [#6004](https://github.com/getsentry/relay/pull/6004), [#6008](https://github.com/getsentry/relay/pull/6008))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 **Bug Fixes**:
 
 - Apply timestamp validation to replays. ([#6018](https://github.com/getsentry/relay/pull/6018))
-- Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005), [#6013](https://github.com/getsentry/relay/pull/6013), [#6015](https://github.com/getsentry/relay/pull/6015)) master
+- Apply timestamp validations to transaction spans. ([#6005](https://github.com/getsentry/relay/pull/6005), [#6013](https://github.com/getsentry/relay/pull/6013), [#6015](https://github.com/getsentry/relay/pull/6015))
 - Obtain PII values for `SpanData` fields from `sentry-conventions`. ([#5997](https://github.com/getsentry/relay/pull/5997))
 - Add `sentry.dsc.transaction` and `sentry.dsc.trace_id` to all spans. ([#6001](https://github.com/getsentry/relay/pull/6001), [#6004](https://github.com/getsentry/relay/pull/6004), [#6008](https://github.com/getsentry/relay/pull/6008))
 - Correctly handle attributes with placeholders during normalization. ([#6012](https://github.com/getsentry/relay/pull/6012))

--- a/relay-event-normalization/src/eap/time.rs
+++ b/relay-event-normalization/src/eap/time.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use relay_event_schema::{
     processor::{self, ProcessValue, ProcessingState},
-    protocol::{OurLog, SpanV2, Timestamp, TraceMetric},
+    protocol::{OurLog, Replay, SpanV2, Timestamp, TraceMetric},
 };
 use relay_protocol::{Annotated, ErrorKind};
 use std::time::Duration;
@@ -92,6 +92,12 @@ impl TimeNormalize for SpanV2 {
 }
 
 impl TimeNormalize for TraceMetric {
+    fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp> {
+        &mut self.timestamp
+    }
+}
+
+impl TimeNormalize for Replay {
     fn reference_timestamp_mut(&mut self) -> &mut Annotated<Timestamp> {
         &mut self.timestamp
     }

--- a/relay-server/src/processing/replays/mod.rs
+++ b/relay-server/src/processing/replays/mod.rs
@@ -198,7 +198,7 @@ impl processing::Processor for ReplaysProcessor {
         let mut replay = process::expand(replays)?;
 
         validate::validate(&replay).reject(&replay)?;
-        process::normalize(&mut replay, &self.geoip_lookup);
+        process::normalize(&mut replay, &self.geoip_lookup, ctx);
         filter::filter(&replay, ctx).reject(&replay)?;
 
         let mut replay = self.limiter.enforce_quotas(replay, ctx).await?;

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -1,5 +1,5 @@
 use relay_dynamic_config::Feature;
-use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo, replay};
+use relay_event_normalization::{GeoIpLookup, RawUserAgentInfo, eap, replay};
 use relay_event_schema::processor::{self, ProcessingState};
 use relay_event_schema::protocol::Replay;
 use relay_pii::PiiProcessor;
@@ -9,10 +9,10 @@ use relay_statsd::metric;
 
 use crate::envelope::Item;
 use crate::managed::{Managed, Rejected};
-use crate::processing::Context;
 use crate::processing::replays::{
     Error, ExpandedReplay, ReplayPayload, ReplayVideoEvent, SerializedReplays,
 };
+use crate::processing::{Context, utils};
 use crate::statsd::RelayTimers;
 
 fn expand_video(item: &Item) -> Result<ReplayPayload, Error> {
@@ -94,9 +94,14 @@ pub fn expand(
 }
 
 /// Normalizes a replay event.
-pub fn normalize(replay: &mut Managed<ExpandedReplay>, geoip_lookup: &GeoIpLookup) {
+pub fn normalize(
+    replay: &mut Managed<ExpandedReplay>,
+    geoip_lookup: &GeoIpLookup,
+    ctx: Context<'_>,
+) {
     let meta = replay.headers.meta();
     let client_addr = meta.client_addr();
+    let time_config = utils::normalize::time_config(&replay.headers, |_| None, ctx);
     let user_agent = RawUserAgentInfo {
         user_agent: meta.user_agent().map(String::from),
         client_hints: meta.client_hints().to_owned(),
@@ -104,6 +109,7 @@ pub fn normalize(replay: &mut Managed<ExpandedReplay>, geoip_lookup: &GeoIpLooku
 
     replay.modify(|replay, _| {
         if let Some(event) = replay.payload.event_mut() {
+            eap::time::normalize(event, time_config);
             replay::normalize(event, client_addr, &user_agent.as_deref(), geoip_lookup)
         }
     })

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -1,4 +1,10 @@
 import uuid
+import json
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from .asserts import time_within_delta
 
 
 def generate_replay_sdk_event(replay_id="d2132d31b39445f1938d7e21b6bf0ec4"):
@@ -147,3 +153,53 @@ def test_replay_events_are_filtered(
     assert outcome["quantity"] == 2
 
     outcomes_consumer.assert_empty()
+
+
+@pytest.mark.parametrize(
+    "delta,error",
+    [
+        (-timedelta(days=2), "past_timestamp"),
+        (timedelta(days=2), "future_timestamp"),
+    ],
+)
+def test_time_corrections(mini_sentry, relay, delta, error):
+    project_id = 42
+    mini_sentry.add_basic_project_config(
+        project_id,
+        extra={
+            "config": {
+                "features": ["organizations:session-replay"],
+                "eventRetention": 1,
+            }
+        },
+    )
+    relay = relay(mini_sentry)
+
+    now = datetime.now(timezone.utc)
+    sdk_ts = (now + delta).timestamp()
+    sdk_start_ts = sdk_ts - 60.0
+
+    replay = generate_replay_sdk_event()
+    replay["timestamp"] = sdk_ts
+    replay["replay_start_timestamp"] = sdk_start_ts
+
+    relay.send_replay_event(project_id, replay)
+    produced = mini_sentry.get_captured_envelope()
+    replay_items = [item for item in produced.items if item.type == "replay_event"]
+    assert len(replay_items) == 1
+
+    payload = json.loads(replay_items[0].payload.bytes.decode())
+
+    assert payload["timestamp"] == time_within_delta(now)
+    assert payload["replay_start_timestamp"] == time_within_delta(
+        now - timedelta(seconds=60)
+    )
+    assert payload["_meta"]["timestamp"][""]["err"] == [
+        [
+            error,
+            {
+                "sdk_time": time_within_delta(now + delta),
+                "server_time": time_within_delta(now),
+            },
+        ]
+    ]

--- a/tests/integration/test_replay_events.py
+++ b/tests/integration/test_replay_events.py
@@ -194,12 +194,19 @@ def test_time_corrections(mini_sentry, relay, delta, error):
     assert payload["replay_start_timestamp"] == time_within_delta(
         now - timedelta(seconds=60)
     )
-    assert payload["_meta"]["timestamp"][""]["err"] == [
-        [
-            error,
-            {
-                "sdk_time": time_within_delta(now + delta),
-                "server_time": time_within_delta(now),
-            },
-        ]
-    ]
+    assert payload["_meta"] == {
+        "timestamp": {
+            "": {
+                "err": [
+                    [
+                        error,
+                        {
+                            "sdk_time": time_within_delta(now + delta),
+                            "server_time": time_within_delta(now),
+                        },
+                    ]
+                ]
+            }
+        },
+        "user": {"email": {"": {"rem": [["@email", "s", 0, 7]], "len": 13}}},
+    }


### PR DESCRIPTION
Adds timestamp normalization and validation for Replays (making use of the existing EAP logic).
Note: Any timestamps in the rrweb payload will not be corrected.

Ref: INGEST-923