### PR TITLE
chore(docker): Upgrade release image to Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Require timestamps and verification in auth signatures. ([#6069](https://github.com/getsentry/relay/pull/6069))
 - Have relay generate metric billing outcomes. ([#6066](https://github.com/getsentry/relay/pull/6066))
 - Update sentry-conventions to 0.12.0.
+- Upgrade release image to Debian 13. ([#6110](https://github.com/getsentry/relay/pull/6110))
 
 ## 26.6.0
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,9 +1,9 @@
-FROM gcr.io/distroless/cc-debian12:debug AS builder
+FROM gcr.io/distroless/cc-debian13:debug AS builder
 
 RUN ["/busybox/busybox", "mkdir", "/work", "/etc/relay"]
 
 
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
Bump the distroless base images in `Dockerfile.release` from `cc-debian12` to `cc-debian13` (trixie).