### PR TITLE
ref(meta): A nil trace id is always nil

### DIFF
--- a/relay-event-schema/src/protocol/contexts/trace.rs
+++ b/relay-event-schema/src/protocol/contexts/trace.rs
@@ -155,7 +155,6 @@ impl FromValue for TraceId {
                 Ok(trace_id) => Annotated(Some(trace_id), meta),
                 Err(InvalidTraceId::Nil) => {
                     meta.add_remark(Remark::new(RemarkType::Substituted, "nil_trace_id"));
-                    meta.set_original_value(Some(value));
                     Annotated(Some(TraceId::random()), meta)
                 }
                 Err(InvalidTraceId::Invalid) => {

--- a/relay-event-schema/src/protocol/trace_metric/mod.rs
+++ b/relay-event-schema/src/protocol/trace_metric/mod.rs
@@ -252,11 +252,7 @@ mod tests {
             ],
             errors: [],
             original_length: None,
-            original_value: Some(
-                String(
-                    "00000000000000000000000000000000",
-                ),
-            ),
+            original_value: None,
         }
         "#);
     }


### PR DESCRIPTION
Error is redundant with the original value.