### PR TITLE
ref(outcomes): Initial implementation for sending outcomes as metrics

### DIFF
--- a/relay-base-schema/src/metrics/mri.rs
+++ b/relay-base-schema/src/metrics/mri.rs
@@ -114,6 +114,10 @@ pub enum MetricNamespace {
     Transactions,
     /// User-defined metrics directly sent by SDKs and applications.
     Custom,
+    /// Relay's outcomes forwarded as metrics.
+    ///
+    /// Usage of this transport is restricted to trusted Relays.
+    Outcomes,
     /// An unknown and unsupported metric.
     ///
     /// Metrics that Relay either doesn't know or recognize the namespace of will be dropped before
@@ -128,12 +132,13 @@ pub enum MetricNamespace {
 
 impl MetricNamespace {
     /// Returns all namespaces/variants of this enum.
-    pub fn all() -> [Self; 5] {
+    pub fn all() -> [Self; 6] {
         [
             Self::Sessions,
             Self::Spans,
             Self::Transactions,
             Self::Custom,
+            Self::Outcomes,
             Self::Unsupported,
         ]
     }
@@ -145,6 +150,7 @@ impl MetricNamespace {
             Self::Spans => "spans",
             Self::Transactions => "transactions",
             Self::Custom => "custom",
+            Self::Outcomes => "outcomes",
             Self::Unsupported => "unsupported",
         }
     }
@@ -159,6 +165,7 @@ impl std::str::FromStr for MetricNamespace {
             "spans" => Ok(Self::Spans),
             "transactions" => Ok(Self::Transactions),
             "custom" => Ok(Self::Custom),
+            "outcomes" => Ok(Self::Outcomes),
             _ => Ok(Self::Unsupported),
         }
     }

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1409,12 +1409,16 @@ impl Default for ObjectstoreServiceConfig {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 
 pub enum EmitOutcomes {
-    /// Do not emit any outcomes
+    /// Do not emit any outcomes.
     None,
-    /// Emit outcomes as client reports
+    /// Emit outcomes as client reports.
     AsClientReports,
-    /// Emit outcomes as outcomes
+    /// Emit outcomes as outcomes.
     AsOutcomes,
+    /// Emit outcomes as metrics.
+    ///
+    /// This is a temporary and experimental option which should not be used and will be removed again.
+    AsMetrics,
 }
 
 impl EmitOutcomes {
@@ -1434,6 +1438,7 @@ impl Serialize for EmitOutcomes {
             Self::None => serializer.serialize_bool(false),
             Self::AsClientReports => serializer.serialize_str("as_client_reports"),
             Self::AsOutcomes => serializer.serialize_bool(true),
+            Self::AsMetrics => serializer.serialize_str("as_metrics"),
         }
     }
 }
@@ -1444,7 +1449,7 @@ impl Visitor<'_> for EmitOutcomesVisitor {
     type Value = EmitOutcomes;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("true, false, or 'as_client_reports'")
+        formatter.write_str("true, false, 'as_client_reports' or 'as_metrics'")
     }
 
     fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
@@ -1462,10 +1467,10 @@ impl Visitor<'_> for EmitOutcomesVisitor {
     where
         E: serde::de::Error,
     {
-        if v == "as_client_reports" {
-            Ok(EmitOutcomes::AsClientReports)
-        } else {
-            Err(E::invalid_value(Unexpected::Str(v), &"as_client_reports"))
+        match v {
+            "as_client_reports" => Ok(EmitOutcomes::AsClientReports),
+            "as_metrics" => Ok(EmitOutcomes::AsMetrics),
+            _ => Err(E::invalid_value(Unexpected::Str(v), &self)),
         }
     }
 }

--- a/relay-metrics/src/cogs.rs
+++ b/relay-metrics/src/cogs.rs
@@ -41,6 +41,7 @@ fn to_app_feature(ns: MetricNamespace) -> AppFeature {
         MetricNamespace::Spans => AppFeature::MetricsSpans,
         MetricNamespace::Transactions => AppFeature::MetricsTransactions,
         MetricNamespace::Custom => AppFeature::MetricsCustom,
+        MetricNamespace::Outcomes => AppFeature::UnattributedMetrics,
         MetricNamespace::Unsupported => AppFeature::MetricsUnsupported,
     }
 }

--- a/relay-metrics/src/utils.rs
+++ b/relay-metrics/src/utils.rs
@@ -23,6 +23,8 @@ pub struct ByNamespace<T> {
     pub transactions: T,
     /// Value for the [`MetricNamespace::Custom`] namespace.
     pub custom: T,
+    /// Value for the [`MetricNamespace::Outcomes`] namespace.
+    pub outcomes: T,
     /// Value for the [`MetricNamespace::Unsupported`] namespace.
     pub unsupported: T,
 }
@@ -35,6 +37,7 @@ impl<T> ByNamespace<T> {
             MetricNamespace::Spans => &self.spans,
             MetricNamespace::Transactions => &self.transactions,
             MetricNamespace::Custom => &self.custom,
+            MetricNamespace::Outcomes => &self.outcomes,
             MetricNamespace::Unsupported => &self.unsupported,
         }
     }
@@ -46,6 +49,7 @@ impl<T> ByNamespace<T> {
             MetricNamespace::Spans => &mut self.spans,
             MetricNamespace::Transactions => &mut self.transactions,
             MetricNamespace::Custom => &mut self.custom,
+            MetricNamespace::Outcomes => &mut self.outcomes,
             MetricNamespace::Unsupported => &mut self.unsupported,
         }
     }
