### PR TITLE
feat(eap): Always infer UA and IP in V2 standalone span pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add metadata support for the `/upload` endpoint. ([#6028](https://github.com/getsentry/relay/pull/6028))
+- Infer user agents and client addresses in the V2 standalone span pipeline. ([#6047](https://github.com/getsentry/relay/pull/6047))
 
 **Bug Fixes**:
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -243,6 +243,10 @@ pub fn normalize_user_agent(
 ) {
     let attributes = attributes.get_or_insert_with(Default::default);
 
+    if attributes.contains_key(BROWSER__NAME) || attributes.contains_key(BROWSER__VERSION) {
+        return;
+    }
+
     // Prefer the stored/explicitly sent user agent over the user agent from the client/transport.
     if let Some(ua) = client_info.and_then(|ci| ci.user_agent) {
         attributes.insert_if_missing(USER_AGENT__ORIGINAL, || ua.to_owned());
@@ -251,10 +255,6 @@ pub fn normalize_user_agent(
     let user_agent = attributes
         .get_value(USER_AGENT__ORIGINAL)
         .and_then(|v| v.as_str());
-
-    if attributes.contains_key(BROWSER__NAME) || attributes.contains_key(BROWSER__VERSION) {
-        return;
-    }
 
     let Some(context) = BrowserContext::from_hints_or_ua(&RawUserAgentInfo {
         user_agent,
@@ -1285,7 +1285,7 @@ mod tests {
             }),
         );
 
-        assert_annotated_snapshot!(attributes, @r###"
+        assert_annotated_snapshot!(attributes, @r#"
         {
           "browser.name": {
             "type": "string",
@@ -1294,13 +1294,9 @@ mod tests {
           "browser.version": {
             "type": "string",
             "value": "13.3.7"
-          },
-          "user_agent.original": {
-            "type": "string",
-            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
           }
         }
-        "###
+        "#
         );
     }
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -243,10 +243,6 @@ pub fn normalize_user_agent(
 ) {
     let attributes = attributes.get_or_insert_with(Default::default);
 
-    if attributes.contains_key(BROWSER__NAME) || attributes.contains_key(BROWSER__VERSION) {
-        return;
-    }
-
     // Prefer the stored/explicitly sent user agent over the user agent from the client/transport.
     if let Some(ua) = client_info.and_then(|ci| ci.user_agent) {
         attributes.insert_if_missing(USER_AGENT__ORIGINAL, || ua.to_owned());
@@ -255,6 +251,10 @@ pub fn normalize_user_agent(
     let user_agent = attributes
         .get_value(USER_AGENT__ORIGINAL)
         .and_then(|v| v.as_str());
+
+    if attributes.contains_key(BROWSER__NAME) || attributes.contains_key(BROWSER__VERSION) {
+        return;
+    }
 
     let Some(context) = BrowserContext::from_hints_or_ua(&RawUserAgentInfo {
         user_agent,

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -1241,7 +1241,7 @@ mod tests {
             }),
         );
 
-        assert_annotated_snapshot!(attributes, @r#"
+        assert_annotated_snapshot!(attributes, @r###"
         {
           "browser.name": {
             "type": "string",
@@ -1250,9 +1250,13 @@ mod tests {
           "browser.version": {
             "type": "string",
             "value": "131.0.0"
+          },
+          "user_agent.original": {
+            "type": "string",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
           }
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -1285,7 +1285,7 @@ mod tests {
             }),
         );
 
-        assert_annotated_snapshot!(attributes, @r#"
+        assert_annotated_snapshot!(attributes, @r###"
         {
           "browser.name": {
             "type": "string",
@@ -1294,9 +1294,13 @@ mod tests {
           "browser.version": {
             "type": "string",
             "value": "13.3.7"
+          },
+          "user_agent.original": {
+            "type": "string",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
           }
         }
-        "#
+        "###
         );
     }
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -248,10 +248,13 @@ pub fn normalize_user_agent(
     }
 
     // Prefer the stored/explicitly sent user agent over the user agent from the client/transport.
+    if let Some(ua) = client_info.and_then(|ci| ci.user_agent) {
+        attributes.insert_if_missing(USER_AGENT__ORIGINAL, || ua.to_owned());
+    }
+
     let user_agent = attributes
         .get_value(USER_AGENT__ORIGINAL)
-        .and_then(|v| v.as_str())
-        .or(client_info.and_then(|ci| ci.user_agent));
+        .and_then(|v| v.as_str());
 
     let Some(context) = BrowserContext::from_hints_or_ua(&RawUserAgentInfo {
         user_agent,

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -138,7 +138,15 @@ fn expand_legacy_spans(
         })
         .collect();
 
-    (Settings::default(), spans)
+    // In the legacy standalone span pipeline we always
+    // inferred both IPs and user agents. If this function
+    // is ever applied to transactions, we may need to rethink this.
+    let settings = Settings {
+        infer_ip: true,
+        infer_user_agent: true,
+    };
+
+    (settings, spans)
 }
 
 fn expand_legacy_span(item: &Item) -> Result<WithHeader<SpanV2>> {

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -66,6 +66,10 @@ def test_nel_converted_to_logs(mini_sentry, relay):
                         "value": "Firefox",
                     },
                     "browser.version": {"type": "string", "value": "42.0"},
+                    "user_agent.original": {
+                        "type": "string",
+                        "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+                    },
                     "sentry.observed_timestamp_nanos": {
                         "type": "string",
                         "value": time_within_delta(expect_resolution="ns"),

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -220,7 +220,7 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
         # If an external Relay/Client makes modifications, sizes can change,
         # this is fuzzy due to slight changes in sizes due to added timestamps
         # and may need to be adjusted when changing normalization.
-        ("managed", 106, 437),
+        ("managed", 165, 496),
     ],
 )
 def test_ourlog_extraction_with_sentry_logs(
@@ -317,6 +317,9 @@ def test_ourlog_extraction_with_sentry_logs(
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.payload_size_bytes": {"intValue": any()},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
+                "user_agent.original": {
+                    "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+                },
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
@@ -395,6 +398,9 @@ def test_ourlog_extraction_with_sentry_logs(
                 "http.response.body.size": {"intValue": "17"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "string.attribute": {"stringValue": "some string"},
+                "user_agent.original": {
+                    "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+                },
                 "string_array": {
                     "arrayValue": {
                         "values": [{"stringValue": "foo"}, {"stringValue": "bar"}]
@@ -508,6 +514,10 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),
+            },
+            "user_agent.original": {
+                "type": "string",
+                "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
             },
         },
         "__header": {"byte_size": any()},
@@ -697,6 +707,9 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
             "sentry.payload_size_bytes": any(),
             "browser.name": {"stringValue": "Firefox"},
+            "user_agent.original": {
+                "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
+            },
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
@@ -748,6 +761,9 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
             "browser.version": {"stringValue": "42.0"},
             "sentry.severity_text": {"stringValue": "warn"},
             "sentry.payload_size_bytes": {"intValue": any()},
+            "user_agent.original": {
+                "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
+            },
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
@@ -888,6 +904,7 @@ def test_browser_name_version_extraction(
             "sentry.body": {"stringValue": "This is really bad"},
             "browser.name": {"stringValue": expected_browser_name},
             "browser.version": {"stringValue": expected_browser_version},
+            "user_agent.original": {"stringValue": user_agent},
             "sentry.severity_text": {"stringValue": "error"},
             "sentry.payload_size_bytes": {"intValue": any()},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
@@ -1135,6 +1152,9 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
             "browser.version": {
                 "stringValue": "42.0",
             },
+            "user_agent.original": {
+                "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
+            },
             "sentry._meta.fields.timestamp": {
                 "stringValue": '{"meta":{"":{"rem":[["timestamp.sequence","s"]]}}}',
             },
@@ -1263,6 +1283,10 @@ def test_ourlog_container_metadata(
                     "browser.version": {
                         "type": "string",
                         "value": "42.0",
+                    },
+                    "user_agent.original": {
+                        "type": "string",
+                        "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
                     },
                 },
             ),

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -9,7 +9,7 @@ import pytest
 # Some profiles from Sentry
 performance_score_profiles = [
     {
-        "name": "Chrome",
+        "name": "Firefox",
         "scoreComponents": [
             {
                 "measurement": "fcp",
@@ -46,18 +46,18 @@ performance_score_profiles = [
                 {
                     "op": "eq",
                     "name": "event.contexts.browser.name",
-                    "value": "Chrome",
+                    "value": "Firefox",
                 },
                 {
                     "op": "eq",
                     "name": "span.attributes.browser.name.value",
-                    "value": "Chrome",
+                    "value": "Firefox",
                 },
             ],
         },
     },
     {
-        "name": "Chrome INP",
+        "name": "Firefox INP",
         "scoreComponents": [
             {
                 "measurement": "inp",
@@ -73,22 +73,12 @@ performance_score_profiles = [
                 {
                     "op": "eq",
                     "name": "event.contexts.browser.name",
-                    "value": "Chrome",
-                },
-                {
-                    "op": "eq",
-                    "name": "event.contexts.browser.name",
-                    "value": "Google Chrome",
+                    "value": "Firefox",
                 },
                 {
                     "op": "eq",
                     "name": "span.attributes.browser.name.value",
-                    "value": "Chrome",
-                },
-                {
-                    "op": "eq",
-                    "name": "span.attributes.browser.name.value",
-                    "value": "Google Chrome",
+                    "value": "Firefox",
                 },
             ],
         },
@@ -118,13 +108,13 @@ def lcp_cls_inp_differences(mode):
     if mode == "legacy":
         attributes = {
             # The legacy pipeline extracts this attribute from `sentry_tags`.
-            "sentry.browser.name": {"type": "string", "value": "Chrome"},
+            "sentry.browser.name": {"type": "string", "value": "Firefox"},
         }
         fields = {}
     else:
         attributes = {
             # We additionally extract the browser version for EAP items
-            "browser.version": {"type": "string", "value": "141.0.0"},
+            "browser.version": {"type": "string", "value": "42.0"},
             # New for EAP items
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -178,7 +168,7 @@ def test_lcp_span(
                 "environment": "prod",
                 "replay_id": "3d76a6311de149b9b3f560827ea0ecf9",
                 "transaction": "/insights/projects/",
-                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
                 "client.address": "{{auto}}",
                 "sentry.exclusive_time": 0,
                 "sentry.pageload.span_id": "8a6626cc9bdd5d9b",
@@ -235,7 +225,7 @@ def test_lcp_span(
                 "type": "string",
                 "value": "https://s1.sentry-cdn.com/../sentry-loader.svg",
             },
-            "browser.name": {"type": "string", "value": "Chrome"},
+            "browser.name": {"type": "string", "value": "Firefox"},
             "sentry.description": {"type": "string", "value": "<unknown>"},
             "sentry.dsc.transaction": {
                 "type": "string",
@@ -265,8 +255,7 @@ def test_lcp_span(
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
-                "Safari/537.36",
+                "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             # Attributes computed by performace score normalization
             "score.lcp": {
@@ -382,7 +371,7 @@ def test_cls_span(
                 "environment": "prod",
                 "replay_id": "3d76a6311de149b9b3f560827ea0ecf9",
                 "transaction": "/insights/projects/",
-                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
                 "client.address": "{{auto}}",
                 "sentry.exclusive_time": 0,
                 "sentry.pageload.span_id": "8a6626cc9bdd5d9b",
@@ -442,7 +431,7 @@ def test_cls_span(
                 "value": "div.app-1azrk9k.etjky0h0 > AppContainer > BodyContainer > BaseFooter",
             },
             "cls.source.3": {"type": "string", "value": "<unknown>"},
-            "browser.name": {"type": "string", "value": "Chrome"},
+            "browser.name": {"type": "string", "value": "Firefox"},
             "sentry.description": {
                 "type": "string",
                 "value": "AppContainer > NavContent > MobileTopbar > StyledButton",
@@ -475,8 +464,7 @@ def test_cls_span(
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
-                "Safari/537.36",
+                "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             # Attributes computed by performace score normalization
             "score.cls": {
@@ -592,7 +580,7 @@ def test_inp_span(
                 "environment": "prod",
                 "replay_id": "3d76a6311de149b9b3f560827ea0ecf9",
                 "transaction": "/insights/projects/",
-                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
                 "client.address": "{{auto}}",
                 "sentry.exclusive_time": 104,
             },
@@ -629,7 +617,7 @@ def test_inp_span(
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "browser.web_vital.inp.value": {"type": "double", "value": 104.0},
-            "browser.name": {"type": "string", "value": "Chrome"},
+            "browser.name": {"type": "string", "value": "Firefox"},
             "sentry.description": {
                 "type": "string",
                 "value": "<unknown>",
@@ -660,8 +648,7 @@ def test_inp_span(
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
-                "Safari/537.36",
+                "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             # Attributes computed by performace score normalization
             "score.inp": {
@@ -835,7 +822,7 @@ def test_mobile_measurements(
                 "release": "frontend@488531b11e6401fa530ac25554d44426e6ef0f0b",
                 "environment": "prod",
                 "replay_id": "3d76a6311de149b9b3f560827ea0ecf9",
-                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+                "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
                 "client.address": "{{auto}}",
                 "sentry.exclusive_time": 104,
             },
@@ -869,7 +856,7 @@ def test_mobile_measurements(
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
-            "browser.name": {"type": "string", "value": "Chrome"},
+            "browser.name": {"type": "string", "value": "Firefox"},
             "sentry.description": {
                 "type": "string",
                 "value": "<unknown>",
@@ -898,8 +885,7 @@ def test_mobile_measurements(
             "user_agent.original": {
                 "type": "string",
                 "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 "
-                "Safari/537.36",
+                "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             "stall_total_time": {"value": 4000.0, "type": "double"},
             "stall_percentage": {"value": 0.8, "type": "double"},
@@ -925,3 +911,118 @@ def test_mobile_measurements(
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
         **fields,
     }
+
+
+@pytest.mark.parametrize("mode", ["legacy", "v2"])
+@pytest.mark.parametrize("client_address_auto", [True, False])
+def test_ua_ip_inference(
+    mini_sentry, relay, relay_with_processing, spans_consumer, client_address_auto, mode
+):
+    """
+    Tests that IP addresses and user agent attributes are inferred.
+    """
+    spans_consumer = spans_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    if mode == "v2":
+        project_config["config"].setdefault("features", []).append(
+            "projects:span-v2-experimental-processing"
+        )
+
+    relay = relay(relay_with_processing())
+
+    ts = datetime.now(timezone.utc)
+
+    envelope = envelope_with_spans(
+        {
+            "data": {
+                "sentry.origin": "auto.http.browser.lcp",
+                "sentry.op": "ui.webvital.lcp",
+                "release": "frontend@488531b11e6401fa530ac25554d44426e6ef0f0b",
+                "environment": "prod",
+                "replay_id": "3d76a6311de149b9b3f560827ea0ecf9",
+                "transaction": "/insights/projects/",
+                **_if_dict(client_address_auto, {"client.address": "{{auto}}"}),
+                "sentry.exclusive_time": 0,
+                "sentry.pageload.span_id": "8a6626cc9bdd5d9b",
+                "sentry.report_event": "navigation",
+            },
+            "description": "<unknown>",
+            "op": "ui.webvital.lcp",
+            "parent_span_id": "8a6626cc9bdd5d9b",
+            "span_id": "9fd17741416e8e4e",
+            "start_timestamp": ts.timestamp() - 0.5,
+            "timestamp": ts.timestamp(),
+            "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+            "origin": "auto.http.browser.lcp",
+            "exclusive_time": 0,
+            "measurements": {},
+            "segment_id": "8a6626cc9bdd5d9b",
+        },
+        trace_info={
+            "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+            "public_key": project_config["publicKeys"][0]["publicKey"],
+            "transaction": "/insights/projects/",
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    attributes, fields = lcp_cls_inp_differences(mode)
+
+    assert spans_consumer.get_span() == {
+        "attributes": {
+            "client.address": {"type": "string", "value": "127.0.0.1"},
+            "browser.name": {"type": "string", "value": "Firefox"},
+            "sentry.description": {"type": "string", "value": "<unknown>"},
+            "sentry.dsc.transaction": {
+                "type": "string",
+                "value": "/insights/projects/",
+            },
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "d3d20f000885466b8c8f947c9b92b8d3",
+            },
+            "sentry.environment": {"type": "string", "value": "prod"},
+            "sentry.exclusive_time": {"type": "double", "value": 0.0},
+            "sentry.op": {"type": "string", "value": "ui.webvital.lcp"},
+            "sentry.origin": {"type": "string", "value": "auto.http.browser.lcp"},
+            "sentry.pageload.span_id": {"type": "string", "value": "8a6626cc9bdd5d9b"},
+            "sentry.release": {
+                "type": "string",
+                "value": "frontend@488531b11e6401fa530ac25554d44426e6ef0f0b",
+            },
+            "sentry.replay_id": {
+                "type": "string",
+                "value": "3d76a6311de149b9b3f560827ea0ecf9",
+            },
+            "sentry.report_event": {"type": "string", "value": "navigation"},
+            "sentry.segment.name": {"type": "string", "value": "/insights/projects/"},
+            "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
+            "user_agent.original": {
+                "type": "string",
+                "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+            },
+            **attributes,
+        },
+        "downsampled_retention_days": 90,
+        "end_timestamp": time_within(ts),
+        "key_id": 123,
+        "name": "ui.webvital.lcp",
+        "organization_id": 1,
+        "project_id": 42,
+        "received": time_within(ts),
+        "retention_days": 90,
+        "accepted_outcome_emitted": True,
+        "span_id": "9fd17741416e8e4e",
+        "start_timestamp": time_within(ts.timestamp() - 0.5),
+        "status": "ok",
+        "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+        **fields,
+    }
+
+
+def _if_dict(cond, then):
+    return then if cond else {}

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -122,6 +122,10 @@ def test_spansv2_basic(
             "invalid": None,
             "browser.name": {"type": "string", "value": "Firefox"},
             "browser.version": {"type": "string", "value": "42.0"},
+            "user_agent.original": {
+                "type": "string",
+                "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+            },
             "sentry.dsc.environment": {"type": "string", "value": "prod"},
             "sentry.dsc.public_key": {
                 "type": "string",
@@ -238,7 +242,7 @@ def test_spansv2_trimming_basic(
             # This is sufficient for all builtin attributes not
             # to be trimmed. The span fields that aren't trimmed
             # also still count for the size limit.
-            "trimming": {"span": {"maxSize": 454}},
+            "trimming": {"span": {"maxSize": 513}},
         }
     )
 
@@ -315,6 +319,10 @@ def test_spansv2_trimming_basic(
             "custom.invalid.attribute": None,
             "browser.name": {"type": "string", "value": "Firefox"},
             "browser.version": {"type": "string", "value": "42.0"},
+            "user_agent.original": {
+                "type": "string",
+                "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+            },
             "sentry.dsc.environment": {"type": "string", "value": "prod"},
             "sentry.dsc.public_key": {
                 "type": "string",
@@ -335,7 +343,7 @@ def test_spansv2_trimming_basic(
         },
         "_meta": {
             "attributes": {
-                "": {"len": 506},
+                "": {"len": 565},
                 "custom.array.attribute": {
                     "value": {
                         "2": {

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -1027,6 +1027,10 @@ def test_trace_metric_container_metadata(
                         "type": "string",
                         "value": "42.0",
                     },
+                    "user_agent.original": {
+                        "type": "string",
+                        "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+                    },
                 },
             ),
             "sentry.observed_timestamp_nanos": {


### PR DESCRIPTION
There was a discrepancy between the legacy and V2 standalone span pipelines: the legacy pipeline would always infer client addresses and user agents, whereas the V2 pipeline would infer client addresses only if the attribute had the value `{{auto}}` and never infer user agents at all. The fix is simply to switch both the corresponding options on when expanding standalone spans in the processor.

It also drive-by fixes a related problem in the V2 pipeline: in the legacy pipeline, the `user_agent.original` field/attribute was backfilled from the client UA, in the V2 pipeline it wasn't.

ref: INGEST-946