### PR TITLE
feat(upload): Pass upstream descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update sentry-conventions to 0.12.0.
 - Upgrade release image to Debian 13. ([#6110](https://github.com/getsentry/relay/pull/6110))
 - Prefix upload location query params for forward compatibility. ([#6076](https://github.com/getsentry/relay/pull/6076))
+- Use upstream descriptor in upload requests. ([#6128](https://github.com/getsentry/relay/pull/6128))
 
 ## 26.6.0
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -8,9 +8,9 @@ use bytes::Bytes;
 use chrono::Utc;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
-use relay_config::{Config, RelayMode, UpstreamDescriptor};
+use relay_config::{Config, RelayMode};
 use relay_event_schema::protocol::{EventId, EventType};
-use relay_quotas::{DataCategory, RateLimits, Scoping};
+use relay_quotas::{DataCategory, RateLimits};
 use relay_statsd::metric;
 use relay_system::Addr;
 use serde::Deserialize;
@@ -24,7 +24,7 @@ use crate::service::ServiceState;
 use crate::services::buffer::{ProjectKeyPair, PushError};
 use crate::services::outcome::{DiscardItemType, DiscardReason, Outcome};
 use crate::services::processor::{BucketSource, MetricData, ProcessMetrics};
-use crate::services::upload::{Create, Stream, Upload};
+use crate::services::upload::{Create, ProjectContext, Stream, Upload};
 use crate::statsd::{RelayCounters, RelayDistributions};
 use crate::utils::{
     self, ApiErrorResponse, BoundedStream, FormDataIter, MeteredStream, find_error_source,
@@ -545,13 +545,6 @@ fn emit_envelope_metrics(envelope: &Envelope) {
     }
 }
 
-/// Combines scoping and upstream information.
-#[derive(Clone)]
-pub struct ProjectContext {
-    pub scoping: Scoping,
-    pub upstream: Option<UpstreamDescriptor>,
-}
-
 /// Uploads the content of `field` to the objectstore and returns an [Item] with an
 /// [AttachmentPlaceholder] as payload.
 pub async fn upload_to_objectstore<S, E>(
@@ -601,12 +594,9 @@ where
     let stream = BoundedStream::new(stream, 1, config.max_upload_size());
     let byte_counter = stream.byte_counter();
 
-    let ProjectContext { scoping, upstream } = project;
-
     let location = upload
         .send(Create {
-            scoping,
-            upstream: upstream.clone(),
+            project: project.clone(),
             length: None,
             attachment_type: item.attachment_type(),
         })
@@ -614,11 +604,12 @@ where
         .ok()?
         .ok()?;
 
+    let scoping = project.scoping;
+
     let result = upload
         .send(Stream {
             received: Utc::now(),
-            scoping,
-            upstream,
+            project,
             location,
             stream,
         })

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use futures::TryStreamExt;
 use futures::stream::BoxStream;
-use relay_config::{Config, RelayMode};
+use relay_config::{Config, RelayMode, UpstreamDescriptor};
 use relay_event_schema::protocol::{EventId, EventType};
 use relay_quotas::{DataCategory, RateLimits, Scoping};
 use relay_statsd::metric;
@@ -553,6 +553,7 @@ pub async fn upload_to_objectstore<S, E>(
     mut item: Managed<Item>,
     config: &Config,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     upload: &Addr<Upload>,
     referrer: &'static str,
 ) -> Result<Managed<Item>, Rejected<()>>
@@ -566,6 +567,7 @@ where
         &mut item,
         config,
         scoping,
+        upstream,
         upload,
         referrer,
     )
@@ -582,6 +584,7 @@ async fn upload_to_objectstore_inner<S, E>(
     item: &mut Managed<Item>,
     config: &Config,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     upload: &Addr<Upload>,
     referrer: &'static str,
 ) -> Option<()>
@@ -597,6 +600,7 @@ where
     let location = upload
         .send(Create {
             scoping,
+            upstream: upstream.clone(),
             length: None,
             attachment_type: item.attachment_type(),
         })
@@ -608,6 +612,7 @@ where
         .send(Stream {
             received: Utc::now(),
             scoping,
+            upstream,
             location,
             stream,
         })

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -545,6 +545,13 @@ fn emit_envelope_metrics(envelope: &Envelope) {
     }
 }
 
+/// Combines scoping and upstream information.
+#[derive(Clone)]
+pub struct ProjectContext {
+    pub scoping: Scoping,
+    pub upstream: Option<UpstreamDescriptor>,
+}
+
 /// Uploads the content of `field` to the objectstore and returns an [Item] with an
 /// [AttachmentPlaceholder] as payload.
 pub async fn upload_to_objectstore<S, E>(
@@ -552,8 +559,7 @@ pub async fn upload_to_objectstore<S, E>(
     content_type: Option<String>,
     mut item: Managed<Item>,
     config: &Config,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     upload: &Addr<Upload>,
     referrer: &'static str,
 ) -> Result<Managed<Item>, Rejected<()>>
@@ -566,8 +572,7 @@ where
         content_type,
         &mut item,
         config,
-        scoping,
-        upstream,
+        project,
         upload,
         referrer,
     )
@@ -583,8 +588,7 @@ async fn upload_to_objectstore_inner<S, E>(
     content_type: Option<String>,
     item: &mut Managed<Item>,
     config: &Config,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     upload: &Addr<Upload>,
     referrer: &'static str,
 ) -> Option<()>
@@ -596,6 +600,8 @@ where
     let stream = MeteredStream::new(stream, referrer);
     let stream = BoundedStream::new(stream, 1, config.max_upload_size());
     let byte_counter = stream.byte_counter();
+
+    let ProjectContext { scoping, upstream } = project;
 
     let location = upload
         .send(Create {

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -8,7 +8,7 @@ use flate2::read::GzDecoder;
 use futures::{self, Stream};
 use liblzma::read::XzDecoder;
 use multer::{Field, Multipart};
-use relay_config::Config;
+use relay_config::{Config, UpstreamDescriptor};
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;
 use relay_quotas::{DataCategory, RateLimits, Scoping};
@@ -227,6 +227,7 @@ enum UploadDecision {
 struct UploadContext<'a> {
     upload: &'a Addr<Upload>,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     upload_attachments: UploadDecision,
     upload_minidumps: UploadDecision,
 }
@@ -279,6 +280,7 @@ impl<'a> AttachmentStrategy for MinidumpAttachmentStrategy<'a> {
                     item,
                     config,
                     upload_context.scoping,
+                    upload_context.upstream.clone(),
                     upload_context.upload,
                     "minidump",
                 )
@@ -322,6 +324,7 @@ pub async fn upload_to_objectstore_checked<S, E>(
     item: Managed<Item>,
     config: &Config,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     upload: &Addr<Upload>,
     referrer: &'static str,
 ) -> Result<Managed<Item>, BadStoreRequest>
@@ -336,6 +339,7 @@ where
             item,
             config,
             scoping,
+            upstream,
             upload,
             referrer,
         )
@@ -357,6 +361,7 @@ where
         item,
         config,
         scoping,
+        upstream,
         upload,
         referrer,
     )
@@ -484,6 +489,7 @@ async fn upload_context<'a>(
     Ok(Some(UploadContext {
         upload: state.upload(),
         scoping,
+        upstream: project_config.upstream.clone(),
         upload_attachments,
         upload_minidumps,
     }))
@@ -518,6 +524,7 @@ async fn raw_minidump_to_item(
             item,
             state.config(),
             upload_context.scoping,
+            upload_context.upstream.clone(),
             upload_context.upload,
             "minidump",
         )

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -22,9 +22,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT};
-use crate::endpoints::common::{
-    self, BadStoreRequest, ProjectContext, TextResponse, upload_to_objectstore,
-};
+use crate::endpoints::common::{self, BadStoreRequest, TextResponse, upload_to_objectstore};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType, Items};
 use crate::extractors::{RawContentType, RequestMeta};
 use crate::managed::{Managed, ManagedResult};
@@ -32,7 +30,7 @@ use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::{DiscardAttachmentType, DiscardItemType, DiscardReason, Outcome};
 use crate::services::projects::project::ProjectState;
-use crate::services::upload::Upload;
+use crate::services::upload::{ProjectContext, Upload};
 use crate::statsd::RelayCounters;
 use crate::utils::{self, AttachmentStrategy, read_bytes_into_item};
 

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -8,10 +8,10 @@ use flate2::read::GzDecoder;
 use futures::{self, Stream};
 use liblzma::read::XzDecoder;
 use multer::{Field, Multipart};
-use relay_config::{Config, UpstreamDescriptor};
+use relay_config::Config;
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;
-use relay_quotas::{DataCategory, RateLimits, Scoping};
+use relay_quotas::{DataCategory, RateLimits};
 use relay_system::Addr;
 use smallvec::smallvec;
 use std::convert::Infallible;
@@ -22,7 +22,9 @@ use tower_http::limit::RequestBodyLimitLayer;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT};
-use crate::endpoints::common::{self, BadStoreRequest, TextResponse, upload_to_objectstore};
+use crate::endpoints::common::{
+    self, BadStoreRequest, ProjectContext, TextResponse, upload_to_objectstore,
+};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType, Items};
 use crate::extractors::{RawContentType, RequestMeta};
 use crate::managed::{Managed, ManagedResult};
@@ -226,8 +228,7 @@ enum UploadDecision {
 
 struct UploadContext<'a> {
     upload: &'a Addr<Upload>,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     upload_attachments: UploadDecision,
     upload_minidumps: UploadDecision,
 }
@@ -279,8 +280,7 @@ impl<'a> AttachmentStrategy for MinidumpAttachmentStrategy<'a> {
                     content_type,
                     item,
                     config,
-                    upload_context.scoping,
-                    upload_context.upstream.clone(),
+                    upload_context.project.clone(),
                     upload_context.upload,
                     "minidump",
                 )
@@ -323,8 +323,7 @@ pub async fn upload_to_objectstore_checked<S, E>(
     content_type: Option<String>,
     item: Managed<Item>,
     config: &Config,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     upload: &Addr<Upload>,
     referrer: &'static str,
 ) -> Result<Managed<Item>, BadStoreRequest>
@@ -338,8 +337,7 @@ where
             content_type,
             item,
             config,
-            scoping,
-            upstream,
+            project,
             upload,
             referrer,
         )
