### PR TITLE
ref(managed): Add Managed::zip function

### DIFF
--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::mem::ManuallyDrop;
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
@@ -15,12 +15,12 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
 
+use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
 use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
-use crate::Envelope;
 
 #[cfg(debug_assertions)]
 mod debug;

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::mem::ManuallyDrop;
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
@@ -15,12 +15,12 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
 
+use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
 use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
-use crate::Envelope;
 
 #[cfg(debug_assertions)]
 mod debug;
@@ -1210,8 +1210,8 @@ mod tests {
 
         let z = Managed::zip(a, b);
 
-        assert_eq!(z.as_ref().0 .0, vec![1, 2]);
-        assert_eq!(z.as_ref().1 .0, 3);
+        assert_eq!((z.as_ref().0).0, vec![1, 2]);
+        assert_eq!((z.as_ref().1).0, 3);
         drop(z);
         handle_a.assert_internal_outcome(DataCategory::Error, 2);
         handle_a.assert_internal_outcome(DataCategory::Error, 1);

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::mem::ManuallyDrop;
 use std::net::IpAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
@@ -15,12 +15,12 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
 
-use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
 use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
+use crate::Envelope;
 
 #[cfg(debug_assertions)]
 mod debug;
@@ -283,12 +283,9 @@ impl<T: Counted> Managed<T> {
     where
         S: Counted,
     {
-        assert!(
-            first
-                .meta
-                .as_ref()
-                .scoping
-                .eq(&second.meta.as_ref().scoping),
+        debug_assert_eq!(
+            first.scoping(),
+            second.scoping(),
             "cannot zip Managed values with different metadata"
         );
         first.map(|first, records| {

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -187,6 +187,19 @@ impl<I, const N: usize> RetainMut<I> for SmallVec<[I; N]> {
 }
 
 impl<T: Counted> Managed<T> {
+    /// Merges two managed instances into one managed tuple.
+    ///
+    /// The returned instance uses the metadata from `first`. `second` is accepted, transferring
+    /// outcome responsibility to the merged instance.
+    pub fn merge<S>(first: Self, second: Managed<S>) -> Managed<(T, S)>
+    where
+        S: Counted,
+    {
+        let (first, meta) = first.destructure();
+        let second = second.accept(|second| second);
+        Managed::from_parts((first, second), meta)
+    }
+
     /// Creates new [`Managed`] instance with the provided `value` and metadata from a [`ManagedEnvelope`].
     ///
     /// The [`Managed`] instance, inherits all metadata from the passed [`ManagedEnvelope`],
@@ -1174,6 +1187,21 @@ mod tests {
         assert_eq!(a.0, vec![1, 2, 3, 4]);
         drop(a);
         handle_a.assert_internal_outcome(DataCategory::Error, 4);
+        handle_b.assert_no_outcomes();
+    }
+
+    #[test]
+    fn test_merge_into_tuple() {
+        let (a, mut handle_a) = Managed::for_test(CountedVec(vec![1, 2])).build();
+        let (b, mut handle_b) = Managed::for_test(CountedValue(3)).build();
+
+        let merged = Managed::merge(a, b);
+
+        assert_eq!(merged.as_ref().0.0, vec![1, 2]);
+        assert_eq!(merged.as_ref().1.0, 3);
+        drop(merged);
+        handle_a.assert_internal_outcome(DataCategory::Error, 2);
+        handle_a.assert_internal_outcome(DataCategory::Error, 1);
         handle_b.assert_no_outcomes();
     }
 

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::mem::ManuallyDrop;
 use std::net::IpAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
@@ -15,12 +15,12 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
 
-use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
 use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
+use crate::Envelope;
 
 #[cfg(debug_assertions)]
 mod debug;
@@ -283,11 +283,18 @@ impl<T: Counted> Managed<T> {
     where
         S: Counted,
     {
-        first.map(|first, recordkepping| {
+        assert!(
+            first
+                .meta
+                .as_ref()
+                .scoping
+                .eq(&second.meta.as_ref().scoping),
+            "cannot zip Managed values with different metadata"
+        );
+        first.map(|first, records| {
             for (category, quantity) in second.quantities() {
-                recordkepping.modify_by(category, quantity as isize);
+                records.modify_by(category, quantity as isize);
             }
-
             let second = second.accept(|second| second);
             (first, second)
         })
@@ -1151,6 +1158,8 @@ where
 mod tests {
     use super::*;
 
+    use relay_base_schema::project::ProjectId;
+
     struct CountedVec(Vec<u32>);
 
     impl Counted for CountedVec {
@@ -1199,14 +1208,36 @@ mod tests {
         let (a, mut handle_a) = Managed::for_test(CountedVec(vec![1, 2])).build();
         let (b, mut handle_b) = Managed::for_test(CountedValue(3)).build();
 
-        let merged = Managed::zip(a, b);
+        let z = Managed::zip(a, b);
 
-        assert_eq!(merged.as_ref().0.0, vec![1, 2]);
-        assert_eq!(merged.as_ref().1.0, 3);
-        drop(merged);
+        assert_eq!(z.as_ref().0 .0, vec![1, 2]);
+        assert_eq!(z.as_ref().1 .0, 3);
+        drop(z);
         handle_a.assert_internal_outcome(DataCategory::Error, 2);
         handle_a.assert_internal_outcome(DataCategory::Error, 1);
         handle_b.assert_no_outcomes();
+    }
+
+    #[test]
+    fn test_zip_rejects_different_metadata() {
+        let (a, mut handle_a) = Managed::for_test(CountedVec(vec![1, 2])).build();
+        let (b, mut handle_b) = Managed::for_test(CountedValue(3))
+            .scoping(Scoping {
+                project_id: ProjectId::new(45),
+                ..a.scoping()
+            })
+            .build();
+
+        let result = std::panic::catch_unwind(move || {
+            Managed::zip(a, b);
+        });
+
+        assert!(
+            result.is_err(),
+            "cannot zip Managed values with different metadata"
+        );
+        handle_a.assert_internal_outcome(DataCategory::Error, 2);
+        handle_b.assert_internal_outcome(DataCategory::Error, 1);
     }
 
     #[test]

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::mem::ManuallyDrop;
 use std::net::IpAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
@@ -15,12 +15,12 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
 
-use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
 use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
+use crate::Envelope;
 
 #[cfg(debug_assertions)]
 mod debug;
@@ -187,19 +187,6 @@ impl<I, const N: usize> RetainMut<I> for SmallVec<[I; N]> {
 }
 
 impl<T: Counted> Managed<T> {
-    /// Merges two managed instances into one managed tuple.
-    ///
-    /// The returned instance uses the metadata from `first`. `second` is accepted, transferring
-    /// outcome responsibility to the merged instance.
-    pub fn merge<S>(first: Self, second: Managed<S>) -> Managed<(T, S)>
-    where
-        S: Counted,
-    {
-        let (first, meta) = first.destructure();
-        let second = second.accept(|second| second);
-        Managed::from_parts((first, second), meta)
-    }
-
     /// Creates new [`Managed`] instance with the provided `value` and metadata from a [`ManagedEnvelope`].
     ///
     /// The [`Managed`] instance, inherits all metadata from the passed [`ManagedEnvelope`],
@@ -286,6 +273,23 @@ impl<T: Counted> Managed<T> {
                 records.modify_by(category, quantity as isize);
             }
             other.accept(|o| f(s, o, records));
+        })
+    }
+    /// Zips two managed instances into one managed tuple.
+    ///
+    /// The returned instance uses the metadata from `first`. `second` is accepted, transferring
+    /// outcome responsibility to the merged instance.
+    pub fn zip<S>(first: Self, second: Managed<S>) -> Managed<(T, S)>
+    where
+        S: Counted,
+    {
+        first.map(|first, recordkepping| {
+            for (category, quantity) in second.quantities() {
+                recordkepping.modify_by(category, quantity as isize);
+            }
+
+            let second = second.accept(|second| second);
+            (first, second)
         })
     }
 
@@ -1191,14 +1195,14 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_into_tuple() {
+    fn test_zip_into_tuple() {
         let (a, mut handle_a) = Managed::for_test(CountedVec(vec![1, 2])).build();
         let (b, mut handle_b) = Managed::for_test(CountedValue(3)).build();
 
-        let merged = Managed::merge(a, b);
+        let merged = Managed::zip(a, b);
 
-        assert_eq!(merged.as_ref().0.0, vec![1, 2]);
-        assert_eq!(merged.as_ref().1.0, 3);
+        assert_eq!(merged.as_ref().0 .0, vec![1, 2]);
+        assert_eq!(merged.as_ref().1 .0, 3);
         drop(merged);
         handle_a.assert_internal_outcome(DataCategory::Error, 2);
         handle_a.assert_internal_outcome(DataCategory::Error, 1);

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::mem::ManuallyDrop;
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
@@ -15,12 +15,12 @@ use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
 
+use crate::Envelope;
 use crate::endpoints::common::BadStoreRequest;
 use crate::extractors::RequestMeta;
 use crate::managed::{Counted, ManagedEnvelope, Quantities};
 use crate::services::outcome::{DiscardReason, Outcome, TrackOutcome};
 use crate::services::processor::ProcessingError;
-use crate::Envelope;
 
 #[cfg(debug_assertions)]
 mod debug;
@@ -1201,8 +1201,8 @@ mod tests {
 
         let merged = Managed::zip(a, b);
 
-        assert_eq!(merged.as_ref().0 .0, vec![1, 2]);
-        assert_eq!(merged.as_ref().1 .0, 3);
+        assert_eq!(merged.as_ref().0.0, vec![1, 2]);
+        assert_eq!(merged.as_ref().1.0, 3);
         drop(merged);
         handle_a.assert_internal_outcome(DataCategory::Error, 2);
         handle_a.assert_internal_outcome(DataCategory::Error, 1);

--- a/relay-server/src/managed/managed/test.rs
+++ b/relay-server/src/managed/managed/test.rs
@@ -51,6 +51,12 @@ impl<T> ManagedTestBuilder<T> {
         }
     }
 
+    /// Sets the scoping of the managed test instance.
+    pub fn scoping(mut self, scoping: Scoping) -> Self {
+        self.scoping = scoping;
+        self
+    }
+
     /// Creates a new [`Managed`] instance and a [`ManagedTestHandle`] to assert outcomes.
     pub fn build(self) -> (Managed<T>, ManagedTestHandle)
     where


### PR DESCRIPTION
https://github.com/getsentry/relay/issues/5985

Added a generic Managed::merge helper that consumes two managed values and returns a single Managed<(T, S)>,
  transferring outcome responsibility into the merged wrapper while preserving metadata from the first value.

  Also added a unit test covering the new behavior: the merged value retains both inner values, emits outcomes
  for both through the first managed handle when dropped, and prevents the second managed value from emitting
  duplicate outcomes after the merge.

I also ran:
- pre-commit --files
- cargo test -p relay-server:
```
test result: ok. 383 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.67s
```
- also ran the new test individually:
```
   cargo test --package relay-server --lib --all-features -- managed::managed::tests::test_merge_into_tuple --exact --nocapture 

    Finished `test` profile [unoptimized] target(s) in 0.78s
     Running unittests src/lib.rs (target/debug/deps/relay_server-ca0b589ee2561a09)

running 1 test
test managed::managed::tests::test_merge_into_tuple ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 406 filtered out; finished in 0.00s
```
   

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
