### PR TITLE
fix(transactions): Do not trim dsc attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**:
 
 - Copy user Sentry tags into conventional attributes. ([#6030](https://github.com/getsentry/relay/pull/6030))
+- Do not trim DSC attributes in transaction spans. ([#6038](https://github.com/getsentry/relay/pull/6038))
 
 **Internal**:
 

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -1,9 +1,8 @@
 //! Span normalization logic.
 
 use regex::Regex;
-use relay_conventions::attributes::*;
 use relay_event_schema::protocol::{Event, SpanData, TraceContext};
-use relay_protocol::{Annotated, Value};
+use relay_protocol::Annotated;
 use std::sync::LazyLock;
 
 use crate::EnrichedDsc;
@@ -84,22 +83,12 @@ pub fn normalize_dsc_for_span_data(span_data: &mut Annotated<SpanData>, dsc: Opt
     };
 
     let data = span_data.get_or_insert_with(SpanData::default);
-    if data.other.contains_key(SENTRY__DSC__TRACE_ID) {
+    if data.sentry_dsc_trace_id.value().is_some() {
         return;
     }
-    data.other.insert(
-        SENTRY__DSC__TRACE_ID.to_owned(),
-        Annotated::new(Value::String(dsc.dsc.trace_id.to_string())),
-    );
-
+    data.sentry_dsc_trace_id = Annotated::new(dsc.dsc.trace_id.to_string());
+    data.sentry_dsc_project_id = Annotated::new(dsc.sampling_project_id.to_string());
     if let Some(transaction) = &dsc.dsc.transaction {
-        data.other.insert(
-            SENTRY__DSC__TRANSACTION.to_owned(),
-            Annotated::new(Value::String(transaction.clone())),
-        );
+        data.sentry_dsc_transaction = Annotated::new(transaction.to_string());
     }
-    data.other.insert(
-        SENTRY__DSC__PROJECT_ID.to_owned(),
-        Annotated::new(Value::String(dsc.sampling_project_id.to_string())),
-    );
 }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -936,6 +936,18 @@ pub struct SpanData {
     #[metastructure(field = "lcp.url")]
     pub lcp_url: Annotated<String>,
 
+    // Trace ID.
+    #[metastructure(field = "sentry.dsc.trace_id")]
+    pub sentry_dsc_trace_id: Annotated<String>,
+
+    // Name of the transaction/segment that started the trace.
+    #[metastructure(field = "sentry.dsc.transaction")]
+    pub sentry_dsc_transaction: Annotated<String>,
+
+    // ID of the project that started the trace.
+    #[metastructure(field = "sentry.dsc.project_id")]
+    pub sentry_dsc_project_id: Annotated<String>,
+
     // The span's name, a brief, human-readable, low cardinality description of operation
     // represented by the span (as per OpenTelemetry/Sentry's Span V2 schema).
     #[metastructure(field = "sentry.name")]
@@ -1204,10 +1216,36 @@ mod tests {
     use crate::protocol::Measurement;
     use chrono::{TimeZone, Utc};
     use relay_base_schema::metrics::{InformationUnit, MetricUnit};
+    use relay_conventions::attributes::*;
     use relay_protocol::RuleCondition;
     use similar_asserts::assert_eq;
 
     use super::*;
+
+    /// Test that span data attributes expected to follow sentry conventions actually do so. This
+    /// is achieved by 1) creating a json which uses sentry conventions constants, 2) creating a
+    /// `SpanData` object from the json, and 3) verifying that the json values end up in the
+    /// expected `SpanData` fields (which wouldn't happen if the sentry conventions constants don't
+    /// match the declared field names).
+    #[test]
+    fn test_span_data_attributes_follow_sentry_conventions() {
+        let my_trace = &"my_trace".to_string();
+        let my_transaction = &"my_transaction".to_string();
+        let my_project_id = &"my_project_id".to_string();
+        let json = format!(
+            r#"{{
+                "{SENTRY__DSC__TRACE_ID}": "{my_trace}",
+                "{SENTRY__DSC__TRANSACTION}": "{my_transaction}",
+                "{SENTRY__DSC__PROJECT_ID}": "{my_project_id}"
+            }}"#,
+        );
+        let data = Annotated::<SpanData>::from_json(&json).unwrap();
+        let data = data.value().unwrap();
+        assert_eq!(data.sentry_dsc_trace_id.value(), Some(my_trace));
+        assert_eq!(data.sentry_dsc_transaction.value(), Some(my_transaction));
+        assert_eq!(data.sentry_dsc_project_id.value(), Some(my_project_id));
+        assert!(data.other.is_empty());
+    }
 
     #[test]
     fn test_span_serialization() {
@@ -1527,6 +1565,9 @@ mod tests {
             lcp_size: ~,
             lcp_id: ~,
             lcp_url: ~,
+            sentry_dsc_trace_id: ~,
+            sentry_dsc_transaction: ~,
+            sentry_dsc_project_id: ~,
             span_name: ~,
             other: {
                 "bar": String(

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -260,6 +260,9 @@ mod tests {
                 lcp_size: ~,
                 lcp_id: ~,
                 lcp_url: ~,
+                sentry_dsc_trace_id: ~,
+                sentry_dsc_transaction: ~,
+                sentry_dsc_project_id: ~,
                 span_name: "my 1st transaction",
                 other: {
                     "custom_attribute": I64(

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -1263,6 +1263,8 @@ def test_spans_dsc_normalization(
     spans_consumer = spans_consumer()
     ts = datetime.now(timezone.utc)
     event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    # Large data for testing if DSC attributes are trimmed from trace context
+    event["contexts"]["trace"]["data"] = {"big_content": "1" * 10000}
     event["spans"] = [
         {
             "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",


### PR DESCRIPTION
Do not trim dsc attributes in transaction spans, including the trace context.

Fixes [INGEST-937](https://linear.app/getsentry/issue/INGEST-937/prevent-trimming-of-dsc-attributes)