@@ -360,8 +358,7 @@ where
         content_type,
         item,
         config,
-        scoping,
-        upstream,
+        project,
         upload,
         referrer,
     )
@@ -488,8 +485,10 @@ async fn upload_context<'a>(
 
     Ok(Some(UploadContext {
         upload: state.upload(),
-        scoping,
-        upstream: project_config.upstream.clone(),
+        project: ProjectContext {
+            scoping,
+            upstream: project_config.upstream.clone(),
+        },
         upload_attachments,
         upload_minidumps,
     }))
@@ -523,8 +522,7 @@ async fn raw_minidump_to_item(
             Some(content_type.to_string()).filter(|s| !s.is_empty()),
             item,
             state.config(),
-            upload_context.scoping,
-            upload_context.upstream.clone(),
+            upload_context.project,
             upload_context.upload,
             "minidump",
         )

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -5,15 +5,15 @@ use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use multer::{Field, Multipart};
-use relay_config::{Config, UpstreamDescriptor};
+use relay_config::Config;
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;
-use relay_quotas::{DataCategory, Scoping};
+use relay_quotas::DataCategory;
 use relay_system::Addr;
 use serde::Serialize;
 use tower_http::limit::RequestBodyLimitLayer;
 
-use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
+use crate::endpoints::common::{self, BadStoreRequest, ProjectContext, TextResponse};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, Items};
 use crate::extractors::{RawContentType, RequestMeta};
 use crate::managed::{Managed, ManagedResult};
