### PR TITLE
fix(objectstore): Guard against org_id 0

### DIFF
--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -106,6 +106,7 @@ impl IntoResponse for Error {
                 upload::Error::ObjectstoreServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
                 #[cfg(feature = "processing")]
                 upload::Error::Objectstore(service_error) => match service_error.kind {
+                    objectstore::ErrorKind::InvalidScoping => StatusCode::INTERNAL_SERVER_ERROR,
                     objectstore::ErrorKind::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
                     objectstore::ErrorKind::LoadShed => StatusCode::SERVICE_UNAVAILABLE,
                     objectstore::ErrorKind::UploadFailed(error) => match error {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -200,6 +200,8 @@ impl<E: Into<ErrorKind>> From<E> for Error {
 /// Errors that can occur when trying to upload an attachment.
 #[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
+    #[error("invalid scoping")]
+    InvalidScoping,
     #[error("timeout: {0}")]
     Timeout(#[from] tokio::time::error::Elapsed),
     #[error("load shed")]
@@ -213,6 +215,7 @@ pub enum ErrorKind {
 impl ErrorKind {
     fn as_str(&self) -> &'static str {
         match self {
+            Self::InvalidScoping => "invalid_scoping",
             Self::Timeout(_) => "timeout",
             Self::LoadShed => "load_shed",
             Self::UploadFailed(_) => "upload_failed",
@@ -397,10 +400,11 @@ impl ObjectstoreServiceInner {
     /// in objectstore.
     async fn handle_envelope(&self, mut envelope: ManagedEnvelope) {
         let scoping = envelope.scoping();
-        let session = self
-            .event_attachments
-            .for_project(scoping.organization_id.value(), scoping.project_id.value())
-            .session(&self.objectstore_client);
+        let session = self.session(
+            &self.event_attachments,
+            scoping.organization_id,
+            scoping.project_id,
+        );
         let retention = envelope.envelope().retention();
 
         let attachments = envelope
@@ -454,10 +458,11 @@ impl ObjectstoreServiceInner {
         }
 
         let scoping = attachment.scoping();
-        let session = self
-            .event_attachments
-            .for_project(scoping.organization_id.value(), scoping.project_id.value())
-            .session(&self.objectstore_client);
+        let session = self.session(
+            &self.event_attachments,
+            scoping.organization_id,
+            scoping.project_id,
+        );
 
         match session {
             Err(error) => Error::from(error).log(MessageKind::EventAttachment),
@@ -494,10 +499,11 @@ impl ObjectstoreServiceInner {
     ) -> Result<(), Rejected<Error>> {
         let scoping = managed.scoping();
         let session = self
-            .trace_attachments
-            .for_project(scoping.organization_id.value(), scoping.project_id.value())
-            .session(&self.objectstore_client)
-            .map_err(|e| Error::from(ErrorKind::UploadFailed(e)))
+            .session(
+                &self.trace_attachments,
+                scoping.organization_id,
+                scoping.project_id,
+            )
             .reject(&managed)?;
 
         let body = Bytes::clone(&managed.body);
@@ -553,10 +559,7 @@ impl ObjectstoreServiceInner {
             key,
             stream,
         } = stream;
-        let session = self
-            .event_attachments
-            .for_project(organization_id.value(), project_id.value())
-            .session(&self.objectstore_client)?;
+        let session = self.session(&self.event_attachments, organization_id, project_id)?;
 
         self.upload(
             MessageKind::Stream,
@@ -676,6 +679,21 @@ impl ObjectstoreServiceInner {
     fn should_skip_upload(item: &Item) -> bool {
         item.is_empty() || item.is_attachment_ref()
     }
+
+    fn session(
+        &self,
+        usecase: &Usecase,
+        organization_id: OrganizationId,
+        project_id: ProjectId,
+    ) -> Result<Session, Error> {
+        if organization_id.value() == 0 || project_id.value() == 0 {
+            return Err(ErrorKind::InvalidScoping.into());
+        }
+        let session = usecase
+            .for_project(organization_id.value(), project_id.value())
+            .session(&self.objectstore_client)?;
+        Ok(session)
+    }
 }
 
 /// Common interface for calls to [`ObjectstoreServiceInner::upload`].
@@ -721,5 +739,52 @@ fn is_retryable(error: &objectstore_client::Error) -> bool {
                 )
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_system::Service;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn org_zero_rejected() {
+        let service = ObjectstoreService::new(&test_config(), Some(Addr::dummy()))
+            .unwrap()
+            .unwrap();
+        let addr = service.start_detached();
+
+        let stream = BoundedStream::new(
+            MeteredStream::new(futures::stream::empty().boxed(), "test"),
+            0,
+            usize::MAX,
+        );
+
+        let result = addr
+            .send(Stream {
+                organization_id: OrganizationId::new(0),
+                project_id: ProjectId::new(1),
+                key: "my_file".into(),
+                stream,
+            })
+            .await
+            .unwrap();
+        let err = result.unwrap_err();
+
+        assert!(matches!(err.kind, ErrorKind::InvalidScoping));
+    }
+
+    fn test_config() -> ObjectstoreServiceConfig {
+        ObjectstoreServiceConfig {
+            objectstore_url: Some("http://objectstore".to_owned()),
+            max_concurrent_requests: 1,
+            max_backlog: 1,
+            timeout: 1,
+            stream_timeout: 1,
+            retry_delay: 1.0,
+            max_attempts: 1.try_into().unwrap(),
+            auth: None,
+        }
     }
 }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -413,7 +413,7 @@ impl ObjectstoreServiceInner {
             .filter(|item| *item.ty() == ItemType::Attachment);
 
         match session {
-            Err(error) => Error::from(error)
+            Err(error) => error
                 .with_amount(attachments.count())
                 .log(MessageKind::Envelope),
             Ok(session) => {
@@ -465,7 +465,7 @@ impl ObjectstoreServiceInner {
         );
 
         match session {
-            Err(error) => Error::from(error).log(MessageKind::EventAttachment),
+            Err(error) => error.log(MessageKind::EventAttachment),
             Ok(session) => {
                 let result = self
                     .upload_bytes(


### PR DESCRIPTION
Earlier iterations of the upload endpoint accidentally wrote files with org_id 0 to objectstore. Guard against this in the service to prevent future bugs.

Fixes INGEST-812