### PR TITLE
fix(instr): Cleanup some of the sentry scope usage

### DIFF
--- a/relay-server/src/envelope/meta.rs
+++ b/relay-server/src/envelope/meta.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// A list well known clients.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClientName<'a> {
@@ -30,7 +32,11 @@ impl<'a> ClientName<'a> {
     ///
     /// Returns `None` if the client name is not a well known client.
     pub fn as_static_str(&self) -> Option<&'static str> {
-        Some(match self {
+        self.maybe_static().ok()
+    }
+
+    fn maybe_static(&self) -> Result<&'static str, &'a str> {
+        Ok(match self {
             Self::Relay => "sentry.relay",
             Self::Ruby => "sentry-ruby",
             Self::CocoaFlutter => "sentry.cocoa.flutter",
@@ -52,7 +58,7 @@ impl<'a> ClientName<'a> {
             Self::Symfony => "sentry.php.symfony",
             Self::Php => "sentry.php",
             Self::Python => "sentry.python",
-            Self::Other(_) => return None,
+            Self::Other(s) => return Err(s),
         })
     }
 }
@@ -82,6 +88,15 @@ impl<'a> From<&'a str> for ClientName<'a> {
             "sentry.php" => Self::Php,
             "sentry.python" => Self::Python,
             other => Self::Other(other),
+        }
+    }
+}
+
+impl fmt::Display for ClientName<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.maybe_static() {
+            Ok(s) => f.write_str(s),
+            Err(s) => f.write_str(s),
         }
     }
 }

--- a/relay-server/src/envelope/meta.rs
+++ b/relay-server/src/envelope/meta.rs
@@ -95,8 +95,7 @@ impl<'a> From<&'a str> for ClientName<'a> {
 impl fmt::Display for ClientName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.maybe_static() {
-            Ok(s) => f.write_str(s),
-            Err(s) => f.write_str(s),
+            Ok(s) | Err(s) => f.write_str(s),
         }
     }
 }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -14,7 +14,6 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use flate2::Compression;
 use flate2::write::{GzEncoder, ZlibEncoder};
-use futures::FutureExt;
 use futures::future::BoxFuture;
 use relay_base_schema::project::{ProjectId, ProjectKey};
 use relay_cogs::{AppFeature, Cogs, FeatureWeights, ResourceId, Token};
@@ -24,6 +23,7 @@ use relay_event_normalization::{ClockDriftProcessor, GeoIpLookup};
 use relay_event_schema::processor::ProcessingAction;
 use relay_event_schema::protocol::ClientReport;
 use relay_filter::FilterStatKey;
+use relay_log::sentry::SentryFutureExt;
 use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricNamespace};
 use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_sampling::evaluation::SamplingDecision;
@@ -677,30 +677,11 @@ impl EnvelopeProcessorService {
             return Vec::new();
         };
 
-        let client = envelope.envelope().meta().client().map(str::to_owned);
-        let user_agent = envelope.envelope().meta().user_agent().map(str::to_owned);
-
-        // We set additional information on the scope, which will be removed after processing the
-        // envelope.
         relay_log::configure_scope(|scope| {
-            scope.set_tag("project", project_id);
-            if let Some(client) = client {
-                scope.set_tag("sdk", client);
-            }
-            if let Some(user_agent) = user_agent {
-                scope.set_extra("user_agent", user_agent.into());
-            }
+            scope.set_tag("project_id", project_id);
         });
 
