### PR TITLE
ref(instr): Add instrumentation around processors

### DIFF
--- a/relay-server/src/processing/relay.rs
+++ b/relay-server/src/processing/relay.rs
@@ -27,6 +27,7 @@ use crate::processing::transactions::TransactionProcessor;
 use crate::processing::user_reports::UserReportsProcessor;
 use crate::processing::{Context, Output, Outputs, Processor, QuotaRateLimiter};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
+use crate::statsd::RelayTimers;
 
 /// Implementation of Relays processing pipeline.
 ///
@@ -184,7 +185,12 @@ impl RelayProcessor {
         );
 
         let _token = self.cogs.timed(ResourceId::Relay, T::cogs());
-        let output = processor.process(item, ctx).await;
+
+        let output = relay_statsd::metric!(
+            timer(RelayTimers::EventProcessingProcess),
+            processor = std::any::type_name::<T>(),
+            { processor.process(item, ctx).await }
+        );
 
         match output {
             Ok(output) => Some(output),

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -405,6 +405,11 @@ pub enum RelayTimers {
     EventProcessingSerialization,
     /// Time used to extract span metrics from an event.
     EventProcessingSpanMetricsExtraction,
+    /// Time in milliseconds spent in each processor.
+    ///
+    /// This metric is tagged with:
+    ///  - `processor`: The processor executed.
+    EventProcessingProcess,
     /// Time spent between the start of request handling and processing of the envelope.
     ///
     /// This includes streaming the request body, scheduling overheads, project config fetching,
@@ -647,6 +652,7 @@ impl TimerMetric for RelayTimers {
                 "event_processing.span_metrics_extraction"
             }
             RelayTimers::EventProcessingSerialization => "event_processing.serialization",
+            RelayTimers::EventProcessingProcess => "event_processing.process",
             RelayTimers::EnvelopeWaitTime => "event.wait_time",
             RelayTimers::EnvelopeProcessingTime => "event.processing_time",
             RelayTimers::EnvelopeTotalTime => "event.total_time",


### PR DESCRIPTION
Uses the already existed `event_processing.process` metric, which seems to have been deleted at some point.