### PR TITLE
fix(spans): Restore top-level _performance_issues_spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add metadata support for the `/upload` endpoint. ([#6028](https://github.com/getsentry/relay/pull/6028))
 
+**Internal**:
+
+- Restore top-level _performance_issues_spans. ([#6045](https://github.com/getsentry/relay/pull/6045))
+
 ## 26.5.2
 
 **Features**:

--- a/relay-cabi/src/processing.rs
+++ b/relay-cabi/src/processing.rs
@@ -273,8 +273,7 @@ pub unsafe extern "C" fn relay_store_normalizer_normalize_event(
         replay_id: config.replay_id,
         span_allowed_hosts: &[],              // only supported in relay
         span_op_defaults: Default::default(), // only supported in relay
-        performance_issues_spans: Default::default(),
-        force_trace_context: true, // always required for Sentry
+        force_trace_context: true,            // always required for Sentry
         dsc: None,
     };
     normalize_event(&mut event, &normalization_config);

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -63,12 +63,6 @@ pub mod attributes {
         // TODO(buenaflor): Add as sentry convention once mobile SDKs can migrate to it.
         // Tracking issue: https://github.com/getsentry/sentry-conventions/issues/318
         pub const APP__VITALS__START__VALUE: &str = "app.vitals.start.value";
-
-        // TODO: We might promote this to a top-level field, there's no real use
-        // to it being an attribute.
-        // (Internal) tracking issue: https://linear.app/getsentry/issue/INGEST-879/fix-flag-performance-issues-spans
-        pub const SENTRY___INTERNAL__PERFORMANCE_ISSUES_SPANS: &str =
-            "sentry._internal.performance_issues_spans";
     }
     pub use self::not_yet_defined::*;
 }

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -170,9 +170,6 @@ pub struct NormalizationConfig<'a> {
     /// Rules to infer `span.op` from other span fields.
     pub span_op_defaults: BorrowedSpanOpDefaults<'a>,
 
-    /// Set a flag to enable performance issue detection on spans.
-    pub performance_issues_spans: bool,
-
     /// Forces a valid trace context for error events.
     ///
     /// Sentry requires a valid trace context for events. This ensures a valid trace context always
@@ -220,7 +217,6 @@ impl Default for NormalizationConfig<'_> {
             replay_id: Default::default(),
             span_allowed_hosts: Default::default(),
             span_op_defaults: Default::default(),
-            performance_issues_spans: Default::default(),
             force_trace_context: Default::default(),
             dsc: None,
         }
@@ -359,10 +355,6 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
         span::normalize_dsc_for_event_spans(event, config.dsc);
         span::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
-    }
-
-    if config.performance_issues_spans && event.ty.value() == Some(&EventType::Transaction) {
-        event.performance_issues_spans = Annotated::new(true);
     }
 
     if config.enrich_spans {

--- a/relay-event-normalization/src/normalize/mod.rs
+++ b/relay-event-normalization/src/normalize/mod.rs
@@ -1849,7 +1849,7 @@ mod tests {
             ..Default::default()
         };
         span::normalize_app_start_spans(&mut event);
-        assert_debug_snapshot!(event.spans, @r###"
+        assert_debug_snapshot!(event.spans, @r#"
         [
             Span {
                 timestamp: ~,
@@ -1875,11 +1875,10 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
-                performance_issues_spans: ~,
                 other: {},
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -1897,7 +1896,7 @@ mod tests {
             ..Default::default()
         };
         span::normalize_app_start_spans(&mut event);
-        assert_debug_snapshot!(event.spans, @r###"
+        assert_debug_snapshot!(event.spans, @r#"
         [
             Span {
                 timestamp: ~,
@@ -1923,11 +1922,10 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
-                performance_issues_spans: ~,
                 other: {},
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]
@@ -1945,7 +1943,7 @@ mod tests {
             ..Default::default()
         };
         span::normalize_app_start_spans(&mut event);
-        assert_debug_snapshot!(event.spans, @r###"
+        assert_debug_snapshot!(event.spans, @r#"
         [
             Span {
                 timestamp: ~,
@@ -1971,10 +1969,9 @@ mod tests {
                 platform: ~,
                 was_transaction: ~,
                 kind: ~,
-                performance_issues_spans: ~,
                 other: {},
             },
         ]
-        "###);
+        "#);
     }
 }

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -121,19 +121,6 @@ pub struct Span {
     #[metastructure(skip_serialization = "empty", trim = false)]
     pub kind: Annotated<SpanKind>,
 
-    /// Temporary flag that controls where performance issues are detected.
-    ///
-    /// When the flag is set to true, performance issues will be detected on this span provided it
-    /// is a root (segment) instead of the transaction event.
-    ///
-    /// Only set on root spans extracted from transactions.
-    #[metastructure(
-        field = "_performance_issues_spans",
-        skip_serialization = "empty",
-        trim = false
-    )]
-    pub performance_issues_spans: Annotated<bool>,
-
     /// Additional arbitrary fields for forwards compatibility.
     #[metastructure(additional_properties, pii = "maybe")]
     pub other: Object<Value>,

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -17,7 +17,7 @@ impl From<&Event> for Span {
 
             measurements,
             _metrics,
-            performance_issues_spans,
+            performance_issues_spans: _,
             ..
         } = event;
 
@@ -81,7 +81,6 @@ impl From<&Event> for Span {
             platform: platform.clone(),
             was_transaction: true.into(),
             kind: Default::default(),
-            performance_issues_spans: performance_issues_spans.clone(),
             other: Default::default(),
         }
     }

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -147,7 +147,7 @@ mod tests {
         .unwrap();
 
         let span_from_event = Span::from(&event);
-        insta::assert_debug_snapshot!(span_from_event, @r###"
+        insta::assert_debug_snapshot!(span_from_event, @r#"
         Span {
             timestamp: ~,
             start_timestamp: ~,
@@ -297,9 +297,8 @@ mod tests {
             platform: "php",
             was_transaction: true,
             kind: ~,
-            performance_issues_spans: ~,
             other: {},
         }
-        "###);
+        "#);
     }
 }

--- a/relay-server/src/processing/legacy_spans/store.rs
+++ b/relay-server/src/processing/legacy_spans/store.rs
@@ -32,5 +32,6 @@ pub fn convert(span: Annotated<Span>, retentions: Retention) -> Result<Box<Store
         downsampled_retention_days: retentions.downsampled,
         event_id: None,
         item: span,
+        performance_issues_spans: false,
     }))
 }

--- a/relay-server/src/processing/spans/store.rs
+++ b/relay-server/src/processing/spans/store.rs
@@ -46,6 +46,7 @@ pub fn convert(span: IndexedSpanOnly, ctx: &Context) -> Result<Box<StoreSpanV2>>
         downsampled_retention_days: ctx.retention.downsampled,
         event_id: None,
         item: span,
+        performance_issues_spans: false,
     }))
 }
 

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -103,8 +103,10 @@ impl Forward for TransactionOutput {
             // instead of an envelope. As long as we have this hack, ignore bookkeeping
             record_keeper.lenient(relay_quotas::DataCategory::Transaction);
 
-            if let Some(event) = work.event.value_mut() {
-                event.performance_issues_spans = Annotated::new(performance_issues_spans)
+            if let Some(event) = work.event.value_mut()
+                && performance_issues_spans
+            {
+                event.performance_issues_spans = Annotated::new(true);
             }
 
             work.serialize_envelope()

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -79,9 +79,14 @@ impl Forward for TransactionOutput {
             let retention = ctx.retention(|r| r.span.as_ref());
 
             for span in spans.split(|spans| spans.into_iter()) {
-                if let Ok(span) = span.try_map(|span, _| {
-                    store::convert_span(span, event_id, retention, performance_issues_spans)
-                }) {
+                if let Ok(span) =
+                    span.try_map(|span, _| store::convert_span(span, event_id, retention))
+                {
+                    if performance_issues_spans && *span.item.is_segment.value().unwrap_or(&false) {
+                        span.map(|mut span, _| {
+                            span.performance_issues_spans = true;
+                        });
+                    }
                     s.send_to_store(span)
                 };
             }
@@ -146,7 +151,6 @@ mod store {
         span: ExtractedIndexedSpan,
         event_id: Option<EventId>,
         retentions: Retention,
-        performance_issues_spans: bool,
     ) -> Result<Box<StoreSpanV2>, Outcome> {
         let span = match span.0 {
             Annotated(Some(span), _) => span,
@@ -161,7 +165,7 @@ mod store {
             retention_days: retentions.standard,
             downsampled_retention_days: retentions.downsampled,
             event_id,
-            performance_issues_spans,
+            performance_issues_spans: false,
             item: span,
         }))
     }

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -79,11 +79,12 @@ impl Forward for TransactionOutput {
             let retention = ctx.retention(|r| r.span.as_ref());
 
             for span in spans.split(|spans| spans.into_iter()) {
-                if let Ok(span) =
+                if let Ok(mut span) =
                     span.try_map(|span, _| store::convert_span(span, event_id, retention))
                 {
-                    if performance_issues_spans && *span.item.is_segment.value().unwrap_or(&false) {
-                        span.map(|mut span, _| {
+                    if performance_issues_spans && *(span.item.is_segment.value().unwrap_or(&false))
+                    {
+                        span.modify(|span, _| {
                             span.performance_issues_spans = true;
                         });
                     }

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -54,6 +54,8 @@ impl Forward for TransactionOutput {
         s: StoreHandle<'_>,
         ctx: ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
+        use relay_dynamic_config::Feature;
+
         let (spans, transaction) = match self {
             TransactionOutput::Full(managed) => {
                 return Err(managed.internal_error("only indexed transactions can be stored"));
@@ -65,14 +67,18 @@ impl Forward for TransactionOutput {
             TransactionOutput::Indexed { spans, transaction } => (spans, transaction),
         };
 
+        let performance_issues_spans = ctx
+            .project_info
+            .has_feature(Feature::PerformanceIssuesSpans);
+
         if let Some(spans) = spans {
             let event_id = transaction.headers.event_id();
             let retention = ctx.retention(|r| r.span.as_ref());
 
             for span in spans.split(|spans| spans.into_iter()) {
-                if let Ok(span) =
-                    span.try_map(|span, _| store::convert_span(span, event_id, retention))
-                {
+                if let Ok(span) = span.try_map(|span, _| {
+                    store::convert_span(span, event_id, retention, performance_issues_spans)
+                }) {
                     s.send_to_store(span)
                 };
             }
@@ -133,6 +139,7 @@ mod store {
         span: ExtractedIndexedSpan,
         event_id: Option<EventId>,
         retentions: Retention,
+        performance_issues_spans: bool,
     ) -> Result<Box<StoreSpanV2>, Outcome> {
         let span = match span.0 {
             Annotated(Some(span), _) => span,
@@ -147,6 +154,7 @@ mod store {
             retention_days: retentions.standard,
             downsampled_retention_days: retentions.downsampled,
             event_id,
+            performance_issues_spans,
             item: span,
         }))
     }

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "processing")]
+use relay_protocol::Annotated;
+
 use crate::Envelope;
 use crate::managed::{Managed, ManagedResult, Rejected};
 #[cfg(feature = "processing")]
@@ -89,10 +92,14 @@ impl Forward for TransactionOutput {
             s.send_to_store(profile.map(|p, _| store::convert_profile(p, true, ctx)));
         }
 
-        let envelope = transaction.try_map(|work, record_keeper| {
+        let envelope = transaction.try_map(|mut work, record_keeper| {
             // TODO: This should raise an error, Indexed output should go straight to Kafka
             // instead of an envelope. As long as we have this hack, ignore bookkeeping
             record_keeper.lenient(relay_quotas::DataCategory::Transaction);
+
+            if let Some(event) = work.event.value_mut() {
+                event.performance_issues_spans = Annotated::new(performance_issues_spans)
+            }
 
             work.serialize_envelope()
                 .map_err(drop)

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -11,7 +11,6 @@ use relay_base_schema::events::EventType;
 use relay_base_schema::project::ProjectId;
 use relay_config::Config;
 use relay_config::NormalizationLevel;
-use relay_dynamic_config::Feature;
 use relay_event_normalization::EnrichedDsc;
 use relay_event_normalization::GeoIpLookup;
 use relay_event_normalization::{
@@ -311,9 +310,6 @@ pub fn normalize(
             replay_id: headers.dsc().and_then(|ctx| ctx.replay_id),
             span_allowed_hosts: http_span_allowed_hosts,
             span_op_defaults: ctx.global_config.span_op_defaults.borrow(),
-            performance_issues_spans: ctx
-                .project_info
-                .has_feature(Feature::PerformanceIssuesSpans),
             force_trace_context: true,
             dsc,
         };

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1586,7 +1586,12 @@ struct SpanMeta {
     /// Indicates whether Relay already emitted an accepted outcome or if EAP still needs to emit it.
     accepted_outcome_emitted: bool,
     /// Whether the segment span should be used for issue detection instead of the transaction.
+    #[serde(rename = "_performance_issues_spans", skip_serializing_if = "is_false")]
     performance_issues_spans: bool,
+}
+
+fn is_false(val: &bool) -> bool {
+    !val
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -140,7 +140,8 @@ pub struct StoreSpanV2 {
     pub event_id: Option<EventId>,
     /// The final Sentry compatible span item.
     pub item: SpanV2,
-    // TODO: docs
+    // Whether to run issue detection on the transaction or on the segment span.
+    // (only true for segment spans created from a transaction).
     pub performance_issues_spans: bool,
 }
 
@@ -783,6 +784,7 @@ impl StoreService {
             downsampled_retention_days: message.downsampled_retention_days,
             received: datetime_to_timestamp(received_at),
             accepted_outcome_emitted: relay_emits_accepted_outcome,
+            performance_issues_spans: message.performance_issues_spans,
         };
 
         message.try_accept(|span| {
@@ -1583,6 +1585,8 @@ struct SpanMeta {
     downsampled_retention_days: u16,
     /// Indicates whether Relay already emitted an accepted outcome or if EAP still needs to emit it.
     accepted_outcome_emitted: bool,
+    /// Whether the segment span should be used for issue detection instead of the transaction.
+    performance_issues_spans: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -140,6 +140,8 @@ pub struct StoreSpanV2 {
     pub event_id: Option<EventId>,
     /// The final Sentry compatible span item.
     pub item: SpanV2,
+    // TODO: docs
+    pub performance_issues_spans: bool,
 }
 
 impl Counted for StoreSpanV2 {

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -41,7 +41,6 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
         platform,
         was_transaction: _,
         kind,
-        performance_issues_spans,
         other: _,
     } = span_v1;
 
@@ -56,10 +55,6 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     attributes.insert(SENTRY__ORIGIN, origin);
     attributes.insert(SENTRY__PROFILE_ID, profile_id.map_value(|v| v.to_string()));
     attributes.insert(SENTRY__PLATFORM, platform);
-    attributes.insert(
-        SENTRY___INTERNAL__PERFORMANCE_ISSUES_SPANS,
-        performance_issues_spans,
-    );
 
     // Use same precedence as `backfill_data` for data bags:
     if let Some(measurements) = measurements.into_value() {

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -400,10 +400,6 @@ mod tests {
               "type": "string",
               "value": "{\"numbers\":[1,2,3]}"
             },
-            "sentry._internal.performance_issues_spans": {
-              "type": "boolean",
-              "value": true
-            },
             "sentry.client_sample_rate": {
               "type": "double",
               "value": 0.11

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -213,7 +213,7 @@ def test_span_extraction(
     del transaction_span["received"]
 
     if performance_issues_spans:
-        assert transaction_span["performance_issues_spans"] is True
+        assert transaction_span.pop("_performance_issues_spans") is True
 
     expected_transaction_span = {
         "attributes": {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -213,12 +213,7 @@ def test_span_extraction(
     del transaction_span["received"]
 
     if performance_issues_spans:
-        assert (
-            transaction_span["attributes"].pop(
-                "sentry._internal.performance_issues_spans"
-            )["value"]
-            is True
-        )
+        assert transaction_span["performance_issues_spans"] is True
 
     expected_transaction_span = {
         "attributes": {


### PR DESCRIPTION
Restore top-level `_performance_issues_spans`, but make it part of the kafka message instead of the span schema.

Fixes INGEST-879