### PR TITLE
ci(gocd): Bump gocd-jsonnet to v3.0.4

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.19.0"
+      "version": "v3.0.4"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "56cc4d91cbaac4569b37b4911998b48c2f9c2ac4",
-      "sum": "J0D//go/146qfReWFTTL5xWWCVlkTjqhnALYPH4Z9rE="
+      "version": "7a25c44956933a57b5ca03beb3b70c470724c2c8",
+      "sum": "0S+eGE0WHdxJxKS/Bdga+NB+cB+ZBwF4LoehKv0azXc="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
## Summary
- Bump `gocd-jsonnet` from `v2.19.0` to `v3.0.4` in `gocd/templates/jsonnetfile.json`
- Regenerated `jsonnetfile.lock.json` via `jb update`

## Test plan
- [x] `jsonnet-lint` on all `*.jsonnet` / `*.libsonnet` files passes
- [x] `processing.jsonnet` renders successfully against the new vendored library

🤖 Generated with [Claude Code](https://claude.com/claude-code)