### PR TITLE
ref(test): Rename `any` to `matches_any`

### DIFF
--- a/tests/integration/asserts/__init__.py
+++ b/tests/integration/asserts/__init__.py
@@ -4,7 +4,7 @@ from .protocol import only_items
 from .utils import PrintLastCompare
 
 __all__ = [
-    "match_any",
+    "matches_any",
     "matches",
     "only_items",
     "time_after",
@@ -52,7 +52,7 @@ class _Any(PrintLastCompare):
         return "<ANY>"
 
 
-def match_any():
+def matches_any():
     """
     A helper object that compares equal to everything."
     """

--- a/tests/integration/asserts/__init__.py
+++ b/tests/integration/asserts/__init__.py
@@ -4,7 +4,7 @@ from .protocol import only_items
 from .utils import PrintLastCompare
 
 __all__ = [
-    "any",
+    "match_any",
     "matches",
     "only_items",
     "time_after",
@@ -52,7 +52,7 @@ class _Any(PrintLastCompare):
         return "<ANY>"
 
 
-def any():
+def match_any():
     """
     A helper object that compares equal to everything."
     """

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -4,7 +4,7 @@ import pytest
 
 from sentry_relay.consts import DataCategory
 
-from .asserts import match_any, time_within_delta
+from .asserts import matches_any, time_within_delta
 
 
 @pytest.mark.parametrize(
@@ -391,7 +391,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": match_any(),
+                    "value": matches_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.45},
@@ -467,7 +467,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI agent operation",
@@ -483,7 +483,7 @@ def test_ai_spans_example_transaction(
             "trace_id": "a9351cd574f092f6acad48e250981f11",
         },
         {
-            "_meta": match_any(),
+            "_meta": matches_any(),
             "attributes": {
                 "gen_ai.conversation.id": {
                     "type": "string",
@@ -491,7 +491,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": match_any(),
+                    "value": matches_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 0.37},
@@ -611,7 +611,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "gen_ai.generate_text",
@@ -692,7 +692,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "POST",
@@ -767,7 +767,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI model operation",
@@ -846,7 +846,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "GET",
@@ -921,7 +921,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI model operation",
@@ -1000,7 +1000,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "GET",
@@ -1016,7 +1016,7 @@ def test_ai_spans_example_transaction(
             "trace_id": "a9351cd574f092f6acad48e250981f11",
         },
         {
-            "_meta": match_any(),
+            "_meta": matches_any(),
             "attributes": {
                 "gen_ai.conversation.id": {
                     "type": "string",
@@ -1024,7 +1024,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": match_any(),
+                    "value": matches_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.08},
@@ -1144,7 +1144,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "gen_ai.generate_text",
@@ -1225,7 +1225,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "POST",
@@ -1280,7 +1280,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": match_any(),
+            "event_id": matches_any(),
             "is_segment": True,
             "key_id": 123,
             "name": "main",

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -4,7 +4,7 @@ import pytest
 
 from sentry_relay.consts import DataCategory
 
-from .asserts import any, time_within_delta
+from .asserts import match_any, time_within_delta
 
 
 @pytest.mark.parametrize(
@@ -391,7 +391,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": any(),
+                    "value": match_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.45},
@@ -467,7 +467,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI agent operation",
@@ -483,7 +483,7 @@ def test_ai_spans_example_transaction(
             "trace_id": "a9351cd574f092f6acad48e250981f11",
         },
         {
-            "_meta": any(),
+            "_meta": match_any(),
             "attributes": {
                 "gen_ai.conversation.id": {
                     "type": "string",
@@ -491,7 +491,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": any(),
+                    "value": match_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 0.37},
@@ -611,7 +611,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "gen_ai.generate_text",
@@ -692,7 +692,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "POST",
@@ -767,7 +767,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI model operation",
@@ -846,7 +846,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "GET",
@@ -921,7 +921,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "Generative AI model operation",
@@ -1000,7 +1000,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "GET",
@@ -1016,7 +1016,7 @@ def test_ai_spans_example_transaction(
             "trace_id": "a9351cd574f092f6acad48e250981f11",
         },
         {
-            "_meta": any(),
+            "_meta": match_any(),
             "attributes": {
                 "gen_ai.conversation.id": {
                     "type": "string",
@@ -1024,7 +1024,7 @@ def test_ai_spans_example_transaction(
                 },
                 "gen_ai.context.utilization": {
                     "type": "double",
-                    "value": any(),
+                    "value": match_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.08},
@@ -1144,7 +1144,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "gen_ai.generate_text",
@@ -1225,7 +1225,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": False,
             "key_id": 123,
             "name": "POST",
@@ -1280,7 +1280,7 @@ def test_ai_spans_example_transaction(
             },
             "downsampled_retention_days": 90,
             "end_timestamp": time_within_delta(),
-            "event_id": any(),
+            "event_id": match_any(),
             "is_segment": True,
             "key_id": 123,
             "name": "main",

--- a/tests/integration/test_attachment_ref.py
+++ b/tests/integration/test_attachment_ref.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import any
+from .asserts import match_any
 from .test_store import make_transaction
 
 
@@ -199,14 +199,14 @@ def test_attachment_ref(
 
     relay.send_envelope(project_id, envelope)
     expected_attachment = {
-        "id": any(),
+        "id": match_any(),
         "name": "test.txt",
         "content_type": "text/plain",
         "attachment_type": "event.attachment",
         "size": len(attachment_data),
         "rate_limited": False,
-        "stored_id": any(),
-        "retention_days": any(),
+        "stored_id": match_any(),
+        "retention_days": match_any(),
     }
 
     if event_type == "event":

--- a/tests/integration/test_attachment_ref.py
+++ b/tests/integration/test_attachment_ref.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import match_any
+from .asserts import matches_any
 from .test_store import make_transaction
 
 
@@ -199,14 +199,14 @@ def test_attachment_ref(
 
     relay.send_envelope(project_id, envelope)
     expected_attachment = {
-        "id": match_any(),
+        "id": matches_any(),
         "name": "test.txt",
         "content_type": "text/plain",
         "attachment_type": "event.attachment",
         "size": len(attachment_data),
         "rate_limited": False,
-        "stored_id": match_any(),
-        "retention_days": match_any(),
+        "stored_id": matches_any(),
+        "retention_days": matches_any(),
     }
 
     if event_type == "event":

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -7,7 +7,7 @@ import json
 from requests.exceptions import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import any
+from .asserts import match_any
 from .test_store import make_transaction
 
 
@@ -164,7 +164,7 @@ def test_attachments_with_objectstore(
     assert stored == {
         "type": "attachment",
         "attachment": {
-            "id": any(),
+            "id": match_any(),
             "name": "foo.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -181,7 +181,7 @@ def test_attachments_with_objectstore(
     assert empty == {
         "type": "attachment",
         "attachment": {
-            "id": any(),
+            "id": match_any(),
             "name": "foobar.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -670,7 +670,7 @@ def test_event_with_attachment(
             "attachment_type": "event.attachment",
             "size": len(b"event attachment"),
             "retention_days": 90,
-            **({"stored_id": any()} if use_objectstore else {"chunks": 1}),
+            **({"stored_id": match_any()} if use_objectstore else {"chunks": 1}),
         }
     ]
 
@@ -699,7 +699,7 @@ def test_event_with_attachment(
         "size": len(b"transaction attachment"),
         "retention_days": 90,
         **(
-            {"stored_id": any()}
+            {"stored_id": match_any()}
             if use_objectstore
             else {"data": b"transaction attachment"}
         ),

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -7,7 +7,7 @@ import json
 from requests.exceptions import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import match_any
+from .asserts import matches_any
 from .test_store import make_transaction
 
 
@@ -164,7 +164,7 @@ def test_attachments_with_objectstore(
     assert stored == {
         "type": "attachment",
         "attachment": {
-            "id": match_any(),
+            "id": matches_any(),
             "name": "foo.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -181,7 +181,7 @@ def test_attachments_with_objectstore(
     assert empty == {
         "type": "attachment",
         "attachment": {
-            "id": match_any(),
+            "id": matches_any(),
             "name": "foobar.txt",
             "rate_limited": False,
             "attachment_type": "event.attachment",
@@ -670,7 +670,7 @@ def test_event_with_attachment(
             "attachment_type": "event.attachment",
             "size": len(b"event attachment"),
             "retention_days": 90,
-            **({"stored_id": match_any()} if use_objectstore else {"chunks": 1}),
+            **({"stored_id": matches_any()} if use_objectstore else {"chunks": 1}),
         }
     ]
 
@@ -699,7 +699,7 @@ def test_event_with_attachment(
         "size": len(b"transaction attachment"),
         "retention_days": 90,
         **(
-            {"stored_id": match_any()}
+            {"stored_id": matches_any()}
             if use_objectstore
             else {"data": b"transaction attachment"}
         ),

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import match_any, time_within_delta, time_is
+from .asserts import matches_any, time_within_delta, time_is
 from .test_spansv2 import envelope_with_spans
 
 from .test_dynamic_sampling import add_sampling_config
@@ -152,10 +152,10 @@ def test_standalone_attachment_store(
         "itemType": "TRACE_ITEM_TYPE_ATTACHMENT",
         "organizationId": "1",
         "projectId": "42",
-        "received": match_any(),
+        "received": matches_any(),
         "retentionDays": 90,
         "serverSampleRate": 1.0,
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "traceId": attachment_metadata["trace_id"].replace("-", ""),
     }
 
@@ -327,7 +327,7 @@ def test_attachment_with_matching_span(mini_sentry, relay):
             "is_segment": True,
             "start_timestamp": time_is(ts),
             "end_timestamp": time_is(ts.timestamp() + 0.5),
-            "attributes": match_any(),
+            "attributes": matches_any(),
         }
     ]
 
@@ -414,10 +414,10 @@ def test_attachment_with_matching_span_store(
         "itemType": "TRACE_ITEM_TYPE_ATTACHMENT",
         "organizationId": "1",
         "projectId": "42",
-        "received": match_any(),
+        "received": matches_any(),
         "retentionDays": 90,
         "serverSampleRate": 1.0,
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "traceId": metadata["trace_id"],
     }
 
@@ -526,7 +526,7 @@ def test_two_attachments_mapping_to_same_span(mini_sentry, relay):
             "is_segment": True,
             "start_timestamp": time_is(ts),
             "end_timestamp": time_is(ts.timestamp() + 0.5),
-            "attributes": match_any(),
+            "attributes": matches_any(),
         }
     ]
 
@@ -637,7 +637,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
 
     assert mini_sentry.get_metrics() == [
         {
-            "metadata": match_any(),
+            "metadata": matches_any(),
             "name": "c:spans/count_per_root_project@none",
             "tags": {
                 "decision": "drop",
@@ -651,7 +651,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
             "width": 1,
         },
         {
-            "metadata": match_any(),
+            "metadata": matches_any(),
             "name": "c:spans/usage@none",
             "tags": {
                 "is_segment": "false",
@@ -1382,8 +1382,10 @@ def test_attachment_pii_scrubbing_meta_attribute(
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": match_any(),
-                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
+                            "len": matches_any(),
+                            "rem": [
+                                [rule_type, matches_any(), matches_any(), matches_any()]
+                            ],
                         }
                     }
                 }

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import any, time_within_delta, time_is
+from .asserts import match_any, time_within_delta, time_is
 from .test_spansv2 import envelope_with_spans
 
 from .test_dynamic_sampling import add_sampling_config
@@ -152,10 +152,10 @@ def test_standalone_attachment_store(
         "itemType": "TRACE_ITEM_TYPE_ATTACHMENT",
         "organizationId": "1",
         "projectId": "42",
-        "received": any(),
+        "received": match_any(),
         "retentionDays": 90,
         "serverSampleRate": 1.0,
-        "timestamp": any(),
+        "timestamp": match_any(),
         "traceId": attachment_metadata["trace_id"].replace("-", ""),
     }
 
@@ -327,7 +327,7 @@ def test_attachment_with_matching_span(mini_sentry, relay):
             "is_segment": True,
             "start_timestamp": time_is(ts),
             "end_timestamp": time_is(ts.timestamp() + 0.5),
-            "attributes": any(),
+            "attributes": match_any(),
         }
     ]
 
@@ -414,10 +414,10 @@ def test_attachment_with_matching_span_store(
         "itemType": "TRACE_ITEM_TYPE_ATTACHMENT",
         "organizationId": "1",
         "projectId": "42",
-        "received": any(),
+        "received": match_any(),
         "retentionDays": 90,
         "serverSampleRate": 1.0,
-        "timestamp": any(),
+        "timestamp": match_any(),
         "traceId": metadata["trace_id"],
     }
 
@@ -526,7 +526,7 @@ def test_two_attachments_mapping_to_same_span(mini_sentry, relay):
             "is_segment": True,
             "start_timestamp": time_is(ts),
             "end_timestamp": time_is(ts.timestamp() + 0.5),
-            "attributes": any(),
+            "attributes": match_any(),
         }
     ]
 
@@ -637,7 +637,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
 
     assert mini_sentry.get_metrics() == [
         {
-            "metadata": any(),
+            "metadata": match_any(),
             "name": "c:spans/count_per_root_project@none",
             "tags": {
                 "decision": "drop",
@@ -651,7 +651,7 @@ def test_span_attachment_ds_drop(mini_sentry, relay, rule_type):
             "width": 1,
         },
         {
-            "metadata": any(),
+            "metadata": match_any(),
             "name": "c:spans/usage@none",
             "tags": {
                 "is_segment": "false",
@@ -1382,8 +1382,8 @@ def test_attachment_pii_scrubbing_meta_attribute(
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": any(),
-                            "rem": [[rule_type, any(), any(), any()]],
+                            "len": match_any(),
+                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
                         }
                     }
                 }

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from urllib3.filepost import encode_multipart_formdata
 
 from sentry_relay.consts import DataCategory
-from .asserts import any, time_within_delta
+from .asserts import match_any, time_within_delta
 from .test_attachment_ref import upload_and_make_ref
 from .consts import DUMMY_UPLOAD_LOCATION
 
@@ -863,18 +863,18 @@ def test_minidump_placeholder(
                 "type": "trace",
             },
         },
-        "grouping_config": any(),
+        "grouping_config": match_any(),
         "key_id": "123",
         "level": "fatal",
         "logger": "",
         "platform": "native",
         "project": 42,
-        "received": any(),
+        "received": match_any(),
         "sdk": {
             "name": "minidump.upload",
             "version": "0.0.0",
         },
-        "timestamp": any(),
+        "timestamp": match_any(),
         "type": "error",
         "version": "5",
     }
@@ -886,12 +886,12 @@ def test_minidump_placeholder(
     assert attachment == {
         "attachment_type": "event.minidump",
         "content_type": "application/x-dmp",
-        "id": any(),
+        "id": match_any(),
         "name": "minidump.dmp",
         "rate_limited": False,
         "retention_days": 90,
         "size": 26,
-        "stored_id": any(),
+        "stored_id": match_any(),
     }
 
     # Verify the actual data is retrievable from the objectstore.

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from urllib3.filepost import encode_multipart_formdata
 
 from sentry_relay.consts import DataCategory
-from .asserts import match_any, time_within_delta
+from .asserts import matches_any, time_within_delta
 from .test_attachment_ref import upload_and_make_ref
 from .consts import DUMMY_UPLOAD_LOCATION
 
@@ -863,18 +863,18 @@ def test_minidump_placeholder(
                 "type": "trace",
             },
         },
-        "grouping_config": match_any(),
+        "grouping_config": matches_any(),
         "key_id": "123",
         "level": "fatal",
         "logger": "",
         "platform": "native",
         "project": 42,
-        "received": match_any(),
+        "received": matches_any(),
         "sdk": {
             "name": "minidump.upload",
             "version": "0.0.0",
         },
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "type": "error",
         "version": "5",
     }
@@ -886,12 +886,12 @@ def test_minidump_placeholder(
     assert attachment == {
         "attachment_type": "event.minidump",
         "content_type": "application/x-dmp",
-        "id": match_any(),
+        "id": matches_any(),
         "name": "minidump.dmp",
         "rate_limited": False,
         "retention_days": 90,
         "size": 26,
-        "stored_id": match_any(),
+        "stored_id": matches_any(),
     }
 
     # Verify the actual data is retrievable from the objectstore.

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from time import sleep
 
-from .asserts import any, time_within_delta
+from .asserts import match_any, time_within_delta
 
 
 def test_nel_converted_to_logs(mini_sentry, relay):
@@ -23,7 +23,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
         "version": 2,
         "items": [
             {
-                "__header": any(),
+                "__header": match_any(),
                 "attributes": {
                     "sentry.origin": {
                         "type": "string",
@@ -78,7 +78,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
                 "body": "The user agent successfully received a response, but it had a 500 status code",
                 "level": "warn",
                 "timestamp": time_within_delta(expected_ts),
-                "trace_id": any(),
+                "trace_id": match_any(),
             }
         ],
     }

--- a/tests/integration/test_nel.py
+++ b/tests/integration/test_nel.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from time import sleep
 
-from .asserts import match_any, time_within_delta
+from .asserts import matches_any, time_within_delta
 
 
 def test_nel_converted_to_logs(mini_sentry, relay):
@@ -23,7 +23,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
         "version": 2,
         "items": [
             {
-                "__header": match_any(),
+                "__header": matches_any(),
                 "attributes": {
                     "sentry.origin": {
                         "type": "string",
@@ -78,7 +78,7 @@ def test_nel_converted_to_logs(mini_sentry, relay):
                 "body": "The user agent successfully received a response, but it had a 500 status code",
                 "level": "warn",
                 "timestamp": time_within_delta(expected_ts),
-                "trace_id": match_any(),
+                "trace_id": matches_any(),
             }
         ],
     }

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone, timedelta
 
 from sentry_relay.consts import DataCategory
 
-from .asserts import any, time_within_delta, time_within, only_items
+from .asserts import match_any, time_within_delta, time_within, only_items
 
 TEST_CONFIG = {
     "outcomes": {
@@ -129,7 +129,7 @@ def test_otlp_logs_conversion(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": any()},
+                "sentry.payload_size_bytes": {"intValue": match_any()},
                 "sentry.severity_text": {"stringValue": "info"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_precise": {
@@ -143,7 +143,7 @@ def test_otlp_logs_conversion(
                 "string.attribute": {"stringValue": "some string"},
             },
             "clientSampleRate": 1.0,
-            "itemId": any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -238,7 +238,7 @@ def test_otlp_logs_multiple_records(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": any()},
+                "sentry.payload_size_bytes": {"intValue": match_any()},
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_precise": {
@@ -251,7 +251,7 @@ def test_otlp_logs_multiple_records(
                 },
             },
             "clientSampleRate": 1.0,
-            "itemId": any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -269,7 +269,7 @@ def test_otlp_logs_multiple_records(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": any()},
+                "sentry.payload_size_bytes": {"intValue": match_any()},
                 "sentry.severity_text": {"stringValue": "debug"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
                 "sentry.timestamp_precise": {
@@ -282,7 +282,7 @@ def test_otlp_logs_multiple_records(
                 },
             },
             "clientSampleRate": 1.0,
-            "itemId": any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone, timedelta
 
 from sentry_relay.consts import DataCategory
 
-from .asserts import match_any, time_within_delta, time_within, only_items
+from .asserts import matches_any, time_within_delta, time_within, only_items
 
 TEST_CONFIG = {
     "outcomes": {
@@ -129,7 +129,7 @@ def test_otlp_logs_conversion(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": match_any()},
+                "sentry.payload_size_bytes": {"intValue": matches_any()},
                 "sentry.severity_text": {"stringValue": "info"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_precise": {
@@ -143,7 +143,7 @@ def test_otlp_logs_conversion(
                 "string.attribute": {"stringValue": "some string"},
             },
             "clientSampleRate": 1.0,
-            "itemId": match_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -238,7 +238,7 @@ def test_otlp_logs_multiple_records(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": match_any()},
+                "sentry.payload_size_bytes": {"intValue": matches_any()},
                 "sentry.severity_text": {"stringValue": "error"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
                 "sentry.timestamp_precise": {
@@ -251,7 +251,7 @@ def test_otlp_logs_multiple_records(
                 },
             },
             "clientSampleRate": 1.0,
-            "itemId": match_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -269,7 +269,7 @@ def test_otlp_logs_multiple_records(
                     "stringValue": time_within(ts, expect_resolution="ns")
                 },
                 "sentry.origin": {"stringValue": "auto.otlp.logs"},
-                "sentry.payload_size_bytes": {"intValue": match_any()},
+                "sentry.payload_size_bytes": {"intValue": matches_any()},
                 "sentry.severity_text": {"stringValue": "debug"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
                 "sentry.timestamp_precise": {
@@ -282,7 +282,7 @@ def test_otlp_logs_multiple_records(
                 },
             },
             "clientSampleRate": 1.0,
-            "itemId": match_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -7,7 +7,7 @@ from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within, matches, match_any
+from .asserts import time_within_delta, time_within, matches, matches_any
 
 import pytest
 
@@ -315,7 +315,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 "browser.name": {"stringValue": "Firefox"},
                 "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "error"},
-                "sentry.payload_size_bytes": {"intValue": match_any()},
+                "sentry.payload_size_bytes": {"intValue": matches_any()},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
                 "user_agent.original": {
                     "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0",
@@ -323,7 +323,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
-            "itemId": match_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -393,7 +393,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 "browser.name": {"stringValue": "Firefox"},
                 "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "info"},
-                "sentry.payload_size_bytes": {"intValue": match_any()},
+                "sentry.payload_size_bytes": {"intValue": matches_any()},
                 "http.response_content_length": {"intValue": "17"},
                 "http.response.body.size": {"intValue": "17"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
@@ -410,7 +410,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
-            "itemId": match_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -520,14 +520,16 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
                 "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
             },
         },
-        "__header": {"byte_size": match_any()},
+        "__header": {"byte_size": matches_any()},
         "_meta": {
             "attributes": {
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": match_any(),
-                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
+                            "len": matches_any(),
+                            "rem": [
+                                [rule_type, matches_any(), matches_any(), matches_any()]
+                            ],
                         }
                     }
                 }
@@ -630,15 +632,15 @@ def test_ourlog_default_pii_body(
     assert log == {
         **_if_dict(
             non_destructive.scrubs(),
-            {"_meta": {"body": {"": {"len": match_any(), "rem": match_any()}}}},
+            {"_meta": {"body": {"": {"len": matches_any(), "rem": matches_any()}}}},
         ),
-        "attributes": match_any(),
+        "attributes": matches_any(),
         "body": non_destructive.expected_output,
         "level": "info",
         "span_id": "eee19b7ec3c1b174",
         "timestamp": time_within(ts),
         "trace_id": "5b8efff798038103d269b633813fc60c",
-        "__header": match_any(),
+        "__header": matches_any(),
     }
 
     if non_destructive.additional_checks:
@@ -705,7 +707,7 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             "sentry.body": {"stringValue": "Test log"},
             "sentry.severity_text": {"stringValue": "info"},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
-            "sentry.payload_size_bytes": match_any(),
+            "sentry.payload_size_bytes": matches_any(),
             "browser.name": {"stringValue": "Firefox"},
             "user_agent.original": {
                 "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
@@ -713,7 +715,7 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -760,14 +762,14 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
             "browser.name": {"stringValue": "Firefox"},
             "browser.version": {"stringValue": "42.0"},
             "sentry.severity_text": {"stringValue": "warn"},
-            "sentry.payload_size_bytes": {"intValue": match_any()},
+            "sentry.payload_size_bytes": {"intValue": matches_any()},
             "user_agent.original": {
                 "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
             },
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -906,12 +908,12 @@ def test_browser_name_version_extraction(
             "browser.version": {"stringValue": expected_browser_version},
             "user_agent.original": {"stringValue": user_agent},
             "sentry.severity_text": {"stringValue": "error"},
-            "sentry.payload_size_bytes": {"intValue": match_any()},
+            "sentry.payload_size_bytes": {"intValue": matches_any()},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -1046,7 +1048,7 @@ def test_filters_are_applied_to_logs(
             "org_id": 1,
             "outcome": 1,
             "project_id": 42,
-            "quantity": match_any(),
+            "quantity": matches_any(),
             "reason": filter_name,
             "timestamp": time_within_delta(ts),
         },
@@ -1105,7 +1107,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": match_any(),
+        "attributes": matches_any(),
         "body": "foo",
         "level": "error",
         "span_id": "eee19b7ec3c1b175",
@@ -1189,7 +1191,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -1295,7 +1297,7 @@ def test_ourlog_container_metadata(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": match_any(),
+        "__header": matches_any(),
         "body": "Test log",
         "level": "info",
         "timestamp": time_within(ts),

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -7,7 +7,7 @@ from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import time_within_delta, time_within, matches, any
+from .asserts import time_within_delta, time_within, matches, match_any
 
 import pytest
 
@@ -315,7 +315,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 "browser.name": {"stringValue": "Firefox"},
                 "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "error"},
-                "sentry.payload_size_bytes": {"intValue": any()},
+                "sentry.payload_size_bytes": {"intValue": match_any()},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
                 "user_agent.original": {
                     "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0",
@@ -323,7 +323,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
-            "itemId": any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -393,7 +393,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 "browser.name": {"stringValue": "Firefox"},
                 "browser.version": {"stringValue": "42.0"},
                 "sentry.severity_text": {"stringValue": "info"},
-                "sentry.payload_size_bytes": {"intValue": any()},
+                "sentry.payload_size_bytes": {"intValue": match_any()},
                 "http.response_content_length": {"intValue": "17"},
                 "http.response.body.size": {"intValue": "17"},
                 "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
@@ -410,7 +410,7 @@ def test_ourlog_extraction_with_sentry_logs(
                 **timestamps(ts),
             },
             "clientSampleRate": 1.0,
-            "itemId": any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_LOG",
             "organizationId": "1",
             "projectId": "42",
@@ -520,14 +520,14 @@ def test_ourlog_extraction_with_string_pii_scrubbing(
                 "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
             },
         },
-        "__header": {"byte_size": any()},
+        "__header": {"byte_size": match_any()},
         "_meta": {
             "attributes": {
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": any(),
-                            "rem": [[rule_type, any(), any(), any()]],
+                            "len": match_any(),
+                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
                         }
                     }
                 }
@@ -630,15 +630,15 @@ def test_ourlog_default_pii_body(
     assert log == {
         **_if_dict(
             non_destructive.scrubs(),
-            {"_meta": {"body": {"": {"len": any(), "rem": any()}}}},
+            {"_meta": {"body": {"": {"len": match_any(), "rem": match_any()}}}},
         ),
-        "attributes": any(),
+        "attributes": match_any(),
         "body": non_destructive.expected_output,
         "level": "info",
         "span_id": "eee19b7ec3c1b174",
         "timestamp": time_within(ts),
         "trace_id": "5b8efff798038103d269b633813fc60c",
-        "__header": any(),
+        "__header": match_any(),
     }
 
     if non_destructive.additional_checks:
@@ -705,7 +705,7 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             "sentry.body": {"stringValue": "Test log"},
             "sentry.severity_text": {"stringValue": "info"},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b174"},
-            "sentry.payload_size_bytes": any(),
+            "sentry.payload_size_bytes": match_any(),
             "browser.name": {"stringValue": "Firefox"},
             "user_agent.original": {
                 "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
@@ -713,7 +713,7 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -760,14 +760,14 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
             "browser.name": {"stringValue": "Firefox"},
             "browser.version": {"stringValue": "42.0"},
             "sentry.severity_text": {"stringValue": "warn"},
-            "sentry.payload_size_bytes": {"intValue": any()},
+            "sentry.payload_size_bytes": {"intValue": match_any()},
             "user_agent.original": {
                 "stringValue": "RelayIntegrationTests/1.0.0 Firefox/42.0"
             },
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -906,12 +906,12 @@ def test_browser_name_version_extraction(
             "browser.version": {"stringValue": expected_browser_version},
             "user_agent.original": {"stringValue": user_agent},
             "sentry.severity_text": {"stringValue": "error"},
-            "sentry.payload_size_bytes": {"intValue": any()},
+            "sentry.payload_size_bytes": {"intValue": match_any()},
             "sentry.span_id": {"stringValue": "eee19b7ec3c1b175"},
             **timestamps(ts),
         },
         "clientSampleRate": 1.0,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -1046,7 +1046,7 @@ def test_filters_are_applied_to_logs(
             "org_id": 1,
             "outcome": 1,
             "project_id": 42,
-            "quantity": any(),
+            "quantity": match_any(),
             "reason": filter_name,
             "timestamp": time_within_delta(ts),
         },
@@ -1105,7 +1105,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": any(),
+        "attributes": match_any(),
         "body": "foo",
         "level": "error",
         "span_id": "eee19b7ec3c1b175",
@@ -1189,7 +1189,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
         "organizationId": "1",
         "projectId": "42",
@@ -1295,7 +1295,7 @@ def test_ourlog_container_metadata(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": any(),
+        "__header": match_any(),
         "body": "Test log",
         "level": "info",
         "timestamp": time_within(ts),

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -8,7 +8,7 @@ from functools import cache
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from urllib3 import encode_multipart_formdata
-from .asserts import match_any, time_within_delta
+from .asserts import matches_any, time_within_delta
 
 
 @cache
@@ -40,7 +40,7 @@ def playstation_project_config():
 def user_data_event_json(response):
     return {
         "event_id": response.text.replace("-", ""),
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "received": time_within_delta(),
         "level": "error",
         "version": "7",
@@ -75,7 +75,7 @@ def user_data_event_json(response):
         "breadcrumbs": {
             "values": [
                 {
-                    "timestamp": match_any(),
+                    "timestamp": matches_any(),
                     "type": "default",
                     "level": "info",
                     "message": "crumb",
@@ -109,20 +109,20 @@ def user_data_event_json(response):
         },
         "key_id": "123",
         "project": 42,
-        "_metrics": match_any(),
-        "grouping_config": match_any(),
+        "_metrics": matches_any(),
+        "grouping_config": matches_any(),
     }
 
 
-def playstation_event_json(sdk=match_any()):
+def playstation_event_json(sdk=matches_any()):
     return {
-        "event_id": match_any(),
+        "event_id": matches_any(),
         "level": "fatal",
-        "version": match_any(),
+        "version": matches_any(),
         "type": "error",
         "logger": "",
         "platform": "native",
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "received": time_within_delta(),
         "contexts": {
             "app": {"app_version": "", "type": "app"},
@@ -146,7 +146,7 @@ def playstation_event_json(sdk=match_any()):
                 "version": "9.20.00.05-00.00.00.0.1",
                 "type": "runtime",
             },
-            "trace": match_any(),
+            "trace": matches_any(),
         },
         "exception": {
             "values": [
@@ -175,19 +175,19 @@ def playstation_event_json(sdk=match_any()):
         "sdk": sdk,
         "key_id": "123",
         "project": 42,
-        "grouping_config": match_any(),
-        "_metrics": match_any(),
+        "grouping_config": matches_any(),
+        "_metrics": matches_any(),
     }
 
 
 def attachments(
-    log_size=match_any(),
-    generated_dump_size=match_any(),
-    playstation_dump_size=match_any(),
+    log_size=matches_any(),
+    generated_dump_size=matches_any(),
+    playstation_dump_size=matches_any(),
 ):
     return [
         {
-            "id": match_any(),
+            "id": matches_any(),
             "name": "console.log",
             "rate_limited": False,
             "content_type": "text/plain",
@@ -197,7 +197,7 @@ def attachments(
             "chunks": 1,
         },
         {
-            "id": match_any(),
+            "id": matches_any(),
             "name": "generated_minidump.dmp",
             "rate_limited": False,
             "content_type": "application/x-dmp",
@@ -207,7 +207,7 @@ def attachments(
             "chunks": 1,
         },
         {
-            "id": match_any(),
+            "id": matches_any(),
             "name": "playstation.prosperodmp",
             "rate_limited": False,
             "content_type": "application/octet-stream",
@@ -773,20 +773,20 @@ def test_playstation_attachment_no_feature_flag(
     event, payload = attachments_consumer.get_event_only()
 
     assert payload == {
-        "event_id": match_any(),
+        "event_id": matches_any(),
         "level": "error",
         "version": "5",
         "type": "error",
         "logger": "",
         "platform": "other",
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "received": time_within_delta(),
         "exception": {"values": [{"type": "ValueError", "value": "Should not happen"}]},
         "sdk": {"name": "raven-node", "version": "2.6.3"},
         "key_id": "123",
         "project": 42,
         "contexts": {
-            "trace": match_any(),
+            "trace": matches_any(),
         },
         "grouping_config": {
             "enhancements": "eJybzDhxY05qemJypZWRgaGlroGxrqHRBABbEwcC",
@@ -799,7 +799,7 @@ def test_playstation_attachment_no_feature_flag(
 
     assert event["attachments"] == (
         {
-            "id": match_any(),
+            "id": matches_any(),
             "name": "playstation.prosperodmp",
             "rate_limited": False,
             "content_type": "application/octet-stream",
@@ -883,7 +883,7 @@ def test_event_merging(
 
     event, payload = attachments_consumer.get_event_only()
     assert payload == {
-        "event_id": match_any(),
+        "event_id": matches_any(),
         "level": "fatal",
         "version": "5",
         "type": "error",

--- a/tests/integration/test_playstation.py
+++ b/tests/integration/test_playstation.py
@@ -8,7 +8,7 @@ from functools import cache
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from urllib3 import encode_multipart_formdata
-from .asserts import any, time_within_delta
+from .asserts import match_any, time_within_delta
 
 
 @cache
@@ -40,7 +40,7 @@ def playstation_project_config():
 def user_data_event_json(response):
     return {
         "event_id": response.text.replace("-", ""),
-        "timestamp": any(),
+        "timestamp": match_any(),
         "received": time_within_delta(),
         "level": "error",
         "version": "7",
@@ -75,7 +75,7 @@ def user_data_event_json(response):
         "breadcrumbs": {
             "values": [
                 {
-                    "timestamp": any(),
+                    "timestamp": match_any(),
                     "type": "default",
                     "level": "info",
                     "message": "crumb",
@@ -109,20 +109,20 @@ def user_data_event_json(response):
         },
         "key_id": "123",
         "project": 42,
-        "_metrics": any(),
-        "grouping_config": any(),
+        "_metrics": match_any(),
+        "grouping_config": match_any(),
     }
 
 
-def playstation_event_json(sdk=any()):
+def playstation_event_json(sdk=match_any()):
     return {
-        "event_id": any(),
+        "event_id": match_any(),
         "level": "fatal",
-        "version": any(),
+        "version": match_any(),
         "type": "error",
         "logger": "",
         "platform": "native",
-        "timestamp": any(),
+        "timestamp": match_any(),
         "received": time_within_delta(),
         "contexts": {
             "app": {"app_version": "", "type": "app"},
@@ -146,7 +146,7 @@ def playstation_event_json(sdk=any()):
                 "version": "9.20.00.05-00.00.00.0.1",
                 "type": "runtime",
             },
-            "trace": any(),
+            "trace": match_any(),
         },
         "exception": {
             "values": [
@@ -175,15 +175,19 @@ def playstation_event_json(sdk=any()):
         "sdk": sdk,
         "key_id": "123",
         "project": 42,
-        "grouping_config": any(),
-        "_metrics": any(),
+        "grouping_config": match_any(),
+        "_metrics": match_any(),
     }
 
 
-def attachments(log_size=any(), generated_dump_size=any(), playstation_dump_size=any()):
+def attachments(
+    log_size=match_any(),
+    generated_dump_size=match_any(),
+    playstation_dump_size=match_any(),
+):
     return [
         {
-            "id": any(),
+            "id": match_any(),
             "name": "console.log",
             "rate_limited": False,
             "content_type": "text/plain",
@@ -193,7 +197,7 @@ def attachments(log_size=any(), generated_dump_size=any(), playstation_dump_size
             "chunks": 1,
         },
         {
-            "id": any(),
+            "id": match_any(),
             "name": "generated_minidump.dmp",
             "rate_limited": False,
             "content_type": "application/x-dmp",
@@ -203,7 +207,7 @@ def attachments(log_size=any(), generated_dump_size=any(), playstation_dump_size
             "chunks": 1,
         },
         {
-            "id": any(),
+            "id": match_any(),
             "name": "playstation.prosperodmp",
             "rate_limited": False,
             "content_type": "application/octet-stream",
@@ -769,20 +773,20 @@ def test_playstation_attachment_no_feature_flag(
     event, payload = attachments_consumer.get_event_only()
 
     assert payload == {
-        "event_id": any(),
+        "event_id": match_any(),
         "level": "error",
         "version": "5",
         "type": "error",
         "logger": "",
         "platform": "other",
-        "timestamp": any(),
+        "timestamp": match_any(),
         "received": time_within_delta(),
         "exception": {"values": [{"type": "ValueError", "value": "Should not happen"}]},
         "sdk": {"name": "raven-node", "version": "2.6.3"},
         "key_id": "123",
         "project": 42,
         "contexts": {
-            "trace": any(),
+            "trace": match_any(),
         },
         "grouping_config": {
             "enhancements": "eJybzDhxY05qemJypZWRgaGlroGxrqHRBABbEwcC",
@@ -795,7 +799,7 @@ def test_playstation_attachment_no_feature_flag(
 
     assert event["attachments"] == (
         {
-            "id": any(),
+            "id": match_any(),
             "name": "playstation.prosperodmp",
             "rate_limited": False,
             "content_type": "application/octet-stream",
@@ -879,7 +883,7 @@ def test_event_merging(
 
     event, payload = attachments_consumer.get_event_only()
     assert payload == {
-        "event_id": any(),
+        "event_id": match_any(),
         "level": "fatal",
         "version": "5",
         "type": "error",

--- a/tests/integration/test_sessions_eap.py
+++ b/tests/integration/test_sessions_eap.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
-from .asserts import time_within_delta, any
+from .asserts import time_within_delta, match_any
 
 
 def test_session_eap_double_write(
@@ -56,8 +56,8 @@ def test_session_eap_double_write(
         {
             "organizationId": "1",
             "projectId": "42",
-            "traceId": any(),
-            "itemId": any(),
+            "traceId": match_any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_USER_SESSION",
             "timestamp": time_within_delta(started, delta=timedelta(seconds=2)),
             "received": time_within_delta(),
@@ -77,8 +77,8 @@ def test_session_eap_double_write(
         {
             "organizationId": "1",
             "projectId": "42",
-            "traceId": any(),
-            "itemId": any(),
+            "traceId": match_any(),
+            "itemId": match_any(),
             "itemType": "TRACE_ITEM_TYPE_USER_SESSION",
             "timestamp": time_within_delta(started, delta=timedelta(seconds=2)),
             "received": time_within_delta(),

--- a/tests/integration/test_sessions_eap.py
+++ b/tests/integration/test_sessions_eap.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
-from .asserts import time_within_delta, match_any
+from .asserts import time_within_delta, matches_any
 
 
 def test_session_eap_double_write(
@@ -56,8 +56,8 @@ def test_session_eap_double_write(
         {
             "organizationId": "1",
             "projectId": "42",
-            "traceId": match_any(),
-            "itemId": match_any(),
+            "traceId": matches_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_USER_SESSION",
             "timestamp": time_within_delta(started, delta=timedelta(seconds=2)),
             "received": time_within_delta(),
@@ -77,8 +77,8 @@ def test_session_eap_double_write(
         {
             "organizationId": "1",
             "projectId": "42",
-            "traceId": match_any(),
-            "itemId": match_any(),
+            "traceId": matches_any(),
+            "itemId": matches_any(),
             "itemType": "TRACE_ITEM_TYPE_USER_SESSION",
             "timestamp": time_within_delta(started, delta=timedelta(seconds=2)),
             "received": time_within_delta(),

--- a/tests/integration/test_span_links.py
+++ b/tests/integration/test_span_links.py
@@ -2,7 +2,7 @@ import uuid
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import match_any
+from .asserts import matches_any
 
 
 def test_event_with_span_link_in_transaction(relay, mini_sentry):
@@ -99,7 +99,7 @@ def test_event_with_span_link_in_transaction(relay, mini_sentry):
             "status": "ok",
             "start_timestamp": 1624366926.0,
             "timestamp": 1624366927.0,
-            "sentry_tags": match_any(),
+            "sentry_tags": matches_any(),
             "data": {"sentry.segment.name": "/users"},
             "links": [
                 {

--- a/tests/integration/test_span_links.py
+++ b/tests/integration/test_span_links.py
@@ -2,7 +2,7 @@ import uuid
 
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import any
+from .asserts import match_any
 
 
 def test_event_with_span_link_in_transaction(relay, mini_sentry):
@@ -99,7 +99,7 @@ def test_event_with_span_link_in_transaction(relay, mini_sentry):
             "status": "ok",
             "start_timestamp": 1624366926.0,
             "timestamp": 1624366927.0,
-            "sentry_tags": any(),
+            "sentry_tags": match_any(),
             "data": {"sentry.segment.name": "/users"},
             "links": [
                 {

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -9,7 +9,7 @@ from requests import HTTPError
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import any
+from .asserts import match_any
 from .test_store import make_transaction
 
 TEST_CONFIG = {
@@ -1235,7 +1235,7 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 1,
             "reason": "too_large:span",
-            "timestamp": any(),
+            "timestamp": match_any(),
         },
         {
             "category": DataCategory.SPAN_INDEXED,
@@ -1245,6 +1245,6 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 1,
             "reason": "too_large:span",
-            "timestamp": any(),
+            "timestamp": match_any(),
         },
     ]

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -9,7 +9,7 @@ from requests import HTTPError
 from sentry_relay.consts import DataCategory
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from .asserts import match_any
+from .asserts import matches_any
 from .test_store import make_transaction
 
 TEST_CONFIG = {
@@ -1235,7 +1235,7 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 1,
             "reason": "too_large:span",
-            "timestamp": match_any(),
+            "timestamp": matches_any(),
         },
         {
             "category": DataCategory.SPAN_INDEXED,
@@ -1245,6 +1245,6 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "project_id": 42,
             "quantity": 1,
             "reason": "too_large:span",
-            "timestamp": match_any(),
+            "timestamp": matches_any(),
         },
     ]

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import any, time_within_delta, time_within, time_is
+from .asserts import match_any, time_within_delta, time_within, time_is
 
 from .test_dynamic_sampling import add_sampling_config
 
@@ -496,7 +496,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
 
     assert mini_sentry.get_metrics() == [
         {
-            "metadata": any(),
+            "metadata": match_any(),
             "name": "c:spans/count_per_root_project@none",
             "tags": {
                 "decision": "drop",
@@ -510,7 +510,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
             "width": 1,
         },
         {
-            "metadata": any(),
+            "metadata": match_any(),
             "name": "c:spans/usage@none",
             "tags": {
                 "is_segment": "false",
@@ -597,7 +597,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
     if rate_limit == DataCategory.SPAN_INDEXED:
         assert mini_sentry.get_metrics() == [
             {
-                "metadata": any(),
+                "metadata": match_any(),
                 "name": "c:spans/count_per_root_project@none",
                 "tags": {
                     "decision": "keep",
@@ -610,7 +610,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
                 "width": 1,
             },
             {
-                "metadata": any(),
+                "metadata": match_any(),
                 "name": "c:spans/usage@none",
                 "tags": {
                     "was_transaction": "false",
@@ -1200,8 +1200,8 @@ def test_spanv2_with_string_pii_scrubbing(
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": any(),
-                            "rem": [[rule_type, any(), any(), any()]],
+                            "len": match_any(),
+                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
                         }
                     }
                 }
@@ -1338,8 +1338,15 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                     "value": {
                         "1": {
                             "": {
-                                "len": any(),
-                                "rem": [["@creditcard", any(), any(), any()]],
+                                "len": match_any(),
+                                "rem": [
+                                    [
+                                        "@creditcard",
+                                        match_any(),
+                                        match_any(),
+                                        match_any(),
+                                    ]
+                                ],
                             }
                         }
                     }
@@ -1721,7 +1728,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": any(),
+        "attributes": match_any(),
         "status": "ok",
         "is_segment": True,
         "name": "some op",

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import match_any, time_within_delta, time_within, time_is
+from .asserts import matches_any, time_within_delta, time_within, time_is
 
 from .test_dynamic_sampling import add_sampling_config
 
@@ -496,7 +496,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
 
     assert mini_sentry.get_metrics() == [
         {
-            "metadata": match_any(),
+            "metadata": matches_any(),
             "name": "c:spans/count_per_root_project@none",
             "tags": {
                 "decision": "drop",
@@ -510,7 +510,7 @@ def test_spansv2_ds_drop(mini_sentry, relay, span, rule_type):
             "width": 1,
         },
         {
-            "metadata": match_any(),
+            "metadata": matches_any(),
             "name": "c:spans/usage@none",
             "tags": {
                 "is_segment": "false",
@@ -597,7 +597,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
     if rate_limit == DataCategory.SPAN_INDEXED:
         assert mini_sentry.get_metrics() == [
             {
-                "metadata": match_any(),
+                "metadata": matches_any(),
                 "name": "c:spans/count_per_root_project@none",
                 "tags": {
                     "decision": "keep",
@@ -610,7 +610,7 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
                 "width": 1,
             },
             {
-                "metadata": match_any(),
+                "metadata": matches_any(),
                 "name": "c:spans/usage@none",
                 "tags": {
                     "was_transaction": "false",
@@ -1200,8 +1200,10 @@ def test_spanv2_with_string_pii_scrubbing(
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": match_any(),
-                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
+                            "len": matches_any(),
+                            "rem": [
+                                [rule_type, matches_any(), matches_any(), matches_any()]
+                            ],
                         }
                     }
                 }
@@ -1338,13 +1340,13 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                     "value": {
                         "1": {
                             "": {
-                                "len": match_any(),
+                                "len": matches_any(),
                                 "rem": [
                                     [
                                         "@creditcard",
-                                        match_any(),
-                                        match_any(),
-                                        match_any(),
+                                        matches_any(),
+                                        matches_any(),
+                                        matches_any(),
                                     ]
                                 ],
                             }
@@ -1728,7 +1730,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": match_any(),
+        "attributes": matches_any(),
         "status": "ok",
         "is_segment": True,
         "name": "some op",

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -5,7 +5,7 @@ from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import any, time_within_delta, time_within, only_items, matches
+from .asserts import match_any, time_within_delta, time_within, only_items, matches
 
 import pytest
 import json
@@ -221,7 +221,7 @@ def test_trace_metric_extraction(
         },
         "clientSampleRate": 0.25,
         "downsampledRetentionDays": 390,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -481,7 +481,7 @@ def test_trace_metric_pii_scrubbing(
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -562,14 +562,14 @@ def test_trace_metric_string_pii_scrubbing(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": any()},
+        "__header": {"byte_size": match_any()},
         "_meta": {
             "attributes": {
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": any(),
-                            "rem": [[rule_type, any(), any(), any()]],
+                            "len": match_any(),
+                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
                         }
                     }
                 }
@@ -635,7 +635,7 @@ def test_trace_metric_default_pii_scrubbing_attributes(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": any()},
+        "__header": {"byte_size": match_any()},
     }
 
     rem_info = meta["attributes"][attribute_key]["value"][""]["rem"]
@@ -706,14 +706,21 @@ def test_trace_metric_default_pii_scrubbing_does_not_scrub_default_attributes(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": any()},
+        "__header": {"byte_size": match_any()},
         "_meta": {
             "attributes": {
                 "custom_field": {
                     "value": {
                         "": {
-                            "len": any(),
-                            "rem": [["remove_custom_field", any(), any(), any()]],
+                            "len": match_any(),
+                            "rem": [
+                                [
+                                    "remove_custom_field",
+                                    match_any(),
+                                    match_any(),
+                                    match_any(),
+                                ]
+                            ],
                         }
                     }
                 }
@@ -819,7 +826,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
     envelope = mini_sentry.get_captured_envelope()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     assert item_payload["items"][0] == {
-        "__header": any(),
+        "__header": match_any(),
         "_meta": {
             "timestamp": {
                 "": {
@@ -835,7 +842,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": any(),
+        "attributes": match_any(),
         "name": "http.request.duration",
         "type": "distribution",
         "value": 123.45,
@@ -904,7 +911,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
             "sentry.observed_timestamp_nanos": {
                 "stringValue": time_within_delta(ts, expect_resolution="ns")
             },
-            "sentry.payload_size_bytes": any(),
+            "sentry.payload_size_bytes": match_any(),
             "sentry.span_id": {
                 "stringValue": "eee19b7ec3c1b175",
             },
@@ -927,7 +934,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -937,7 +944,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
         "timestamp": time_within_delta(
             ts + timedelta(seconds=seq_shift_in_secs), delta=timedelta(), precision="ms"
         ),
-        "traceId": any(),
+        "traceId": match_any(),
     }
 
 
@@ -1032,7 +1039,7 @@ def test_trace_metric_container_metadata(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": any(),
+        "__header": match_any(),
         "name": "test.metric",
         "type": "counter",
         "value": 1.0,

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -5,7 +5,7 @@ from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
-from .asserts import match_any, time_within_delta, time_within, only_items, matches
+from .asserts import matches_any, time_within_delta, time_within, only_items, matches
 
 import pytest
 import json
@@ -221,7 +221,7 @@ def test_trace_metric_extraction(
         },
         "clientSampleRate": 0.25,
         "downsampledRetentionDays": 390,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -481,7 +481,7 @@ def test_trace_metric_pii_scrubbing(
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -562,14 +562,16 @@ def test_trace_metric_string_pii_scrubbing(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": match_any()},
+        "__header": {"byte_size": matches_any()},
         "_meta": {
             "attributes": {
                 "test_pii": {
                     "value": {
                         "": {
-                            "len": match_any(),
-                            "rem": [[rule_type, match_any(), match_any(), match_any()]],
+                            "len": matches_any(),
+                            "rem": [
+                                [rule_type, matches_any(), matches_any(), matches_any()]
+                            ],
                         }
                     }
                 }
@@ -635,7 +637,7 @@ def test_trace_metric_default_pii_scrubbing_attributes(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": match_any()},
+        "__header": {"byte_size": matches_any()},
     }
 
     rem_info = meta["attributes"][attribute_key]["value"][""]["rem"]
@@ -706,19 +708,19 @@ def test_trace_metric_default_pii_scrubbing_does_not_scrub_default_attributes(
                 "value": time_within(start, expect_resolution="ns"),
             },
         },
-        "__header": {"byte_size": match_any()},
+        "__header": {"byte_size": matches_any()},
         "_meta": {
             "attributes": {
                 "custom_field": {
                     "value": {
                         "": {
-                            "len": match_any(),
+                            "len": matches_any(),
                             "rem": [
                                 [
                                     "remove_custom_field",
-                                    match_any(),
-                                    match_any(),
-                                    match_any(),
+                                    matches_any(),
+                                    matches_any(),
+                                    matches_any(),
                                 ]
                             ],
                         }
@@ -826,7 +828,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
     envelope = mini_sentry.get_captured_envelope()
     item_payload = json.loads(envelope.items[0].payload.bytes.decode())
     assert item_payload["items"][0] == {
-        "__header": match_any(),
+        "__header": matches_any(),
         "_meta": {
             "timestamp": {
                 "": {
@@ -842,7 +844,7 @@ def test_time_corrections(mini_sentry, relay, delta, error):
                 }
             }
         },
-        "attributes": match_any(),
+        "attributes": matches_any(),
         "name": "http.request.duration",
         "type": "distribution",
         "value": 123.45,
@@ -911,7 +913,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
             "sentry.observed_timestamp_nanos": {
                 "stringValue": time_within_delta(ts, expect_resolution="ns")
             },
-            "sentry.payload_size_bytes": match_any(),
+            "sentry.payload_size_bytes": matches_any(),
             "sentry.span_id": {
                 "stringValue": "eee19b7ec3c1b175",
             },
@@ -934,7 +936,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
         },
         "clientSampleRate": 1.0,
         "downsampledRetentionDays": 90,
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_METRIC",
         "organizationId": "1",
         "projectId": "42",
@@ -944,7 +946,7 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
         "timestamp": time_within_delta(
             ts + timedelta(seconds=seq_shift_in_secs), delta=timedelta(), precision="ms"
         ),
-        "traceId": match_any(),
+        "traceId": matches_any(),
     }
 
 
@@ -1039,7 +1041,7 @@ def test_trace_metric_container_metadata(
                 "value": time_within(ts, expect_resolution="ns"),
             },
         },
-        "__header": match_any(),
+        "__header": matches_any(),
         "name": "test.metric",
         "type": "counter",
         "value": 1.0,

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 import json
 
-from .asserts import any, time_within_delta
+from .asserts import match_any, time_within_delta
 
 from sentry_relay.consts import DataCategory
 
@@ -59,10 +59,10 @@ EXPECTED_ITEMS = [
     {
         "organizationId": "1",
         "projectId": "42",
-        "traceId": any(),
-        "itemId": any(),
+        "traceId": match_any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
-        "timestamp": any(),
+        "timestamp": match_any(),
         "attributes": {
             "vercel.id": {"stringValue": "1573817187330377061717300000"},
             "sentry.origin": {"stringValue": "auto.log_drain.vercel"},
@@ -73,12 +73,12 @@ EXPECTED_ITEMS = [
             "sentry.body": {"stringValue": "Build completed successfully"},
             "vercel.project_name": {"stringValue": "my-app"},
             "sentry.severity_text": {"stringValue": "info"},
-            "sentry.observed_timestamp_nanos": {"stringValue": any()},
+            "sentry.observed_timestamp_nanos": {"stringValue": match_any()},
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(expect_resolution="ns")
             },
             "vercel.build_id": {"stringValue": "bld_cotnkcr76"},
-            "sentry.payload_size_bytes": {"intValue": any()},
+            "sentry.payload_size_bytes": {"intValue": match_any()},
             "vercel.project_id": {"stringValue": "gdufoJxB6b9b1fEqr1jUtFkyavUU"},
             "sentry._meta.fields.trace_id": {
                 "stringValue": '{"meta":{"":{"rem":[["trace_id.missing","s"]]}}}'
@@ -87,16 +87,16 @@ EXPECTED_ITEMS = [
         "clientSampleRate": 1.0,
         "serverSampleRate": 1.0,
         "retentionDays": 90,
-        "received": any(),
+        "received": match_any(),
         "downsampledRetentionDays": 90,
     },
     {
         "organizationId": "1",
         "projectId": "42",
         "traceId": "1b02cd14bb8642fd092bc23f54c7ffcd",
-        "itemId": any(),
+        "itemId": match_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
-        "timestamp": any(),
+        "timestamp": match_any(),
         "attributes": {
             "vercel.path": {"stringValue": "/api/users"},
             "vercel.proxy.scheme": {"stringValue": "https"},
@@ -125,17 +125,17 @@ EXPECTED_ITEMS = [
             "vercel.proxy.timestamp": {"intValue": "1573817250172"},
             "sentry.body": {"stringValue": "API request processed"},
             "vercel.proxy.status_code": {"intValue": "200"},
-            "sentry.observed_timestamp_nanos": {"stringValue": any()},
+            "sentry.observed_timestamp_nanos": {"stringValue": match_any()},
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(expect_resolution="ns")
             },
-            "sentry.payload_size_bytes": {"intValue": any()},
+            "sentry.payload_size_bytes": {"intValue": match_any()},
             "vercel.proxy.region": {"stringValue": "sfo1"},
         },
         "clientSampleRate": 1.0,
         "serverSampleRate": 1.0,
         "retentionDays": 90,
-        "received": any(),
+        "received": match_any(),
         "downsampledRetentionDays": 90,
     },
 ]

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 import json
 
-from .asserts import match_any, time_within_delta
+from .asserts import matches_any, time_within_delta
 
 from sentry_relay.consts import DataCategory
 
@@ -59,10 +59,10 @@ EXPECTED_ITEMS = [
     {
         "organizationId": "1",
         "projectId": "42",
-        "traceId": match_any(),
-        "itemId": match_any(),
+        "traceId": matches_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "attributes": {
             "vercel.id": {"stringValue": "1573817187330377061717300000"},
             "sentry.origin": {"stringValue": "auto.log_drain.vercel"},
@@ -73,12 +73,12 @@ EXPECTED_ITEMS = [
             "sentry.body": {"stringValue": "Build completed successfully"},
             "vercel.project_name": {"stringValue": "my-app"},
             "sentry.severity_text": {"stringValue": "info"},
-            "sentry.observed_timestamp_nanos": {"stringValue": match_any()},
+            "sentry.observed_timestamp_nanos": {"stringValue": matches_any()},
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(expect_resolution="ns")
             },
             "vercel.build_id": {"stringValue": "bld_cotnkcr76"},
-            "sentry.payload_size_bytes": {"intValue": match_any()},
+            "sentry.payload_size_bytes": {"intValue": matches_any()},
             "vercel.project_id": {"stringValue": "gdufoJxB6b9b1fEqr1jUtFkyavUU"},
             "sentry._meta.fields.trace_id": {
                 "stringValue": '{"meta":{"":{"rem":[["trace_id.missing","s"]]}}}'
@@ -87,16 +87,16 @@ EXPECTED_ITEMS = [
         "clientSampleRate": 1.0,
         "serverSampleRate": 1.0,
         "retentionDays": 90,
-        "received": match_any(),
+        "received": matches_any(),
         "downsampledRetentionDays": 90,
     },
     {
         "organizationId": "1",
         "projectId": "42",
         "traceId": "1b02cd14bb8642fd092bc23f54c7ffcd",
-        "itemId": match_any(),
+        "itemId": matches_any(),
         "itemType": "TRACE_ITEM_TYPE_LOG",
-        "timestamp": match_any(),
+        "timestamp": matches_any(),
         "attributes": {
             "vercel.path": {"stringValue": "/api/users"},
             "vercel.proxy.scheme": {"stringValue": "https"},
@@ -125,17 +125,17 @@ EXPECTED_ITEMS = [
             "vercel.proxy.timestamp": {"intValue": "1573817250172"},
             "sentry.body": {"stringValue": "API request processed"},
             "vercel.proxy.status_code": {"intValue": "200"},
-            "sentry.observed_timestamp_nanos": {"stringValue": match_any()},
+            "sentry.observed_timestamp_nanos": {"stringValue": matches_any()},
             "sentry.timestamp_precise": {
                 "intValue": time_within_delta(expect_resolution="ns")
             },
-            "sentry.payload_size_bytes": {"intValue": match_any()},
+            "sentry.payload_size_bytes": {"intValue": matches_any()},
             "vercel.proxy.region": {"stringValue": "sfo1"},
         },
         "clientSampleRate": 1.0,
         "serverSampleRate": 1.0,
         "retentionDays": 90,
-        "received": match_any(),
+        "received": matches_any(),
         "downsampledRetentionDays": 90,
     },
 ]


### PR DESCRIPTION
`any` is a builtin function in python. Importing a custom function called `any` hides the original one so it can no longer be used. 