### PR TITLE
test: Limit Relay thread count in integ tests

### DIFF
--- a/tests/integration/fixtures/relay.py
+++ b/tests/integration/fixtures/relay.py
@@ -154,7 +154,7 @@ def relay(mini_sentry, random_port, background_process, config_dir, get_relay_bi
                 "tls_cert": None,
             },
             "sentry": {"dsn": mini_sentry.internal_error_dsn, "enabled": True},
-            "limits": {"max_api_file_upload_size": "1MiB"},
+            "limits": {"max_api_file_upload_size": "1MiB", "max_thread_count": 1},
             "cache": {"batch_interval": 0},
             "logging": {"level": "trace"},
             "http": {"timeout": 2},


### PR DESCRIPTION
Limit the integ test config for Relay to `max_thread_count: 1`. This fixes flaky tests which fail stochastically on machines with enough cores to spawn multiple store service workers - workers race against each other to produce items in Kafka, leading to a non-deterministic ordering of items produced concurrently.

Fixes [RELAY-235](https://linear.app/getsentry/issue/RELAY-235/flaky-ci-otlp-logs-and-vercel-logs)
Fixes [RELAY-252](https://linear.app/getsentry/issue/RELAY-252/flaky-citest-scrubs-ip-addresses)
Fixes [RELAY-251](https://linear.app/getsentry/issue/RELAY-251/flaky-ci-test-ai-spans-example-transaction)