@@ -64,8 +64,7 @@ struct Parts {
 
 struct UploadContext<'a> {
     upload: &'a Addr<Upload>,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
 }
 
 /// Created an [UploadContext].
@@ -114,8 +113,10 @@ async fn upload_context<'a>(
     {
         true => Ok(Some(UploadContext {
             upload: state.upload(),
-            scoping,
-            upstream: project_config.upstream.clone(),
+            project: ProjectContext {
+                scoping,
+                upstream: project_config.upstream.clone(),
+            },
         })),
         false => Ok(None),
     }
@@ -151,8 +152,7 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
                     content_type,
                     item,
                     config,
-                    upload_context.scoping,
-                    upload_context.upstream.clone(),
+                    upload_context.project.clone(),
                     upload_context.upload,
                     "playstation",
                 )

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -5,7 +5,7 @@ use axum::extract::{DefaultBodyLimit, Request};
 use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use multer::{Field, Multipart};
-use relay_config::Config;
+use relay_config::{Config, UpstreamDescriptor};
 use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;
 use relay_quotas::{DataCategory, Scoping};
@@ -65,6 +65,7 @@ struct Parts {
 struct UploadContext<'a> {
     upload: &'a Addr<Upload>,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
 }
 
 /// Created an [UploadContext].
@@ -114,6 +115,7 @@ async fn upload_context<'a>(
         true => Ok(Some(UploadContext {
             upload: state.upload(),
             scoping,
+            upstream: project_config.upstream.clone(),
         })),
         false => Ok(None),
     }
@@ -150,6 +152,7 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
                     item,
                     config,
                     upload_context.scoping,
+                    upload_context.upstream.clone(),
                     upload_context.upload,
                     "playstation",
                 )

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -13,7 +13,7 @@ use relay_system::Addr;
 use serde::Serialize;
 use tower_http::limit::RequestBodyLimitLayer;
 
-use crate::endpoints::common::{self, BadStoreRequest, ProjectContext, TextResponse};
+use crate::endpoints::common::{self, BadStoreRequest, TextResponse};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, Items};
 use crate::extractors::{RawContentType, RequestMeta};
 use crate::managed::{Managed, ManagedResult};
@@ -21,7 +21,7 @@ use crate::middlewares;
 use crate::service::ServiceState;
 use crate::services::outcome::DiscardReason;
 use crate::services::projects::project::ProjectState;
-use crate::services::upload::Upload;
+use crate::services::upload::{ProjectContext, Upload};
 use crate::utils::{self, AttachmentStrategy};
 
 /// The extension of a prosperodump in the multipart form-data upload.

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -15,7 +15,7 @@ use axum::routing::{MethodRouter, patch, post};
 use chrono::Utc;
 use futures::StreamExt;
 use http::header;
