### PR TITLE
chore(conventions): Update sentry-conventions to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Have relay generate metric billing outcomes. ([#6066](https://github.com/getsentry/relay/pull/6066))
+- Update sentry-conventions to 0.12.0.
 
 ## 26.6.0
 


### PR DESCRIPTION
Bumps the `sentry-conventions` submodule from 0.11.0 to 0.12.0.

## Changes in 0.12.0

- Aligns MCP attributes with OTel semantic conventions ([sentry-conventions#420](https://github.com/getsentry/sentry-conventions/pull/420))
- Deprecates MCP-specific attributes in favor of `gen_ai.*`/`jsonrpc.*` OTel equivalents
- Adds new `gen_ai.prompt.name` and `jsonrpc.*` attributes