### PR TITLE
ref(server): Remove ProjectState::enabled()

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ workspace with multiple features, so when running building or running tests
 always make sure to pass the `--all` and `--all-features` flags.
 The `processing` feature additionally requires a C compiler and CMake.
 
+To install cmake run `brew install cmake`.
+
 To install the development environment, run `direnv allow` then `devenv sync`.
 ([Install devenv](https://github.com/getsentry/devenv/?tab=readme-ov-file#install) if you haven't already.)
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -430,6 +430,7 @@ async fn upload_context<'a>(
 
     let project_config = match project.state() {
         ProjectState::Enabled(info) => info.clone(),
+        // TODO(INGEST-925): Support proxy mode
         ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
             return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
         }

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -29,6 +29,7 @@ use crate::managed::{Managed, ManagedResult, Rejected};
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason, Outcome};
+use crate::services::projects::project::ProjectState;
 use crate::services::upload::Upload;
 use crate::statsd::RelayCounters;
 use crate::utils::{self, AttachmentStrategy, read_bytes_into_item};
@@ -427,11 +428,12 @@ async fn upload_context<'a>(
         .await
         .ok_or(BadStoreRequest::ProjectUnavailable)?;
 
-    let project_config = project
-        .state()
-        .clone()
-        .enabled()
-        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+    let project_config = match project.state() {
+        ProjectState::Enabled(info) => info.clone(),
+        ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
+            return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
+        }
+    };
 
     let scoping = project_config
         .scoping(meta.public_key())

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -3,7 +3,7 @@
 //! Crashes are received as multipart uploads in this [format](https://game.develop.playstation.net/resources/documents/SDK/12.000/Core_Dump_System-Overview/ps5-core-dump-file-set-sending-format.html).
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
-use axum::routing::{post, MethodRouter};
+use axum::routing::{MethodRouter, post};
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_dynamic_config::Feature;

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -3,7 +3,7 @@
 //! Crashes are received as multipart uploads in this [format](https://game.develop.playstation.net/resources/documents/SDK/12.000/Core_Dump_System-Overview/ps5-core-dump-file-set-sending-format.html).
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
-use axum::routing::{MethodRouter, post};
+use axum::routing::{post, MethodRouter};
 use multer::{Field, Multipart};
 use relay_config::Config;
 use relay_dynamic_config::Feature;
@@ -92,6 +92,7 @@ async fn upload_context<'a>(
 
     let project_config = match project.state() {
         ProjectState::Enabled(info) => info.clone(),
+        // TODO(INGEST-925): Support proxy mode
         ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
             return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
         }

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -20,6 +20,7 @@ use crate::managed::{Managed, ManagedResult};
 use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::DiscardReason;
+use crate::services::projects::project::ProjectState;
 use crate::services::upload::Upload;
 use crate::utils::{self, AttachmentStrategy};
 
@@ -89,11 +90,12 @@ async fn upload_context<'a>(
         .await
         .ok_or(BadStoreRequest::ProjectUnavailable)?;
 
-    let project_config = project
-        .state()
-        .clone()
-        .enabled()
-        .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+    let project_config = match project.state() {
+        ProjectState::Enabled(info) => info.clone(),
+        ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
+            return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
+        }
+    };
 
     let scoping = project_config
         .scoping(meta.public_key())

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -1,6 +1,6 @@
 use axum::extract::{DefaultBodyLimit, FromRequest, Query};
 use axum::response::IntoResponse;
-use axum::routing::{MethodRouter, post};
+use axum::routing::{post, MethodRouter};
 use bytes::Bytes;
 use relay_config::Config;
 use relay_dynamic_config::Feature;
@@ -66,6 +66,7 @@ impl UnrealParams {
 
             let project_config = match project.state() {
                 ProjectState::Enabled(info) => info.clone(),
+                // TODO(INGEST-925): Support proxy mode
                 ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
                     return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
                 }

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -15,6 +15,7 @@ use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::{DiscardItemType, DiscardReason};
 use crate::services::processor::ProcessingError;
+use crate::services::projects::project::ProjectState;
 use crate::statsd::RelayCounters;
 use crate::utils::extract_items;
 
@@ -63,11 +64,12 @@ impl UnrealParams {
                 .await
                 .ok_or(BadStoreRequest::ProjectUnavailable)?;
 
-            let project_config = project
-                .state()
-                .clone()
-                .enabled()
-                .ok_or(BadStoreRequest::EventRejected(DiscardReason::ProjectId))?;
+            let project_config = match project.state() {
+                ProjectState::Enabled(info) => info.clone(),
+                ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
+                    return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
+                }
+            };
 
             if project_config.has_feature(Feature::UnrealEndpointExpansion) {
                 for mut item in

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -1,6 +1,6 @@
 use axum::extract::{DefaultBodyLimit, FromRequest, Query};
 use axum::response::IntoResponse;
-use axum::routing::{post, MethodRouter};
+use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
 use relay_config::Config;
 use relay_dynamic_config::Feature;

--- a/relay-server/src/services/projects/project/mod.rs
+++ b/relay-server/src/services/projects/project/mod.rs
@@ -51,14 +51,6 @@ impl ProjectState {
         matches!(self, Self::Pending)
     }
 
-    /// Utility function that returns the project config if enabled.
-    pub fn enabled(self) -> Option<Arc<ProjectInfo>> {
-        match self {
-            Self::Enabled(info) => Some(info),
-            Self::Dummy | Self::Disabled | Self::Pending => None,
-        }
-    }
-
     /// Returns the revision of the contained project info.
     ///
     /// `None` if the revision is missing or not available.


### PR DESCRIPTION


This PR removes the old function of `enabled` mentioned in https://github.com/getsentry/relay/issues/6020. The files where this update occurred are; mod.rs and updates the use case of it in the playstation.rs, minidump.rs, & unreal.rs.

Testing:

- cargo check --all --all-features compiles without issues.
- running `make test` completes 
   - does fail with ```thread 'redis::tests::test_quota_go_over' (2101507) panicked at relay-quotas/src/redis.rs:787:14:
called `Result::unwrap()` on an `Err` value: RateLimitingError(Pool(Backend(Connection refused (os error 61))))``` But that's likely because I don't have the redis running locally. Happens for these 9 tests:
   ```
   test redis::tests::test_quota_with_cache ... FAILED
   test redis::tests::test_quota_go_over ... FAILED
   test redis::tests::test_namespace_quota ... FAILED
   test redis::tests::test_quantity_0 ... FAILED
   test redis::tests::test_is_rate_limited_script ... FAILED
   test redis::tests::test_quota_with_cache_slightly_over_account ... FAILED
   test redis::tests::test_limited_with_unlimited_quota ... FAILED
   test redis::tests::test_quota_with_quantity ... FAILED
   test redis::tests::test_simple_quota ... FAILED
    ```



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