@@ -53,7 +57,7 @@ impl<T> ByNamespace<T> {
 
 impl<T> IntoIterator for ByNamespace<T> {
     type Item = (MetricNamespace, T);
-    type IntoIter = std::array::IntoIter<(MetricNamespace, T), 5>;
+    type IntoIter = std::array::IntoIter<(MetricNamespace, T), 6>;
 
     fn into_iter(self) -> Self::IntoIter {
         let Self {
@@ -61,6 +65,7 @@ impl<T> IntoIterator for ByNamespace<T> {
             spans,
             transactions,
             custom,
+            outcomes,
             unsupported,
         } = self;
 
@@ -69,6 +74,7 @@ impl<T> IntoIterator for ByNamespace<T> {
             (MetricNamespace::Spans, spans),
             (MetricNamespace::Transactions, transactions),
             (MetricNamespace::Custom, custom),
+            (MetricNamespace::Outcomes, outcomes),
             (MetricNamespace::Unsupported, unsupported),
         ]
         .into_iter()
@@ -112,6 +118,7 @@ macro_rules! impl_op {
                     spans,
                     transactions,
                     custom,
+                    outcomes,
                     unsupported,
                 } = self;
 
@@ -119,6 +126,7 @@ macro_rules! impl_op {
                 $op::$opfn(spans, rhs.spans);
                 $op::$opfn(transactions, rhs.transactions);
                 $op::$opfn(custom, rhs.custom);
+                $op::$opfn(outcomes, rhs.outcomes);
                 $op::$opfn(unsupported, rhs.unsupported);
             }
         }

--- a/relay-server/src/metrics/outcomes.rs
+++ b/relay-server/src/metrics/outcomes.rs
@@ -147,7 +147,12 @@ where
     let mut quantities = SourceQuantities::default();
 
     for bucket in buckets {
-        quantities.buckets += 1;
+        let namespace = bucket.name().namespace();
+        // Never count unsupported metrics, they are considered invalid.
+        // Never count outcomes, as that would create more outcomes creating a loop of outcomes.
+        if namespace != MetricNamespace::Unsupported && namespace != MetricNamespace::Outcomes {
+            quantities.buckets += 1;
+        }
 
         // Only count metrics for outcomes, where the indexed payload no longer exists.
         let summary = bucket.summary();

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -199,10 +199,13 @@ impl ServiceState {
             relay_config::RelayMode::Managed => channel(EnvelopeProcessorService::name()),
         };
 
+        let (aggregator, aggregator_rx) = channel(RouterService::name());
+
         let outcome_producer = services.start(OutcomeProducerService::create(
             config.clone(),
             upstream_relay.clone(),
             processor.clone(),
+            aggregator.clone(),
         )?);
         let outcome_aggregator =
             services.start(OutcomeAggregator::new(&config, outcome_producer.clone()));
@@ -282,15 +285,15 @@ impl ServiceState {
             relay_config::RelayMode::Managed => {
                 let processor_pool = create_processor_pool(&config)?;
 
-                let aggregator = RouterService::new(
+                let router = RouterService::new(
                     handle.clone(),
                     config.default_aggregator_config().clone(),
                     config.secondary_aggregator_configs().clone(),
                     Some(processor.clone().recipient()),
                     project_cache_handle.clone(),
                 );
-                let aggregator_handle = aggregator.handle();
-                let aggregator = services.start(aggregator);
+                let router_handle = router.handle();
+                services.start_with(router, aggregator_rx);
 
                 let cogs = CogsService::new(&config);
                 let cogs = Cogs::new(CogsServiceRecorder::new(&config, services.start(cogs)));
@@ -325,11 +328,7 @@ impl ServiceState {
                     processor_pool.clone(),
                 ));
 
-                (
-                    Some(processor_pool),
-                    Some(aggregator_handle),
-                    Some(autoscaling),
-                )
+                (Some(processor_pool), Some(router_handle), Some(autoscaling))
             }
         };
 

--- a/relay-server/src/services/outcome/aggregator.rs
+++ b/relay-server/src/services/outcome/aggregator.rs
@@ -36,6 +36,10 @@ pub struct OutcomeAggregator {
     ///
     /// If `true`, all outcomes will be dropped.
     disabled: bool,
+    /// Whether outcomes should be aggregated.
+    ///
+    /// If `false` outcomes are not aggregated and just immediately forwarded.
+    aggregate: bool,
     /// The width of each aggregated bucket in seconds
     bucket_interval: u64,
     /// The number of seconds between flushes of all buckets
@@ -51,9 +55,11 @@ pub struct OutcomeAggregator {
 impl OutcomeAggregator {
     pub fn new(config: &Config, outcome_producer: Addr<OutcomeProducer>) -> Self {
         let disabled = matches!(config.emit_outcomes(), EmitOutcomes::None);
+        let aggregate = !matches!(config.emit_outcomes(), EmitOutcomes::AsMetrics);
 
         Self {
             disabled,
+            aggregate,
             bucket_interval: config.outcome_aggregator().bucket_interval,
             flush_interval: config.outcome_aggregator().flush_interval,
             buckets: HashMap::new(),
@@ -71,6 +77,13 @@ impl OutcomeAggregator {
 
     fn handle_track_outcome(&mut self, msg: TrackOutcome) {
         if self.disabled {
+            return;
+        }
+
+        // This is a temporary measure until the aggregator can be entirely removed in favor of
+        // using metrics as the primary aggregator and forward mechanism for outcomes.
+        if !self.aggregate {
+            self.outcome_producer.send(msg);
             return;
         }
 

--- a/relay-server/src/services/outcome/metric.rs
+++ b/relay-server/src/services/outcome/metric.rs
@@ -1,0 +1,255 @@
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use relay_config::Config;
+use relay_metrics::{Bucket, BucketValue, MetricName, UnixTimestamp};
+
+#[cfg(any(test, feature = "processing"))]
+use crate::services::outcome::OutcomeId;
+use crate::services::outcome::{Outcome, TrackOutcome};
+
+/// Metric MRI for [`OutcomeId::ACCEPTED`] outcomes.
+const OUTCOME_ACCEPTED_MRI: &str = "c:outcomes/accepted@none";
+/// Metric MRI for [`OutcomeId::FILTERED`] outcomes.
+const FILTERED_MRI: &str = "c:outcomes/filtered@none";
+/// Metric MRI for [`OutcomeId::RATE_LIMITED`] outcomes.
+const RATE_LIMITED_MRI: &str = "c:outcomes/rate_limited@none";
+/// Metric MRI for [`OutcomeId::INVALID`] outcomes.
+const INVALID_MRI: &str = "c:outcomes/invalid@none";
+/// Metric MRI for [`OutcomeId::ABUSE`] outcomes.
+const ABUSE_MRI: &str = "c:outcomes/abuse@none";
+/// Metric MRI for [`OutcomeId::CLIENT_DISCARD`] outcomes.
+const CLIENT_DISCARD_MRI: &str = "c:outcomes/client_discard@none";
+/// Metric MRI for [`OutcomeId::CARDINALITY_LIMITED`] outcomes.
+#[cfg(any(test, feature = "processing"))]
+const CARDINALITY_LIMITED_MRI: &str = "c:outcomes/cardinality_limited@none";
+
+/// Converts a [`TrackOutcome`] to a metric [`Bucket`].
+pub fn to_metric(outcome: &TrackOutcome, config: &Config) -> Bucket {
+    static ACCEPTED: LazyLock<MetricName> = LazyLock::new(|| OUTCOME_ACCEPTED_MRI.into());
+    static FILTERED: LazyLock<MetricName> = LazyLock::new(|| FILTERED_MRI.into());
+    static RATE_LIMITED: LazyLock<MetricName> = LazyLock::new(|| RATE_LIMITED_MRI.into());
+    static INVALID: LazyLock<MetricName> = LazyLock::new(|| INVALID_MRI.into());
+    static ABUSE: LazyLock<MetricName> = LazyLock::new(|| ABUSE_MRI.into());
+    static CLIENT_DISCARD: LazyLock<MetricName> = LazyLock::new(|| CLIENT_DISCARD_MRI.into());
+
+    let TrackOutcome {
+        timestamp,
+        // Metrics are attached to the project key already, no need to add information from the scoping.
+        scoping: _,
+        outcome,
+        event_id,
+        remote_addr,
+        category,
+        quantity,
+    } = outcome;
+
+    let name = match outcome {
+        Outcome::Accepted => ACCEPTED.clone(),
+        Outcome::Filtered(_) => FILTERED.clone(),
+        Outcome::FilteredSampling(_) => FILTERED.clone(),
+        Outcome::RateLimited(_) => RATE_LIMITED.clone(),
+        Outcome::Invalid(_) => INVALID.clone(),
+        Outcome::Abuse => ABUSE.clone(),
+        Outcome::ClientDiscard(_) => CLIENT_DISCARD.clone(),
+    };
+
+    let tags = {
+        let mut tags = BTreeMap::new();
+        // `TrackOutcome` can only be created within this Relay -> set the source.
+        if let Some(source) = config.outcome_source() {
+            tags.insert("source".to_owned(), source.to_owned());
+        }
+        if let Some(reason) = outcome.to_reason() {
+            tags.insert("reason".to_owned(), reason.to_string());
+        }
+        // We stopped adding event id and remote addr to outcomes for cardinality reasons.
+        let _ = event_id;
+        let _ = remote_addr;
+        if let Some(category) = category.value() {
+            tags.insert("category".to_owned(), category.to_string());
+        }
+        tags
+    };
+
+    Bucket {
+        name,
+        value: BucketValue::Counter((*quantity).into()),
+        timestamp: UnixTimestamp::from_datetime(*timestamp).unwrap_or_else(UnixTimestamp::now),
+        tags,
+        width: 0,
+        metadata: Default::default(),
+    }
+}
+
+/// Converts a outcome metric name to a [`OutcomeId`].
+///
+/// Returns `None` for unknown or invalid metric names.
+#[cfg(any(test, feature = "processing"))]
+pub fn to_outcome_id(name: &MetricName) -> Option<OutcomeId> {
+    Some(match name.as_ref() {
+        OUTCOME_ACCEPTED_MRI => OutcomeId::ACCEPTED,
+        FILTERED_MRI => OutcomeId::FILTERED,
+        RATE_LIMITED_MRI => OutcomeId::RATE_LIMITED,
+        INVALID_MRI => OutcomeId::INVALID,
+        ABUSE_MRI => OutcomeId::ABUSE,
+        CLIENT_DISCARD_MRI => OutcomeId::CLIENT_DISCARD,
+        CARDINALITY_LIMITED_MRI => OutcomeId::CARDINALITY_LIMITED,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use relay_base_schema::data_category::DataCategory;
+    use relay_base_schema::organization::OrganizationId;
+    use relay_base_schema::project::ProjectId;
+    use relay_filter::FilterStatKey;
+    use relay_metrics::{MetricNamespace, MetricType};
+    use relay_quotas::Scoping;
+
+    use crate::services::outcome::{DiscardReason, RuleCategories};
+
+    use super::*;
+
+    fn scoping() -> Scoping {
+        Scoping {
+            organization_id: OrganizationId::new(42),
+            project_id: ProjectId::new(43),
+            project_key: "a94ae32be2584e0bbd7a4cbb95971fee".parse().unwrap(),
+            key_id: Some(12),
+        }
+    }
+
+    fn config() -> Config {
+        Config::from_json_value(serde_json::json!({
+            "outcomes": {
+                "source": "I bims",
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_metric_mri_valid() {
+        let name = MetricName::from(OUTCOME_ACCEPTED_MRI);
+        assert_eq!(name.try_namespace(), Some(MetricNamespace::Outcomes));
+        assert_eq!(name.try_name(), Some("accepted"));
+        assert_eq!(name.try_type(), Some(MetricType::Counter));
+
+        let name = MetricName::from(FILTERED_MRI);
+        assert_eq!(name.try_namespace(), Some(MetricNamespace::Outcomes));
+        assert_eq!(name.try_name(), Some("filtered"));
+        assert_eq!(name.try_type(), Some(MetricType::Counter));
+
+        let name = MetricName::from(RATE_LIMITED_MRI);
+        assert_eq!(name.try_namespace(), Some(MetricNamespace::Outcomes));
+        assert_eq!(name.try_name(), Some("rate_limited"));
+        assert_eq!(name.try_type(), Some(MetricType::Counter));
+
+        let name = MetricName::from(INVALID_MRI);
+        assert_eq!(name.try_namespace(), Some(MetricNamespace::Outcomes));
+        assert_eq!(name.try_name(), Some("invalid"));
+        assert_eq!(name.try_type(), Some(MetricType::Counter));
+
+        let name = MetricName::from(ABUSE_MRI);
+        assert_eq!(name.try_namespace(), Some(MetricNamespace::Outcomes));
+        assert_eq!(name.try_name(), Some("abuse"));
+        assert_eq!(name.try_type(), Some(MetricType::Counter));
+
+        let name = MetricName::from(CLIENT_DISCARD_MRI);
+        assert_eq!(name.try_namespace(), Some(MetricNamespace::Outcomes));
+        assert_eq!(name.try_name(), Some("client_discard"));
+        assert_eq!(name.try_type(), Some(MetricType::Counter));
+    }
+
+    #[test]
+    fn test_to_metric_invalid() {
+        let outcome = TrackOutcome {
+            timestamp: chrono::DateTime::from_timestamp_nanos(123_000_000_000),
+            scoping: scoping(),
+            outcome: Outcome::Invalid(DiscardReason::InvalidEventId),
+            event_id: Some("ec75d3980a1f42638ec45f091c2d9b24".parse().unwrap()),
+            remote_addr: Some([192, 168, 2, 1].into()),
+            category: DataCategory::Error,
+            quantity: 42,
+        };
+
+        let bucket = to_metric(&outcome, &config());
+
+        insta::assert_json_snapshot!(&bucket, @r#"
+        {
+          "timestamp": 123,
+          "width": 0,
+          "name": "c:outcomes/invalid@none",
+          "type": "c",
+          "value": 42.0,
+          "tags": {
+            "category": "1",
+            "reason": "invalid_event_id",
+            "source": "I bims"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_to_metric_accepted() {
+        let outcome = TrackOutcome {
+            timestamp: chrono::DateTime::from_timestamp_nanos(123_000_000_000),
+            scoping: scoping(),
+            outcome: Outcome::Accepted,
+            event_id: None,
+            remote_addr: None,
+            category: DataCategory::Error,
+            quantity: 42,
+        };
+
+        let bucket = to_metric(&outcome, &config());
+
+        insta::assert_json_snapshot!(&bucket, @r#"
+        {
+          "timestamp": 123,
+          "width": 0,
+          "name": "c:outcomes/accepted@none",
+          "type": "c",
+          "value": 42.0,
+          "tags": {
+            "category": "1",
+            "source": "I bims"
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_to_outcome_id_roundtrip() {
+        let outcomes = [
+            Outcome::Accepted,
+            Outcome::Filtered(FilterStatKey::IpAddress),
+            Outcome::FilteredSampling(RuleCategories(Default::default())),
+            Outcome::RateLimited(None),
+            Outcome::Invalid(DiscardReason::Duplicate),
+            Outcome::Abuse,
+            Outcome::ClientDiscard("foo".to_owned()),
+        ];
+
+        for outcome in outcomes {
+            let bucket = to_metric(
+                &TrackOutcome {
+                    timestamp: chrono::DateTime::from_timestamp_nanos(123_000_000_000),
+                    scoping: scoping(),
+                    outcome: outcome.clone(),
+                    event_id: None,
+                    remote_addr: None,
+                    category: DataCategory::Error,
+                    quantity: 42,
+                },
+                &config(),
+            );
+
+            let id = to_outcome_id(&bucket.name).unwrap();
+            assert_eq!(id, outcome.to_outcome_id(), "{} | {outcome:?}", bucket.name);
+        }
+    }
+}

--- a/relay-server/src/services/outcome/mod.rs
+++ b/relay-server/src/services/outcome/mod.rs
@@ -10,6 +10,7 @@ use relay_sampling::config::RuleId;
 use relay_sampling::evaluation::MatchedRuleIds;
 
 mod aggregator;
+pub mod metric;
 mod service;
 
 use crate::envelope::{AttachmentType, ItemType};
@@ -33,6 +34,11 @@ impl OutcomeId {
 
     pub fn as_u8(self) -> u8 {
         self.0
+    }
+
+    /// Returns `true` for outcomes which are critical for billing.
+    pub fn is_billing(self) -> bool {
+        matches!(self, OutcomeId::ACCEPTED | OutcomeId::RATE_LIMITED)
     }
 }
 

--- a/relay-server/src/services/outcome/service.rs
+++ b/relay-server/src/services/outcome/service.rs
@@ -14,7 +14,8 @@ use std::time::Duration;
 
 #[cfg(feature = "processing")]
 use crate::service::ServiceError;
-use crate::services::outcome::{DiscardReason, Outcome, OutcomeId, TrackOutcomeLike};
+use crate::services::metrics::{Aggregator, MergeBuckets};
+use crate::services::outcome::{self, DiscardReason, Outcome, OutcomeId, TrackOutcomeLike};
 use crate::services::processor::{EnvelopeProcessor, SubmitClientReports};
 use crate::services::upstream::{Method, SendQuery, UpstreamQuery, UpstreamRelay};
 use crate::statsd::RelayCounters;
@@ -186,7 +187,7 @@ impl TrackRawOutcome {
 
     #[cfg(feature = "processing")]
     fn is_billing(&self) -> bool {
-        matches!(self.outcome, OutcomeId::ACCEPTED | OutcomeId::RATE_LIMITED)
+        self.outcome.is_billing()
     }
 }
 
@@ -491,6 +492,7 @@ fn send_outcome_metric(message: &impl TrackOutcomeLike, to: &'static str) {
 enum OutcomeBroker {
     ClientReport(Addr<TrackOutcome>),
     Http(Addr<TrackRawOutcome>),
+    Metric(Addr<Aggregator>),
     #[cfg(feature = "processing")]
     Kafka(KafkaOutcomesProducer),
     Disabled,
@@ -539,6 +541,13 @@ impl OutcomeBroker {
                 send_outcome_metric(&message, "http");
                 producer.send(TrackRawOutcome::from_outcome(message, config));
             }
+            Self::Metric(metrics) => {
+                send_outcome_metric(&message, "metric");
+                metrics.send(MergeBuckets {
+                    project_key: message.scoping.project_key,
+                    buckets: vec![outcome::metric::to_metric(&message, config)],
+                })
+            }
             Self::Disabled => (),
         }
     }
@@ -555,6 +564,12 @@ impl OutcomeBroker {
                 producer.send(message);
             }
             Self::ClientReport(_) => (),
+            // Currently not supported. Processing Relays must send raw outcomes to Kafka, which is
+            // also enforced in the config.
+            //
+            // Once the rollout is complete and the `Http` and `Kafka` transports are replaced with
+            // `Metric` this branch will go away completely.
+            Self::Metric(_) => (),
             Self::Disabled => (),
         }
     }
@@ -590,6 +605,7 @@ enum ProducerInner {
     #[cfg(feature = "processing")]
     Kafka(KafkaOutcomesProducer),
     Http(HttpOutcomeProducer),
+    Metric(Addr<Aggregator>),
     ClientReport(ClientReportOutcomeProducer),
     Disabled,
 }
@@ -600,6 +616,7 @@ impl ProducerInner {
             #[cfg(feature = "processing")]
             ProducerInner::Kafka(inner) => OutcomeBroker::Kafka(inner),
             ProducerInner::Http(inner) => OutcomeBroker::Http(inner.start_detached()),
+            ProducerInner::Metric(inner) => OutcomeBroker::Metric(inner),
             ProducerInner::ClientReport(inner) => {
                 OutcomeBroker::ClientReport(inner.start_detached())
             }
@@ -620,6 +637,7 @@ impl OutcomeProducerService {
         config: Arc<Config>,
         upstream_relay: Addr<UpstreamRelay>,
         envelope_processor: Addr<EnvelopeProcessor>,
+        metric_aggregator: Addr<Aggregator>,
     ) -> anyhow::Result<Self> {
         let inner = match config.emit_outcomes() {
             #[cfg(feature = "processing")]
@@ -642,6 +660,10 @@ impl OutcomeProducerService {
                     &config,
                     envelope_processor,
                 ))
+            }
+            EmitOutcomes::AsMetrics => {
+                relay_log::info!("Configured to emit outcomes as metrics");
+                ProducerInner::Metric(metric_aggregator)
             }
             EmitOutcomes::None => {
                 relay_log::info!("Configured to drop all outcomes");

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -25,7 +25,7 @@ use relay_event_schema::protocol::ClientReport;
 use relay_filter::FilterStatKey;
 use relay_log::sentry::SentryFutureExt;
 use relay_metrics::{Bucket, BucketMetadata, BucketView, BucketsView, MetricNamespace};
-use relay_quotas::{DataCategory, RateLimits, Scoping};
+use relay_quotas::{RateLimits, Scoping};
 use relay_sampling::evaluation::SamplingDecision;
 use relay_statsd::metric;
 use relay_system::{Addr, FromMessage, NoResponse, Service};
@@ -773,7 +773,8 @@ impl EnvelopeProcessorService {
                 return false;
             }
 
-            if !self::metrics::is_valid_namespace(bucket) {
+            if !self::metrics::is_valid_namespace(bucket, source) {
+                relay_log::debug!("dropping bucket in invalid namespace {bucket:?}");
                 return false;
             }
 
@@ -997,16 +998,17 @@ impl EnvelopeProcessorService {
             scoping,
         );
 
-        let namespaces: BTreeSet<MetricNamespace> = buckets
+        let mut namespaces: BTreeSet<MetricNamespace> = buckets
             .iter()
             .filter_map(|bucket| bucket.name.try_namespace())
             .collect();
 
+        // Never rate limit outcomes.
+        namespaces.remove(&MetricNamespace::Outcomes);
+
         for namespace in namespaces {
-            let limits = rate_limits.check_with_quotas(
-                project_info.get_quotas(),
-                scoping.item(DataCategory::MetricBucket),
-            );
+            let limits = rate_limits
+                .check_with_quotas(project_info.get_quotas(), scoping.metric_bucket(namespace));
 
             if limits.is_limited() {
                 let rejected;
@@ -1045,10 +1047,13 @@ impl EnvelopeProcessorService {
         };
 
         let global_config = self.inner.global_config.current().unwrap_or_default();
-        let namespaces = buckets
+        let mut namespaces = buckets
             .iter()
             .filter_map(|bucket| bucket.name.try_namespace())
             .counts();
+
+        // Never rate limit outcomes.
+        namespaces.remove(&MetricNamespace::Outcomes);
 
         let quotas = CombinedQuotas::new(&global_config, project_info.get_quotas());
 
@@ -1822,6 +1827,8 @@ mod tests {
     use relay_event_schema::protocol::{Event, EventId, TransactionSource};
     use relay_pii::DataScrubbingConfig;
     use relay_protocol::Annotated;
+    #[cfg(feature = "processing")]
+    use relay_quotas::DataCategory;
     use similar_asserts::assert_eq;
 
     use crate::testutils::{create_test_processor, create_test_processor_with_addrs};

--- a/relay-server/src/services/processor/metrics.rs
+++ b/relay-server/src/services/processor/metrics.rs
@@ -5,18 +5,21 @@ use relay_quotas::Scoping;
 
 use crate::metrics::MetricOutcomes;
 use crate::services::outcome::Outcome;
+use crate::services::processor::BucketSource;
 use crate::services::projects::project::ProjectInfo;
 
 /// Checks if the namespace of the passed bucket is valid.
 ///
 /// This is returns `true` for most namespaces except:
 ///  - [`MetricNamespace::Unsupported`]: Equal to invalid/unknown namespaces.
-pub fn is_valid_namespace(bucket: &Bucket) -> bool {
+///  - [`MetricNamespace::Outcomes`]: Outcomes are only allowed if the `source` is [`BucketSource::Internal`].
+pub fn is_valid_namespace(bucket: &Bucket, source: BucketSource) -> bool {
     match bucket.name.namespace() {
         MetricNamespace::Sessions => true,
         MetricNamespace::Spans => true,
         MetricNamespace::Transactions => true,
         MetricNamespace::Custom => true,
+        MetricNamespace::Outcomes => source == BucketSource::Internal,
         MetricNamespace::Unsupported => false,
     }
 }
@@ -32,8 +35,13 @@ pub fn apply_project_info(
     buckets = buckets
         .into_iter()
         .filter_map(|bucket| {
-            if !is_metric_namespace_valid(project_info, bucket.name.namespace()) {
-                relay_log::trace!(mri = &*bucket.name, "dropping metric in disabled namespace");
+            let namespace = bucket.name.namespace();
+            if !is_metric_namespace_valid(project_info, namespace) {
+                relay_log::trace!(
+                    mri = &*bucket.name,
+                    namespace = %namespace,
+                    "dropping metric in disabled namespace"
+                );
                 disabled_namespace_buckets.push(bucket);
                 return None;
             };
@@ -59,6 +67,7 @@ fn is_metric_namespace_valid(state: &ProjectInfo, namespace: MetricNamespace) ->
         MetricNamespace::Spans => true,
         MetricNamespace::Transactions => true,
         MetricNamespace::Custom => state.has_feature(Feature::CustomMetrics),
+        MetricNamespace::Outcomes => true,
         MetricNamespace::Unsupported => false,
     }
 }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::task;
 
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use prost::Message as _;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 use serde::Serialize;
@@ -37,7 +37,7 @@ use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities
 use crate::metrics::{ArrayEncoding, BucketEncoder, MetricOutcomes};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
-use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
+use crate::services::outcome::{self, DiscardReason, Outcome, OutcomeId, TrackOutcome};
 use crate::services::upload::{Final, SignedLocation};
 use crate::statsd::{RelayCounters, RelayGauges, RelayTimers};
 use crate::utils::{self, FormDataIter};
@@ -83,11 +83,7 @@ impl Producer {
     pub fn create(config: &Config) -> anyhow::Result<Self> {
         let mut client_builder = KafkaClient::builder();
 
-        for topic in KafkaTopic::iter().filter(|t| {
-            // Outcomes should not be sent from the store forwarder.
-            // See `KafkaOutcomesProducer`.
-            **t != KafkaTopic::Outcomes && **t != KafkaTopic::OutcomesBilling
-        }) {
+        for topic in KafkaTopic::iter() {
             let kafka_configs = config.kafka_configs(*topic)?;
             client_builder = client_builder
                 .add_kafka_topic_config(*topic, &kafka_configs, config.kafka_validate_topics())
@@ -642,14 +638,8 @@ impl StoreService {
                 .by_size(batch_size)
                 .flatten()
             {
-                let message = self.create_metric_message(
-                    scoping.organization_id,
-                    scoping.project_id,
-                    &mut encoder,
-                    namespace,
-                    &view,
-                    retention,
-                );
+                let message =
+                    self.create_metric_message(&scoping, &mut encoder, namespace, &view, retention);
 
                 let result =
                     message.and_then(|message| self.send_metric_message(namespace, message));
@@ -932,8 +922,7 @@ impl StoreService {
 
     fn create_metric_message<'a>(
         &self,
-        organization_id: OrganizationId,
-        project_id: ProjectId,
+        scoping: &Scoping,
         encoder: &'a mut BucketEncoder,
         namespace: MetricNamespace,
         view: &BucketView<'a>,
@@ -955,8 +944,9 @@ impl StoreService {
         };
 
         Ok(MetricKafkaMessage {
-            org_id: organization_id,
-            project_id,
+            org_id: scoping.organization_id,
+            project_id: scoping.project_id,
+            key_id: scoping.key_id,
             name: view.name(),
             value,
             timestamp: view.timestamp(),
@@ -1204,10 +1194,13 @@ impl StoreService {
     ) -> Result<(), StoreError> {
         let topic = match namespace {
             MetricNamespace::Sessions => KafkaTopic::MetricsSessions,
+            MetricNamespace::Outcomes => {
+                return self.send_metric_based_outcome(message);
+            }
             MetricNamespace::Unsupported => {
-                relay_log::with_scope(
-                    |scope| scope.set_extra("metric_message.name", message.name.as_ref().into()),
-                    || relay_log::error!("store service dropping unknown metric usecase"),
+                relay_log::error!(
+                    metric_message.name = message.name.as_ref(),
+                    "store service dropping unknown metric usecase"
                 );
                 return Ok(());
             }
@@ -1217,6 +1210,52 @@ impl StoreService {
         let headers = BTreeMap::from([("namespace".to_owned(), namespace.to_string())]);
         self.produce(topic, KafkaMessage::Metric { headers, message })?;
         Ok(())
+    }
+
+    fn send_metric_based_outcome(&self, message: MetricKafkaMessage) -> Result<(), StoreError> {
+        let Some(outcome) = outcome::metric::to_outcome_id(message.name) else {
+            relay_log::error!(
+                mri = message.name.as_ref(),
+                "invalid outcome metric, cannot infer outcome id from metric name"
+            );
+            return Ok(());
+        };
+        let quantity = match message.value {
+            MetricValue::Counter(c) => c.to_f64() as u32,
+            v => {
+                relay_log::error!(
+                    mri = message.name.as_ref(),
+                    "invalid outcome metric, expected a counter got '{}'",
+                    v.variant()
+                );
+                return Ok(());
+            }
+        };
+
+        let outcome = OutcomeMessage {
+            timestamp: message
+                .timestamp
+                .as_datetime()
+                .unwrap_or_else(Utc::now)
+                .to_rfc3339_opts(SecondsFormat::Micros, true),
+            org_id: Some(message.org_id).filter(|id| id.value() != 0),
+            project_id: message.project_id,
+            key_id: message.key_id,
+            outcome,
+            reason: message.tags.get("reason").map(|s| s.as_str()),
+            event_id: message.tags.get("event_id").map(|s| s.as_str()),
+            remote_addr: message.tags.get("remote_addr").map(|s| s.as_str()),
+            source: message.tags.get("source").map(|s| s.as_str()),
+            category: message.tags.get("category").and_then(|s| s.parse().ok()),
+            quantity: Some(quantity),
+        };
+
+        let topic = match outcome.outcome.is_billing() {
+            true => KafkaTopic::OutcomesBilling,
+            false => KafkaTopic::Outcomes,
+        };
+
+        self.produce(topic, KafkaMessage::Outcome(outcome))
     }
 
     fn produce_profile(
@@ -1483,6 +1522,8 @@ struct UserReportKafkaMessage {
 struct MetricKafkaMessage<'a> {
     org_id: OrganizationId,
     project_id: ProjectId,
+    #[serde(skip)]
+    key_id: Option<u64>,
     name: &'a MetricName,
     #[serde(flatten)]
     value: MetricValue<'a>,
@@ -1523,6 +1564,41 @@ impl MetricValue<'_> {
             _ => None,
         }
     }
+}
+
+/// Raw representation of an outcome for Kafka.
+#[derive(Debug, Serialize, Clone)]
+pub struct OutcomeMessage<'a> {
+    /// The timespan of the event outcome.
+    timestamp: String,
+    /// Organization id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    org_id: Option<OrganizationId>,
+    /// Project id.
+    project_id: ProjectId,
+    /// The DSN project key id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key_id: Option<u64>,
+    /// The outcome.
+    outcome: OutcomeId,
+    /// Reason for the outcome.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+    /// The event id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    event_id: Option<&'a str>,
+    /// The client ip address.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_addr: Option<&'a str>,
+    /// The source of the outcome (which Relay sent it)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<&'a str>,
+    /// The event's data category.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<u8>,
+    /// The number of events or total attachment size in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quantity: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1660,6 +1736,8 @@ enum KafkaMessage<'a> {
     ProfileChunk(ProfileChunkKafkaMessage),
 
     ReplayRecordingNotChunked(ReplayRecordingNotChunkedKafkaMessage<'a>),
+
+    Outcome(OutcomeMessage<'a>),
 }
 
 impl KafkaMessage<'_> {
@@ -1687,6 +1765,7 @@ impl Message for KafkaMessage<'_> {
                 MetricNamespace::Spans => "metric_spans",
                 MetricNamespace::Transactions => "metric_transactions",
                 MetricNamespace::Custom => "metric_custom",
+                MetricNamespace::Outcomes => "metric_outcomes",
                 MetricNamespace::Unsupported => "metric_unsupported",
             },
             KafkaMessage::CheckIn(_) => "check_in",
@@ -1700,6 +1779,8 @@ impl Message for KafkaMessage<'_> {
             KafkaMessage::ProfileChunk(_) => "profile_chunk",
 
             KafkaMessage::ReplayRecordingNotChunked(_) => "replay_recording_not_chunked",
+
+            KafkaMessage::Outcome(_) => "outcome",
         }
     }
 
@@ -1728,7 +1809,8 @@ impl Message for KafkaMessage<'_> {
             | Self::Item { .. }
             | Self::Profile(_)
             | Self::ProfileChunk(_)
-            | Self::ReplayRecordingNotChunked(_) => None,
+            | Self::ReplayRecordingNotChunked(_)
+            | Self::Outcome(_) => None,
         }
         .filter(|(uuid, _)| !uuid.is_nil())
         .map(|(uuid, org_id)| {
@@ -1755,7 +1837,8 @@ impl Message for KafkaMessage<'_> {
             | KafkaMessage::CheckIn(_)
             | KafkaMessage::Attachment(_)
             | KafkaMessage::AttachmentChunk(_)
-            | KafkaMessage::ReplayRecordingNotChunked(_) => None,
+            | KafkaMessage::ReplayRecordingNotChunked(_)
+            | KafkaMessage::Outcome(_) => None,
         }
     }
 
@@ -1770,6 +1853,7 @@ impl Message for KafkaMessage<'_> {
                     Err(_) => Err(ClientError::ProtobufEncodingFailed),
                 }
             }
+            KafkaMessage::Outcome(outcome) => serialize_as_json(outcome),
             KafkaMessage::Event(_)
             | KafkaMessage::UserReport(_)
             | KafkaMessage::CheckIn(_)
@@ -1816,43 +1900,4 @@ fn safe_timestamp(timestamp: DateTime<Utc>) -> u64 {
 
     // We assume this call can't return < 0.
     Utc::now().timestamp() as u64
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn disallow_outcomes() {
-        struct TestMessage;
-        impl relay_kafka::Message for TestMessage {
-            fn key(&self) -> Option<relay_kafka::Key> {
-                None
-            }
-
-            fn variant(&self) -> &'static str {
-                "test"
-            }
-
-            fn headers(&self) -> Option<&BTreeMap<String, String>> {
-                None
-            }
-
-            fn serialize(&self) -> Result<SerializationOutput<'_>, ClientError> {
-                Ok(SerializationOutput::Json(Cow::Borrowed(
-                    br#"{"timestamp": "foo", "outcome": 1}"#,
-                )))
-            }
-        }
-
-        let config = Config::default();
-        let producer = Producer::create(&config).unwrap();
-
-        for topic in [KafkaTopic::Outcomes, KafkaTopic::OutcomesBilling] {
-            let res = producer.client.send_message(topic, &TestMessage);
-
-            assert!(matches!(res, Err(ClientError::InvalidTopicName)));
-        }
-    }
 }

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -2006,3 +2006,172 @@ def test_replay_outcomes_item_failed(
     }
     expected["timestamp"] = outcomes[0]["timestamp"]
     assert outcomes[0] == expected
+
+
+def test_outcomes_as_metrics_forwarded_as_metrics(relay, mini_sentry):
+    """
+    Test forwarding of outcomes as metrics to the next upstream.
+    """
+    config = {"outcomes": {"emit_outcomes": "as_metrics"}}
+
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+
+    relay = relay(mini_sentry, config)
+
+    relay.send_client_report(
+        project_id,
+        {
+            "timestamp": datetime.now(tz=timezone.utc).timestamp(),
+            "discarded_events": [
+                {"reason": "queue_overflow", "category": "error", "quantity": 42},
+            ],
+        },
+    )
+
+    envelope = mini_sentry.get_captured_envelope()
+    assert len(envelope.items) == 1
+    payload = json.loads(envelope.items[0].payload.get_bytes())
+
+    assert payload == [
+        {
+            "name": "c:outcomes/client_discard@none",
+            "tags": {
+                "category": "1",
+                "reason": "queue_overflow",
+            },
+            "timestamp": time_within_delta(),
+            "type": "c",
+            "value": 42.0,
+            "width": 1,
+        }
+    ]
+
+    assert mini_sentry.captured_envelopes.empty()
+
+
+@pytest.mark.parametrize("to_billing", [True, False])
+def test_outcomes_as_metrics_forwarded_to_kafka_billing(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    relay_credentials,
+    outcomes_consumer,
+    processing_config,
+    get_topic_name,
+    to_billing,
+):
+    """
+    Test forwarding of outcomes as metrics and production to Kafka.
+
+    Outcomes need to be produced to the billing topic if configured.
+    """
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["quotas"] = [
+        {
+            "categories": ["error"],
+            "limit": 0,
+            "reasonCode": "static_disabled_quota",
+        },
+        # This quota should not affect the metric outcomes.
+        {
+            "categories": ["metric_bucket"],
+            "limit": 0,
+            "reasonCode": "metric_bucket_quota",
+        },
+    ]
+
+    billing_consumer = outcomes_consumer(topic="outbilling")
+    outcomes_consumer = outcomes_consumer()
+
+    consumer_with_outcome, consumer_empty = (
+        (billing_consumer, outcomes_consumer)
+        if to_billing
+        else (outcomes_consumer, billing_consumer)
+    )
+
+    credentials = relay_credentials()
+    static_relays = {
+        credentials["id"]: {
+            "public_key": credentials["public_key"],
+            "internal": True,
+        },
+    }
+    # Change from default, which would inherit the outcomes topic
+    processing = processing_config(None)
+    # Create an additional processing for outcomes_billing topic
+    processing["processing"]["secondary_kafka_config"] = {
+        "bar": processing["processing"]["kafka_config"]
+    }
+    if to_billing:
+        processing["processing"]["topics"]["outcomes_billing"] = {
+            "name": get_topic_name("outbilling"),
+            "processing": "bar",
+        }
+
+    relay = relay(
+        relay_with_processing(options=processing, static_relays=static_relays),
+        options={"outcomes": {"emit_outcomes": "as_metrics", "source": "aaa"}},
+        credentials=credentials,
+    )
+
+    # First event does not have a cached rate limit in the first Relay.
+    relay.send_event(42, {"message": "this is rate limited"})
+    assert consumer_with_outcome.get_aggregated_outcomes(n=1) == [
+        {
+            "category": 1,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "static_disabled_quota",
+        },
+    ]
+    consumer_empty.assert_empty()
+
+    # Second event now will actually be sent as a metric, we can verify that with the source.
+    with pytest.raises(requests.HTTPError, match="429 Client Error"):
+        relay.send_event(42, {"message": "this is rate limited"})
+    assert consumer_with_outcome.get_aggregated_outcomes(n=1) == [
+        {
+            "category": 1,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 2,
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "static_disabled_quota",
+            "source": "aaa",
+        },
+    ]
+    consumer_empty.assert_empty()
+
+
+def test_outcomes_as_metrics_forwarded_non_internal(
+    mini_sentry, relay, relay_with_processing, outcomes_consumer
+):
+    """
+    Test making sure Relay does not accept outcome metrics from non-internal Relays.
+    """
+    config = {"outcomes": {"emit_outcomes": "as_metrics"}}
+
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+
+    outcomes_consumer = outcomes_consumer()
+
+    relay = relay(relay_with_processing(), options=config)
+
+    relay.send_client_report(
+        project_id,
+        {
+            "timestamp": datetime.now(tz=timezone.utc).timestamp(),
+            "discarded_events": [
+                {"reason": "queue_overflow", "category": "error", "quantity": 42},
+            ],
+        },
+    )
+
+    outcomes_consumer.assert_empty()


### PR DESCRIPTION
This is the first step in migrating outcomes to metrics. It allows configuring metrics as a transport for outcomes. This can only be configured for internal and non-processing Relays. Processing Relays will already convert metrics to outcomes and produce them to the correct topic.

No one should use this until it is the default for `AsOutcomes`.

The next steps (somewhat ordered):
- Deprecate `AsMetrics` again, this is only for a temporary rollout, make metrics the default for `AsOutcomes`. This will then also enable usage in processing Relays.
- Completely remove the existing outcome aggregator, as it is now functionality fully provided by the metrics aggregator
- Implement `AsClientReports` as a transport for outcome metrics to allow external Relays to still function as well Proxy Relays

Will add a changelog entry once the internal mechanism has switched to metrics, before that it's just experimental and should not be used.