### PR TITLE
ref(conventions): Update PII terms

### DIFF
--- a/relay-conventions/build/attributes.rs
+++ b/relay-conventions/build/attributes.rs
@@ -19,17 +19,17 @@ static KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         .unwrap()
 });
 
-/// Whether an attribute can contain PII.
+/// Whether an attribute should be scrubbed.
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "key")]
-pub enum Pii {
-    /// The field will be stripped by default
-    True,
-    /// The field will only be stripped when addressed with a specific path selector, but generic
+pub enum ApplyScrubbing {
+    /// The attribute will be stripped by default.
+    Auto,
+    /// The attribute will only be stripped when addressed with a specific path selector, but generic
     /// selectors such as `$string` do not apply.
-    Maybe,
-    /// The field cannot be stripped at all
-    False,
+    Manual,
+    /// The attribute cannot be stripped at all.
+    Never,
 }
 
 /// How to handle an attribute's deprecation.
@@ -61,8 +61,8 @@ pub struct Attribute {
     pub key: String,
     /// Short description of the attribute.
     pub brief: String,
-    /// Whether the attribute can contain PII.
-    pub pii: Pii,
+    /// Whether the attribute should be scrubbed.
+    pub apply_scrubbing: ApplyScrubbing,
     /// If the attribute is deprecated, this contains
     /// information on its replacement name and what should
     /// be done when the original name is encountered.
@@ -83,7 +83,7 @@ pub fn check_attribute(attribute: &Attribute) {
     let Attribute {
         key,
         brief: _,
-        pii: _,
+        apply_scrubbing: _,
         deprecation,
         alias: _,
     } = attribute;
@@ -134,7 +134,7 @@ pub fn format_attribute_info(attr: &Attribute) -> String {
     let Attribute {
         key: _,
         brief: _,
-        pii,
+        apply_scrubbing,
         deprecation,
         alias,
     } = attr;
@@ -144,7 +144,7 @@ pub fn format_attribute_info(attr: &Attribute) -> String {
     format!(
         "AttributeInfo {{
             write_behavior: {write_behavior},
-            pii: Pii::{pii:?},
+            apply_scrubbing: ApplyScrubbing::{apply_scrubbing:?},
             aliases: &{alias:?},
         }}"
     )
@@ -155,7 +155,7 @@ pub fn format_constant(attr: &Attribute) -> String {
     let Attribute {
         key,
         brief,
-        pii,
+        apply_scrubbing,
         deprecation,
         alias,
     } = attr;
@@ -177,7 +177,7 @@ pub fn format_constant(attr: &Attribute) -> String {
         writeln!(&mut out).unwrap();
     }
 
-    writeln!(&mut out, "/// * PII: {pii:?}").unwrap();
+    writeln!(&mut out, "/// * Scrubbing: {apply_scrubbing:?}").unwrap();
     writeln!(
         &mut out,
         "/// * Rewriting behavior: {}",
@@ -214,7 +214,7 @@ pub fn format_interpolating_fn(attribute: &Attribute) -> Option<String> {
     let Attribute {
         key,
         brief: _,
-        pii: _,
+        apply_scrubbing: _,
         deprecation,
         alias: _,
     } = attribute;
@@ -300,7 +300,7 @@ pub fn constant_pair(attribute: &Attribute) -> Option<(String, String)> {
     let Attribute {
         key,
         brief: _,
-        pii: _,
+        apply_scrubbing: _,
         deprecation,
         alias: _,
     } = attribute;

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -93,16 +93,16 @@ include!(concat!(env!("OUT_DIR"), "/attribute_map.rs"));
 include!(concat!(env!("OUT_DIR"), "/canonical_fn.rs"));
 include!(concat!(env!("OUT_DIR"), "/measurement_replacement_fn.rs"));
 
-/// Whether an attribute should be PII-strippable/should be subject to datascrubbers
+/// Whether an attribute should be scrubbed.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Pii {
-    /// The field will be stripped by default
-    True,
-    /// The field cannot be stripped at all
-    False,
-    /// The field will only be stripped when addressed with a specific path selector, but generic
+pub enum ApplyScrubbing {
+    /// The attribute will be stripped by default.
+    Auto,
+    /// The attribute will only be stripped when addressed with a specific path selector, but generic
     /// selectors such as `$string` do not apply.
-    Maybe,
+    Manual,
+    /// The attribute cannot be stripped at all.
+    Never,
 }
 
 /// The name of the replacement of a deprecated attribute.
@@ -148,7 +148,7 @@ pub struct AttributeInfo {
     /// How this attribute should be saved.
     pub write_behavior: WriteBehavior,
     /// Whether this attribute can contain PII.
-    pub pii: Pii,
+    pub apply_scrubbing: ApplyScrubbing,
     /// Other attribute names that alias to this attribute.
     pub aliases: &'static [&'static str],
 }
@@ -219,20 +219,20 @@ mod tests {
     fn test_http_response_content_length() {
         let info = attribute_info("http.response_content_length").unwrap();
 
-        insta::assert_debug_snapshot!(info, @r###"
+        insta::assert_debug_snapshot!(info, @r#"
         AttributeInfo {
             write_behavior: BothNames(
                 Static(
                     "http.response.body.size",
                 ),
             ),
-            pii: Maybe,
+            apply_scrubbing: Manual,
             aliases: [
                 "http.response.body.size",
                 "http.response.header.content-length",
             ],
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -241,15 +241,15 @@ mod tests {
         let (info, fragment) = attribute_info_with_fragment("url.path.parameter.'id=123'").unwrap();
         assert_eq!(fragment, Some("'id=123'"));
 
-        insta::assert_debug_snapshot!(info, @r###"
+        insta::assert_debug_snapshot!(info, @r#"
         AttributeInfo {
             write_behavior: CurrentName,
-            pii: True,
+            apply_scrubbing: Auto,
             aliases: [
                 "params.<key>",
             ],
         }
-        "###);
+        "#);
     }
 
     /// Tests that `cls.source.<key>` is rewritten to `browser.web_vital.cls.source.<key>`.

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -1435,13 +1435,13 @@ mod tests {
         }
 
         fn mock_attribute_info(name: &str) -> Option<(&'static AttributeInfo, Option<&str>)> {
-            use relay_conventions::Pii;
+            use relay_conventions::ApplyScrubbing;
 
             match name {
                 "replace.empty" => Some((
                     &AttributeInfo {
                         write_behavior: WriteBehavior::NewName(ReplacementName::Static("replaced")),
-                        pii: Pii::Maybe,
+                        apply_scrubbing: ApplyScrubbing::Manual,
                         aliases: &["replaced"],
                     },
                     None,
@@ -1451,7 +1451,7 @@ mod tests {
                         write_behavior: WriteBehavior::NewName(ReplacementName::Static(
                             "not.replaced",
                         )),
-                        pii: Pii::Maybe,
+                        apply_scrubbing: ApplyScrubbing::Manual,
                         aliases: &["not.replaced"],
                     },
                     None,
@@ -1461,7 +1461,7 @@ mod tests {
                         write_behavior: WriteBehavior::BothNames(ReplacementName::Static(
                             "backfilled",
                         )),
-                        pii: Pii::Maybe,
+                        apply_scrubbing: ApplyScrubbing::Manual,
                         aliases: &["backfilled"],
                     },
                     None,
@@ -1471,7 +1471,7 @@ mod tests {
                         write_behavior: WriteBehavior::BothNames(ReplacementName::Static(
                             "not.backfilled",
                         )),
-                        pii: Pii::Maybe,
+                        apply_scrubbing: ApplyScrubbing::Manual,
                         aliases: &["not.backfilled"],
                     },
                     None,
@@ -1481,7 +1481,7 @@ mod tests {
                         write_behavior: WriteBehavior::NewName(ReplacementName::Dynamic(
                             replace_key,
                         )),
-                        pii: Pii::Maybe,
+                        apply_scrubbing: ApplyScrubbing::Manual,
                         aliases: &["placeholder.replaced.<key>"],
                     },
                     Some(fragment),
@@ -1491,7 +1491,7 @@ mod tests {
                         write_behavior: WriteBehavior::BothNames(ReplacementName::Dynamic(
                             backfill_key,
                         )),
-                        pii: Pii::Maybe,
+                        apply_scrubbing: ApplyScrubbing::Manual,
                         aliases: &["placeholder.backfilled.<key>"],
                     },
                     Some(fragment),

--- a/relay-event-schema/src/protocol/attributes.rs
+++ b/relay-event-schema/src/protocol/attributes.rs
@@ -123,10 +123,10 @@ pub fn attribute_pii_from_conventions(state: &ProcessingState) -> Pii {
             continue;
         };
 
-        return match info.pii {
-            relay_conventions::Pii::True => Pii::True,
-            relay_conventions::Pii::False => Pii::False,
-            relay_conventions::Pii::Maybe => Pii::Maybe,
+        return match info.apply_scrubbing {
+            relay_conventions::ApplyScrubbing::Auto => Pii::True,
+            relay_conventions::ApplyScrubbing::Never => Pii::False,
+            relay_conventions::ApplyScrubbing::Manual => Pii::Maybe,
         };
     }
 

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -450,10 +450,10 @@ fn span_data_pii_from_conventions(state: &ProcessingState) -> Pii {
         // path, i.e. the field name.
         let key = state.keys().next()?;
 
-        match relay_conventions::attribute_info(key)?.pii {
-            relay_conventions::Pii::True => Some(Pii::True),
-            relay_conventions::Pii::False => Some(Pii::False),
-            relay_conventions::Pii::Maybe => Some(Pii::Maybe),
+        match relay_conventions::attribute_info(key)?.apply_scrubbing {
+            relay_conventions::ApplyScrubbing::Auto => Some(Pii::True),
+            relay_conventions::ApplyScrubbing::Never => Some(Pii::False),
+            relay_conventions::ApplyScrubbing::Manual => Some(Pii::Maybe),
         }
     }
 


### PR DESCRIPTION
This updates `sentry-conventions` to https://github.com/getsentry/sentry-conventions/pull/426, in which the `pii` field is renamed to `apply_scrubbing` and the possible values are renamed from `false`, `maybe`, `true` to `never`, `manual`, `auto`, respectively.

The change is purely internal, and Relay's own PII definitions are unchanged.