### PR TITLE
ci(ci): Switch to gcloud storage for gocd uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v3"
         with:
           # https://github.com/google-github-actions/auth#authenticating-via-workload-identity-federation
-          # You must use the Cloud SDK version 390.0.0 or later to authenticate the bq and gsutil tools.
+          # You must use the Cloud SDK version 390.0.0 or later to authenticate with workload identity federation.
           version: ">= 390.0.0"
 
       - name: Configure docker
@@ -707,7 +707,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v3"
         with:
           # https://github.com/google-github-actions/auth#authenticating-via-workload-identity-federation
-          # You must use the Cloud SDK version 390.0.0 or later to authenticate the bq and gsutil tools.
+          # You must use the Cloud SDK version 390.0.0 or later to authenticate with workload identity federation.
           version: ">= 390.0.0"
 
       - uses: actions/download-artifact@v8
@@ -728,15 +728,11 @@ jobs:
       - name: Upload gocd deployment assets
         run: |
           set -euxo pipefail
-          # Keep resumable upload state out of ~/.gsutil, which may be unwritable in CI.
-          GSUTIL_STATE_DIR="${RUNNER_TEMP}/gsutil-state"
-          mkdir -p "${GSUTIL_STATE_DIR}"
-
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            gsutil -o "GSUtil:state_dir=${GSUTIL_STATE_DIR}" -m cp \
+            gcloud storage cp \
               "${PLATFORM}/relay-debug.zip" "${PLATFORM}/relay.src.zip" ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,6 +921,8 @@ jobs:
           /name/ { pkg = $2 }
           /version/ { if (pkg == "devservices") print "version="$2 }
         ' uv.lock >> $GITHUB_OUTPUT
+        mkdir -p ~/.config/sentry-devenv
+        printf '[devenv]\ncoderoot = %s\n' "$(dirname "$GITHUB_WORKSPACE")" >> ~/.config/sentry-devenv/config.ini
 
     - uses: getsentry/action-validate-devservices-config@711ae7221998ddf81211f25f5e3873ecffd22387
       name: Validate devservices config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v3"
         with:
           # https://github.com/google-github-actions/auth#authenticating-via-workload-identity-federation
-          # You must use the Cloud SDK version 390.0.0 or later to authenticate with workload identity federation.
+          # You must use the Cloud SDK version 390.0.0 or later to authenticate the bq and gsutil tools.
           version: ">= 390.0.0"
 
       - name: Configure docker
@@ -707,7 +707,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v3"
         with:
           # https://github.com/google-github-actions/auth#authenticating-via-workload-identity-federation
-          # You must use the Cloud SDK version 390.0.0 or later to authenticate with workload identity federation.
+          # You must use the Cloud SDK version 390.0.0 or later to authenticate the bq and gsutil tools.
           version: ">= 390.0.0"
 
       - uses: actions/download-artifact@v8
@@ -728,11 +728,15 @@ jobs:
       - name: Upload gocd deployment assets
         run: |
           set -euxo pipefail
+          # Keep resumable upload state out of ~/.gsutil, which may be unwritable in CI.
+          GSUTIL_STATE_DIR="${RUNNER_TEMP}/gsutil-state"
+          mkdir -p "${GSUTIL_STATE_DIR}"
+
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            gcloud storage cp \
+            gsutil -o "GSUtil:state_dir=${GSUTIL_STATE_DIR}" -m cp \
               "${PLATFORM}/relay-debug.zip" "${PLATFORM}/relay.src.zip" ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,16 +728,13 @@ jobs:
       - name: Upload gocd deployment assets
         run: |
           set -euxo pipefail
-          # Keep resumable upload state out of ~/.gsutil, which may be unwritable in CI.
-          GSUTIL_STATE_DIR="${RUNNER_TEMP}/gsutil-state"
-          mkdir -p "${GSUTIL_STATE_DIR}"
-
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
+          # the upload SA has no delete perms; disable parallel composite uploads since their chunk cleanup would fail on delete
+          export CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED=false
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            gsutil -o "GSUtil:state_dir=${GSUTIL_STATE_DIR}" -m cp \
-              "${PLATFORM}/relay-debug.zip" "${PLATFORM}/relay.src.zip" ./release-name \
+            gcloud storage cp --no-clobber $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,13 +726,15 @@ jobs:
           done
 
       - name: Upload gocd deployment assets
+        env:
+          # the upload SA has no delete perms; disable parallel composite uploads 
+          # since their chunk cleanup would fail on delete
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: false
         run: |
           set -euxo pipefail
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
-          # the upload SA has no delete perms; disable parallel composite uploads since their chunk cleanup would fail on delete
-          export CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED=false
           for PLATFORM in "linux/amd64" "linux/arm64"; do
             gcloud storage cp --no-clobber $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,11 +728,16 @@ jobs:
       - name: Upload gocd deployment assets
         run: |
           set -euxo pipefail
+          # Keep resumable upload state out of ~/.gsutil, which may be unwritable in CI.
+          GSUTIL_STATE_DIR="${RUNNER_TEMP}/gsutil-state"
+          mkdir -p "${GSUTIL_STATE_DIR}"
+
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            gsutil -m cp $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
+            gsutil -o "GSUtil:state_dir=${GSUTIL_STATE_DIR}" -m cp \
+              "${PLATFORM}/relay-debug.zip" "${PLATFORM}/relay.src.zip" ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"
           done
 


### PR DESCRIPTION
`gsutil` is deprecated and sometimes fails to upload to gocd because of an unwritable directory.