### PR TITLE
ref: Remove `eap-outcomes.rollout-rate`

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -156,16 +156,6 @@ pub struct Options {
     )]
     pub sessions_eap_rollout_rate: f32,
 
-    /// Rollout rate for accepted outcomes being emitted by EAP instead of Relay.
-    ///
-    /// Rate needs to be between `0.0` and `1.0`.
-    #[serde(
-        rename = "relay.eap-outcomes.rollout-rate",
-        deserialize_with = "default_on_error",
-        skip_serializing_if = "is_default"
-    )]
-    pub eap_outcomes_rollout_rate: f32,
-
     /// Kill-switch for fetching project configs in endpoints.
     #[serde(
         default = "default_killswitched",

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -246,7 +246,6 @@ impl ServiceState {
                     store_pool.clone(),
                     config.clone(),
                     global_config_handle.clone(),
-                    outcome_aggregator.clone(),
                     metric_outcomes.clone(),
                 )
                 .map(|s| services.start(s))

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -29,7 +29,7 @@ use relay_metrics::{
 use relay_protocol::{Annotated, FiniteF64, SerializableAnnotated};
 use relay_quotas::Scoping;
 use relay_statsd::metric;
-use relay_system::{Addr, FromMessage, Interface, NoResponse, Service};
+use relay_system::{FromMessage, Interface, NoResponse, Service};
 use relay_threading::AsyncPool;
 
 use crate::envelope::{AttachmentPlaceholder, AttachmentType, ContentType, Item, ItemType};
@@ -38,7 +38,7 @@ use crate::metrics::{ArrayEncoding, BucketEncoder, MetricOutcomes};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
 use crate::services::objectstore::ObjectstoreKey;
-use crate::services::outcome::{self, DiscardReason, Outcome, OutcomeId, TrackOutcome};
+use crate::services::outcome::{self, DiscardReason, Outcome, OutcomeId};
 use crate::services::upload::{Final, SignedLocation};
 use crate::statsd::{RelayCounters, RelayGauges, RelayTimers};
 use crate::utils::{self, FormDataIter};
@@ -386,7 +386,6 @@ pub struct StoreService {
     pool: StoreServicePool,
     config: Arc<Config>,
     global_config: GlobalConfigHandle,
-    outcome_aggregator: Addr<TrackOutcome>,
     metric_outcomes: MetricOutcomes,
     producer: Producer,
 }
@@ -396,7 +395,6 @@ impl StoreService {
         pool: StoreServicePool,
         config: Arc<Config>,
         global_config: GlobalConfigHandle,
-        outcome_aggregator: Addr<TrackOutcome>,
         metric_outcomes: MetricOutcomes,
     ) -> anyhow::Result<Self> {
         let producer = Producer::create(&config)?;
@@ -404,7 +402,6 @@ impl StoreService {
             pool,
             config,
             global_config,
-            outcome_aggregator,
             metric_outcomes,
             producer,
         })
@@ -716,45 +713,11 @@ impl StoreService {
         message: Managed<StoreTraceItem>,
     ) -> Result<(), Rejected<StoreError>> {
         let scoping = message.scoping();
-        let received_at = message.received_at();
 
-        let eap_emits_outcomes = utils::is_rolled_out(
-            scoping.organization_id.value(),
-            self.global_config
-                .current()
-                .unwrap_or_default()
-                .options
-                .eap_outcomes_rollout_rate,
-        )
-        .is_keep();
-
-        let outcomes = message.try_accept(|mut item| {
-            let outcomes = match eap_emits_outcomes {
-                true => None,
-                false => item.trace_item.outcomes.take(),
-            };
-
+        message.try_accept(|item| {
             let message = KafkaMessage::for_item(scoping, item.trace_item);
-            self.produce(KafkaTopic::Items, message).map(|()| outcomes)
+            self.produce(KafkaTopic::Items, message)
         })?;
-
-        // Accepted outcomes when items have been successfully produced to rdkafka.
-        //
-        // This is only a temporary measure, long term these outcomes will be part of the trace
-        // item and emitted by Snuba to guarantee a delivery to storage.
-        if let Some(outcomes) = outcomes {
-            for (category, quantity) in outcomes.quantities() {
-                self.outcome_aggregator.send(TrackOutcome {
-                    category,
-                    event_id: None,
-                    outcome: Outcome::Accepted,
-                    quantity: quantity as u64,
-                    remote_addr: None,
-                    scoping,
-                    timestamp: received_at,
-                });
-            }
-        }
 
         Ok(())
     }

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -157,6 +157,19 @@ def test_standalone_attachment_store(
         "serverSampleRate": 1.0,
         "timestamp": matches_any(),
         "traceId": attachment_metadata["trace_id"].replace("-", ""),
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.ATTACHMENT.value,
+                    "quantity": "36",
+                },
+                {
+                    "dataCategory": DataCategory.ATTACHMENT_ITEM.value,
+                    "quantity": "1",
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
     objectstore = objectstore(usecase="trace_attachments", project_id=project_id)
@@ -164,26 +177,6 @@ def test_standalone_attachment_store(
         objectstore.get(attachment_metadata["attachment_id"]).payload.read()
         == attachment_body
     )
-
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-    assert outcomes == [
-        {
-            "category": DataCategory.ATTACHMENT.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 36,
-        },
-        {
-            "category": DataCategory.ATTACHMENT_ITEM.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 1,
-        },
-    ]
 
 
 @pytest.mark.parametrize(
@@ -414,12 +407,25 @@ def test_attachment_with_matching_span_store(
         "serverSampleRate": 1.0,
         "timestamp": matches_any(),
         "traceId": metadata["trace_id"],
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.ATTACHMENT.value,
+                    "quantity": "23",
+                },
+                {
+                    "dataCategory": DataCategory.ATTACHMENT_ITEM.value,
+                    "quantity": "1",
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
     objectstore = objectstore(usecase="trace_attachments", project_id=project_id)
     assert objectstore.get(metadata["attachment_id"]).payload.read() == body
 
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=4)
+    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
     assert outcomes == [
         {
             "category": DataCategory.TRANSACTION.value,
@@ -430,23 +436,7 @@ def test_attachment_with_matching_span_store(
             "quantity": 1,
         },
         {
-            "category": DataCategory.ATTACHMENT.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 23,
-        },
-        {
             "category": DataCategory.SPAN.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 1,
-        },
-        {
-            "category": DataCategory.ATTACHMENT_ITEM.value,
             "key_id": 123,
             "org_id": 1,
             "outcome": 0,

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -153,27 +153,20 @@ def test_otlp_logs_conversion(
             "serverSampleRate": 1.0,
             "timestamp": time_within_delta(ts, delta=timedelta(seconds=1)),
             "traceId": "5b8efff798038103d269b633813fc60c",
+            "outcomes": {
+                "categoryCount": [
+                    {
+                        "dataCategory": DataCategory.LOG_ITEM.value,
+                        "quantity": "1",
+                    },
+                    {
+                        "dataCategory": DataCategory.LOG_BYTE.value,
+                        "quantity": "318",
+                    },
+                ],
+                "keyId": "123",
+            },
         }
-    ]
-
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-    assert outcomes == [
-        {
-            "category": DataCategory.LOG_ITEM.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 1,
-        },
-        {
-            "category": DataCategory.LOG_BYTE.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 318,
-        },
     ]
 
 
@@ -262,6 +255,19 @@ def test_otlp_logs_multiple_records(
             "serverSampleRate": 1.0,
             "timestamp": time_within_delta(ts, delta=timedelta(seconds=1)),
             "traceId": "5b8efff798038103d269b633813fc60c",
+            "outcomes": {
+                "categoryCount": [
+                    {
+                        "dataCategory": DataCategory.LOG_ITEM.value,
+                        "quantity": "1",
+                    },
+                    {
+                        "dataCategory": DataCategory.LOG_BYTE.value,
+                        "quantity": "92",
+                    },
+                ],
+                "keyId": "123",
+            },
         },
         {
             "attributes": {
@@ -293,26 +299,19 @@ def test_otlp_logs_multiple_records(
             "serverSampleRate": 1.0,
             "timestamp": time_within_delta(ts, delta=timedelta(seconds=1)),
             "traceId": "5b8efff798038103d269b633813fc60c",
-        },
-    ]
-
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-    assert outcomes == [
-        {
-            "category": DataCategory.LOG_ITEM.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 2,
-        },
-        {
-            "category": DataCategory.LOG_BYTE.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 185,
+            "outcomes": {
+                "categoryCount": [
+                    {
+                        "dataCategory": DataCategory.LOG_ITEM.value,
+                        "quantity": "1",
+                    },
+                    {
+                        "dataCategory": DataCategory.LOG_BYTE.value,
+                        "quantity": "93",
+                    },
+                ],
+                "keyId": "123",
+            },
         },
     ]
 

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 from datetime import datetime, timezone, timedelta
 import uuid
@@ -196,7 +197,6 @@ def test_fast_path_rate_limits(mini_sentry, relay, categories):
     ]
 
 
-@pytest.mark.parametrize("eap_emits_outcomes", [True, False])
 @pytest.mark.parametrize(
     "external_mode,expected_byte_size_1,expected_byte_size_2",
     [
@@ -222,15 +222,11 @@ def test_ourlog_extraction_with_sentry_logs(
     external_mode,
     expected_byte_size_1,
     expected_byte_size_2,
-    eap_emits_outcomes,
 ):
     relay_fn = relay
 
     items_consumer = items_consumer()
     outcomes_consumer = outcomes_consumer()
-
-    if eap_emits_outcomes:
-        mini_sentry.global_config["options"]["relay.eap-outcomes.rollout-rate"] = 1.0
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -324,24 +320,19 @@ def test_ourlog_extraction_with_sentry_logs(
                 ts, delta=timedelta(seconds=1), expect_resolution="ns"
             ),
             "traceId": "5b8efff798038103d269b633813fc60c",
-            **_if_dict(
-                eap_emits_outcomes,
-                {
-                    "outcomes": {
-                        "categoryCount": [
-                            {
-                                "dataCategory": DataCategory.LOG_ITEM.value,
-                                "quantity": "1",
-                            },
-                            {
-                                "dataCategory": DataCategory.LOG_BYTE.value,
-                                "quantity": f"{expected_byte_size_1}",
-                            },
-                        ],
-                        "keyId": "123",
-                    }
-                },
-            ),
+            "outcomes": {
+                "categoryCount": [
+                    {
+                        "dataCategory": DataCategory.LOG_ITEM.value,
+                        "quantity": "1",
+                    },
+                    {
+                        "dataCategory": DataCategory.LOG_BYTE.value,
+                        "quantity": f"{expected_byte_size_1}",
+                    },
+                ],
+                "keyId": "123",
+            },
         },
         {
             "attributes": {
@@ -411,47 +402,21 @@ def test_ourlog_extraction_with_sentry_logs(
                 ts, delta=timedelta(seconds=1), expect_resolution="ns"
             ),
             "traceId": "5b8efff798038103d269b633813fc60c",
-            **_if_dict(
-                eap_emits_outcomes,
-                {
-                    "outcomes": {
-                        "categoryCount": [
-                            {
-                                "dataCategory": DataCategory.LOG_ITEM.value,
-                                "quantity": "1",
-                            },
-                            {
-                                "dataCategory": DataCategory.LOG_BYTE.value,
-                                "quantity": f"{expected_byte_size_2}",
-                            },
-                        ],
-                        "keyId": "123",
-                    }
-                },
-            ),
+            "outcomes": {
+                "categoryCount": [
+                    {
+                        "dataCategory": DataCategory.LOG_ITEM.value,
+                        "quantity": "1",
+                    },
+                    {
+                        "dataCategory": DataCategory.LOG_BYTE.value,
+                        "quantity": f"{expected_byte_size_2}",
+                    },
+                ],
+                "keyId": "123",
+            },
         },
     ]
-
-    if not eap_emits_outcomes:
-        outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-        assert outcomes == [
-            {
-                "category": DataCategory.LOG_ITEM.value,
-                "key_id": 123,
-                "org_id": 1,
-                "outcome": 0,
-                "project_id": 42,
-                "quantity": 2,
-            },
-            {
-                "category": DataCategory.LOG_BYTE.value,
-                "key_id": 123,
-                "org_id": 1,
-                "outcome": 0,
-                "project_id": 42,
-                "quantity": expected_byte_size_1 + expected_byte_size_2,
-            },
-        ]
 
 
 def test_ourlog_extraction_with_string_pii_scrubbing(
@@ -716,6 +681,19 @@ def test_ourlog_extraction_default_pii_scrubbing_does_not_scrub_default_attribut
             ts, delta=timedelta(seconds=1), expect_resolution="ns"
         ),
         "traceId": "5b8efff798038103d269b633813fc60c",
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.LOG_ITEM.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.LOG_BYTE.value,
+                    "quantity": "32",
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
 
@@ -770,6 +748,19 @@ def test_ourlog_extraction_with_sentry_logs_with_missing_fields(
             ts, delta=timedelta(seconds=1), expect_resolution="ns"
         ),
         "traceId": "5b8efff798038103d269b633813fc60c",
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.LOG_ITEM.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.LOG_BYTE.value,
+                    "quantity": "20",
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
 
@@ -914,6 +905,19 @@ def test_browser_name_version_extraction(
             ts, delta=timedelta(seconds=1), expect_resolution="ns"
         ),
         "traceId": "5b8efff798038103d269b633813fc60c",
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.LOG_ITEM.value,
+                    "quantity": mock.ANY,
+                },
+                {
+                    "dataCategory": DataCategory.LOG_BYTE.value,
+                    "quantity": mock.ANY,
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
 
@@ -1185,6 +1189,19 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
             ts + timedelta(seconds=seq_shift_in_secs), delta=timedelta(), precision="ms"
         ),
         "traceId": "5b8efff798038103d269b633813fc60c",
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.LOG_ITEM.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.LOG_BYTE.value,
+                    "quantity": "36",
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
 

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -91,7 +91,6 @@ def test_trace_metric_multiple_containers_not_allowed(
     ]
 
 
-@pytest.mark.parametrize("eap_emits_outcomes", [True, False])
 @pytest.mark.parametrize(
     "external_mode,expected_byte_size",
     [
@@ -116,15 +115,11 @@ def test_trace_metric_extraction(
     outcomes_consumer,
     external_mode,
     expected_byte_size,
-    eap_emits_outcomes,
 ):
     relay_fn = relay
 
     items_consumer = items_consumer()
     outcomes_consumer = outcomes_consumer()
-
-    if eap_emits_outcomes:
-        mini_sentry.global_config["options"]["relay.eap-outcomes.rollout-rate"] = 1.0
 
     project_id = 42
     project_config = mini_sentry.add_full_project_config(project_id)
@@ -224,46 +219,20 @@ def test_trace_metric_extraction(
         "serverSampleRate": 1.0,
         "timestamp": time_within_delta(start, expect_resolution="ns"),
         "traceId": "5b8efff798038103d269b633813fc60c",
-        **_if_dict(
-            eap_emits_outcomes,
-            {
-                "outcomes": {
-                    "categoryCount": [
-                        {
-                            "dataCategory": DataCategory.TRACE_METRIC.value,
-                            "quantity": "1",
-                        },
-                        {
-                            "dataCategory": DataCategory.TRACE_METRIC_BYTE.value,
-                            "quantity": f"{expected_byte_size}",
-                        },
-                    ],
-                    "keyId": "123",
-                }
-            },
-        ),
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.TRACE_METRIC.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.TRACE_METRIC_BYTE.value,
+                    "quantity": f"{expected_byte_size}",
+                },
+            ],
+            "keyId": "123",
+        },
     }
-
-    if not eap_emits_outcomes:
-        outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-        assert outcomes == [
-            {
-                "category": DataCategory.TRACE_METRIC.value,
-                "key_id": 123,
-                "org_id": 1,
-                "outcome": 0,
-                "project_id": 42,
-                "quantity": 1,
-            },
-            {
-                "category": DataCategory.TRACE_METRIC_BYTE.value,
-                "key_id": 123,
-                "org_id": 1,
-                "outcome": 0,
-                "project_id": 42,
-                "quantity": expected_byte_size,
-            },
-        ]
 
 
 @pytest.mark.parametrize(
@@ -473,27 +442,20 @@ def test_trace_metric_pii_scrubbing(
         "serverSampleRate": 1.0,
         "timestamp": time_within_delta(start, expect_resolution="ns"),
         "traceId": "5b8efff798038103d269b633813fc60c",
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.TRACE_METRIC.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.TRACE_METRIC_BYTE.value,
+                    "quantity": "99",
+                },
+            ],
+            "keyId": "123",
+        },
     }
-
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-    assert outcomes == [
-        {
-            "category": DataCategory.TRACE_METRIC.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 1,
-        },
-        {
-            "category": DataCategory.TRACE_METRIC_BYTE.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 99,
-        },
-    ]
 
 
 def test_trace_metric_string_pii_scrubbing(
@@ -924,6 +886,19 @@ def test_time_sequence_shift(mini_sentry, relay_with_processing, items_consumer)
             ts + timedelta(seconds=seq_shift_in_secs), delta=timedelta(), precision="ms"
         ),
         "traceId": matches_any(),
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.TRACE_METRIC.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.TRACE_METRIC_BYTE.value,
+                    "quantity": "62",
+                },
+            ],
+            "keyId": "123",
+        },
     }
 
 

