### PR TITLE
fix(spans): Set `sentry.trace.status` on segment spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))
 - Infer span names PII-safely. ([#6112](https://github.com/getsentry/relay/pull/6112))
 - Unset segment info for web vital spans. ([#6042](https://github.com/getsentry/relay/pull/6042))
+- Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
 
 **Internal**:
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -456,7 +456,7 @@ pub fn normalize_trace_status(
     is_segment: &Annotated<bool>,
     status: &Annotated<SpanV2Status>,
 ) {
-    if !is_segment.value().is_some_and(|is_segment| *is_segment) {
+    if is_segment.value().is_none_or(|is_segment| !*is_segment) {
         return;
     }
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -461,18 +461,18 @@ pub fn normalize_trace_status(
     }
 
     let attributes = attributes.get_or_insert_with(Default::default);
-    if attributes.contains_key("sentry.trace.status") {
+    if attributes.contains_key(SENTRY__TRACE__STATUS) {
         return;
     }
 
     let trace_status = attributes
-        .get_value("sentry.status")
+        .get_value(SENTRY__STATUS)
         .and_then(|v| v.as_str())
         .map(|s| s.to_owned())
         .or_else(|| status.value().map(|s| s.to_string()));
 
     if let Some(trace_status) = trace_status {
-        attributes.insert("sentry.trace.status", trace_status);
+        attributes.insert(SENTRY__TRACE__STATUS, trace_status);
     }
 }
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -10,7 +10,7 @@ use relay_common::time::UnixTimestamp;
 use relay_conventions::attributes::*;
 use relay_conventions::{AttributeInfo, ReplacementName, WriteBehavior};
 use relay_event_schema::protocol::{
-    Attribute, AttributeType, Attributes, BrowserContext, Geo, SpanV2,
+    Attribute, AttributeType, Attributes, BrowserContext, Geo, SpanV2, SpanV2Status,
 };
 use relay_protocol::{Annotated, Empty, Error, ErrorKind, Meta, Remark, RemarkType, Value};
 use relay_sampling::DynamicSamplingContext;
@@ -444,6 +444,35 @@ pub fn normalize_dsc(
         if let Some(sampled) = dsc.sampled {
             attributes.insert(SENTRY__DSC__SAMPLED, sampled);
         }
+    }
+}
+
+/// Sets the `sentry.trace.status` attribute on segment spans.
+///
+/// The value is derived from the `sentry.status` attribute if present, falling back to the span's
+/// top-level `status` field.
+pub fn normalize_trace_status(
+    attributes: &mut Annotated<Attributes>,
+    is_segment: &Annotated<bool>,
+    status: &Annotated<SpanV2Status>,
+) {
+    if !is_segment.value().is_some_and(|is_segment| *is_segment) {
+        return;
+    }
+
+    let attributes = attributes.get_or_insert_with(Default::default);
+    if attributes.contains_key("sentry.trace.status") {
+        return;
+    }
+
+    let trace_status = attributes
+        .get_value("sentry.status")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned())
+        .or_else(|| status.value().map(|s| s.to_string()));
+
+    if let Some(trace_status) = trace_status {
+        attributes.insert("sentry.trace.status", trace_status);
     }
 }
 
@@ -981,6 +1010,90 @@ mod tests {
           }
         }
         "#);
+    }
+
+    #[test]
+    fn test_normalize_trace_status_not_segment() {
+        let mut attributes = Annotated::empty();
+        normalize_trace_status(
+            &mut attributes,
+            &Annotated::new(false),
+            &Annotated::new(SpanV2Status::Ok),
+        );
+        assert!(attributes.value().is_none());
+    }
+
+    #[test]
+    fn test_normalize_trace_status_already_set() {
+        let mut attributes = Annotated::from_json(
+            r#"{"sentry.trace.status": {"type": "string", "value": "internal_error"}}"#,
+        )
+        .unwrap();
+        normalize_trace_status(
+            &mut attributes,
+            &Annotated::new(true),
+            &Annotated::new(SpanV2Status::Error),
+        );
+        assert_eq!(
+            attributes
+                .value()
+                .unwrap()
+                .get_value("sentry.trace.status")
+                .and_then(|v| v.as_str()),
+            Some("internal_error"),
+        );
+    }
+
+    #[test]
+    fn test_normalize_trace_status_from_sentry_status_attribute() {
+        let mut attributes = Annotated::from_json(
+            r#"{"sentry.status": {"type": "string", "value": "internal_error"}}"#,
+        )
+        .unwrap();
+        normalize_trace_status(
+            &mut attributes,
+            &Annotated::new(true),
+            &Annotated::new(SpanV2Status::Error),
+        );
+        assert_eq!(
+            attributes
+                .value()
+                .unwrap()
+                .get_value("sentry.trace.status")
+                .and_then(|v| v.as_str()),
+            Some("internal_error"),
+        );
+    }
+
+    #[test]
+    fn test_normalize_trace_status_from_span_status() {
+        let mut attributes = Annotated::empty();
+        normalize_trace_status(
+            &mut attributes,
+            &Annotated::new(true),
+            &Annotated::new(SpanV2Status::Error),
+        );
+        assert_eq!(
+            attributes
+                .value()
+                .unwrap()
+                .get_value("sentry.trace.status")
+                .and_then(|v| v.as_str()),
+            Some("error"),
+        );
+    }
+
+    #[test]
+    fn test_normalize_trace_status_no_status() {
+        let mut attributes = Annotated::empty();
+        normalize_trace_status(&mut attributes, &Annotated::new(true), &Annotated::empty());
+        assert!(
+            attributes
+                .value()
+                .unwrap()
+                .get_value("sentry.trace.status")
+                .is_none(),
+        );
     }
 
     #[test]

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -244,6 +244,7 @@ fn normalize_span(
         eap::normalize_user_agent(&mut span.attributes, client_ua_info);
         eap::normalize_user_geo(&mut span.attributes, |ip| geo_lookup.lookup(ip));
         eap::normalize_dsc(&mut span.attributes, &span.is_segment, headers.dsc());
+        eap::normalize_trace_status(&mut span.attributes, &span.is_segment, &span.status);
         if ctx.is_processing() {
             eap::normalize_ai(&mut span.attributes, duration, model_metdata);
         }
@@ -1035,6 +1036,16 @@ mod tests {
                 "attribute mismatch for {key}"
             )
         });
+    }
+
+    #[test]
+    fn test_normalize_trace_status_on_segment_span() {
+        let (mut span, headers, geo_lookup, ctx) = prepare_normalize_span_params(&[], &[]);
+        span.value_mut().as_mut().unwrap().is_segment = Annotated::new(true);
+
+        normalize_span(&mut span, Default::default(), &headers, &geo_lookup, ctx).unwrap();
+
+        assert_attributes_contains(&span, &[("sentry.trace.status", "ok")], &[]);
     }
 
     #[test]

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -133,6 +133,7 @@ def test_spansv2_basic(
                 "value": time_within(ts, expect_resolution="ns"),
             },
             "sentry.op": {"type": "string", "value": "default"},
