### PR TITLE
chore(transactions): Add counter metric for unresolved sampling project

### DIFF
--- a/relay-server/src/processing/utils/dsc.rs
+++ b/relay-server/src/processing/utils/dsc.rs
@@ -5,6 +5,7 @@ use relay_sampling::{DynamicSamplingContext, dsc::TraceUserContext};
 
 use crate::envelope::EnvelopeHeaders;
 use crate::processing::Context;
+use crate::statsd::RelayCounters;
 
 /// Ensures there is a valid dynamic sampling context and corresponding project state.
 ///
@@ -38,6 +39,12 @@ pub fn validate_and_set_dsc(
     let original_dsc = headers.dsc();
     if original_dsc.is_some() && ctx.sampling_project_info.is_some() {
         return;
+    }
+    if ctx.sampling_project_info.is_none() {
+        relay_statsd::metric!(
+            counter(RelayCounters::SamplingProjectUnresolved) += 1,
+            item = "transaction"
+        );
     }
 
     // The DSC can only be computed if there's a transaction event. Note that `dsc_from_event`

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -967,6 +967,11 @@ pub enum RelayCounters {
     /// The amount of times PlayStation processing was attempted.
     #[cfg(all(sentry, feature = "processing"))]
     PlaystationProcessing,
+    /// The number of times the sampling project was unresolved.
+    ///
+    /// This metric is tagged with:
+    /// - `item`: what item the decision is taken for (transaction vs span).
+    SamplingProjectUnresolved,
     /// The number of times a sampling decision was made.
     ///
     /// This metric is tagged with:
@@ -1066,6 +1071,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::MetricDelayCount => "metrics.delay.count",
             #[cfg(all(sentry, feature = "processing"))]
             RelayCounters::PlaystationProcessing => "processing.playstation",
+            RelayCounters::SamplingProjectUnresolved => "sampling.project_unresolved",
             RelayCounters::SamplingDecision => "sampling.decision",
             RelayCounters::UploadKillswitched => "upload.killswitched",
             RelayCounters::UploadCreate => "upload.create",


### PR DESCRIPTION
Add a counter metric for how often the trace root (sampling) project is unresolved, which happens when the trace root org is different from the spans currently being processed. 

Reason for adding this metric: when the sampling project belongs to a different org than the spans, we need to re-synthesize the DSC to be able to apply dynamic sampling and to not share data across orgs. The idea is to use span attributes like `sentry.segment_name` to re-synthesize the DSC. But in v2 spans, there is no guarantee that all spans in an envelope have the same values for these attributes, so we can't re-synthesize the DSC. The solution would be to re-synthesize and apply dynamic sampling per span, but that's a bigger change. The added metric aims to help us determine if this would be worth it. In this PR, the metric is added for transaction spans because it gives us how big the problem **could** be (e.g. if customers currently sending transactions were to start sending v2 spans instead).

Ref [INGEST-958](https://linear.app/getsentry/issue/INGEST-958/org-mismatch-metrics)