### PR TITLE
ref(outcomes): Outcomes are 64 bit now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Rename objectstore use-case from `profiles_raw` to `profile_attachments`. ([#6108](https://github.com/getsentry/relay/pull/6108))
 - Require timestamps and verification in auth signatures. ([#6069](https://github.com/getsentry/relay/pull/6069))
+- Expand size of outcome quantities from `u32` to `u64`. ([#6133](https://github.com/getsentry/relay/pull/6133))
 - Internally handle outcomes as metrics. ([#6107](https://github.com/getsentry/relay/pull/6107))
 - Have relay generate metric billing outcomes. ([#6066](https://github.com/getsentry/relay/pull/6066))
 - Update sentry-conventions to 0.12.0.

--- a/relay-event-schema/src/protocol/client_report.rs
+++ b/relay-event-schema/src/protocol/client_report.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct DiscardedEvent {
     pub reason: String,
     pub category: DataCategory,
-    pub quantity: u32,
+    pub quantity: u64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/relay-server/src/managed/envelope.rs
+++ b/relay-server/src/managed/envelope.rs
@@ -205,9 +205,7 @@ impl ManagedEnvelope {
             event_id: self.envelope.event_id(),
             remote_addr: self.meta().remote_addr(),
             category,
-            // Quantities are usually `usize` which lets us go all the way to 64-bit on our
-            // machines, but the protocol and data store can only do 32-bit.
-            quantity: quantity as u32,
+            quantity: quantity as u64,
         });
     }
 

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -766,7 +766,7 @@ impl Meta {
             event_id: self.event_id,
             remote_addr: self.remote_addr,
             category,
-            quantity: quantity.try_into().unwrap_or(u32::MAX),
+            quantity: quantity as _,
         });
     }
 }

--- a/relay-server/src/managed/managed/test.rs
+++ b/relay-server/src/managed/managed/test.rs
@@ -99,7 +99,7 @@ impl ManagedTestHandle {
 
     /// Asserts a single emitted outcome.
     #[track_caller]
-    pub fn assert_outcome(&mut self, outcome: &Outcome, category: DataCategory, quantity: u32) {
+    pub fn assert_outcome(&mut self, outcome: &Outcome, category: DataCategory, quantity: u64) {
         match self.outcomes.try_recv() {
             Ok(next) => {
                 assert_eq!(&next.outcome, outcome);
@@ -121,7 +121,7 @@ impl ManagedTestHandle {
     /// A shorthand for [`Self::assert_outcome`] with a [`Outcome::Invalid`] /
     /// [`DiscardReason::Internal`].
     #[track_caller]
-    pub fn assert_internal_outcome(&mut self, category: DataCategory, quantity: u32) {
+    pub fn assert_internal_outcome(&mut self, category: DataCategory, quantity: u64) {
         self.assert_outcome(
             &Outcome::Invalid(DiscardReason::Internal),
             category,

--- a/relay-server/src/metrics/outcomes.rs
+++ b/relay-server/src/metrics/outcomes.rs
@@ -38,9 +38,9 @@ impl MetricOutcomes {
             } = extract_quantities(buckets);
 
             let categories = [
-                (DataCategory::Transaction, transactions as u32),
-                (DataCategory::Span, spans as u32),
-                (DataCategory::MetricBucket, buckets as u32),
+                (DataCategory::Transaction, transactions as _),
+                (DataCategory::Span, spans as _),
+                (DataCategory::MetricBucket, buckets as _),
             ];
 
             for (category, quantity) in categories {
@@ -95,7 +95,7 @@ impl MetricOutcomes {
                             event_id: None,
                             remote_addr: None,
                             category: *category,
-                            quantity: count as u32,
+                            quantity: count as _,
                         });
                     }
                 }

--- a/relay-server/src/metrics/rate_limits.rs
+++ b/relay-server/src/metrics/rate_limits.rs
@@ -214,7 +214,7 @@ mod tests {
     fn run_limiter(
         metrics: Vec<Bucket>,
         quotas: Vec<Quota>,
-    ) -> (Vec<Bucket>, Vec<(Outcome, DataCategory, u32)>) {
+    ) -> (Vec<Bucket>, Vec<(Outcome, DataCategory, u64)>) {
         let (outcome_sink, mut rx) = Addr::custom();
         let metric_outcomes = MetricOutcomes::new(outcome_sink.clone());
 

--- a/relay-server/src/processing/client_reports/mod.rs
+++ b/relay-server/src/processing/client_reports/mod.rs
@@ -152,7 +152,7 @@ pub struct ClientOutcome {
     timestamp: UnixTimestamp,
     reason: String,
     category: DataCategory,
-    quantity: u32,
+    quantity: u64,
 }
 
 impl Counted for ClientOutcome {

--- a/relay-server/src/services/outcome/metric.rs
+++ b/relay-server/src/services/outcome/metric.rs
@@ -5,6 +5,7 @@ use relay_base_schema::data_category::DataCategory;
 use relay_config::Config;
 use relay_event_schema::protocol::{ClientReport, DiscardedEvent};
 use relay_metrics::{Bucket, BucketValue, MetricName, MetricNamespace, UnixTimestamp};
+use relay_protocol::FiniteF64;
 
 #[cfg(any(test, feature = "processing"))]
 use crate::services::outcome::OutcomeId;
@@ -76,7 +77,7 @@ pub fn to_metric(outcome: &TrackOutcome, config: &Config) -> Bucket {
 
     Bucket {
         name,
-        value: BucketValue::Counter((*quantity).into()),
+        value: BucketValue::Counter(FiniteF64::cast_from_u64(*quantity)),
         timestamp: UnixTimestamp::from_datetime(*timestamp).unwrap_or_else(UnixTimestamp::now),
         tags,
         width: 0,
@@ -179,7 +180,7 @@ fn to_discarded_event(bucket: &Bucket) -> Option<(ClientReportSection, Discarded
     debug_assert_ne!(category, Some(DataCategory::Unknown));
 
     let quantity = match &bucket.value {
-        BucketValue::Counter(value) => value.to_f64() as u32,
+        BucketValue::Counter(value) => value.to_f64() as _,
         _ => return None,
     };
 

--- a/relay-server/src/services/outcome/service.rs
+++ b/relay-server/src/services/outcome/service.rs
@@ -41,7 +41,7 @@ pub struct TrackOutcome {
     /// The event's data category.
     pub category: DataCategory,
     /// The number of events or total attachment size in bytes.
-    pub quantity: u32,
+    pub quantity: u64,
 }
 
 impl Interface for TrackOutcome {}
@@ -264,7 +264,7 @@ fn send_outcome_metric(message: &TrackOutcome) {
     };
 
     metric!(
-        counter(RelayCounters::OutcomeQuantity) += message.quantity.into(),
+        counter(RelayCounters::OutcomeQuantity) += message.quantity,
         category = message.category.name(),
         outcome = outcome_name,
     );

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -748,7 +748,7 @@ impl StoreService {
                     category,
                     event_id: None,
                     outcome: Outcome::Accepted,
-                    quantity: u32::try_from(quantity).unwrap_or(u32::MAX),
+                    quantity: quantity as u64,
                     remote_addr: None,
                     scoping,
                     timestamp: received_at,
@@ -1224,7 +1224,7 @@ impl StoreService {
             return Ok(());
         };
         let quantity = match message.value {
-            MetricValue::Counter(c) => c.to_f64() as u32,
+            MetricValue::Counter(c) => c.to_f64() as _,
             v => {
                 relay_log::error!(
                     mri = message.name.as_ref(),
@@ -1601,7 +1601,7 @@ pub struct OutcomeMessage<'a> {
     category: Option<u8>,
     /// The number of events or total attachment size in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    quantity: Option<u32>,
+    quantity: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize)]


### PR DESCRIPTION
Outcomes support 64 bits now:
- https://github.com/getsentry/snuba/pull/8072
- https://github.com/getsentry/snuba/pull/8036

Was thinking maybe of changing `Quantities` from `(_, usize)` to `(_, u64)` but that's a bigger change.