### PR TITLE
feat(upload): Support Proxy Mode

### DIFF
--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -441,8 +441,10 @@ async fn upload_context<'a>(
 
     let project_config = match project.state() {
         ProjectState::Enabled(info) => info.clone(),
-        // TODO(INGEST-925): Support proxy mode
-        ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
+        // Note: In Proxy mode we should never make it here since the endpoint_fetch_config_enabled
+        // check should already fail.
+        ProjectState::Dummy => return Ok(None),
+        ProjectState::Disabled | ProjectState::Pending => {
             return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
         }
     };

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -93,7 +93,7 @@ async fn upload_context<'a>(
 
     let project_config = match project.state() {
         ProjectState::Enabled(info) => info.clone(),
-        // TODO(INGEST-925): Support proxy mode
+        // Note: The playstation endpoint is not available in customer hosted relays.
         ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
             return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
         }

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -65,14 +65,18 @@ impl UnrealParams {
                 .ok_or(BadStoreRequest::ProjectUnavailable)?;
 
             let project_config = match project.state() {
-                ProjectState::Enabled(info) => info.clone(),
-                // TODO(INGEST-925): Support proxy mode
-                ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => {
+                ProjectState::Enabled(info) => Some(info.clone()),
+                // Note: In Proxy mode we should never make it here since the endpoint_fetch_config_enabled
+                // check should already fail.
+                ProjectState::Dummy => None,
+                ProjectState::Disabled | ProjectState::Pending => {
                     return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
                 }
             };
 
-            if project_config.has_feature(Feature::UnrealEndpointExpansion) {
+            if let Some(project_config) = project_config
+                && project_config.has_feature(Feature::UnrealEndpointExpansion)
+            {
                 for mut item in
                     extract_items(data, state.config()).map_err(|error| match error {
                         ProcessingError::PayloadTooLarge(_) => {

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -1684,3 +1684,22 @@ def test_minidump_upload_failure_bubbles_up(mini_sentry, relay):
             "quantity": 1,
         },
     ]
+
+
+def test_minidump_proxy_mode(mini_sentry, relay):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(mini_sentry, options={"relay": {"mode": "proxy"}})
+
+    response = relay.send_minidump(
+        project_id=project_id,
+        files=[(MINIDUMP_ATTACHMENT_NAME, "minidump.dmp", "MDMP content")],
+    )
+    assert response.ok
+
+    envelope = mini_sentry.get_captured_envelope()
+    assert envelope
+    assert len(envelope.items) == 1
+    item = envelope.items[0]
+    assert item.headers.get("type") == "attachment"
+    assert item.headers.get("attachment_type") == "event.minidump"

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -386,3 +386,19 @@ def test_unreal_minidump_with_config_and_processing(
 
     assert mini_dump_process_marker_found
     assert "errors" not in event
+
+
+def test_unreal_proxy_mode(mini_sentry, relay):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(mini_sentry, options={"relay": {"mode": "proxy"}})
+
+    response = relay.send_unreal_request(project_id, load_dump_file("unreal_crash"))
+    assert response.ok
+
+    envelope = mini_sentry.get_captured_envelope()
+    assert envelope
+    assert len(envelope.items) == 1
+    item = envelope.items[0]
+    assert item.headers.get("type") == "unreal_report"
+    assert item.headers.get("content_type") == "application/octet-stream"


### PR DESCRIPTION
This updates the logic so that it 'works' in Proxy mode as well as add some clarifying logic as to why this new logic is purely defensive and should not be needed (as in it already worked correctly).

Follow up to https://github.com/getsentry/relay/pull/6036. 
Closes: INGEST-925