### PR TITLE
fix(ci): Make gocd asset uploads retry-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,8 +731,10 @@ jobs:
           VERSION="$(docker run --rm "us-central1-docker.pkg.dev/internal-sentry/relay/${{ matrix.image_name }}:${REVISION}" --version | cut -d" " -f2)"
           echo "${{ matrix.image_name }}@${VERSION}+${REVISION}" > release-name
 
+          # the upload SA has no delete perms; disable parallel composite uploads since their chunk cleanup would fail on delete
+          export CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED=false
           for PLATFORM in "linux/amd64" "linux/arm64"; do
-            gsutil -m cp $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
+            gcloud storage cp --no-clobber $PLATFORM/relay-debug.zip $PLATFORM/relay.src.zip ./release-name \
               "gs://dicd-team-devinfra-cd--relay/deployment-assets/${REVISION}/${{ matrix.image_name }}/${PLATFORM}/"
           done
 


### PR DESCRIPTION
The `Upload gocd deployment assets` step sometimes fails partway. Some files are already uploaded by then, so re-running it fails. The SA only has create permissions.

Let's add a read grant to the SA in getsentry/devinfra-deployment-service#879. 

We can then modify the upload to skip files that already exist.