-use relay_config::Config;
+use relay_config::{Config, UpstreamDescriptor};
 use relay_dynamic_config::Feature;
 use relay_quotas::Scoping;
 use relay_system::SendError;
@@ -30,6 +30,7 @@ use crate::service::ServiceState;
 #[cfg(feature = "processing")]
 use crate::services::objectstore;
 use crate::services::projects::cache::Project;
+use crate::services::projects::project::ProjectState;
 use crate::services::upload::{
     self, ByteStream, Final, LocationQueryParams, Provisional, SignedLocation, UploadLength,
 };
@@ -179,11 +180,17 @@ async fn handle_post(
         })?;
 
     relay_log::trace!("Checking request");
-    let scoping = validate_and_limit(&state, meta, &headers, project).await?;
+    let checked_upload = validate_and_limit(&state, meta, &headers, project).await?;
 
     // Unconditionally create the upload location:
     relay_log::trace!("Creating upload location");
-    let result = create(&state, scoping, &headers).await;
+    let result = create(
+        &state,
+        checked_upload.scoping,
+        checked_upload.upstream,
+        &headers,
+    )
+    .await;
     let location = result.inspect_err(|e| {
         relay_log::warn!(error = e as &dyn std::error::Error, "create failed");
     })?;
@@ -231,7 +238,7 @@ async fn handle_patch(
         })?;
 
     relay_log::trace!("Checking request");
-    let scoping = validate(&state, meta, project).await?;
+    let checked_upload = validate(&state, meta, project).await?;
 
     let stream = body
         .into_data_stream()
