### PR TITLE
chore(ci): Pin macOS runner to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-15, windows-latest]
 
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub is migrating the `macos-latest` label to the macOS 26 runner image, rolling out between June 15 and July 15, 2026. Pin the test matrix to `macos-15` to stay on the current stable image.

