### PR TITLE
fix(otel): Wider type support for OTel log bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**:
 
+- Wider type support for OTel log bodies. ([#6106](https://github.com/getsentry/relay/pull/6106))
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))
 
 **Internal**:

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -9,6 +9,8 @@
     html_favicon_url = "https://raw.githubusercontent.com/getsentry/relay/master/artwork/relay-icon.png"
 )]
 
+use opentelemetry_proto::tonic::common::v1::ArrayValue as OtelArrayValue;
+use opentelemetry_proto::tonic::common::v1::KeyValueList;
 use opentelemetry_proto::tonic::common::v1::any_value;
 use opentelemetry_proto::tonic::{
     common::v1::{InstrumentationScope, any_value::Value as OtelValue},
@@ -17,6 +19,52 @@ use opentelemetry_proto::tonic::{
 use opentelemetry_semantic_conventions::attribute as otel_semconv;
 use relay_event_schema::protocol::{Attribute, AttributeType, Attributes};
 use relay_protocol::{Annotated, Value};
+
+/// Converts a key-value list to a JSON object and serializes it as a string.
+///
+/// Key-value pairs are supported by the type definition, but handling varies between spans and
+/// logs, so we serialize to JSON for consistency.
+pub fn otel_kvlist_to_string(kvlist: KeyValueList) -> Option<String> {
+    let mut json_obj = serde_json::Map::new();
+    for kv in kvlist.values {
+        if let Some(val) = kv.value.and_then(|v| match v.value? {
+            OtelValue::StringValue(s) => Some(serde_json::Value::String(s)),
+            OtelValue::BoolValue(b) => Some(serde_json::Value::Bool(b)),
+            OtelValue::IntValue(i) => Some(serde_json::Value::Number(serde_json::Number::from(i))),
+            OtelValue::DoubleValue(d) => {
+                serde_json::Number::from_f64(d).map(serde_json::Value::Number)
+            }
+            OtelValue::BytesValue(bytes) => {
+                String::from_utf8(bytes).ok().map(serde_json::Value::String)
+            }
+            OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => None,
+        }) {
+            json_obj.insert(kv.key, val);
+        }
+    }
+    serde_json::to_string(&json_obj).ok()
+}
+
+/// Converts an OpenTelemetry array value to a vec of Sentry values.
+///
+/// Nested complex types (arrays and key-value lists) are filtered out.
+pub fn otel_array_to_sentry_array(array: OtelArrayValue) -> Vec<Annotated<Value>> {
+    array
+        .values
+        .into_iter()
+        .filter_map(|v| {
+            Some(match v.value? {
+                OtelValue::StringValue(s) => Value::String(s),
+                OtelValue::BoolValue(b) => Value::Bool(b),
+                OtelValue::IntValue(i) => Value::I64(i),
+                OtelValue::DoubleValue(d) => Value::F64(d),
+                OtelValue::BytesValue(bytes) => Value::String(String::from_utf8(bytes).ok()?),
+                OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => return None,
+            })
+        })
+        .map(Annotated::new)
+        .collect()
+}
 
 /// Converts an OpenTelemetry AnyValue to a Sentry attribute.
 ///
@@ -36,53 +84,12 @@ pub fn otel_value_to_attribute(otel_value: OtelValue) -> Option<Attribute> {
             let s = String::from_utf8(bytes).ok()?;
             (AttributeType::String, Value::String(s))
         }
-        OtelValue::ArrayValue(array) => {
-            let values: Vec<Annotated<Value>> = array
-                .values
-                .into_iter()
-                .filter_map(|v| {
-                    Some(match v.value? {
-                        OtelValue::StringValue(s) => Value::String(s),
-                        OtelValue::BoolValue(b) => Value::Bool(b),
-                        OtelValue::IntValue(i) => Value::I64(i),
-                        OtelValue::DoubleValue(d) => Value::F64(d),
-                        OtelValue::BytesValue(bytes) => {
-                            Value::String(String::from_utf8(bytes).ok()?)
-                        }
-                        // Currently not supported.
-                        OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => return None,
-                    })
-                })
-                .map(Annotated::new)
-                .collect();
-
-            (AttributeType::Array, Value::Array(values))
-        }
+        OtelValue::ArrayValue(array) => (
+            AttributeType::Array,
+            Value::Array(otel_array_to_sentry_array(array)),
+        ),
         OtelValue::KvlistValue(kvlist) => {
-            // Convert key-value list to JSON object and serialize as string.
-            // Key-value pairs are supported by the type definition, but handling
-            // varies between spans and logs, so we serialize to JSON for consistency.
-            let mut json_obj = serde_json::Map::new();
-            for kv in kvlist.values {
-                if let Some(val) = kv.value.and_then(|v| match v.value? {
-                    OtelValue::StringValue(s) => Some(serde_json::Value::String(s)),
-                    OtelValue::BoolValue(b) => Some(serde_json::Value::Bool(b)),
-                    OtelValue::IntValue(i) => {
-                        Some(serde_json::Value::Number(serde_json::Number::from(i)))
-                    }
-                    OtelValue::DoubleValue(d) => {
-                        serde_json::Number::from_f64(d).map(serde_json::Value::Number)
-                    }
-                    OtelValue::BytesValue(bytes) => {
-                        String::from_utf8(bytes).ok().map(serde_json::Value::String)
-                    }
-                    // Skip nested complex types for safety
-                    OtelValue::ArrayValue(_) | OtelValue::KvlistValue(_) => None,
-                }) {
-                    json_obj.insert(kv.key, val);
-                }
-            }
-            let json = serde_json::to_string(&json_obj).ok()?;
+            let json = otel_kvlist_to_string(kvlist)?;
             (AttributeType::String, Value::String(json))
         }
     };

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -4,14 +4,17 @@
 //! into Sentry's internal log format (`OurLog`).
 
 use chrono::{TimeZone, Utc};
-use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtelValue;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope};
 use opentelemetry_proto::tonic::logs::v1::LogRecord as OtelLogRecord;
 
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use relay_conventions::attributes::{EVENT__NAME, SENTRY__ORIGIN, SENTRY__PLATFORM};
 use relay_event_schema::protocol::{Attributes, OurLog, OurLogLevel, SpanId, Timestamp, TraceId};