+            "sentry.trace.status": {"type": "string", "value": "ok"},
         },
         "_meta": {
             "attributes": {
@@ -310,7 +311,7 @@ def test_spansv2_trimming_basic(
         "attributes": {
             "custom.array.attribute": {
                 "type": "array",
-                "value": ["A string", "Another longer string", "Yet anothe..."],
+                "value": ["A string", "Another lo...", None],
             },
             "custom.string.attribute": {
                 "type": "string",
@@ -340,21 +341,32 @@ def test_spansv2_trimming_basic(
                 "value": time_within(ts, expect_resolution="ns"),
             },
             "sentry.op": {"type": "string", "value": "default"},
+            "sentry.trace.status": {"type": "string", "value": "ok"},
         },
         "_meta": {
             "attributes": {
-                "": {"len": 565},
+                "": {"len": 586},
                 "custom.array.attribute": {
                     "value": {
-                        "2": {
+                        "1": {
                             "": {
-                                "len": 18,
+                                "len": 21,
                                 "rem": [
                                     [
                                         "!limit",
                                         "s",
                                         10,
                                         13,
+                                    ],
+                                ],
+                            },
+                        },
+                        "2": {
+                            "": {
+                                "rem": [
+                                    [
+                                        "trimmed",
+                                        "x",
                                     ],
                                 ],
                             },

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -102,6 +102,7 @@ def test_span_ingestion(
                 "value": time_within(ts, expect_resolution="ns"),
             },
             "sentry.op": {"type": "string", "value": "default"},
+            "sentry.trace.status": {"type": "string", "value": "ok"},
             "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
             "sentry.segment.id": {"type": "string", "value": "f0b809703e783d00"},
             "sentry.segment.name": {"type": "string", "value": "A Proto Span"},


### PR DESCRIPTION
The product currently exposes `sentry.trace.status` to users (as `trace.status`). This is currently only set for v1 spans (extracted from the transaction's trace context's `status` field). Despite the name, it represents the transaction's status, not the whole trace.

For backwards compatibility we have to expose this on v2 spans as well. This only makes sense on segment spans (but [segment enrichment will copy the value to all children](https://github.com/getsentry/sentry/blob/42fc58ad27656b89215d8459f903c5d6a1555a5e/src/sentry/spans/consumers/process_segments/enrichment.py#L24)). The order of precedence is:
1. Existing `sentry.trace.status` attribute (v1 span)
2. Existing `sentry.status` attribute (v1 span missing trace context `status` field)
3. Span's top-level `status` field (v2 and OTel spans)

I'm doing this in Relay because it:
- only involves individual spans (does not depend on a complete segment)
- is not related to the conversion of spans to EAP trace items

---

🤖: Used Claude for the test cases