### PR TITLE
chore(profile-chunks): Rename objectstore use-case from profiles_raw to profile_attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Internal**:
 
+- Rename objectstore use-case from `profiles_raw` to `profile_attachments`. ([#6108](https://github.com/getsentry/relay/pull/6108))
 - Require timestamps and verification in auth signatures. ([#6069](https://github.com/getsentry/relay/pull/6069))
 - Have relay generate metric billing outcomes. ([#6066](https://github.com/getsentry/relay/pull/6066))
 - Update sentry-conventions to 0.12.0.

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -361,7 +361,7 @@ impl ObjectstoreService {
             .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
         let trace_attachments = Usecase::new("trace_attachments")
             .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
-        let profiles = Usecase::new("profiles_raw")
+        let profile_attachments = Usecase::new("profile_attachments")
             .with_expiration_policy(ExpirationPolicy::TimeToLive(DEFAULT_ATTACHMENT_RETENTION));
 
         let inner = ObjectstoreServiceInner {
@@ -369,7 +369,7 @@ impl ObjectstoreService {
             objectstore_client,
             event_attachments,
             trace_attachments,
-            profiles,
+            profile_attachments,
             timeout: Duration::from_secs(*timeout),
             stream_timeout: Duration::from_secs(*stream_timeout),
             retry_interval: Duration::from_secs_f64(*retry_delay),
@@ -424,7 +424,7 @@ struct ObjectstoreServiceInner {
     objectstore_client: Client,
     event_attachments: Usecase,
     trace_attachments: Usecase,
-    profiles: Usecase,
+    profile_attachments: Usecase,
     timeout: Duration,
     stream_timeout: Duration,
     retry_interval: Duration,
@@ -668,7 +668,7 @@ impl ObjectstoreServiceInner {
         }
 
         let session = self
-            .profiles
+            .profile_attachments
             .for_project(scoping.organization_id.value(), scoping.project_id.value())
             .session(&self.objectstore_client)?;
 

--- a/tests/integration/test_profile_chunks_perfetto.py
+++ b/tests/integration/test_profile_chunks_perfetto.py
@@ -124,6 +124,6 @@ def test_perfetto_profile_chunk_objectstore_content_type(
     attachments = profile["attachments"]
     object_store_key = attachments[0]["stored_id"]
 
-    stored = objectstore("profiles_raw", project_id).get(object_store_key)
+    stored = objectstore("profile_attachments", project_id).get(object_store_key)
     assert stored.metadata.content_type == "application/x-perfetto-trace"
     assert len(stored.payload.read()) == 97252


### PR DESCRIPTION
As we switched to a concept of generic profile attachments rather than a single raw profile, it makes sense to rename the use case accordingly.

This affects object store retrieval, but I guess we can skip any migration here, as the feature hasn't fully shipped e2e yet.