### PR TITLE
feat: Remove `relay-measurements-smart-conversion` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Features**:
 
 - Implement mobile measurements calculation for V2 spans. ([#6022](https://github.com/getsentry/relay/pull/6022))
+- Globally enable `sentry-conventions`-based conversion from measurements to attributes and remove the
+  `projects:relay-measurements-smart-conversion` feature flag. ([#6034](https://github.com/getsentry/relay/pull/6034))
 
 **Internal**:
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -105,10 +105,6 @@ pub enum Feature {
     /// Stream minidumps to objectstore.
     #[serde(rename = "projects:relay-minidump-uploads")]
     MinidumpUploads,
-    /// When converting measurements into attributes, use the name from the measurement
-    /// definition.
-    #[serde(rename = "projects:relay-measurements-smart-conversion")]
-    MeasurementsSmartConversion,
 
     /// Enables OTLP spans to use the Span V2 processing pipeline in Relay.
     ///

--- a/relay-server/src/processing/legacy_spans/mod.rs
+++ b/relay-server/src/processing/legacy_spans/mod.rs
@@ -194,7 +194,7 @@ impl Forward for LegacySpanOutput {
         let retention = ctx.retention(|r| r.span.as_ref());
 
         for span in spans.split(|spans| spans.spans.into_iter().map(IndexedOnly)) {
-            if let Ok(span) = span.try_map(|span, _| store::convert(span.0, retention, ctx)) {
+            if let Ok(span) = span.try_map(|span, _| store::convert(span.0, retention)) {
                 s.send_to_store(span)
             };
         }

--- a/relay-server/src/processing/legacy_spans/store.rs
+++ b/relay-server/src/processing/legacy_spans/store.rs
@@ -1,9 +1,8 @@
-use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::Span;
 use relay_protocol::Annotated;
 
+use crate::processing::Retention;
 use crate::processing::legacy_spans::{Error, Result};
-use crate::processing::{ForwardContext, Retention};
 use crate::services::outcome::DiscardReason;
 use crate::services::store::StoreSpanV2;
 
@@ -23,16 +22,8 @@ macro_rules! required {
 }
 
 /// Converts a [`Span`] into a [`StoreSpanV2`] to be sent to Kafka.
-pub fn convert(
-    span: Annotated<Span>,
-    retentions: Retention,
-    ctx: ForwardContext<'_>,
-) -> Result<Box<StoreSpanV2>> {
-    let use_measurements_smart_conversion = ctx
-        .project_info
-        .has_feature(Feature::MeasurementsSmartConversion);
-    let span = span
-        .map_value(|span| relay_spans::span_v1_to_span_v2(span, use_measurements_smart_conversion));
+pub fn convert(span: Annotated<Span>, retentions: Retention) -> Result<Box<StoreSpanV2>> {
+    let span = span.map_value(relay_spans::span_v1_to_span_v2);
     let span = required!(span);
 
     Ok(Box::new(StoreSpanV2 {

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -180,7 +180,7 @@ impl processing::Processor for SpansProcessor {
         dynamic_sampling::validate_configs(ctx);
         dynamic_sampling::validate_dsc_presence(&spans).reject(&spans)?;
 
-        let spans = process::expand(spans, ctx)?;
+        let spans = process::expand(spans)?;
 
         let mut spans = match dynamic_sampling::run(spans, ctx) {
             Ok(spans) => spans,

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use relay_dynamic_config::Feature;
 use relay_event_normalization::eap::ClientUserAgentInfo;
 use relay_event_normalization::{EnrichedDsc, GeoIpLookup, RequiredMode, SchemaProcessor, eap};
 use relay_event_schema::processor::{ProcessingState, ValueType, process_value};
@@ -20,10 +19,7 @@ use crate::services::outcome::DiscardReason;
 /// Parses all serialized spans.
 ///
 /// Individual, invalid spans are discarded.
-pub fn expand(
-    spans: Managed<SerializedSpans>,
-    ctx: Context<'_>,
-) -> Result<Managed<ExpandedSpans>, Rejected<Error>> {
+pub fn expand(spans: Managed<SerializedSpans>) -> Result<Managed<ExpandedSpans>, Rejected<Error>> {
     spans.try_map(|spans, records| {
         let SerializedSpans {
             headers,
@@ -39,7 +35,7 @@ pub fn expand(
 
         let (settings, spans) = match items {
             SpanItems::Container(item) => expand_span_container(&item)?,
-            SpanItems::Legacy(items) => expand_legacy_spans(items, records, ctx),
+            SpanItems::Legacy(items) => expand_legacy_spans(items, records),
             SpanItems::Integration(item) => spans::integrations::expand(records, &[item]),
             SpanItems::None => (Default::default(), Vec::new()),
         };
@@ -130,11 +126,10 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
 fn expand_legacy_spans(
     items: Vec<Item>,
     records: &mut RecordKeeper<'_>,
-    ctx: Context<'_>,
 ) -> (Settings, ContainerItems<SpanV2>) {
     let spans = items
         .into_iter()
-        .filter_map(|item| match expand_legacy_span(&item, ctx) {
+        .filter_map(|item| match expand_legacy_span(&item) {
             Ok(span) => Some(span),
             Err(err) => {
                 records.reject_err(err, item);
@@ -146,18 +141,15 @@ fn expand_legacy_spans(
     (Settings::default(), spans)
 }
 
-fn expand_legacy_span(item: &Item, ctx: Context<'_>) -> Result<WithHeader<SpanV2>> {
+fn expand_legacy_span(item: &Item) -> Result<WithHeader<SpanV2>> {
     let payload = item.payload();
-    let use_measurements_smart_conversion = ctx
-        .project_info
-        .has_feature(Feature::MeasurementsSmartConversion);
 
     let span = Annotated::<Span>::from_json_bytes(&payload)
         .map_err(|err| {
             relay_log::debug!("failed to parse span: {err}");
             Error::Invalid(DiscardReason::InvalidJson)
         })?
-        .map_value(|span| relay_spans::span_v1_to_span_v2(span, use_measurements_smart_conversion));
+        .map_value(relay_spans::span_v1_to_span_v2);
 
     Ok(WithHeader::new(span))
 }

--- a/relay-server/src/processing/transactions/process.rs
+++ b/relay-server/src/processing/transactions/process.rs
@@ -488,19 +488,20 @@ pub fn extract_spans(
     );
 
     transaction.split_once(|mut tx, r| {
-        let spans = spans::extract_from_event(tx.headers.dsc(), &tx.event, ctx, server_sample_rate)
-            .into_iter()
-            .filter_map(|span| match span {
-                Ok(span) => Some(span),
-                Err(()) => {
-                    r.reject_err(
-                        Outcome::Invalid(DiscardReason::InvalidSpan),
-                        IndexedSpans(1),
-                    );
-                    None
-                }
-            })
-            .collect();
+        let spans =
+            spans::extract_from_event(tx.headers.dsc(), &tx.event, ctx.config, server_sample_rate)
+                .into_iter()
+                .filter_map(|span| match span {
+                    Ok(span) => Some(span),
+                    Err(()) => {
+                        r.reject_err(
+                            Outcome::Invalid(DiscardReason::InvalidSpan),
+                            IndexedSpans(1),
+                        );
+                        None
+                    }
+                })
+                .collect();
 
         // Once spans are extracted, they are no longer counted towards the transaction.
         tx.flags.spans_extracted = true;

--- a/relay-server/src/processing/transactions/spans.rs
+++ b/relay-server/src/processing/transactions/spans.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use crate::processing;
 use crate::processing::utils::event::event_type;
 use relay_base_schema::events::EventType;
-use relay_dynamic_config::Feature;
+use relay_config::Config;
 use relay_event_schema::protocol::{Event, Measurement, Measurements, Span, SpanV2};
 use relay_metrics::MetricNamespace;
 use relay_metrics::{FractionUnit, MetricUnit};
@@ -13,7 +13,7 @@ use relay_sampling::DynamicSamplingContext;
 pub fn extract_from_event(
     dsc: Option<&DynamicSamplingContext>,
     event: &Annotated<Event>,
-    ctx: processing::Context<'_>,
+    config: &Config,
     server_sample_rate: Option<f64>,
 ) -> Vec<Result<Annotated<SpanV2>, ()>> {
     // Only extract spans from transactions (not errors).
@@ -29,7 +29,7 @@ pub fn extract_from_event(
 
     let Some(transaction_span) = processing::transactions::extraction::extract_segment_span(
         event,
-        ctx.config
+        config
             .aggregator_config_for(MetricNamespace::Spans)
             .max_tag_value_length,
         &[],
@@ -60,7 +60,6 @@ pub fn extract_from_event(
 
             results.push(make_span_item(
                 new_span,
-                ctx,
                 client_sample_rate,
                 server_sample_rate,
             ));
@@ -69,7 +68,6 @@ pub fn extract_from_event(
 
     results.push(make_span_item(
         transaction_span,
-        ctx,
         client_sample_rate,
         server_sample_rate,
     ));
@@ -79,7 +77,6 @@ pub fn extract_from_event(
 
 fn make_span_item(
     mut span: Span,
-    ctx: processing::Context<'_>,
     client_sample_rate: Option<f64>,
     server_sample_rate: Option<f64>,
 ) -> Result<Annotated<SpanV2>, ()> {
@@ -107,12 +104,7 @@ fn make_span_item(
         })
         .map_err(|_| ())?;
 
-    let use_measurements_smart_conversion = ctx
-        .project_info
-        .has_feature(Feature::MeasurementsSmartConversion);
-
-    Ok(span
-        .map_value(|span| relay_spans::span_v1_to_span_v2(span, use_measurements_smart_conversion)))
+    Ok(span.map_value(relay_spans::span_v1_to_span_v2))
 }
 
 /// Any violation of the span schema.

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -14,10 +14,9 @@ use crate::name::name_for_attributes;
 /// - `tags`, `sentry_tags`, `measurements` and `data` are transferred to `attributes`.
 /// - Nested `data` items are encoded as JSON.
 ///
-/// If `use_measurements_smart_conversion` is `true`, measurements will be converted
-/// to attributes by looking up the replacement attribute's name in `sentry-conventions`.
-/// Otherwise, the measurement name will be reused as the attribute name verbatim.
-pub fn span_v1_to_span_v2(span_v1: SpanV1, use_measurements_smart_conversion: bool) -> SpanV2 {
+/// Measurements will be converted to attributes by looking up the
+/// replacement attribute's name in `sentry-conventions`.
+pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     let SpanV1 {
         timestamp,
         start_timestamp,
@@ -66,16 +65,12 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1, use_measurements_smart_conversion: bo
     if let Some(measurements) = measurements.into_value() {
         for (key, measurement) in measurements.0 {
             let key = match key.as_str() {
-                // TODO: If these measurements were defined in conventions we could get rid of the match entirely
+                // These measurements aren't defined in conventions; they are not sent
+                // by SDKs but inserted into `measurements` by Relay. As such, we
+                // special-case them here.
                 "client_sample_rate" => SENTRY__CLIENT_SAMPLE_RATE,
                 "server_sample_rate" => SENTRY__SERVER_SAMPLE_RATE,
-                other => {
-                    if use_measurements_smart_conversion {
-                        relay_conventions::measurement_to_attribute(other).unwrap_or(other)
-                    } else {
-                        other
-                    }
-                }
+                other => relay_conventions::measurement_to_attribute(other).unwrap_or(other),
             };
 
             attributes.insert_if_missing(key, || match measurement {
@@ -325,7 +320,7 @@ mod tests {
         });
 
         let span_v1 = SpanV1::from_value(json.into()).into_value().unwrap();
-        let span_v2 = span_v1_to_span_v2(span_v1, false);
+        let span_v2 = span_v1_to_span_v2(span_v1);
 
         let annotated_span_v2: Annotated<SpanV2> = Annotated::new(span_v2);
         insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span_v2), @r#"
@@ -492,7 +487,7 @@ mod tests {
         }
         "###);
 
-        let span_v2 = span_v1_to_span_v2(span_v1, false);
+        let span_v2 = span_v1_to_span_v2(span_v1);
 
         // The `name` and the `sentry.segment.name` attribute are the same as the transaction.
         insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::new(span_v2)), @r###"
@@ -522,7 +517,7 @@ mod tests {
     fn start_timestamp() {
         let json = r#"{"timestamp": 123, "end_timestamp": "invalid data"}"#;
         let span_v1 = Annotated::<SpanV1>::from_json(json).unwrap();
-        let span_v2 = span_v1_to_span_v2(span_v1.into_value().unwrap(), false);
+        let span_v2 = span_v1_to_span_v2(span_v1.into_value().unwrap());
 
         // Parsed version is still fine:
         assert_eq!(

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -497,20 +497,14 @@ def envelope_with_transaction_and_spans(start: datetime, end: datetime) -> Envel
     return envelope
 
 
-@pytest.mark.parametrize("measurements_conversion", ["direct", "smart"])
 def test_span_ingestion_with_performance_scores(
-    mini_sentry, relay_with_processing, spans_consumer, measurements_conversion
+    mini_sentry, relay_with_processing, spans_consumer
 ):
     spans_consumer = spans_consumer()
     relay = relay_with_processing()
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
-    if measurements_conversion == "smart":
-        project_config["config"]["features"] = [
-            "projects:relay-measurements-smart-conversion"
-        ]
-
     project_config["config"]["performanceScore"] = {
         "profiles": [
             {
@@ -616,29 +610,6 @@ def test_span_ingestion_with_performance_scores(
     # endpoint might overtake envelope
     spans.sort(key=lambda msg: msg["span_id"])
 
-    if measurements_conversion == "smart":
-        measurements1 = {
-            "browser.web_vital.cls.value": 100.0,
-            "browser.web_vital.fcp.value": 200.0,
-            "fid": 300.0,
-            "browser.web_vital.lcp.value": 400.0,
-            "browser.web_vital.ttfb.value": 500.0,
-        }
-        measurements2 = {
-            "browser.web_vital.inp.value": 100.0,
-        }
-    else:
-        measurements1 = {
-            "cls": 100.0,
-            "fcp": 200.0,
-            "fid": 300.0,
-            "lcp": 400.0,
-            "ttfb": 500.0,
-        }
-        measurements2 = {
-            "inp": 100.0,
-        }
-
     expected_scores = [
         {
             "score.fcp": 0.14999972769539766,
@@ -656,15 +627,19 @@ def test_span_ingestion_with_performance_scores(
             "score.weight.fid": 0.3,
             "score.weight.lcp": 0.3,
             "score.weight.ttfb": 0.0,
+            "browser.web_vital.cls.value": 100.0,
+            "browser.web_vital.fcp.value": 200.0,
+            "fid": 300.0,
+            "browser.web_vital.lcp.value": 400.0,
+            "browser.web_vital.ttfb.value": 500.0,
             "score.cls": 0.0,
-            **measurements1,
         },
         {
+            "browser.web_vital.inp.value": 100.0,
             "score.inp": 0.9948129113413748,
             "score.ratio.inp": 0.9948129113413748,
             "score.total": 0.9948129113413748,
             "score.weight.inp": 1.0,
-            **measurements2,
         },
     ]
 

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -144,15 +144,8 @@ def lcp_cls_inp_differences(mode):
 
 
 @pytest.mark.parametrize("mode", ["legacy", "v2"])
-@pytest.mark.parametrize("measurements_conversion", ["direct", "smart"])
 def test_lcp_span(
-    mini_sentry,
-    relay,
-    relay_with_processing,
-    spans_consumer,
-    metrics_consumer,
-    mode,
-    measurements_conversion,
+    mini_sentry, relay, relay_with_processing, spans_consumer, metrics_consumer, mode
 ):
     """
     Test verifies LCP spans processed via the SpanV2 and legacy standalone processing pipeline are equally processed.
@@ -170,10 +163,6 @@ def test_lcp_span(
     if mode == "v2":
         project_config["config"].setdefault("features", []).append(
             "projects:span-v2-experimental-processing"
-        )
-    if measurements_conversion == "smart":
-        project_config["config"].setdefault("features", []).append(
-            "projects:relay-measurements-smart-conversion"
         )
 
     relay = relay(relay_with_processing())
@@ -225,8 +214,6 @@ def test_lcp_span(
     lcp_backfill = {}
     if mode == "v2":
         lcp_backfill = {
-            # In the v2 pipeline we will always get this attribute regardless of whether we use "smart"
-            # measurement conversion, because of backfilling.
             "browser.web_vital.lcp.value": {"type": "double", "value": 548.0},
             "browser.web_vital.lcp.load_time": {"type": "double", "value": 527.5},
             "browser.web_vital.lcp.render_time": {"type": "integer", "value": 548},
@@ -237,15 +224,10 @@ def test_lcp_span(
             },
         }
 
-    if measurements_conversion == "smart":
-        lcp_measurement_name = "browser.web_vital.lcp.value"
-    else:
-        lcp_measurement_name = "lcp"
-
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
-            lcp_measurement_name: {"type": "double", "value": 548.0},
+            "browser.web_vital.lcp.value": {"type": "double", "value": 548.0},
             "lcp.loadTime": {"type": "double", "value": 527.5},
             "lcp.renderTime": {"type": "integer", "value": 548},
             "lcp.size": {"type": "integer", "value": 8100},
@@ -366,15 +348,8 @@ def test_lcp_span(
 
 
 @pytest.mark.parametrize("mode", ["legacy", "v2"])
-@pytest.mark.parametrize("measurements_conversion", ["direct", "smart"])
 def test_cls_span(
-    mini_sentry,
-    relay,
-    relay_with_processing,
-    spans_consumer,
-    metrics_consumer,
-    mode,
-    measurements_conversion,
+    mini_sentry, relay, relay_with_processing, spans_consumer, metrics_consumer, mode
 ):
     """
     Test verifies CLS spans processed via the SpanV2 and legacy standalone processing pipeline are equally processed.
@@ -392,10 +367,6 @@ def test_cls_span(
     if mode == "v2":
         project_config["config"].setdefault("features", []).append(
             "projects:span-v2-experimental-processing"
-        )
-    if measurements_conversion == "smart":
-        project_config["config"].setdefault("features", []).append(
-            "projects:relay-measurements-smart-conversion"
         )
 
     relay = relay(relay_with_processing())
@@ -446,8 +417,6 @@ def test_cls_span(
     cls_backfill = {}
     if mode == "v2":
         cls_backfill = {
-            # In the v2 pipeline we will always get this attribute regardless of whether we use "smart"
-            # measurement conversion, because of backfilling.
             "browser.web_vital.cls.value": {"type": "double", "value": 0.1},
             "browser.web_vital.cls.source.1": {
                 "type": "string",
@@ -460,15 +429,10 @@ def test_cls_span(
             "browser.web_vital.cls.source.3": {"type": "string", "value": "<unknown>"},
         }
 
-    if measurements_conversion == "smart":
-        cls_measurement_name = "browser.web_vital.cls.value"
-    else:
-        cls_measurement_name = "cls"
-
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
-            cls_measurement_name: {"type": "double", "value": 0.1},
+            "browser.web_vital.cls.value": {"type": "double", "value": 0.1},
             "cls.source.1": {
                 "type": "string",
                 "value": "AppContainer > NavContent > MobileTopbar > StyledButton",
@@ -594,15 +558,8 @@ def test_cls_span(
 
 
 @pytest.mark.parametrize("mode", ["legacy", "v2"])
-@pytest.mark.parametrize("measurements_conversion", ["direct", "smart"])
 def test_inp_span(
-    mini_sentry,
-    relay,
-    relay_with_processing,
-    spans_consumer,
-    metrics_consumer,
-    mode,
-    measurements_conversion,
+    mini_sentry, relay, relay_with_processing, spans_consumer, metrics_consumer, mode
 ):
     """
     Test verifies INP spans processed via the SpanV2 and legacy standalone processing pipeline are equally processed.
@@ -620,10 +577,6 @@ def test_inp_span(
     if mode == "v2":
         project_config["config"].setdefault("features", []).append(
             "projects:span-v2-experimental-processing"
-        )
-    if measurements_conversion == "smart":
-        project_config["config"].setdefault("features", []).append(
-            "projects:relay-measurements-smart-conversion"
         )
 
     relay = relay(relay_with_processing())
@@ -669,20 +622,13 @@ def test_inp_span(
     inp_backfill = {}
     if mode == "v2":
         inp_backfill = {
-            # In the v2 pipeline we will always get this attribute regardless of whether we use "smart"
-            # measurement conversion, because of backfilling.
             "browser.web_vital.inp.value": {"type": "double", "value": 104.0},
         }
-
-    if measurements_conversion == "smart":
-        inp_measurement_name = "browser.web_vital.inp.value"
-    else:
-        inp_measurement_name = "inp"
 
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
-            inp_measurement_name: {"type": "double", "value": 104.0},
+            "browser.web_vital.inp.value": {"type": "double", "value": 104.0},
             "browser.name": {"type": "string", "value": "Chrome"},
             "sentry.description": {
                 "type": "string",
@@ -858,14 +804,12 @@ def test_spans_standalone_dsc_normalization(
 
 
 @pytest.mark.parametrize("mode", ["legacy", "v2"])
-@pytest.mark.parametrize("measurements_conversion", ["direct", "smart"])
 def test_mobile_measurements(
     mini_sentry,
     relay,
     relay_with_processing,
     spans_consumer,
     mode,
-    measurements_conversion,
 ):
     """
     Verify mobile measurements calculations (slow/frozen frames, stalls).
@@ -877,10 +821,6 @@ def test_mobile_measurements(
     if mode == "v2":
         project_config["config"].setdefault("features", []).append(
             "projects:span-v2-experimental-processing"
-        )
-    if measurements_conversion == "smart":
-        project_config["config"].setdefault("features", []).append(
-            "projects:relay-measurements-smart-conversion"
         )
 
     relay = relay(relay_with_processing())
@@ -926,63 +866,6 @@ def test_mobile_measurements(
     relay.send_envelope(project_id, envelope)
     attributes, fields = lcp_cls_inp_differences(mode)
 
-    measurement_attributes = {
-        "stall_total_time": {"value": 4000.0, "type": "double"},
-        "stall_percentage": {"value": 0.8, "type": "double"},
-    }
-    if mode == "legacy":
-        if measurements_conversion == "direct":
-            # Measurements are computed by the old pipeline and measurements
-            # are converted to attributes verbatim, with no normalization.
-            measurement_attributes.update(
-                {
-                    "frames_slow": {"value": 1.0, "type": "double"},
-                    "frames_frozen": {"value": 2.0, "type": "double"},
-                    "frames_total": {"value": 4.0, "type": "double"},
-                    "frames_frozen_rate": {"value": 0.5, "type": "double"},
-                    "frames_slow_rate": {"value": 0.25, "type": "double"},
-                }
-            )
-        elif measurements_conversion == "smart":
-            # Measurements are computed by the old pipeline and measurements
-            # are converted to attributes with current names.
-            #
-            # "frames_frozen_rate" and "frames_slow_rate" don't have "better"
-            # names yet.
-            measurement_attributes.update(
-                {
-                    "app.vitals.frames.slow.count": {"value": 1.0, "type": "double"},
-                    "app.vitals.frames.frozen.count": {"value": 2.0, "type": "double"},
-                    "app.vitals.frames.total.count": {"value": 4.0, "type": "double"},
-                    "frames_frozen_rate": {"value": 0.5, "type": "double"},
-                    "frames_slow_rate": {"value": 0.25, "type": "double"},
-                }
-            )
-    elif mode == "v2":
-        if measurements_conversion == "direct":
-            # Measurements are _first_ converted verbatim, then the calculation
-            # runs. Since the frame count attributes aren't present under their
-            # expected names, the calculation doesn't work.
-            measurement_attributes.update(
-                {
-                    "frames_slow": {"value": 1.0, "type": "double"},
-                    "frames_frozen": {"value": 2.0, "type": "double"},
-                    "frames_total": {"value": 4.0, "type": "double"},
-                }
-            )
-        elif measurements_conversion == "smart":
-            # Measurements are _first_ converted to attribute with "current"
-            # names, then the calculation runs.
-            measurement_attributes.update(
-                {
-                    "app.vitals.frames.slow.count": {"value": 1.0, "type": "double"},
-                    "app.vitals.frames.frozen.count": {"value": 2.0, "type": "double"},
-                    "app.vitals.frames.total.count": {"value": 4.0, "type": "double"},
-                    "frames_frozen_rate": {"value": 0.5, "type": "double"},
-                    "frames_slow_rate": {"value": 0.25, "type": "double"},
-                }
-            )
-
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
@@ -1018,7 +901,13 @@ def test_mobile_measurements(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
                 "Safari/537.36",
             },
-            **measurement_attributes,
+            "stall_total_time": {"value": 4000.0, "type": "double"},
+            "stall_percentage": {"value": 0.8, "type": "double"},
+            "app.vitals.frames.slow.count": {"value": 1.0, "type": "double"},
+            "app.vitals.frames.frozen.count": {"value": 2.0, "type": "double"},
+            "app.vitals.frames.total.count": {"value": 4.0, "type": "double"},
+            "frames_frozen_rate": {"value": 0.5, "type": "double"},
+            "frames_slow_rate": {"value": 0.25, "type": "double"},
             **attributes,
         },
         "downsampled_retention_days": 90,


### PR DESCRIPTION
The feature has been generally enabled for a while with no issues. This PR removes it and makes the behavior the default.

ref: INGEST-939