### PR TITLE
ref(minidump): Instrument additional exceptions

### DIFF
--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -72,13 +72,14 @@ fn write_native_placeholder(
         .get_or_insert_with(Vec::new);
 
     let allow_multiple_exceptions = project_info.has_feature(Feature::MinidumpMultiException);
-    if let Some(exc) = exceptions.get(1) {
+    if let Some(exc) = exceptions.first() {
         relay_log::info!(
-            exceptions = exceptions.len(),
-            mechanism = ?get_value!(exc.mechanism.ty),
+            additional_exceptions = exceptions.len(),
+            native_exception_mechanism = placeholder.exception_type,
+            additional_exception_mechanism = ?get_value!(exc.mechanism.ty),
             project = ?event.project,
             has_feature = allow_multiple_exceptions,
-            "Minidump event has additional exceptions",
+            "Native event has additional exceptions",
         )
     }
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -71,16 +71,18 @@ fn write_native_placeholder(
         .value_mut()
         .get_or_insert_with(Vec::new);
 
+    let allow_multiple_exceptions = project_info.has_feature(Feature::MinidumpMultiException);
     if let Some(exc) = exceptions.iter().nth(1) {
         relay_log::info!(
             exceptions = exceptions.len(),
             mechanism = ?get_value!(exc.mechanism.ty),
             project = ?event.project,
+            allow_multiple_exceptions = allow_multiple_exceptions,
             "Minidump event has additional exceptions",
         )
     }
 
-    if !project_info.has_feature(Feature::MinidumpMultiException) {
+    if !allow_multiple_exceptions {
         exceptions.clear(); // clear previous errors if any
     }
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -15,7 +15,7 @@ use relay_event_schema::protocol::{
     ClientSdkInfo, Context, Contexts, Event, Exception, JsonLenientString, Level, Mechanism,
     StabilityReportContext, Values,
 };
-use relay_protocol::{Annotated, Value};
+use relay_protocol::{Annotated, Value, get_value};
 
 use crate::envelope::{Item, ItemType};
 use crate::services::projects::project::ProjectInfo;
@@ -71,7 +71,16 @@ fn write_native_placeholder(
         .value_mut()
         .get_or_insert_with(Vec::new);
 
-    if !project_info.has_feature(Feature::MinidumpMultiException) {
+    if project_info.has_feature(Feature::MinidumpMultiException) {
+        if let Some(exc) = exceptions.iter().nth(1) {
+            relay_log::info!(
+                exceptions = exceptions.len(),
+                mechanism = ?get_value!(exc.mechanism.ty),
+                project = ?event.project,
+                "Minidump event has additional exceptions",
+            )
+        }
+    } else {
         exceptions.clear(); // clear previous errors if any
     }
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -71,16 +71,16 @@ fn write_native_placeholder(
         .value_mut()
         .get_or_insert_with(Vec::new);
 
-    if project_info.has_feature(Feature::MinidumpMultiException) {
-        if let Some(exc) = exceptions.iter().nth(1) {
-            relay_log::info!(
-                exceptions = exceptions.len(),
-                mechanism = ?get_value!(exc.mechanism.ty),
-                project = ?event.project,
-                "Minidump event has additional exceptions",
-            )
-        }
-    } else {
+    if let Some(exc) = exceptions.iter().nth(1) {
+        relay_log::info!(
+            exceptions = exceptions.len(),
+            mechanism = ?get_value!(exc.mechanism.ty),
+            project = ?event.project,
+            "Minidump event has additional exceptions",
+        )
+    }
+
+    if !project_info.has_feature(Feature::MinidumpMultiException) {
         exceptions.clear(); // clear previous errors if any
     }
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -72,12 +72,12 @@ fn write_native_placeholder(
         .get_or_insert_with(Vec::new);
 
     let allow_multiple_exceptions = project_info.has_feature(Feature::MinidumpMultiException);
-    if let Some(exc) = exceptions.iter().nth(1) {
+    if let Some(exc) = exceptions.get(1) {
         relay_log::info!(
             exceptions = exceptions.len(),
             mechanism = ?get_value!(exc.mechanism.ty),
             project = ?event.project,
-            allow_multiple_exceptions = allow_multiple_exceptions,
+            has_feature = allow_multiple_exceptions,
             "Minidump event has additional exceptions",
         )
     }


### PR DESCRIPTION
Additional exceptions in a minidump event should work with javascript but not with additional native exceptions, because sentry will send at most one native symbolication request to symbolicator.

Count occurrences of multiple exceptions so we know how commonly this happens.

ref: #6046 