### PR TITLE
fix(spans): Stop double-billing AI cache-write tokens in cost calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 **Bug Fixes**:
 
+- Stop double-billing AI cache-write tokens in cost calculation. ([#6090](https://github.com/getsentry/relay/pull/6090))
 - Correctly handle minidump objecstore upload failures. ([#6033](https://github.com/getsentry/relay/pull/6033))
 - Add `client.address` attribute to known IP fields. ([#6058](https://github.com/getsentry/relay/pull/6058))
 - Fix a bug in mobile attribute normalization. ([#6065](https://github.com/getsentry/relay/pull/6065))

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -51,11 +51,14 @@ impl UsedTokens {
         self.input_tokens > 0.0 || self.output_tokens > 0.0
     }
 
-    /// Calculates the total amount of uncached input tokens.
+    /// Calculates the total amount of input tokens billed at the standard rate.
     ///
-    /// Subtracts cached tokens from the total token count.
+    /// Both [`Self::input_cached_tokens`] and [`Self::input_cache_write_tokens`] are
+    /// subsets of [`Self::input_tokens`] and are billed separately at their own
+    /// (cached / cache-write) rates, so both are subtracted here to avoid charging
+    /// them twice.
     pub fn raw_input_tokens(&self) -> f64 {
-        self.input_tokens - self.input_cached_tokens
+        self.input_tokens - self.input_cached_tokens - self.input_cache_write_tokens
     }
 
     /// Calculates the total amount of raw, non-reasoning output tokens.
@@ -618,9 +621,12 @@ mod tests {
         )
         .unwrap();
 
+        // input: (100 - 20 - 30) * 1.0 + 20 * 0.5 + 30 * 0.75 = 50 + 10 + 22.5 = 82.5
+        //   (cache-write tokens are billed once at the cache-write rate, not also at
+        //    the standard input rate). output: 40 * 2.0 + 10 * 3.0 = 110.0
         insta::assert_debug_snapshot!(cost, @r"
         CalculatedCost {
-            input: 112.5,
+            input: 82.5,
             output: 110.0,
         }
         ");


### PR DESCRIPTION
Fixes #6084

`UsedTokens::raw_input_tokens()` subtracted only `input_cached_tokens` from `input_tokens`. Per the field docs, `input_cache_write_tokens` is *also* a subset of `input_tokens`, so cache-write tokens were billed twice: once at the standard input rate (they stayed inside `raw_input_tokens`) and again at the cache-write rate in `calculate_costs`.

This subtracts `input_cache_write_tokens` as well, mirroring the existing cached-token handling, so each token class is charged exactly once at its own rate.

### Change
- `raw_input_tokens()` now returns `input_tokens - input_cached_tokens - input_cache_write_tokens`.
- Updated the `test_calculate_cost_with_cache_writes` snapshot to the corrected value, with the arithmetic inline:
  `(100 - 20 - 30) * 1.0 + 20 * 0.5 + 30 * 0.75 = 82.5` (was `112.5`).

Other cost tests are unaffected because they use `input_cache_write_tokens: 0.0`.

---

_Transparency note: I don't currently have a local Rust toolchain set up, so I haven't run the test suite locally — I'm relying on CI. The change is a one-line arithmetic fix plus the corresponding snapshot update shown above; happy to iterate if anything in CI is off._

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
