### PR TITLE
chore(conventions): Update sentry-conventions to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 **Internal**:
 
 - Restore top-level _performance_issues_spans. ([#6045](https://github.com/getsentry/relay/pull/6045))
-- Update sentry-conventions to 0.11.0, migrating deprecated `gen_ai` attribute constants.
+- Update sentry-conventions to 0.11.0, migrating deprecated `gen_ai` attribute constants. ([#6068](https://github.com/getsentry/relay/pull/6068))
 
 ## 26.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Internal**:
 
 - Restore top-level _performance_issues_spans. ([#6045](https://github.com/getsentry/relay/pull/6045))
+- Update sentry-conventions to 0.11.0, migrating deprecated `gen_ai` attribute constants.
 
 ## 26.5.2
 

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -194,10 +194,10 @@ fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&Model
 
     let tokens = ai::UsedTokens {
         input_tokens: get_tokens(GEN_AI__USAGE__INPUT_TOKENS),
-        input_cached_tokens: get_tokens(GEN_AI__USAGE__INPUT_TOKENS__CACHED),
-        input_cache_write_tokens: get_tokens(GEN_AI__USAGE__INPUT_TOKENS__CACHE_WRITE),
+        input_cached_tokens: get_tokens(GEN_AI__USAGE__CACHE_READ__INPUT_TOKENS),
+        input_cache_write_tokens: get_tokens(GEN_AI__USAGE__CACHE_CREATION__INPUT_TOKENS),
         output_tokens: get_tokens(GEN_AI__USAGE__OUTPUT_TOKENS),
-        output_reasoning_tokens: get_tokens(GEN_AI__USAGE__OUTPUT_TOKENS__REASONING),
+        output_reasoning_tokens: get_tokens(GEN_AI__USAGE__REASONING__OUTPUT_TOKENS),
     };
 
     let Some(costs) = ai::calculate_costs(model_cost, tokens, integration, platform_tag) else {

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -292,8 +292,8 @@ mod tests {
             "gen_ai.operation.type" => "ai_client".to_owned(),
             "gen_ai.usage.input_tokens" => 1000,
             "gen_ai.usage.output_tokens" => 2000,
-            "gen_ai.usage.output_tokens.reasoning" => 1000,
-            "gen_ai.usage.input_tokens.cached" => 500,
+            "gen_ai.usage.reasoning.output_tokens" => 1000,
+            "gen_ai.usage.cache_read.input_tokens" => 500,
             "gen_ai.request.model" => "claude-2.1".to_owned(),
         });
 
@@ -333,19 +333,19 @@ mod tests {
             "type": "double",
             "value": 2000.0
           },
+          "gen_ai.usage.cache_read.input_tokens": {
+            "type": "integer",
+            "value": 500
+          },
           "gen_ai.usage.input_tokens": {
             "type": "integer",
             "value": 1000
-          },
-          "gen_ai.usage.input_tokens.cached": {
-            "type": "integer",
-            "value": 500
           },
           "gen_ai.usage.output_tokens": {
             "type": "integer",
             "value": 2000
           },
-          "gen_ai.usage.output_tokens.reasoning": {
+          "gen_ai.usage.reasoning.output_tokens": {
             "type": "integer",
             "value": 1000
           },


### PR DESCRIPTION
## Bump sentry-conventions to 0.11.0

Updates `sentry-conventions` from 0.10.0 to [0.11.0](https://github.com/getsentry/sentry-conventions/releases/tag/0.11.0).

### Changes in 0.11.0

**New Features**
- Add `session.id` attribute ([sentry-conventions#412](https://github.com/getsentry/sentry-conventions/pull/412))
- Update several attributes to latest OTel representation ([sentry-conventions#418](https://github.com/getsentry/sentry-conventions/pull/418))
- Add `db.operation.batch.size` ([sentry-conventions#407](https://github.com/getsentry/sentry-conventions/pull/407))
- Add `app.vitals.start.prewarmed` attribute ([sentry-conventions#379](https://github.com/getsentry/sentry-conventions/pull/379))
- Add and deprecate runtime context attributes ([sentry-conventions#383](https://github.com/getsentry/sentry-conventions/pull/383))
- Add Android Runtime (ART) GC and memory attributes ([sentry-conventions#382](https://github.com/getsentry/sentry-conventions/pull/382))
- Add `db.stored_procedure.name` and ensure span name attribute consistency ([sentry-conventions#398](https://github.com/getsentry/sentry-conventions/pull/398))
- Add Cloudflare SDK attributes ([sentry-conventions#392](https://github.com/getsentry/sentry-conventions/pull/392))
- Add missing GCP and FaaS attributes ([sentry-conventions#403](https://github.com/getsentry/sentry-conventions/pull/403))

**Bug Fixes**
- Set `pii: 'maybe'` on `faas` string attributes ([sentry-conventions#415](https://github.com/getsentry/sentry-conventions/pull/415))
- Add missing Cloudflare visibility attributes ([sentry-conventions#408](https://github.com/getsentry/sentry-conventions/pull/408))

**Internal**
- Remove `sdks` field from attribute schema and definitions ([sentry-conventions#410](https://github.com/getsentry/sentry-conventions/pull/410))
