### PR TITLE
fix(spans): Infer names PII-safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Wider type support for OTel log bodies. ([#6106](https://github.com/getsentry/relay/pull/6106))
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))
+- Infer span names PII-safely. ([#6112](https://github.com/getsentry/relay/pull/6112))
 
 **Internal**:
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -9,7 +9,9 @@ use chrono::{DateTime, Utc};
 use relay_common::time::UnixTimestamp;
 use relay_conventions::attributes::*;
 use relay_conventions::{AttributeInfo, ReplacementName, WriteBehavior};
-use relay_event_schema::protocol::{Attribute, AttributeType, Attributes, BrowserContext, Geo};
+use relay_event_schema::protocol::{
+    Attribute, AttributeType, Attributes, BrowserContext, Geo, SpanV2,
+};
 use relay_protocol::{Annotated, Empty, Error, ErrorKind, Meta, Remark, RemarkType, Value};
 use relay_sampling::DynamicSamplingContext;
 use relay_spans::{derive_description_for_v2_span, derive_op_for_v2_span};
@@ -72,6 +74,27 @@ pub fn normalize_sentry_description(
 
     if let Some(description) = derive_description_for_v2_span(attributes, name) {
         attributes.insert(SENTRY__DESCRIPTION, description);
+    }
+}
+
+/// Normalizes a V2 span's name.
+///
+/// If the span has no name, this will attempt to synthesize one from its
+/// attributes using [relay_spans::name_for_attributes].
+///
+/// This is only relevant for spans converted from V1. Spans that were sent
+/// as V2 should always have a name.
+pub fn normalize_span_name(span: &mut SpanV2) {
+    if span.name.value().is_some() {
+        return;
+    }
+
+    let Some(attributes) = span.attributes.value() else {
+        return;
+    };
+
+    if let Some(name) = relay_spans::name_for_attributes(attributes) {
+        span.name = name.into();
     }
 }
 

--- a/relay-server/src/processing/legacy_spans/store.rs
+++ b/relay-server/src/processing/legacy_spans/store.rs
@@ -23,7 +23,9 @@ macro_rules! required {
 
 /// Converts a [`Span`] into a [`StoreSpanV2`] to be sent to Kafka.
 pub fn convert(span: Annotated<Span>, retentions: Retention) -> Result<Box<StoreSpanV2>> {
-    let span = span.map_value(relay_spans::span_v1_to_span_v2_with_name_inference);
+    // It's ok to enable `infer_name` here—the span has gone through the legacy standalone
+    // pipeline, so it has been PII scrubbed.
+    let span = span.map_value(|span| relay_spans::span_v1_to_span_v2(span, true));
     let span = required!(span);
 
     Ok(Box::new(StoreSpanV2 {

--- a/relay-server/src/processing/legacy_spans/store.rs
+++ b/relay-server/src/processing/legacy_spans/store.rs
@@ -23,7 +23,7 @@ macro_rules! required {
 
 /// Converts a [`Span`] into a [`StoreSpanV2`] to be sent to Kafka.
 pub fn convert(span: Annotated<Span>, retentions: Retention) -> Result<Box<StoreSpanV2>> {
-    let span = span.map_value(relay_spans::span_v1_to_span_v2);
+    let span = span.map_value(relay_spans::span_v1_to_span_v2_with_name_inference);
     let span = required!(span);
 
     Ok(Box::new(StoreSpanV2 {

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -379,6 +379,12 @@ struct Settings {
     infer_ip: bool,
     /// Whether the user agent/browser should inferred from client headers.
     infer_user_agent: bool,
+    /// Whether the name should be inferred.
+    ///
+    /// This should never be enabled for V2 spans sent by SDKs, it exists purely
+    /// for the benefit of standalone spans which need to have a name inferred
+    /// after conversion to V2.
+    infer_name: bool,
 }
 
 /// Spans which have been parsed and expanded from their serialized state.

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -164,10 +164,10 @@ fn expand_legacy_span(item: &Item) -> Result<WithHeader<SpanV2>> {
             relay_log::debug!("failed to parse span: {err}");
             Error::Invalid(DiscardReason::InvalidJson)
         })?
-        // We can't use `relay_spans::span_v1_to_span_v2_with_name_inference` here:
+        // We can't enable `infer_name` here:
         // These spans haven't been PII scrubbed yet, so inferring a name would risk
         // leaking PII.
-        .map_value(relay_spans::span_v1_to_span_v2);
+        .map_value(|span| relay_spans::span_v1_to_span_v2(span, false));
 
     Ok(WithHeader::new(span))
 }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -276,6 +276,10 @@ pub fn normalize_derived(spans: &mut Managed<ExpandedSpans>, ctx: Context<'_>) {
 
 fn normalize_span_derived(span: &mut Annotated<SpanV2>, ctx: Context<'_>) -> Result<()> {
     if let Some(span) = span.value_mut() {
+        // The order of operations shouldn't matter here—we should never _actually_
+        // need to synthesize both the name and description. If the span was sent as
+        // V2 it should have a name and if it was sent as V1 it should have a description.
+        eap::normalize_span_name(span);
         eap::normalize_sentry_description(&mut span.attributes, &span.name);
     }
 

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -157,6 +157,9 @@ fn expand_legacy_span(item: &Item) -> Result<WithHeader<SpanV2>> {
             relay_log::debug!("failed to parse span: {err}");
             Error::Invalid(DiscardReason::InvalidJson)
         })?
+        // We can't use `relay_spans::span_v1_to_span_v2_with_name_inference` here:
+        // These spans haven't been PII scrubbed yet, so inferring a name would risk
+        // leaking PII.
         .map_value(relay_spans::span_v1_to_span_v2);
 
     Ok(WithHeader::new(span))

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -113,6 +113,9 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
                     infer_user_agent: is
                         .and_then(|is| is.infer_user_agent)
                         .is_some_and(|infer| infer.is_auto()),
+                    // We don't want to infer names for V2 spans. If an SDK sent a
+                    // V2 span without a name it's just invalid.
+                    infer_name: false,
                 },
                 // Unsupported, fall back to the safe default.
                 Some(_) => Default::default(),
@@ -138,12 +141,16 @@ fn expand_legacy_spans(
         })
         .collect();
 
-    // In the legacy standalone span pipeline we always
-    // inferred both IPs and user agents. If this function
-    // is ever applied to transactions, we may need to rethink this.
     let settings = Settings {
+        // In the legacy standalone span pipeline we always
+        // inferred both IPs and user agents. If this function
+        // is ever applied to transactions, we may need to rethink this.
         infer_ip: true,
         infer_user_agent: true,
+        // We want to infer names during processing for legacy spans.
+        // The inference can't happen during the conversion
+        // because PII scrubbing needs to run first.
+        infer_name: true,
     };
 
     (settings, spans)
@@ -264,22 +271,29 @@ fn normalize_span(
 /// It also takes care of trimming and schema validation because those procedures need
 /// to also run for derived fields.
 pub fn normalize_derived(spans: &mut Managed<ExpandedSpans>, ctx: Context<'_>) {
+    let settings = spans.settings;
     spans.retain_with_context(
         |spans| (&mut spans.spans, &()),
         |span, _, _| {
-            normalize_span_derived(&mut span.span, ctx).inspect_err(|err| {
+            normalize_span_derived(&mut span.span, settings, ctx).inspect_err(|err| {
                 relay_log::debug!("failed to normalize span: {err}");
             })
         },
     );
 }
 
-fn normalize_span_derived(span: &mut Annotated<SpanV2>, ctx: Context<'_>) -> Result<()> {
+fn normalize_span_derived(
+    span: &mut Annotated<SpanV2>,
+    settings: Settings,
+    ctx: Context<'_>,
+) -> Result<()> {
     if let Some(span) = span.value_mut() {
         // The order of operations shouldn't matter here—we should never _actually_
         // need to synthesize both the name and description. If the span was sent as
         // V2 it should have a name and if it was sent as V1 it should have a description.
-        eap::normalize_span_name(span);
+        if settings.infer_name {
+            eap::normalize_span_name(span);
+        }
         eap::normalize_sentry_description(&mut span.attributes, &span.name);
     }
 

--- a/relay-server/src/processing/transactions/spans.rs
+++ b/relay-server/src/processing/transactions/spans.rs
@@ -113,7 +113,7 @@ fn make_span_item(
         })
         .map_err(|_| ())?;
 
-    Ok(span.map_value(relay_spans::span_v1_to_span_v2))
+    Ok(span.map_value(relay_spans::span_v1_to_span_v2_with_name_inference))
 }
 
 /// Any violation of the span schema.

--- a/relay-server/src/processing/transactions/spans.rs
+++ b/relay-server/src/processing/transactions/spans.rs
@@ -113,7 +113,9 @@ fn make_span_item(
         })
         .map_err(|_| ())?;
 
-    Ok(span.map_value(relay_spans::span_v1_to_span_v2_with_name_inference))
+    // It's ok to enable `infer_name` here—the span has gone through the transaction pipeline,
+    // so PII has been scrubbed.
+    Ok(span.map_value(|span| relay_spans::span_v1_to_span_v2(span, true)))
 }
 
 /// Any violation of the span schema.

--- a/relay-spans/src/lib.rs
+++ b/relay-spans/src/lib.rs
@@ -9,7 +9,7 @@
 pub use crate::description::derive_description_for_v2_span;
 pub use crate::op::derive_op_for_v2_span;
 pub use crate::otel_to_sentry_v2::otel_to_sentry_span as otel_to_sentry_span_v2;
-pub use crate::v1_to_v2::span_v1_to_span_v2;
+pub use crate::v1_to_v2::{span_v1_to_span_v2, span_v1_to_span_v2_with_name_inference};
 
 pub use opentelemetry_proto::tonic::trace::v1 as otel_trace;
 

--- a/relay-spans/src/lib.rs
+++ b/relay-spans/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 
 pub use crate::description::derive_description_for_v2_span;
+pub use crate::name::name_for_attributes;
 pub use crate::op::derive_op_for_v2_span;
 pub use crate::otel_to_sentry_v2::otel_to_sentry_span as otel_to_sentry_span_v2;
 pub use crate::v1_to_v2::{span_v1_to_span_v2, span_v1_to_span_v2_with_name_inference};

--- a/relay-spans/src/lib.rs
+++ b/relay-spans/src/lib.rs
@@ -10,7 +10,7 @@ pub use crate::description::derive_description_for_v2_span;
 pub use crate::name::name_for_attributes;
 pub use crate::op::derive_op_for_v2_span;
 pub use crate::otel_to_sentry_v2::otel_to_sentry_span as otel_to_sentry_span_v2;
-pub use crate::v1_to_v2::{span_v1_to_span_v2, span_v1_to_span_v2_with_name_inference};
+pub use crate::v1_to_v2::span_v1_to_span_v2;
 
 pub use opentelemetry_proto::tonic::trace::v1 as otel_trace;
 

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -9,12 +9,27 @@ use relay_protocol::{Annotated, Empty, Error, IntoValue, Meta, Value};
 
 use crate::name::name_for_attributes;
 
+/// Like [`span_v1_to_span_v2`], but also infers a name for the span based on `sentry-conventions`.
+///
+/// Use this only if the source span has gone through PII scrubbing, otherwise the name
+/// might end up containing PII that doesn't get scrubbed later!
+pub fn span_v1_to_span_v2_with_name_inference(span_v1: SpanV1) -> SpanV2 {
+    let mut span_v2 = span_v1_to_span_v2(span_v1);
+
+    if span_v2.name.value().is_none() {
+        span_v2.name =
+            name_for_attributes(span_v2.attributes.get_or_insert_with(Default::default)).into();
+    }
+
+    span_v2
+}
+
 /// Converts a legacy span to the new Span V2 schema.
 ///
 /// - `tags`, `sentry_tags`, `measurements` and `data` are transferred to `attributes`.
 /// - Nested `data` items are encoded as JSON.
 ///
-/// Measurements will be converted to attributes by looking up the
+/// Measurements are converted to attributes by looking up the
 /// replacement attribute's name in `sentry-conventions`.
 pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     let SpanV1 {
@@ -126,7 +141,7 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     let name = attributes
         .remove("sentry.name")
         .and_then(|name| name.map_value(|attr| attr.into_string()).transpose())
-        .unwrap_or_else(|| name_for_attributes(attributes).into());
+        .unwrap_or(Annotated::empty());
 
     if let Some(is_remote) = is_remote.value() {
         attributes.insert(SENTRY__IS_REMOTE, *is_remote);
@@ -347,8 +362,291 @@ mod tests {
         let span_v1 = SpanV1::from_value(json.into()).into_value().unwrap();
         let span_v2 = span_v1_to_span_v2(span_v1);
 
-        let annotated_span_v2: Annotated<SpanV2> = Annotated::new(span_v2);
-        insta::assert_json_snapshot!(SerializableAnnotated(&annotated_span_v2), @r#"
+        insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::new(span_v2)), @r#"
+        {
+          "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+          "parent_span_id": "fa90fdead5f74051",
+          "span_id": "fa90fdead5f74052",
+          "status": "ok",
+          "is_segment": true,
+          "start_timestamp": -63158400.0,
+          "end_timestamp": 0.0,
+          "links": [
+            {
+              "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+              "span_id": "fa90fdead5f74052",
+              "sampled": true,
+              "attributes": {
+                "boolAttr": {
+                  "type": "boolean",
+                  "value": true
+                },
+                "numAttr": {
+                  "type": "integer",
+                  "value": 123
+                },
+                "stringAttr": {
+                  "type": "string",
+                  "value": "foo"
+                }
+              }
+            }
+          ],
+          "attributes": {
+            "foo": {
+              "type": "string",
+              "value": "bar"
+            },
+            "memory": {
+              "type": "double",
+              "value": 9001.0
+            },
+            "my.array": {
+              "type": "string",
+              "value": "[\"str\",123]"
+            },
+            "my.data.field": {
+              "type": "string",
+              "value": "my.data.value"
+            },
+            "my.nested": {
+              "type": "string",
+              "value": "{\"numbers\":[1,2,3]}"
+            },
+            "sentry.client_sample_rate": {
+              "type": "double",
+              "value": 0.11
+            },
+            "sentry.description": {
+              "type": "string",
+              "value": "raw description"
+            },
+            "sentry.exclusive_time": {
+              "type": "double",
+              "value": 1.23
+            },
+            "sentry.is_remote": {
+              "type": "boolean",
+              "value": true
+            },
+            "sentry.kind": {
+              "type": "string",
+              "value": "server"
+            },
+            "sentry.normalized_description": {
+              "type": "string",
+              "value": "normalized description"
+            },
+            "sentry.op": {
+              "type": "string",
+              "value": "operation"
+            },
+            "sentry.origin": {
+              "type": "string",
+              "value": "auto.http"
+            },
+            "sentry.platform": {
+              "type": "string",
+              "value": "javascript"
+            },
+            "sentry.profile_id": {
+              "type": "string",
+              "value": "4c79f60c11214eb38604f4ae0781bfb0"
+            },
+            "sentry.segment.id": {
+              "type": "string",
+              "value": "fa90fdead5f74050"
+            },
+            "sentry.server_sample_rate": {
+              "type": "double",
+              "value": 0.22
+            },
+            "sentry.user": {
+              "type": "string",
+              "value": "id:user123"
+            },
+            "sentry.user.email": {
+              "type": "string",
+              "value": "john@example.com"
+            },
+            "sentry.user.geo.city": {
+              "type": "string",
+              "value": "Vienna"
+            },
+            "sentry.user.geo.country_code": {
+              "type": "string",
+              "value": "AT"
+            },
+            "sentry.user.geo.region": {
+              "type": "string",
+              "value": "Europe"
+            },
+            "sentry.user.geo.subdivision": {
+              "type": "string",
+              "value": "AT-9"
+            },
+            "sentry.user.geo.subregion": {
+              "type": "string",
+              "value": "155"
+            },
+            "sentry.user.id": {
+              "type": "string",
+              "value": "user123"
+            },
+            "sentry.user.ip": {
+              "type": "string",
+              "value": "127.0.0.1"
+            },
+            "sentry.user.username": {
+              "type": "string",
+              "value": "john"
+            },
+            "user.email": {
+              "type": "string",
+              "value": "john@example.com"
+            },
+            "user.geo.city": {
+              "type": "string",
+              "value": "Vienna"
+            },
+            "user.geo.country_code": {
+              "type": "string",
+              "value": "AT"
+            },
+            "user.geo.region": {
+              "type": "string",
+              "value": "Europe"
+            },
+            "user.geo.subdivision": {
+              "type": "string",
+              "value": "AT-9"
+            },
+            "user.id": {
+              "type": "string",
+              "value": "user123"
+            },
+            "user.ip_address": {
+              "type": "string",
+              "value": "127.0.0.1"
+            },
+            "user.name": {
+              "type": "string",
+              "value": "john"
+            }
+          },
+          "_meta": {
+            "attributes": {
+              "my.array": {
+                "": {
+                  "err": [
+                    [
+                      "invalid_data",
+                      {
+                        "reason": "expected scalar attribute"
+                      }
+                    ]
+                  ]
+                }
+              },
+              "my.nested": {
+                "": {
+                  "err": [
+                    [
+                      "invalid_data",
+                      {
+                        "reason": "expected scalar attribute"
+                      }
+                    ]
+                  ]
+                }
+              }
+            }
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn parse_with_name_inference() {
+        let json = serde_json::json!({
+          "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+          "parent_span_id": "fa90fdead5f74051",
+          "span_id": "fa90fdead5f74052",
+          "status": "ok",
+          "is_remote": true,
+          "kind": "server",
+          "start_timestamp": -63158400.0,
+          "timestamp": 0.0,
+          "links": [
+            {
+            "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+            "span_id": "fa90fdead5f74052",
+            "sampled": true,
+              "attributes": {
+                "boolAttr": true,
+                "numAttr": 123,
+                "stringAttr": "foo"
+              }
+            }
+          ],
+          "tags": {
+            "foo": "bar"
+          },
+          "measurements": {
+            "memory": {
+              "value": 9001.0,
+              "unit": "byte"
+            },
+            "client_sample_rate": {
+              "value": 0.11
+            },
+            "server_sample_rate": {
+              "value": 0.22
+            }
+          },
+          "data": {
+            "my.data.field": "my.data.value",
+            "my.array": ["str", 123],
+            "my.nested": {
+              "numbers": [
+                1,
+                2,
+                3
+              ]
+            }
+          },
+          "_performance_issues_spans": true,
+          "description": "raw description",
+          "exclusive_time": 1.23,
+          "is_segment": true,
+          "sentry_tags": {
+            "description": "normalized description",
+            "user": "id:user123",
+            "user.email": "john@example.com",
+            "user.geo.city": "Vienna",
+            "user.geo.country_code": "AT",
+            "user.geo.region": "Europe",
+            "user.geo.subdivision": "AT-9",
+            "user.geo.subregion": "155",
+            "user.id": "user123",
+            "user.ip": "127.0.0.1",
+            "user.username": "john",
+          },
+          "op": "operation",
+          "origin": "auto.http",
+          "platform": "javascript",
+          "profile_id": "4c79f60c11214eb38604f4ae0781bfb0",
+          "segment_id": "fa90fdead5f74050",
+          "was_transaction": true,
+
+          "received": 0.2,
+          "additional_field": "additional field value"
+        });
+
+        let span_v1 = SpanV1::from_value(json.into()).into_value().unwrap();
+        let span_v2 = span_v1_to_span_v2_with_name_inference(span_v1);
+
+        insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::new(span_v2)), @r#"
         {
           "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
           "parent_span_id": "fa90fdead5f74051",

--- a/relay-spans/src/v1_to_v2.rs
+++ b/relay-spans/src/v1_to_v2.rs
@@ -9,21 +9,6 @@ use relay_protocol::{Annotated, Empty, Error, IntoValue, Meta, Value};
 
 use crate::name::name_for_attributes;
 
-/// Like [`span_v1_to_span_v2`], but also infers a name for the span based on `sentry-conventions`.
-///
-/// Use this only if the source span has gone through PII scrubbing, otherwise the name
-/// might end up containing PII that doesn't get scrubbed later!
-pub fn span_v1_to_span_v2_with_name_inference(span_v1: SpanV1) -> SpanV2 {
-    let mut span_v2 = span_v1_to_span_v2(span_v1);
-
-    if span_v2.name.value().is_none() {
-        span_v2.name =
-            name_for_attributes(span_v2.attributes.get_or_insert_with(Default::default)).into();
-    }
-
-    span_v2
-}
-
 /// Converts a legacy span to the new Span V2 schema.
 ///
 /// - `tags`, `sentry_tags`, `measurements` and `data` are transferred to `attributes`.
@@ -31,7 +16,11 @@ pub fn span_v1_to_span_v2_with_name_inference(span_v1: SpanV1) -> SpanV2 {
 ///
 /// Measurements are converted to attributes by looking up the
 /// replacement attribute's name in `sentry-conventions`.
-pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
+///
+/// `infer_name` controls whether the span's name is inferred based on its attributes.
+/// Only enable it if the source span has gone through PII scrubbing, otherwise the name
+/// might end up containing PII that doesn't get scrubbed later!
+pub fn span_v1_to_span_v2(span_v1: SpanV1, infer_name: bool) -> SpanV2 {
     let SpanV1 {
         timestamp,
         start_timestamp,
@@ -141,6 +130,13 @@ pub fn span_v1_to_span_v2(span_v1: SpanV1) -> SpanV2 {
     let name = attributes
         .remove("sentry.name")
         .and_then(|name| name.map_value(|attr| attr.into_string()).transpose())
+        .or_else(|| {
+            if infer_name {
+                name_for_attributes(attributes).map(Annotated::new)
+            } else {
+                None
+            }
+        })
         .unwrap_or(Annotated::empty());
 
     if let Some(is_remote) = is_remote.value() {
@@ -360,7 +356,7 @@ mod tests {
         });
 
         let span_v1 = SpanV1::from_value(json.into()).into_value().unwrap();
-        let span_v2 = span_v1_to_span_v2(span_v1);
+        let span_v2 = span_v1_to_span_v2(span_v1, false);
 
         insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::new(span_v2)), @r#"
         {
@@ -644,7 +640,7 @@ mod tests {
         });
 
         let span_v1 = SpanV1::from_value(json.into()).into_value().unwrap();
-        let span_v2 = span_v1_to_span_v2_with_name_inference(span_v1);
+        let span_v2 = span_v1_to_span_v2(span_v1, true);
 
         insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::new(span_v2)), @r#"
         {
@@ -874,7 +870,7 @@ mod tests {
         }
         "###);
 
-        let span_v2 = span_v1_to_span_v2(span_v1);
+        let span_v2 = span_v1_to_span_v2(span_v1, false);
 
         // The `name` and the `sentry.segment.name` attribute are the same as the transaction.
         insta::assert_json_snapshot!(SerializableAnnotated(&Annotated::new(span_v2)), @r###"
@@ -904,7 +900,7 @@ mod tests {
     fn start_timestamp() {
         let json = r#"{"timestamp": 123, "end_timestamp": "invalid data"}"#;
         let span_v1 = Annotated::<SpanV1>::from_json(json).unwrap();
-        let span_v2 = span_v1_to_span_v2(span_v1.into_value().unwrap());
+        let span_v2 = span_v1_to_span_v2(span_v1.into_value().unwrap(), false);
 
         // Parsed version is still fine:
         assert_eq!(

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -1056,6 +1056,12 @@ def test_name_inference(
         project_config["config"].setdefault("features", []).append(
             "projects:span-v2-experimental-processing"
         )
+    project_config["config"]["piiConfig"]["applications"]["data.'http.route'"] = [
+        "@anything:mask"
+    ]
+    project_config["config"]["piiConfig"]["applications"][
+        "$span.attributes.'http.route'.value"
+    ] = ["@anything:mask"]
 
     relay = relay(relay_with_processing())
 
@@ -1063,18 +1069,15 @@ def test_name_inference(
 
     envelope = envelope_with_spans(
         {
+            # The combination of op, `http.request.method`, and
+            # `http.route` means this span has its name synthesized as
+            # `GET https://example.com`.
+            "op": "http.client",
             "data": {
-                "sentry.op": "ui.webvital.lcp",
-                "release": "frontend@488531b11e6401fa530ac25554d44426e6ef0f0b",
-                "environment": "prod",
-                "replay_id": "3d76a6311de149b9b3f560827ea0ecf9",
-                "transaction": "/insights/projects/",
-                "sentry.exclusive_time": 0,
-                "sentry.pageload.span_id": "8a6626cc9bdd5d9b",
-                "sentry.report_event": "navigation",
+                "http.request.method": "GET",
+                "http.route": "https://example.com",
             },
             "description": "Test span",
-            "op": "ui.webvital.lcp",
             "parent_span_id": "8a6626cc9bdd5d9b",
             "span_id": "9fd17741416e8e4e",
             "start_timestamp": ts.timestamp() - 0.5,
@@ -1084,6 +1087,7 @@ def test_name_inference(
             "exclusive_time": 0,
             "measurements": {},
             "segment_id": "8a6626cc9bdd5d9b",
+            "is_segment": False,
         },
         trace_info={
             "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
@@ -1097,15 +1101,60 @@ def test_name_inference(
     attributes, fields = lcp_cls_inp_differences(mode)
 
     # If the span's origin is "manual", the name should be the same as the description.
-    # Otherwise it should be backfilled according to conventions, which falls back to op.
-    expected_name = "ui.webvital.lcp"
+    # Otherwise it should be backfilled according to conventions, which includes
+    # a redacted attribute.
     if origin == "manual":
         expected_name = "Test span"
+    else:
+        expected_name = "GET *******************"
+
+    # _meta unfortunately differs slightly between the pipelines
+    if mode == "v2":
+        meta = {
+            "attributes": {
+                "http.route": {
+                    "value": {
+                        "": {
+                            "len": 19,
+                            "rem": [
+                                [
+                                    "@anything:mask",
+                                    "m",
+                                    0,
+                                    19,
+                                ],
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+    else:
+        meta = {
+            "attributes": {
+                "http.route": {
+                    "": {
+                        "len": 19,
+                        "rem": [
+                            [
+                                "@anything:mask",
+                                "m",
+                                0,
+                                19,
+                            ],
+                        ],
+                    },
+                },
+            }
+        }
 
     assert spans_consumer.get_span() == {
         "attributes": {
             "client.address": {"type": "string", "value": "127.0.0.1"},
             "browser.name": {"type": "string", "value": "Firefox"},
+            "http.request.method": {"type": "string", "value": "GET"},
+            "http.route": {"type": "string", "value": "*******************"},
+            "sentry.category": {"type": "string", "value": "http"},
             "sentry.description": {"type": "string", "value": "Test span"},
             "sentry.dsc.transaction": {
                 "type": "string",
@@ -1116,26 +1165,21 @@ def test_name_inference(
                 "type": "string",
                 "value": "d3d20f000885466b8c8f947c9b92b8d3",
             },
-            "sentry.environment": {"type": "string", "value": "prod"},
             "sentry.exclusive_time": {"type": "double", "value": 0.0},
-            "sentry.op": {"type": "string", "value": "ui.webvital.lcp"},
+            "sentry.op": {"type": "string", "value": "http.client"},
             "sentry.origin": {"type": "string", "value": origin},
-            "sentry.pageload.span_id": {"type": "string", "value": "8a6626cc9bdd5d9b"},
-            "sentry.release": {
-                "type": "string",
-                "value": "frontend@488531b11e6401fa530ac25554d44426e6ef0f0b",
-            },
-            "sentry.replay_id": {
-                "type": "string",
-                "value": "3d76a6311de149b9b3f560827ea0ecf9",
-            },
-            "sentry.report_event": {"type": "string", "value": "navigation"},
-            "sentry.segment.name": {"type": "string", "value": "/insights/projects/"},
-            "sentry.transaction": {"type": "string", "value": "/insights/projects/"},
+            "sentry.segment.id": {"type": "string", "value": "8a6626cc9bdd5d9b"},
             "user_agent.original": {
                 "type": "string",
                 "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
             },
+            **_if_dict(
+                mode == "v2",
+                {
+                    # The V2 pipeline backfills `sentry.action` from `http.method`.
+                    "sentry.action": {"type": "string", "value": "GET"}
+                },
+            ),
             **attributes,
         },
         "downsampled_retention_days": 90,
@@ -1151,6 +1195,9 @@ def test_name_inference(
         "start_timestamp": time_within(ts.timestamp() - 0.5),
         "status": "ok",
         "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+        "is_segment": False,
+        "parent_span_id": "8a6626cc9bdd5d9b",
+        "_meta": meta,
         **fields,
     }
 


### PR DESCRIPTION
When inferring names for V1 spans, PII has to be taken into account. This means that unconditionally inferring names during V1 -> V2 conversion, as we do now, is unsafe—it's fine for spans that have gone through PII scrubbing (to wit, standalone spans that have gone through the legacy pipeline, as well as spans extracted from transactions), but for standalone spans we have to do it later.

This addresses the problem in the following ways:
* It adds a flag to `span_v1_to_span_v2` for whether to infer a name.
* It adds an `infer_name` flag to span processing settings, controlling whether names should be inferred in the pipeline. This is disabled for V2 spans but enabled for legacy spans.

With this PR, name inference is now PII-safe in all cases:
* transaction spans go through the transaction pipeline, are scrubbed, and have the name inferred at the very end during conversion;
* the same for standalone spans in the legacy pipeline;
* standalone spans in the V2 pipeline go through V2 scrubbing and have their name inferred after that;
* V2 spans never have a name inferred.

Closes INGEST-957.