### PR TITLE
ref: Make `name_for_op_and_attributes` return `Option`

### DIFF
--- a/relay-conventions/build/name.rs
+++ b/relay-conventions/build/name.rs
@@ -69,13 +69,13 @@ pub fn name_file_output(names: impl Iterator<Item = Name>) -> TokenStream {
 
             Some(quote! {
                 if #(#if_clauses)&&* {
-                    return format!(#format_string, #(#format_args),*);
+                    return Some(format!(#format_string, #(#format_args),*));
                 };
             })
         });
 
         let literal_name_fallback = quote! {
-            #literal_template.to_owned()
+            Some(#literal_template.to_owned())
         };
 
         // Assemble the match arm, with `ops` forming the match clause and the match body checking
@@ -93,10 +93,10 @@ pub fn name_file_output(names: impl Iterator<Item = Name>) -> TokenStream {
         use std::fmt;
         use std::fmt::Display;
 
-        pub fn name_for_op_and_attributes(op: &str, attributes: &impl Getter) -> String {
+        pub fn name_for_op_and_attributes(op: &str, attributes: &impl Getter) -> Option<String> {
             match op {
                 #(#match_arms)*
-                _ => op.to_owned()
+                _ => None
             }
         }
 

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -301,7 +301,7 @@ mod tests {
     fn only_literal_template() {
         let attributes = GetterMap(HashMap::new());
         assert_eq!(
-            name_for_op_and_attributes("op_with_literal_name", &attributes,),
+            name_for_op_and_attributes("op_with_literal_name", &attributes,).unwrap(),
             "literal name"
         );
     }
@@ -310,11 +310,11 @@ mod tests {
     fn multiple_ops_same_template() {
         let attributes = GetterMap(HashMap::from([("attr1", Val::String("foo"))]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "foo"
         );
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_2", &attributes),
+            name_for_op_and_attributes("op_with_attributes_2", &attributes).unwrap(),
             "foo"
         );
     }
@@ -326,7 +326,7 @@ mod tests {
             ("attr3", Val::String("baz")),
         ]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "bar baz"
         );
     }
@@ -335,7 +335,7 @@ mod tests {
     fn handles_literal_prefixes_and_suffixes() {
         let attributes = GetterMap(HashMap::from([("attr3", Val::String("baz"))]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "prefix baz suffix",
         );
     }
@@ -344,43 +344,40 @@ mod tests {
     fn considers_multiple_files() {
         let attributes = GetterMap(HashMap::new());
         assert_eq!(
-            name_for_op_and_attributes("op_in_second_name_file", &attributes),
+            name_for_op_and_attributes("op_in_second_name_file", &attributes).unwrap(),
             "second file literal name",
         );
     }
 
     #[test]
-    fn falls_back_to_op_for_unknown_ops() {
+    fn returns_none_for_unknown_ops() {
         let attributes = GetterMap(HashMap::new());
-        assert_eq!(
-            name_for_op_and_attributes("unknown_op", &attributes),
-            "unknown_op",
-        );
+        assert!(name_for_op_and_attributes("unknown_op", &attributes).is_none());
     }
 
     #[test]
     fn handles_multiple_value_types() {
         let attributes = GetterMap(HashMap::from([("attr1", Val::Bool(true))]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "true",
         );
 
         let attributes = GetterMap(HashMap::from([("attr1", Val::I64(123))]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "123",
         );
 
         let attributes = GetterMap(HashMap::from([("attr1", Val::U64(123))]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "123",
         );
 
         let attributes = GetterMap(HashMap::from([("attr1", Val::F64(1.23))]));
         assert_eq!(
-            name_for_op_and_attributes("op_with_attributes_1", &attributes),
+            name_for_op_and_attributes("op_with_attributes_1", &attributes).unwrap(),
             "1.23",
         );
     }

--- a/relay-spans/src/name.rs
+++ b/relay-spans/src/name.rs
@@ -8,6 +8,11 @@ use relay_protocol::{Getter, Val};
 /// If the attributes contain [`SENTRY__ORIGIN`] with the value `"manual"`,
 /// the description (contained in [`SENTRY__DESCRIPTION`]) is used as the name.
 /// Otherwise, the name is constructed following the rules defined in sentry-conventions.
+///
+/// If no rule in `sentry-conventions` matches the span's [`SENTRY__OP`], the op is
+/// returned as the name.
+///
+/// Finally, if the span doesn't have an op, `None` is returned.
 pub fn name_for_attributes(attributes: &Attributes) -> Option<String> {
     let origin = attributes
         .get_value(SENTRY__ORIGIN)
@@ -23,7 +28,7 @@ pub fn name_for_attributes(attributes: &Attributes) -> Option<String> {
     }
 
     let op = attributes.get_value(SENTRY__OP)?.as_str()?;
-    Some(name_for_op_and_attributes(op, &AttributeGetter(attributes)))
+    Some(name_for_op_and_attributes(op, &AttributeGetter(attributes)).unwrap_or(op.to_owned()))
 }
 
 /// A custom getter for [`Attributes`] which only resolves values based on the attribute name.


### PR DESCRIPTION
No functional change, this is purely for clarity/aesthetics.

`name_for_op_and_attributes` is meant to implement the name logic defined in `sentry-conventions`. It is not specified in `sentry-conventions` what should happen for an unknown `op`. Therefore, I think it's clearer to pull the `op` fallback out of the generated `name_for_op_and_attributes` and have that function return `Option<String>`. The `op` fallback can instead be supplied at the function's only callsite.