### PR TITLE
feat(upload): Check type specific feature flag

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -23,7 +23,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
-use crate::envelope::{ContentType, Item, ItemType};
+use crate::envelope::{AttachmentType, ContentType, Item, ItemType};
 use crate::extractors::RequestMeta;
 use crate::managed::Managed;
 use crate::service::ServiceState;
@@ -341,6 +341,10 @@ async fn validate_and_limit(
     item.set_attachment_length(headers.upload_length.unwrap_or(1));
     if let Some(ref metadata) = headers.metadata {
         item.set_attachment_type(metadata.attachment_type);
+
+        if let Some(feature) = required_feature(metadata.attachment_type) {
+            envelope.require_feature(feature);
+        }
     }
     envelope.add_item(item);
     let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
@@ -358,6 +362,14 @@ async fn validate_and_limit(
     let scoping = envelope.scoping();
     envelope.accept(|x| x);
     Ok(scoping)
+}
+
+/// Returns the feature a project must have enabled to upload attachments with the given type.
+fn required_feature(attachment_type: AttachmentType) -> Option<Feature> {
+    match attachment_type {
+        AttachmentType::Minidump => Some(Feature::MinidumpUploads),
+        _ => None,
+    }
 }
 
 async fn validate(

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -24,6 +24,7 @@ def project_config(mini_sentry):
     project_id = 42
     config = mini_sentry.add_full_project_config(project_id)["config"]
     config.setdefault("features", []).append("projects:relay-upload-endpoint")
+    config.setdefault("features", []).append("projects:relay-minidump-uploads")
     return config
 
 
@@ -654,3 +655,68 @@ def upload_something(relay, project_id, project_key):
         },
         data=data,
     )
+
+
+@pytest.mark.parametrize(
+    "opted_in,metadata,expected_status_code",
+    [
+        pytest.param(False, False, 201, id="default_type_allowed"),
+        pytest.param(True, True, 201, id="minidump_opted_in"),
+        pytest.param(False, True, 403, id="minidump_not_opted_in"),
+    ],
+)
+def test_upload_minidump_opt_in(
+    mini_sentry,
+    relay,
+    dummy_upload,
+    project_config,
+    opted_in,
+    metadata,
+    expected_status_code,
+):
+    project_id = 42
+    config = mini_sentry.add_full_project_config(project_id)["config"]
+    features = config.setdefault("features", [])
+    features.append("projects:relay-upload-endpoint")
+    if opted_in:
+        features.append("projects:relay-minidump-uploads")
+
+    relay = relay(
+        mini_sentry,
+        options={
+            "outcomes": {
+                "emit_outcomes": True,
+                "batch_size": 1,
+                "batch_interval": 1,
+            }
+        },
+    )
+
+    headers = {
+        "Tus-Resumable": "1.0.0",
+        "Upload-Length": "11",
+    }
+    if metadata:
+        headers["Upload-Metadata"] = (
+            "sentry eyJhdHRhY2htZW50X3R5cGUiOiAiZXZlbnQubWluaWR1bXAifQ=="
+        )
+
+    response = relay.post(
+        "/api/%s/upload/?sentry_key=%s"
+        % (project_id, mini_sentry.get_dsn_public_key(project_id)),
+        headers=headers,
+    )
+
+    assert response.status_code == expected_status_code
+
+    if expected_status_code == 403:
+        assert (
+            response.json()["detail"]
+            == "event submission rejected with_reason: FeatureDisabled(MinidumpUploads)"
+        )
+        outcomes = mini_sentry.get_outcomes(1)
+        assert any(
+            o["outcome"] == 3 and o["reason"] == "feature_disabled" for o in outcomes
+        )
+    else:
+        assert mini_sentry.captured_outcomes.empty()


### PR DESCRIPTION
Since we can't do PII scrubbing on a minidump that is send via the upload endpoint, being able to send a minidump should be opt-in. This adds a check to ensure the `MinidumpUploads` feature is enabled if the item that is send is a Minidump. Note, this flag is not yet enabled for any customers.

Fix: INGEST-854