--- a/tests/integration/test_vercel_logs.py
+++ b/tests/integration/test_vercel_logs.py
@@ -89,6 +89,19 @@ EXPECTED_ITEMS = [
         "retentionDays": 90,
         "received": matches_any(),
         "downsampledRetentionDays": 90,
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.LOG_ITEM.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.LOG_BYTE.value,
+                    "quantity": "376",
+                },
+            ],
+            "keyId": "123",
+        },
     },
     {
         "organizationId": "1",
@@ -137,6 +150,19 @@ EXPECTED_ITEMS = [
         "retentionDays": 90,
         "received": matches_any(),
         "downsampledRetentionDays": 90,
+        "outcomes": {
+            "categoryCount": [
+                {
+                    "dataCategory": DataCategory.LOG_ITEM.value,
+                    "quantity": "1",
+                },
+                {
+                    "dataCategory": DataCategory.LOG_BYTE.value,
+                    "quantity": "829",
+                },
+            ],
+            "keyId": "123",
+        },
     },
 ]
 
@@ -167,26 +193,6 @@ def test_vercel_logs_json_array(
     items = items_consumer.get_items(n=2)
     assert items == EXPECTED_ITEMS
 
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-    assert outcomes == [
-        {
-            "category": DataCategory.LOG_ITEM.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 2,
-        },
-        {
-            "category": DataCategory.LOG_BYTE.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 1205,
-        },
-    ]
-
 
 def test_vercel_logs_ndjson(
     mini_sentry, relay, relay_with_processing, outcomes_consumer, items_consumer
@@ -211,23 +217,3 @@ def test_vercel_logs_ndjson(
 
     items = items_consumer.get_items(n=2)
     assert items == EXPECTED_ITEMS
-
-    outcomes = outcomes_consumer.get_aggregated_outcomes(n=2)
-    assert outcomes == [
-        {
-            "category": DataCategory.LOG_ITEM.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 2,
-        },
-        {
-            "category": DataCategory.LOG_BYTE.value,
-            "key_id": 123,
-            "org_id": 1,
-            "outcome": 0,
-            "project_id": 42,
-            "quantity": 1205,
-        },
-    ]


### PR DESCRIPTION
This has been rolled out everywhere as such we can remove this flag now.
The logic change is small but a couple of tests needed to be updated.