### PR TITLE
ref(relay): Add received timestamp to outcome metrics

### DIFF
--- a/relay-server/src/services/outcome/metric.rs
+++ b/relay-server/src/services/outcome/metric.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use relay_config::Config;
-use relay_metrics::{Bucket, BucketValue, MetricName, UnixTimestamp};
+use relay_metrics::{Bucket, BucketMetadata, BucketValue, MetricName, UnixTimestamp};
 
 #[cfg(any(test, feature = "processing"))]
 use crate::services::outcome::OutcomeId;
@@ -72,13 +72,15 @@ pub fn to_metric(outcome: &TrackOutcome, config: &Config) -> Bucket {
         tags
     };
 
+    let timestamp = UnixTimestamp::from_datetime(*timestamp).unwrap_or_else(UnixTimestamp::now);
+
     Bucket {
         name,
         value: BucketValue::Counter((*quantity).into()),
-        timestamp: UnixTimestamp::from_datetime(*timestamp).unwrap_or_else(UnixTimestamp::now),
+        timestamp,
         tags,
         width: 0,
-        metadata: Default::default(),
+        metadata: BucketMetadata::new(timestamp),
     }
 }
 
@@ -188,6 +190,10 @@ mod tests {
             "category": "1",
             "reason": "invalid_event_id",
             "source": "I bims"
+          },
+          "metadata": {
+            "merges": 1,
+            "received_at": 123
           }
         }
         "#);
@@ -217,6 +223,10 @@ mod tests {
           "tags": {
             "category": "1",
             "source": "I bims"
+          },
+          "metadata": {
+            "merges": 1,
+            "received_at": 123
           }
         }
         "#);


### PR DESCRIPTION
Not technically necessary but that gives us a latency metric, which is nice.