### PR TITLE
feat(build): Switch to docker hardened image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Switches the container base image from distroless to docker hardened. ([#6117](https://github.com/getsentry/relay/pull/6117))
 - Infer span descriptions via `sentry-conventions`. ([#6093](https://github.com/getsentry/relay/pull/6093))
 - Raises the size limit for the flags context to 64KiB. ([#6137](https://github.com/getsentry/relay/pull/6137))
 - Add segment_names field to Replay events. ([#6134](https://github.com/getsentry/relay/pull/6134))

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,16 +1,16 @@
-FROM gcr.io/distroless/cc-debian13:debug AS builder
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/static:20250419-glibc-debian13 AS builder
 
-RUN ["/busybox/busybox", "mkdir", "/work", "/etc/relay"]
-
-
-FROM gcr.io/distroless/cc-debian13:nonroot
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/static:20250419-glibc-debian13
 
 ARG TARGETPLATFORM
 
 EXPOSE 3000
 
-COPY --from=builder --chown=nonroot:nonroot /etc/relay /etc/relay
-COPY --from=builder --chown=nonroot:nonroot /work /work
+# The base image does not have a shell available, which means we cannot
+# `mkdir` the volume directories. As an alternative we can use the empty
+# home directory instead.
+COPY --from=builder --chown=nonroot:nonroot /home/nonroot /etc/relay
+COPY --from=builder --chown=nonroot:nonroot /home/nonroot /work
 
 VOLUME ["/etc/relay", "/work"]
 WORKDIR /work


### PR DESCRIPTION
See: https://github.com/getsentry/rfcs/pull/157 ([Rendered](https://github.com/getsentry/rfcs/blob/rfc/distroless-base-images/text/0157-distroless-base-images.md))

Switches from distroless to dhi. This is now possible because we no longer link against `libstdc++` since `relay-crash` is gone.

```
└─ % llvm-readelf --needed-libs relay
NeededLibraries [
  ld-linux-x86-64.so.2
  libc.so.6
  libgcc_s.so.1
  libm.so.6
]
```

Another nice upside - ~13 MiB smaller:

```
REPOSITORY                TAG                                        IMAGE ID       CREATED          SIZE
ghcr.io/getsentry/relay   52824874f1c376153f43c04cb4924f63305ca489   9c24a95c0bda   22 minutes ago   83.8MB
ghcr.io/getsentry/relay   8421d6859682657eaa8cc183166cbf6e568eebd1   2529bda2f319   4 hours ago      96.4MB
```