### PR TITLE
build: Update objectstore-client to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,7 +1415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2014,6 +2014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,7 +2322,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3307,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "objectstore-client"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e5089ca231d450c233b98f2bed7ce3f4cb43bc512df5d638f8ce93adb5211d"
+checksum = "2713028097b2f0f00696d7d389a877f7370c02813548124c4422941f669732f3"
 dependencies = [
  "async-compression",
  "bytes",
@@ -3320,22 +3330,24 @@ dependencies = [
  "objectstore-types",
  "percent-encoding",
  "reqwest",
- "sentry-core 0.48.1",
+ "sentry-core",
  "serde",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "url",
+ "zstd-safe",
 ]
 
 [[package]]
 name = "objectstore-types"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c1eee221b1c0eb5cf6c6427b4cca12ec3a60de48e6f1be4c9b3f5fdaba5290"
+checksum = "c83aedfcc050322caefbfdba0372518f316624995f04f97a1f00cafb08ce1d0c"
 dependencies = [
  "http",
  "humantime",
+ "humantime-serde",
  "mediatype",
  "serde",
  "thiserror 2.0.18",
@@ -4622,7 +4634,7 @@ dependencies = [
  "relay-common",
  "relay-crash",
  "sentry",
- "sentry-core 0.47.0",
+ "sentry-core",
  "serde",
  "tracing",
  "tracing-subscriber",
@@ -5227,7 +5239,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5382,7 +5394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5403,7 +5415,7 @@ dependencies = [
  "reqwest",
  "sentry-backtrace",
  "sentry-contexts",
- "sentry-core 0.47.0",
+ "sentry-core",
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
@@ -5421,7 +5433,7 @@ checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
 dependencies = [
  "backtrace",
  "regex",
- "sentry-core 0.47.0",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5434,7 +5446,7 @@ dependencies = [
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core 0.47.0",
+ "sentry-core",
  "uname",
 ]
 
@@ -5452,26 +5464,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-core"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f5abf20c42cb1593ec1638976e2647da55f79bccac956444c1707b6cce259a"
-dependencies = [
- "rand 0.9.4",
- "sentry-types 0.48.1",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "sentry-debug-images"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
 dependencies = [
  "findshlibs",
- "sentry-core 0.47.0",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5498,7 +5497,7 @@ checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
 dependencies = [
  "bitflags",
  "log",
- "sentry-core 0.47.0",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5508,7 +5507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
 dependencies = [
  "sentry-backtrace",
- "sentry-core 0.47.0",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5531,7 +5530,7 @@ checksum = "61c5253dc4ad89863a866b93aeaaac1c9d60f2f774663b5024afe2d57e0a101c"
 dependencies = [
  "http",
  "pin-project",
- "sentry-core 0.47.0",
+ "sentry-core",
  "tower-layer",
  "tower-service",
  "url",
@@ -5545,7 +5544,7 @@ checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
 dependencies = [
  "bitflags",
  "sentry-backtrace",
- "sentry-core 0.47.0",
+ "sentry-core",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -5572,23 +5571,6 @@ name = "sentry-types"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d8e81058ec155992191f61c7b29bfa7b2cf12012131e7cdc0678020898a7c9"
 dependencies = [
  "debugid",
  "hex",
@@ -6289,7 +6271,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7086,7 +7068,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -503,8 +503,12 @@ def test_uses_trace_public_key(mini_sentry, relay):
     # send the event, the transaction should be removed.
     relay.send_envelope(project_id2, envelope)
     # Dynamic sampling metrics
-    assert mini_sentry.get_global_metrics() is not None
-    assert mini_sentry.get_global_metrics() is not None
+    metrics_batch1 = mini_sentry.get_global_metrics()
+    print(metrics_batch1)
+    metrics_batch2 = mini_sentry.get_global_metrics()
+    print(metrics_batch2)
+    assert metrics_batch1 is not None
+    assert metrics_batch2 is not None
     assert mini_sentry.get_aggregated_outcomes(n=2) == [
         {
             "category": DataCategory.TRANSACTION_INDEXED,


### PR DESCRIPTION
- Adds `humantime-serde`
- Removes additional `sentry-core` and `sentry-types`