### PR TITLE
ref(replays): Downgrade error to info

### DIFF
--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -79,7 +79,7 @@ pub fn expand(
                 expand_video(video).map(|payload| ExpandedReplay { headers, payload })
             }
             (events, recordings, videos) => {
-                relay_log::error!(
+                relay_log::info!(
                     sdk = headers.meta().client().unwrap_or("unknown"),
                     event_count = events.len(),
                     recording_count = recordings.len(),


### PR DESCRIPTION
Downgrade the error `unexpected replay item count` to an info log, so that it still shows up in Logs but doesn't pollute the list of issues.