### PR TITLE
fix(eap): Don't reject empty attributes with metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))
+
 ## 26.6.0
 
 **Features**:

--- a/relay-event-derive/src/lib.rs
+++ b/relay-event-derive/src/lib.rs
@@ -354,6 +354,43 @@ impl Pii {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+enum Required {
+    True,
+    False,
+    ValueOrMeta,
+}
+
+impl Required {
+    fn as_tokens(&self) -> TokenStream {
+        match self {
+            Self::True => quote!(::relay_event_schema::processor::Required::Value),
+            Self::False => quote!(::relay_event_schema::processor::Required::False),
+            Self::ValueOrMeta => quote!(::relay_event_schema::processor::Required::ValueOrMeta),
+        }
+    }
+}
+
+impl syn::parse::Parse for Required {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let head = input.fork();
+        if let Ok(bool) = input.parse::<LitBool>() {
+            return match bool.value() {
+                true => Ok(Self::True),
+                false => Ok(Self::False),
+            };
+        }
+
+        let input = head.fork();
+        let value = input.parse::<LitStr>()?;
+
+        match value.value().as_str() {
+            "value_or_meta" => Ok(Self::ValueOrMeta),
+            _ => Err(head.error(r#"Expected one of `true`, `false`, or `"value_or_meta"`"#)),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 enum Size {
     Static(usize),
@@ -426,7 +463,7 @@ struct FieldAttrs {
     omit_from_schema: bool,
     field_name: String,
     flatten: bool,
-    required: Option<bool>,
+    required: Option<Required>,
     nonempty: Option<bool>,
     trim_whitespace: Option<bool>,
     pii: Option<Pii>,
@@ -454,11 +491,11 @@ impl FieldAttrs {
             );
         }
         let required = if let Some(required) = self.required {
-            quote!(#required)
+            required.as_tokens()
         } else if let Some(ref parent_attrs) = inherit_from_field_attrs {
             quote!(#parent_attrs.required)
         } else {
-            quote!(false)
+            quote!(::relay_event_schema::processor::Required::False)
         };
 
         let nonempty = if let Some(nonempty) = self.nonempty {
@@ -601,8 +638,7 @@ fn parse_field_attributes(
             } else if ident == "flatten" {
                 rv.flatten = true;
             } else if ident == "required" {
-                let s = meta.value()?.parse::<LitBool>()?;
-                rv.required = Some(s.value());
+                rv.required = Some(meta.value()?.parse::<Required>()?);
             } else if ident == "nonempty" {
                 let s = meta.value()?.parse::<LitBool>()?;
                 rv.nonempty = Some(s.value());

--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -1,5 +1,5 @@
 use relay_event_schema::processor::{
-    ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor,
+    ProcessValue, ProcessingAction, ProcessingResult, ProcessingState, Processor, Required,
 };
 use relay_protocol::{Annotated, Array, Empty, Error, ErrorKind, Meta, Object, Value};
 use smallvec::SmallVec;
@@ -139,8 +139,15 @@ impl Processor for SchemaProcessor {
             RequiredMode::DeleteParent => {
                 self.stack.push(SchemaState::default());
             }
+
             RequiredMode::DeleteValue => {
-                if value.is_none() && state.attrs().required && !meta.has_errors() {
+                let required_violation = match state.attrs().required {
+                    Required::Value if value.is_none() => true,
+                    Required::ValueOrMeta if value.is_none() && meta.is_empty() => true,
+                    _ => false,
+                };
+
+                if required_violation && !meta.has_errors() {
                     meta.add_error(ErrorKind::MissingAttribute);
                 }
             }
@@ -167,14 +174,26 @@ impl Processor for SchemaProcessor {
         // A local violation indicates that the current field violates a required requirement.
         // In such a case the parent must be deleted.
         let mut local_violation = None;
-        if state.attrs().required {
-            local_violation = current.required_violation.take();
-            if value.is_none() {
-                let violation = local_violation.get_or_insert_default();
-                if self.verbose_errors {
-                    violation.add(state);
+        match state.attrs().required {
+            Required::Value => {
+                local_violation = current.required_violation.take();
+                if value.is_none() {
+                    let violation = local_violation.get_or_insert_default();
+                    if self.verbose_errors {
+                        violation.add(state);
+                    }
                 }
             }
+            Required::ValueOrMeta => {
+                local_violation = current.required_violation.take();
+                if value.is_none() && meta.is_empty() {
+                    let violation = local_violation.get_or_insert_default();
+                    if self.verbose_errors {
+                        violation.add(state);
+                    }
+                }
+            }
+            Required::False => {}
         }
 
         if let Some(violation) = local_violation {
@@ -251,7 +270,7 @@ fn verify_value_nonempty<T>(
 where
     T: Empty,
 {
-    if state.attrs().nonempty && value.is_empty() {
+    if state.attrs().nonempty && value.is_empty() && meta.is_empty() {
         meta.add_error(Error::nonempty());
         Err(ProcessingAction::DeleteValueHard)
     } else {
@@ -267,7 +286,7 @@ fn verify_value_nonempty_string<T>(
 where
     T: Empty,
 {
-    if state.attrs().nonempty && value.is_empty() {
+    if state.attrs().nonempty && value.is_empty() && meta.is_empty() {
         meta.add_error(Error::nonempty_string());
         Err(ProcessingAction::DeleteValueHard)
     } else {

--- a/relay-event-normalization/src/schema.rs
+++ b/relay-event-normalization/src/schema.rs
@@ -270,7 +270,7 @@ fn verify_value_nonempty<T>(
 where
     T: Empty,
 {
-    if state.attrs().nonempty && value.is_empty() && meta.is_empty() {
+    if state.attrs().nonempty && value.is_empty() {
         meta.add_error(Error::nonempty());
         Err(ProcessingAction::DeleteValueHard)
     } else {
@@ -286,7 +286,7 @@ fn verify_value_nonempty_string<T>(
 where
     T: Empty,
 {
-    if state.attrs().nonempty && value.is_empty() && meta.is_empty() {
+    if state.attrs().nonempty && value.is_empty() {
         meta.add_error(Error::nonempty_string());
         Err(ProcessingAction::DeleteValueHard)
     } else {

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -126,13 +126,24 @@ pub enum SizeMode {
     Dynamic(fn(&ProcessingState) -> Option<usize>),
 }
 
+/// Whether a field must be present.
+#[derive(Debug, Clone, Copy)]
+pub enum Required {
+    /// The field is not required.
+    False,
+    /// The field requires a value or metadata.
+    ValueOrMeta,
+    /// The field requires a value.
+    Value,
+}
+
 /// Meta information about a field.
 #[derive(Debug, Clone, Copy)]
 pub struct FieldAttrs {
     /// Optionally the name of the field.
     pub name: Option<&'static str>,
     /// If the field is required.
-    pub required: bool,
+    pub required: Required,
     /// If the field should be non-empty.
     pub nonempty: bool,
     /// Whether to trim whitespace from this string.
@@ -190,7 +201,7 @@ impl FieldAttrs {
     pub const fn new() -> Self {
         FieldAttrs {
             name: None,
-            required: false,
+            required: Required::False,
             nonempty: false,
             trim_whitespace: false,
             characters: None,
@@ -206,7 +217,7 @@ impl FieldAttrs {
     }
 
     /// Sets whether a value in this field is required.
-    pub const fn required(mut self, required: bool) -> Self {
+    pub const fn required(mut self, required: Required) -> Self {
         self.required = required;
         self
     }
@@ -373,7 +384,7 @@ impl ProcessingStateBuilder {
     }
 
     /// Sets whether a value in the root field is required.
-    pub fn required(self, required: bool) -> Self {
+    pub fn required(self, required: Required) -> Self {
         self.attrs(|attrs| attrs.required(required))
     }
 

--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -64,7 +64,7 @@ where
 pub struct AttributeValue {
     #[metastructure(field = "type", required = true, trim = false, pii = "false")]
     pub ty: Annotated<AttributeType>,
-    #[metastructure(required = true, pii = "attribute_pii_from_conventions")]
+    #[metastructure(required = "value_or_meta", pii = "attribute_pii_from_conventions")]
     pub value: Annotated<Value>,
 }
 

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -364,7 +364,7 @@ mod tests {
     use relay_conventions::attributes::*;
     use relay_event_schema::protocol::{Attributes, EventId, SpanKind};
     use relay_pii::PiiConfig;
-    use relay_protocol::SerializableAnnotated;
+    use relay_protocol::{SerializableAnnotated, assert_annotated_snapshot};
 
     use crate::Envelope;
     use crate::extractors::RequestMeta;
@@ -1168,5 +1168,89 @@ mod tests {
             ],
             &[],
         );
+    }
+
+    /// Tests that schema validation doesn't reject attributes that have no value, but
+    /// do have metadata (such as attributes that have been deleted by scrubbing).
+    #[test]
+    fn test_schema_validation_scrubbed_attribute() {
+        let mut span = Annotated::<SpanV2>::from_json(
+            r#"
+        {
+            "start_timestamp": 1544719859.0,
+            "end_timestamp": 1544719860.0,
+            "trace_id": "5b8efff798038103d269b633813fc60c",
+            "span_id": "eee19b7ec3c1b174",
+            "name": "test",
+            "status": "ok",
+            "attributes": {
+                "foo": {"type": "string", "value": null},
+                "bar": {"type": "string", "value": null}
+            },
+            "_meta": {
+                "attributes": {
+                    "foo": {
+                        "value": {
+                            "": {
+                                "rem": [["@anything:remove", "x"]]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    "#,
+        )
+        .unwrap();
+
+        process_value(
+            &mut span,
+            &mut SchemaProcessor::new()
+                .with_required(RequiredMode::DeleteParent)
+                .with_verbose_errors(relay_log::enabled!(relay_log::Level::DEBUG)),
+            ProcessingState::root(),
+        )
+        .unwrap();
+
+        assert_annotated_snapshot!(span, @r#"
+        {
+          "trace_id": "5b8efff798038103d269b633813fc60c",
+          "span_id": "eee19b7ec3c1b174",
+          "name": "test",
+          "status": "ok",
+          "start_timestamp": 1544719859.0,
+          "end_timestamp": 1544719860.0,
+          "attributes": {
+            "bar": null,
+            "foo": {
+              "type": "string",
+              "value": null
+            }
+          },
+          "_meta": {
+            "attributes": {
+              "bar": {
+                "": {
+                  "err": [
+                    "missing_attribute"
+                  ]
+                }
+              },
+              "foo": {
+                "value": {
+                  "": {
+                    "rem": [
+                      [
+                        "@anything:remove",
+                        "x"
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#);
     }
 }


### PR DESCRIPTION
If `AttributeValue::value` is marked as `"required"`, schema validation will remove any attribute that has been deleted by PII scrubbing outright. Therefore, we remove the required annotation.