-use relay_otel::{otel_resource_to_platform, otel_value_to_attribute};
+use relay_otel::{
+    otel_array_to_sentry_array, otel_kvlist_to_string, otel_resource_to_platform,
+    otel_value_to_attribute,
+};
 use relay_protocol::{Annotated, Object};
 
 /// Maps OpenTelemetry severity number to Sentry log level.
@@ -45,6 +48,24 @@ fn map_severity_to_level(severity_number: i32, severity_text: &str) -> OurLogLev
     }
 }
 
+fn otel_body_to_sentry_body(body: Option<AnyValue>) -> Option<String> {
+    body.and_then(|v| v.value).and_then(|v| match v {
+        OtelValue::StringValue(s) => Some(s),
+        OtelValue::BoolValue(b) => Some(b.to_string()),
+        OtelValue::IntValue(i) => Some(i.to_string()),
+        OtelValue::DoubleValue(d) => Some(d.to_string()),
+        OtelValue::BytesValue(bytes) => String::from_utf8(bytes).ok(),
+        OtelValue::KvlistValue(kvlist) => otel_kvlist_to_string(kvlist),
+        OtelValue::ArrayValue(array) => {
+            let values: Vec<_> = otel_array_to_sentry_array(array)
+                .into_iter()
+                .filter_map(|v| v.into_value())
+                .collect();
+            serde_json::to_string(&values).ok()
+        }
+    })
+}
+
 /// Transforms an OpenTelemetry log record to a Sentry log.
 pub fn otel_to_sentry_log(
     otel_log: OtelLogRecord,
@@ -72,10 +93,7 @@ pub fn otel_to_sentry_log(
     let trace_id = TraceId::try_from_slice_or_random(trace_id.as_slice());
     let timestamp = Utc.timestamp_nanos(time_unix_nano as i64);
     let level = map_severity_to_level(severity_number, &severity_text);
-    let body = body.and_then(|v| v.value).and_then(|v| match v {
-        OtelValue::StringValue(s) => Some(s),
-        _ => None,
-    });
+    let body = otel_body_to_sentry_body(body);
 
     let mut attribute_data = Attributes::default();
     attribute_data.insert(SENTRY__ORIGIN, "auto.otlp.logs".to_owned());
@@ -114,6 +132,7 @@ pub fn otel_to_sentry_log(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opentelemetry_proto::tonic::common::v1::{ArrayValue, KeyValue, KeyValueList};
     use relay_protocol::{SerializableAnnotated, get_path};
 
     #[test]
@@ -651,5 +670,96 @@ mod tests {
           }
         }
         "#);
+    }
+
+    #[test]
+    fn test_otel_body_string_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::StringValue("hello world".to_owned())),
+        });
+        assert_eq!(
+            otel_body_to_sentry_body(body),
+            Some("hello world".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_otel_body_bool_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::BoolValue(true)),
+        });
+        assert_eq!(otel_body_to_sentry_body(body), Some("true".to_owned()));
+    }
+
+    #[test]
+    fn test_otel_body_int_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::IntValue(42)),
+        });
+        assert_eq!(otel_body_to_sentry_body(body), Some("42".to_owned()));
+    }
+
+    #[test]
+    fn test_otel_body_double_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::DoubleValue(3.14)),
+        });
+        assert_eq!(otel_body_to_sentry_body(body), Some("3.14".to_owned()));
+    }
+
+    #[test]
+    fn test_otel_body_bytes_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::BytesValue(b"hello bytes".to_vec())),
+        });
+        assert_eq!(
+            otel_body_to_sentry_body(body),
+            Some("hello bytes".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_otel_body_array_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::ArrayValue(ArrayValue {
+                values: vec![
+                    AnyValue {
+                        value: Some(OtelValue::StringValue("a".to_owned())),
+                    },
+                    AnyValue {
+                        value: Some(OtelValue::IntValue(1)),
+                    },
+                ],
+            })),
+        });
+        let result = otel_body_to_sentry_body(body).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed, serde_json::json!(["a", 1]));
+    }
+
+    #[test]
+    fn test_otel_body_kvlist_value() {
+        let body = Some(AnyValue {
+            value: Some(OtelValue::KvlistValue(KeyValueList {
+                values: vec![
+                    KeyValue {
+                        key: "key1".to_owned(),
+                        value: Some(AnyValue {
+                            value: Some(OtelValue::StringValue("value1".to_owned())),
+                        }),
+                    },
+                    KeyValue {
+                        key: "key2".to_owned(),
+                        value: Some(AnyValue {
+                            value: Some(OtelValue::IntValue(42)),
+                        }),
+                    },
+                ],
+            })),
+        });
+        let result = otel_body_to_sentry_body(body).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["key1"], "value1");
+        assert_eq!(parsed["key2"], 42);
     }
 }

