### PR TITLE
ref(spans): Gate description inference behind boolean flag

### DIFF
--- a/relay-server/src/processing/spans/integrations/mod.rs
+++ b/relay-server/src/processing/spans/integrations/mod.rs
@@ -50,7 +50,15 @@ pub fn expand(
         }
     }
 
-    (Settings::default(), result)
+    let settings = Settings {
+        infer_ip: false,
+        infer_user_agent: false,
+        infer_name: false,
+        // OTEL spans don't usually have a description, we want to infer it.
+        infer_description: true,
+    };
+
+    (settings, result)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -385,6 +385,11 @@ struct Settings {
     /// for the benefit of standalone spans which need to have a name inferred
     /// after conversion to V2.
     infer_name: bool,
+    /// Whether the description should be inferred.
+    ///
+    /// This should only be enabled for V2 (and OTEL) spans sent by SDKs. V1
+    /// spans should already have a description.
+    infer_description: bool,
 }
 
 /// Spans which have been parsed and expanded from their serialized state.

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -98,14 +98,21 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
         .into_parts();
 
     relay_log::trace!("span container metadata: {metadata:?}");
+
+    // By default, we only want to infer descriptions for V2 spans.
+    let default_settings = Settings {
+        infer_description: true,
+        ..Default::default()
+    };
+
     let settings = metadata
         .map(|metadata| {
             let is = metadata.ingest_settings.as_ref();
 
             match metadata.version {
-                None => Settings::default(),
+                None => default_settings,
                 // Technically invalid.
-                Some(0 | 1) => Settings::default(),
+                Some(0 | 1) => default_settings,
                 Some(2) => Settings {
                     infer_ip: is
                         .and_then(|is| is.infer_ip)
@@ -120,10 +127,10 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
                     infer_description: true,
                 },
                 // Unsupported, fall back to the safe default.
-                Some(_) => Default::default(),
+                Some(_) => default_settings,
             }
         })
-        .unwrap_or_default();
+        .unwrap_or(default_settings);
 
     Ok((settings, spans))
 }

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -116,6 +116,8 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
                     // We don't want to infer names for V2 spans. If an SDK sent a
                     // V2 span without a name it's just invalid.
                     infer_name: false,
+                    // We want to infer descriptions for V2 spans.
+                    infer_description: true,
                 },
                 // Unsupported, fall back to the safe default.
                 Some(_) => Default::default(),
@@ -151,6 +153,9 @@ fn expand_legacy_spans(
         // The inference can't happen during the conversion
         // because PII scrubbing needs to run first.
         infer_name: true,
+        // We don't want to infer descriptions for legacy spans; they
+        // should already have one.
+        infer_description: false,
     };
 
     (settings, spans)
@@ -294,7 +299,10 @@ fn normalize_span_derived(
         if settings.infer_name {
             eap::normalize_span_name(span);
         }
-        eap::normalize_sentry_description(&mut span.attributes, &span.name);
+
+        if settings.infer_description {
+            eap::normalize_sentry_description(&mut span.attributes, &span.name);
+        }
     }
 
     // Set a max_bytes value on the root state if it's defined in the project config.


### PR DESCRIPTION
Small follow-up to #6112. That PR introduced a flag for name inference; this one does the same for description inference. It's not strictly speaking necessary because nothing goes wrong if we run the inference unnecessarily (it never overwrites existing descriptions), but I like it for symmetry and clarity.