### PR TITLE
chore(spanv2): Add counter metric for unresolved sampling project

### DIFF
--- a/relay-server/src/processing/spans/dynamic_sampling.rs
+++ b/relay-server/src/processing/spans/dynamic_sampling.rs
@@ -100,6 +100,10 @@ pub fn validate_and_set_dsc(
                     replay_id: None,
                     other: Default::default(),
                 };
+                relay_statsd::metric!(
+                    counter(RelayCounters::SamplingProjectUnresolved) += 1,
+                    item = "span"
+                );
             }
             Some(sampling_project_info) => {
                 dsc.project_id = sampling_project_info.project_id;


### PR DESCRIPTION
Add a counter metric for how often the trace root (sampling) project is unresolved, which happens when the trace root org is different from the spans currently being processed.

Reason for adding this metric: when the sampling project belongs to a different org than the spans, we need to re-synthesize the DSC to be able to apply dynamic sampling and to not share data across orgs. The idea is to use span attributes like sentry.segment_name to re-synthesize the DSC. But in v2 spans, there is no guarantee that all spans in an envelope have the same values for these attributes, so we can't re-synthesize the DSC. The solution would be to re-synthesize and apply dynamic sampling per span, but that's a bigger change. The added metric aims to help us determine if this would be worth it.

Fixes [INGEST-958](https://linear.app/getsentry/issue/INGEST-958/org-mismatch-metrics)