--- a/relay-ourlogs/src/otel_to_sentry.rs
+++ b/relay-ourlogs/src/otel_to_sentry.rs
@@ -702,9 +702,9 @@ mod tests {
     #[test]
     fn test_otel_body_double_value() {
         let body = Some(AnyValue {
-            value: Some(OtelValue::DoubleValue(3.14)),
+            value: Some(OtelValue::DoubleValue(1.23)),
         });
-        assert_eq!(otel_body_to_sentry_body(body), Some("3.14".to_owned()));
+        assert_eq!(otel_body_to_sentry_body(body), Some("1.23".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
I noticed that we dropped OTel logs that had hashes/dicts for bodies (relatively common). In fact we were dropping everything except strings (non-strings would result in a `None` `body` on `OurLog`, which ends up wiping the entire log via `RequiredMode::DeleteParent`). 

This PR updates the body conversion to handle all OTel value types. Even though the other types are probably a lot rarer than string and hash, I implemented them all for completeness. (It wouldn't bother me at all to cut this back down to only hashes, if you prefer - hashes are the only thing I feel strongly about supporting).

Note that I used identical handling to our OTel-to-Sentry attribute conversion for hashes (extracted into a method). I also piggy-backed off of our array attribute handling before stringifying, so that we were consistent there too.

---

🤖: A lot of Claude Code (Opus 4.6) in here for the code, although I told it exactly what to do in babysteps.