@@ -247,7 +254,14 @@ async fn handle_patch(
     let byte_counter = stream.byte_counter();
 
     relay_log::trace!("Uploading");
-    let result = upload(&state, scoping, location, stream).await;
+    let result = upload(
+        &state,
+        checked_upload.scoping,
+        checked_upload.upstream,
+        location,
+        stream,
+    )
+    .await;
     let location = result.inspect_err(|e| {
         relay_log::warn!(error = e as &dyn std::error::Error, "upload failed");
     })?;
@@ -298,12 +312,14 @@ fn check_kill_switch(state: &ServiceState) -> Result<(), StatusCode> {
 async fn create(
     state: &ServiceState,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     headers: &tus::Headers,
 ) -> Result<SignedLocation<Provisional>, Error> {
     let location = state
         .upload()
         .send(upload::Create {
             scoping,
+            upstream,
             length: headers.upload_length,
             attachment_type: headers.metadata.map(|m| m.attachment_type),
         })
@@ -315,6 +331,7 @@ async fn create(
 async fn upload(
     state: &ServiceState,
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     location: SignedLocation<Provisional>,
     stream: BoundedStream<MeteredStream<ByteStream>>,
 ) -> Result<SignedLocation<Final>, Error> {
@@ -323,12 +340,18 @@ async fn upload(
         .send(upload::Stream {
             received: Utc::now(),
             scoping,
+            upstream,
             location,
             stream,
         })
         .await??;
 
     Ok(location)
+}
+
+struct CheckedUpload {
+    scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
 }
 
 /// Check request by converting it into a pseudo-envelope.
@@ -340,7 +363,7 @@ async fn validate_and_limit(
     meta: RequestMeta,
     headers: &tus::Headers,
     project: Project<'_>,
-) -> Result<Scoping, BadStoreRequest> {
+) -> Result<CheckedUpload, BadStoreRequest> {
     let mut envelope = Envelope::from_request(None, meta);
     envelope.require_feature(Feature::UploadEndpoint);
     let mut item = Item::new(ItemType::Attachment);
@@ -367,8 +390,9 @@ async fn validate_and_limit(
 
     // We are not really processing an envelope here, only keep the updated scoping:
     let scoping = envelope.scoping();
+    let upstream = project_upstream(&project);
     envelope.accept(|x| x);
-    Ok(scoping)
+    Ok(CheckedUpload { scoping, upstream })
 }
 
 /// Returns the feature a project must have enabled to upload attachments with the given type.
@@ -383,7 +407,7 @@ async fn validate(
     state: &ServiceState,
     meta: RequestMeta,
     project: Project<'_>,
-) -> Result<Scoping, BadStoreRequest> {
+) -> Result<CheckedUpload, BadStoreRequest> {
     let mut envelope = Envelope::from_request(None, meta);
     envelope.require_feature(Feature::UploadEndpoint);
     let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
@@ -395,8 +419,16 @@ async fn validate(
 
     // We are not really processing an envelope here, only keep the updated scoping:
     let scoping = envelope.scoping();
+    let upstream = project_upstream(&project);
     envelope.accept(|x| x);
-    Ok(scoping)
+    Ok(CheckedUpload { scoping, upstream })
+}
+
+fn project_upstream(project: &Project<'_>) -> Option<UpstreamDescriptor> {
+    match project.state() {
+        ProjectState::Enabled(info) => info.upstream.clone(),
+        ProjectState::Dummy | ProjectState::Disabled | ProjectState::Pending => None,
+    }
 }
 
 fn is_hyper_user_error(error: &(dyn std::error::Error + 'static)) -> bool {

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -17,7 +17,6 @@ use futures::StreamExt;
 use http::header;
 use relay_config::{Config, UpstreamDescriptor};
 use relay_dynamic_config::Feature;
-use relay_quotas::Scoping;
 use relay_system::SendError;
 use tower_http::limit::RequestBodyLimitLayer;
 
@@ -32,7 +31,8 @@ use crate::services::objectstore;
 use crate::services::projects::cache::Project;
 use crate::services::projects::project::ProjectState;
 use crate::services::upload::{
-    self, ByteStream, Final, LocationQueryParams, Provisional, SignedLocation, UploadLength,
+    self, ByteStream, Final, LocationQueryParams, ProjectContext, Provisional, SignedLocation,
+    UploadLength,
 };
 use crate::services::upstream::UpstreamRequestError;
 use crate::statsd::RelayCounters;
@@ -180,11 +180,11 @@ async fn handle_post(
         })?;
 
     relay_log::trace!("Checking request");
-    let (scoping, upstream) = validate_and_limit(&state, meta, &headers, project).await?;
+    let project_context = validate_and_limit(&state, meta, &headers, project).await?;
 
     // Unconditionally create the upload location:
     relay_log::trace!("Creating upload location");
-    let result = create(&state, scoping, upstream, &headers).await;
+    let result = create(&state, project_context, &headers).await;
     let location = result.inspect_err(|e| {
         relay_log::warn!(error = e as &dyn std::error::Error, "create failed");
     })?;
@@ -232,7 +232,7 @@ async fn handle_patch(
         })?;
 
     relay_log::trace!("Checking request");
-    let (scoping, upstream) = validate(&state, meta, project).await?;
+    let project_context = validate(&state, meta, project).await?;
 
     let stream = body
         .into_data_stream()
@@ -248,7 +248,7 @@ async fn handle_patch(
     let byte_counter = stream.byte_counter();
 
     relay_log::trace!("Uploading");
-    let result = upload(&state, scoping, upstream, location, stream).await;
+    let result = upload(&state, project_context, location, stream).await;
     let location = result.inspect_err(|e| {
         relay_log::warn!(error = e as &dyn std::error::Error, "upload failed");
     })?;
@@ -298,15 +298,13 @@ fn check_kill_switch(state: &ServiceState) -> Result<(), StatusCode> {
 
 async fn create(
     state: &ServiceState,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     headers: &tus::Headers,
 ) -> Result<SignedLocation<Provisional>, Error> {
     let location = state
         .upload()
         .send(upload::Create {
-            scoping,
-            upstream,
+            project,
             length: headers.upload_length,
             attachment_type: headers.metadata.map(|m| m.attachment_type),
         })
@@ -317,8 +315,7 @@ async fn create(
 
 async fn upload(
     state: &ServiceState,
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     location: SignedLocation<Provisional>,
     stream: BoundedStream<MeteredStream<ByteStream>>,
 ) -> Result<SignedLocation<Final>, Error> {
@@ -326,8 +323,7 @@ async fn upload(
         .upload()
         .send(upload::Stream {
             received: Utc::now(),
-            scoping,
-            upstream,
+            project,
             location,
             stream,
         })
@@ -345,7 +341,7 @@ async fn validate_and_limit(
     meta: RequestMeta,
     headers: &tus::Headers,
     project: Project<'_>,
-) -> Result<(Scoping, Option<UpstreamDescriptor>), BadStoreRequest> {
+) -> Result<ProjectContext, BadStoreRequest> {
     let mut envelope = Envelope::from_request(None, meta);
     envelope.require_feature(Feature::UploadEndpoint);
     let mut item = Item::new(ItemType::Attachment);
@@ -374,7 +370,7 @@ async fn validate_and_limit(
     let scoping = envelope.scoping();
     let upstream = project_upstream(&project);
     envelope.accept(|x| x);
-    Ok((scoping, upstream))
+    Ok(ProjectContext { scoping, upstream })
 }
 
 /// Returns the feature a project must have enabled to upload attachments with the given type.
@@ -389,7 +385,7 @@ async fn validate(
     state: &ServiceState,
     meta: RequestMeta,
     project: Project<'_>,
-) -> Result<(Scoping, Option<UpstreamDescriptor>), BadStoreRequest> {
+) -> Result<ProjectContext, BadStoreRequest> {
     let mut envelope = Envelope::from_request(None, meta);
     envelope.require_feature(Feature::UploadEndpoint);
     let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
@@ -403,7 +399,7 @@ async fn validate(
     let scoping = envelope.scoping();
     let upstream = project_upstream(&project);
     envelope.accept(|x| x);
-    Ok((scoping, upstream))
+    Ok(ProjectContext { scoping, upstream })
 }
 
 fn project_upstream(project: &Project<'_>) -> Option<UpstreamDescriptor> {

--- a/relay-server/src/endpoints/upload.rs
+++ b/relay-server/src/endpoints/upload.rs
@@ -180,17 +180,11 @@ async fn handle_post(
         })?;
 
     relay_log::trace!("Checking request");
-    let checked_upload = validate_and_limit(&state, meta, &headers, project).await?;
+    let (scoping, upstream) = validate_and_limit(&state, meta, &headers, project).await?;
 
     // Unconditionally create the upload location:
     relay_log::trace!("Creating upload location");
-    let result = create(
-        &state,
-        checked_upload.scoping,
-        checked_upload.upstream,
-        &headers,
-    )
-    .await;
+    let result = create(&state, scoping, upstream, &headers).await;
     let location = result.inspect_err(|e| {
         relay_log::warn!(error = e as &dyn std::error::Error, "create failed");
     })?;
@@ -238,7 +232,7 @@ async fn handle_patch(
         })?;
 
     relay_log::trace!("Checking request");
-    let checked_upload = validate(&state, meta, project).await?;
+    let (scoping, upstream) = validate(&state, meta, project).await?;
 
     let stream = body
         .into_data_stream()
@@ -254,14 +248,7 @@ async fn handle_patch(
     let byte_counter = stream.byte_counter();
 
     relay_log::trace!("Uploading");
-    let result = upload(
-        &state,
-        checked_upload.scoping,
-        checked_upload.upstream,
-        location,
-        stream,
-    )
-    .await;
+    let result = upload(&state, scoping, upstream, location, stream).await;
     let location = result.inspect_err(|e| {
         relay_log::warn!(error = e as &dyn std::error::Error, "upload failed");
     })?;
@@ -349,11 +336,6 @@ async fn upload(
     Ok(location)
 }
 
-struct CheckedUpload {
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
-}
-
 /// Check request by converting it into a pseudo-envelope.
 ///
 /// This is currently the easiest way to guarantee that the upload gets checked the same way as
@@ -363,7 +345,7 @@ async fn validate_and_limit(
     meta: RequestMeta,
     headers: &tus::Headers,
     project: Project<'_>,
-) -> Result<CheckedUpload, BadStoreRequest> {
+) -> Result<(Scoping, Option<UpstreamDescriptor>), BadStoreRequest> {
     let mut envelope = Envelope::from_request(None, meta);
     envelope.require_feature(Feature::UploadEndpoint);
     let mut item = Item::new(ItemType::Attachment);
@@ -392,7 +374,7 @@ async fn validate_and_limit(
     let scoping = envelope.scoping();
     let upstream = project_upstream(&project);
     envelope.accept(|x| x);
-    Ok(CheckedUpload { scoping, upstream })
+    Ok((scoping, upstream))
 }
 
 /// Returns the feature a project must have enabled to upload attachments with the given type.
@@ -407,7 +389,7 @@ async fn validate(
     state: &ServiceState,
     meta: RequestMeta,
     project: Project<'_>,
-) -> Result<CheckedUpload, BadStoreRequest> {
+) -> Result<(Scoping, Option<UpstreamDescriptor>), BadStoreRequest> {
     let mut envelope = Envelope::from_request(None, meta);
     envelope.require_feature(Feature::UploadEndpoint);
     let mut envelope = Managed::from_envelope(envelope, state.outcome_aggregator().clone());
@@ -421,7 +403,7 @@ async fn validate(
     let scoping = envelope.scoping();
     let upstream = project_upstream(&project);
     envelope.accept(|x| x);
-    Ok(CheckedUpload { scoping, upstream })
+    Ok((scoping, upstream))
 }
 
 fn project_upstream(project: &Project<'_>) -> Option<UpstreamDescriptor> {

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -18,8 +18,7 @@ use relay_auth::SignatureError;
 #[cfg(feature = "processing")]
 use relay_auth::SignatureHeader;
 use relay_base_schema::project::ProjectId;
-use relay_config::Config;
-use relay_config::HttpEncoding;
+use relay_config::{Config, HttpEncoding, UpstreamDescriptor};
 use relay_quotas::Scoping;
 use relay_system::{
     Addr, AsyncResponse, ConcurrentService, FromMessage, Interface, LoadShed, SendError, Sender,
@@ -117,6 +116,8 @@ impl Interface for Upload {}
 pub struct Create {
     /// The project to create the upload for.
     pub scoping: Scoping,
+    /// Optional upstream override where the request will be sent to.
+    pub upstream: Option<UpstreamDescriptor>,
     /// The size of the intended upload in bytes, as specified in the `Upload-Length` header.
     ///
     /// Trusted clients (i.e. PoP Relays) are allowed to omit the length (see `Upload-Defer-Length: 1`).
@@ -134,6 +135,8 @@ pub struct Stream {
     pub received: DateTime<Utc>,
     /// The organization & project that the stream belongs to.
     pub scoping: Scoping,
+    /// Optional upstream override where the request will be sent to.
+    pub upstream: Option<UpstreamDescriptor>,
     /// The location to upload to.
     pub location: SignedLocation<Provisional>,
     /// The body to be uploaded to objectstore, with length validation.
@@ -252,13 +255,15 @@ impl Service {
         &self,
         Create {
             scoping,
+            upstream,
             length,
             attachment_type,
         }: Create,
     ) -> Result<SignedLocation<Provisional>, Error> {
         match &self.backend {
             Backend::Upstream { addr } => {
-                let (request, rx) = UploadRequest::create(scoping, length, attachment_type);
+                let (request, rx) =
+                    UploadRequest::create(scoping, upstream, length, attachment_type);
                 addr.send(SendRequest(request));
                 let response = rx.await??;
                 SignedLocation::try_from_response(response)
@@ -283,12 +288,14 @@ impl Service {
             #[cfg_attr(not(feature = "processing"), expect(unused))]
             received,
             scoping,
+            upstream,
             location,
             stream,
         } = stream;
         match &self.backend {
             Backend::Upstream { addr } => {
-                let (request, rx) = UploadRequest::upload(scoping, location.try_to_uri()?, stream);
+                let (request, rx) =
+                    UploadRequest::upload(scoping, upstream, location.try_to_uri()?, stream);
                 addr.send(SendRequest(request));
                 let response = rx.await??;
                 SignedLocation::try_from_response(response)
@@ -693,6 +700,7 @@ enum RequestKind {
 /// An upstream request made to the `/upload` endpoint.
 struct UploadRequest {
     scoping: Scoping,
+    upstream: Option<UpstreamDescriptor>,
     kind: RequestKind,
     sender: oneshot::Sender<Result<Response, UpstreamRequestError>>,
 }
@@ -700,6 +708,7 @@ struct UploadRequest {
 impl UploadRequest {
     fn create(
         scoping: Scoping,
+        upstream: Option<UpstreamDescriptor>,
         length: Option<usize>,
         attachment_type: Option<AttachmentType>,
     ) -> (
@@ -711,6 +720,7 @@ impl UploadRequest {
         (
             Self {
                 scoping,
+                upstream,
                 kind: RequestKind::Create {
                     length,
                     attachment_type,
@@ -723,6 +733,7 @@ impl UploadRequest {
 
     fn upload(
         scoping: Scoping,
+        upstream: Option<UpstreamDescriptor>,
         uri: String,
         stream: BoundedStream<MeteredStream<ByteStream>>,
     ) -> (
@@ -733,6 +744,7 @@ impl UploadRequest {
         (
             Self {
                 scoping,
+                upstream,
                 kind: RequestKind::Upload {
                     uri,
                     stream: TakeOnce::new(stream),
@@ -754,6 +766,10 @@ impl fmt::Debug for UploadRequest {
 }
 
 impl UpstreamRequest for UploadRequest {
+    fn upstream(&self) -> Option<&UpstreamDescriptor> {
+        self.upstream.as_ref()
+    }
+
     fn method(&self) -> Method {
         match self.kind {
             RequestKind::Create { .. } => Method::POST,

--- a/relay-server/src/services/upload.rs
+++ b/relay-server/src/services/upload.rs
@@ -112,12 +112,19 @@ pub enum Upload {
 
 impl Interface for Upload {}
 
+/// Project information necessary for uploading.
+#[derive(Debug, Clone)]
+pub struct ProjectContext {
+    /// The organization and project identifiers.
+    pub scoping: Scoping,
+    /// Where to send the request.
+    pub upstream: Option<UpstreamDescriptor>,
+}
+
 /// Request to create an upload resource.
 pub struct Create {
     /// The project to create the upload for.
-    pub scoping: Scoping,
-    /// Optional upstream override where the request will be sent to.
-    pub upstream: Option<UpstreamDescriptor>,
+    pub project: ProjectContext,
     /// The size of the intended upload in bytes, as specified in the `Upload-Length` header.
     ///
     /// Trusted clients (i.e. PoP Relays) are allowed to omit the length (see `Upload-Defer-Length: 1`).
@@ -133,10 +140,8 @@ pub type ByteStream = BoxStream<'static, std::io::Result<Bytes>>;
 pub struct Stream {
     /// Time of arrival of the request.
     pub received: DateTime<Utc>,
-    /// The organization & project that the stream belongs to.
-    pub scoping: Scoping,
-    /// Optional upstream override where the request will be sent to.
-    pub upstream: Option<UpstreamDescriptor>,
+    /// The project to create the upload for.
+    pub project: ProjectContext,
     /// The location to upload to.
     pub location: SignedLocation<Provisional>,
     /// The body to be uploaded to objectstore, with length validation.
@@ -254,16 +259,14 @@ impl Service {
     async fn create(
         &self,
         Create {
-            scoping,
-            upstream,
+            project,
             length,
             attachment_type,
         }: Create,
     ) -> Result<SignedLocation<Provisional>, Error> {
         match &self.backend {
             Backend::Upstream { addr } => {
-                let (request, rx) =
-                    UploadRequest::create(scoping, upstream, length, attachment_type);
+                let (request, rx) = UploadRequest::create(project, length, attachment_type);
                 addr.send(SendRequest(request));
                 let response = rx.await??;
                 SignedLocation::try_from_response(response)
@@ -273,7 +276,7 @@ impl Service {
                 // We can create & sign a location right here, no need to query the objectstore service.
                 let key = Uuid::now_v7().as_simple().to_string();
                 Location {
-                    project_id: scoping.project_id,
+                    project_id: project.scoping.project_id,
                     key,
                     length: Provisional(length),
                     other: Default::default(),
@@ -287,15 +290,13 @@ impl Service {
         let Stream {
             #[cfg_attr(not(feature = "processing"), expect(unused))]
             received,
-            scoping,
-            upstream,
+            project,
             location,
             stream,
         } = stream;
         match &self.backend {
             Backend::Upstream { addr } => {
-                let (request, rx) =
-                    UploadRequest::upload(scoping, upstream, location.try_to_uri()?, stream);
+                let (request, rx) = UploadRequest::upload(project, location.try_to_uri()?, stream);
                 addr.send(SendRequest(request));
                 let response = rx.await??;
                 SignedLocation::try_from_response(response)
@@ -309,6 +310,7 @@ impl Service {
                     other,
                 } = location.verify(received, config)?;
 
+                let scoping = project.scoping;
                 debug_assert_eq!(scoping.project_id, project_id);
                 debug_assert!(stream.length().is_none_or(|l| Some(l) == length.value()));
                 let byte_counter = stream.byte_counter();
@@ -699,16 +701,14 @@ enum RequestKind {
 
 /// An upstream request made to the `/upload` endpoint.
 struct UploadRequest {
-    scoping: Scoping,
-    upstream: Option<UpstreamDescriptor>,
+    project: ProjectContext,
     kind: RequestKind,
     sender: oneshot::Sender<Result<Response, UpstreamRequestError>>,
 }
 
 impl UploadRequest {
     fn create(
-        scoping: Scoping,
-        upstream: Option<UpstreamDescriptor>,
+        project: ProjectContext,
         length: Option<usize>,
         attachment_type: Option<AttachmentType>,
     ) -> (
@@ -719,8 +719,7 @@ impl UploadRequest {
 
         (
             Self {
-                scoping,
-                upstream,
+                project,
                 kind: RequestKind::Create {
                     length,
                     attachment_type,
@@ -732,8 +731,7 @@ impl UploadRequest {
     }
 
     fn upload(
-        scoping: Scoping,
-        upstream: Option<UpstreamDescriptor>,
+        project: ProjectContext,
         uri: String,
         stream: BoundedStream<MeteredStream<ByteStream>>,
     ) -> (
@@ -743,8 +741,7 @@ impl UploadRequest {
         let (sender, rx) = oneshot::channel();
         (
             Self {
-                scoping,
-                upstream,
+                project,
                 kind: RequestKind::Upload {
                     uri,
                     stream: TakeOnce::new(stream),
@@ -759,15 +756,20 @@ impl UploadRequest {
 
 impl fmt::Debug for UploadRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            project,
+            kind: _,
+            sender: _,
+        } = self;
         f.debug_struct("UploadRequest")
-            .field("scoping", &self.scoping)
+            .field("project", project)
             .finish()
     }
 }
 
 impl UpstreamRequest for UploadRequest {
     fn upstream(&self) -> Option<&UpstreamDescriptor> {
-        self.upstream.as_ref()
+        self.project.upstream.as_ref()
     }
 
     fn method(&self) -> Method {
@@ -778,7 +780,7 @@ impl UpstreamRequest for UploadRequest {
     }
 
     fn path(&self) -> Cow<'_, str> {
-        let project_id = self.scoping.project_id;
+        let project_id = self.project.scoping.project_id;
         match &self.kind {
             RequestKind::Create { .. } => Cow::Owned(format!("/api/{project_id}/upload/")),
             RequestKind::Upload { uri, .. } => Cow::Borrowed(uri),
@@ -840,7 +842,7 @@ impl UpstreamRequest for UploadRequest {
             }
         };
 
-        let project_key = self.scoping.project_key;
+        let project_key = self.project.scoping.project_key;
         builder.header("X-Sentry-Auth", format!("Sentry sentry_key={project_key}"));
         builder.timeout(Duration::MAX); // rely on service timeout to cancel requests
 


### PR DESCRIPTION
Pass the upstream descriptor from the project config into all requests to the upload service.

Closes INGEST-971