-        let result = self.process_envelope(project_id, envelope, ctx).await;
-
-        relay_log::configure_scope(|scope| {
-            scope.remove_tag("project");
-            scope.remove_tag("sdk");
-            scope.remove_tag("user_agent");
-        });
-
-        result
+        self.process_envelope(project_id, envelope, ctx).await
     }
 
     async fn handle_process_envelope(&self, cogs: &mut Token, message: ProcessEnvelope) {
@@ -729,6 +710,21 @@ impl EnvelopeProcessorService {
             .sampling_project_info
             .and_then(|p| p.get_public_key_config())
             .map(|pkc| pkc.public_key);
+
+        relay_log::configure_scope(|scope| {
+            scope.set_tag("project_key", project_key);
+            if let Some(sampling_key) = sampling_key {
+                scope.set_tag("sampling_key", sampling_key);
+            }
+            let meta = message.envelope.envelope().meta();
+            scope.set_tag("sdk_name", meta.client_name());
+            if let Some(client) = meta.client() {
+                scope.set_tag("sdk", client);
+            }
+            if let Some(user_agent) = meta.user_agent() {
+                scope.set_extra("user_agent", user_agent.into());
+            }
+        });
 
         let outputs = metric!(timer(RelayTimers::EnvelopeProcessingTime), {
             self.process(message.envelope, ctx).await
@@ -1401,7 +1397,7 @@ impl EnvelopeProcessorService {
         self.inner.rate_limiter.is_some()
     }
 
-    async fn handle_message(&self, message: EnvelopeProcessor) {
+    async fn handle_message(self, message: EnvelopeProcessor) {
         let ty = message.variant();
         let feature_weights = self.feature_weights(&message);
 
@@ -1454,14 +1450,10 @@ impl Service for EnvelopeProcessorService {
     async fn run(self, mut rx: relay_system::Receiver<Self::Interface>) {
         while let Some(message) = rx.recv().await {
             let service = self.clone();
+            let hub = relay_log::Hub::with(|h| relay_log::Hub::new_from_top(h));
             self.inner
                 .pool
-                .spawn_async(
-                    async move {
-                        service.handle_message(message).await;
-                    }
-                    .boxed(),
-                )
+                .spawn_async(Box::pin(service.handle_message(message).bind_hub(hub)))
                 .await;
         }
     }

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -1450,7 +1450,9 @@ impl Service for EnvelopeProcessorService {
     async fn run(self, mut rx: relay_system::Receiver<Self::Interface>) {
         while let Some(message) = rx.recv().await {
             let service = self.clone();
+            // Create a new hub to prevent sentry scopes from bleeding to other tasks.
             let hub = relay_log::Hub::with(|h| relay_log::Hub::new_from_top(h));
+
             self.inner
                 .pool
                 .spawn_async(Box::pin(service.handle_message(message).bind_hub(hub)))

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -4,12 +4,12 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::error::Error;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use futures::FutureExt;
-use futures::future::BoxFuture;
 use prost::Message as _;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 use serde::Serialize;
@@ -247,7 +247,7 @@ impl Counted for StoreProfile {
 }
 
 /// The asynchronous thread pool used for scheduling storing tasks in the envelope store.
-pub type StoreServicePool = AsyncPool<BoxFuture<'static, ()>>;
+pub type StoreServicePool = AsyncPool<StoreTask>;
 
 /// Service interface for the [`StoreEnvelope`] message.
 #[derive(Debug)]
@@ -399,11 +399,6 @@ impl StoreService {
     }
 
     fn handle_message(&self, message: Store) {
-        // relay_kafka configures the scope
-        relay_log::with_scope(|_| {}, || self.handle_message_inner(message))
-    }
-
-    fn handle_message_inner(&self, message: Store) {
         let ty = message.variant();
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {
@@ -1287,15 +1282,33 @@ impl Service for StoreService {
         relay_log::info!("store forwarder started");
 
         while let Some(message) = rx.recv().await {
-            let service = Arc::clone(&this);
-            // For now, we run each task synchronously, in the future we might explore how to make
-            // the store async.
-            this.pool
-                .spawn_async(async move { service.handle_message(message) }.boxed())
-                .await;
+            let task = StoreTask {
+                service: Arc::clone(&this),
+                message: Some(message),
+            };
+            this.pool.spawn_async(task).await;
         }
 
         relay_log::info!("store forwarder stopped");
+    }
+}
+
+/// Task executed by [`StoreService`].
+pub struct StoreTask {
+    service: Arc<StoreService>,
+    message: Option<Store>,
+}
+
+impl Future for StoreTask {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        let message = self
+            .message
+            .take()
+            .expect("StoreTask polled after completion");
+        let () = relay_log::with_scope(|_| {}, || self.service.handle_message(message));
+        task::Poll::Ready(())
     }
 }
 


### PR DESCRIPTION
Fix some instrumentation around Sentry scopes.

There is more to do, this is just an initial change to fix the big problem with the processor:
- The processor scope was leaked all over the place, it was never bound to the future and would bleed between tasks on the same thread
- Aligned the store service a bit, initially also wanted to use `bind_hub` there but ended up just removing the `boxed()` as more wasn't necessary.
- Adds some additional tags for the processor (sampling key, sdk client name)
- The scope is no longer recycled, so there is no need to clear it at the end

Actual changes I want to eventually get to:
- The thread pool can automatically wrap all futures with a new hub
- relay-system creates a new hub for each `service.run`
- Rename `project*` tags as it [interacts badly](https://web.archive.org/web/20260306083108/https://sentry.zendesk.com/hc/en-us/articles/37918222336539-Querying-by-Custom-Tags-Shows-No-Result) with [Sentry](https://docs.sentry.io/concepts/search/#explicit-tag-syntax)

Changes I dream about:
- Make relay-system message aware
- Messages inherit/pass a `SentryTrace` along between services
- Each message is a transaction/sets the `SentryTrace` in the hub
- Pass the trace id along across Relay instances

Then we end up with an actually working 'distributed' tracing per envelope, from start to finish across all Relay instances.