### PR TITLE
ref(instr): Expose rdkafka broker state as a metric

### DIFF
--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -119,25 +119,32 @@ impl ClientContext for Context {
 
         for (_, broker) in statistics.brokers {
             relay_statsd::metric!(
-                gauge(KafkaGauges::OutboundBufferRequests) = broker.outbuf_cnt as u64,
+                gauge(KafkaGauges::BrokerState) = 1,
+                broker_name = &broker.name,
+                producer_name = producer_name,
+                source = broker.source,
+                state = broker.state
+            );
+            relay_statsd::metric!(
+                gauge(KafkaGauges::BrokerOutboundBufferRequests) = broker.outbuf_cnt as u64,
                 broker_name = &broker.name,
                 producer_name = producer_name
             );
             relay_statsd::metric!(
-                gauge(KafkaGauges::OutboundBufferMessages) = broker.outbuf_msg_cnt as u64,
+                gauge(KafkaGauges::BrokerOutboundBufferMessages) = broker.outbuf_msg_cnt as u64,
                 broker_name = &broker.name,
                 producer_name = producer_name
             );
             if let Some(connects) = broker.connects {
                 relay_statsd::metric!(
-                    gauge(KafkaGauges::Connects) = connects as u64,
+                    gauge(KafkaGauges::BrokerConnects) = connects as u64,
                     broker_name = &broker.name,
                     producer_name = producer_name
                 );
             }
             if let Some(disconnects) = broker.disconnects {
                 relay_statsd::metric!(
-                    gauge(KafkaGauges::Disconnects) = disconnects as u64,
+                    gauge(KafkaGauges::BrokerDisconnects) = disconnects as u64,
                     broker_name = &broker.name,
                     producer_name = producer_name
                 );

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -145,33 +145,44 @@ pub enum KafkaGauges {
     /// - `producer_name`: The configured producer name/deployment identifier.
     TxMsgs,
 
+    /// The current state of the broker.
+    ///
+    /// The metric is always emitted with the value `1` - the state is available as a tag.
+    ///
+    /// This metric is tagged with:
+    /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
+    /// - `producer_name`: The configured producer name/deployment identifier.
+    /// - `source`: The [`rdkafka::statistics::Broker::source`] of the broker.
+    /// - `state`: The current [`rdkafka::statistics::Broker::state`] of the broker.
+    BrokerState,
+
     /// The number of requests awaiting transmission to the broker.
     ///
     /// This metric is tagged with:
     /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
     /// - `producer_name`: The configured producer name/deployment identifier.
-    OutboundBufferRequests,
+    BrokerOutboundBufferRequests,
 
     /// The number of messages awaiting transmission to the broker.
     ///
     /// This metric is tagged with:
     /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
     /// - `producer_name`: The configured producer name/deployment identifier.
-    OutboundBufferMessages,
+    BrokerOutboundBufferMessages,
 
     /// The number of connection attempts, including successful and failed attempts, and name resolution failures.
     ///
     /// This metric is tagged with:
     /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
     /// - `producer_name`: The configured producer name/deployment identifier.
-    Connects,
+    BrokerConnects,
 
     /// The number of disconnections, whether triggered by the broker, the network, the load balancer, or something else.
     ///
     /// This metric is tagged with:
     /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
     /// - `producer_name`: The configured producer name/deployment identifier.
-    Disconnects,
+    BrokerDisconnects,
 
     /// Average internal producer queue latency, in milliseconds.
     ///
@@ -239,10 +250,11 @@ impl GaugeMetric for KafkaGauges {
             KafkaGauges::MessageSize => "kafka.stats.message_size",
             KafkaGauges::MessageSizeMax => "kafka.stats.message_size_max",
             KafkaGauges::TxMsgs => "kafka.stats.txmsgs",
-            KafkaGauges::OutboundBufferRequests => "kafka.stats.broker.outbuf.requests",
-            KafkaGauges::OutboundBufferMessages => "kafka.stats.broker.outbuf.messages",
-            KafkaGauges::Connects => "kafka.stats.broker.connects",
-            KafkaGauges::Disconnects => "kafka.stats.broker.disconnects",
+            KafkaGauges::BrokerState => "kafka.stats.broker.state",
+            KafkaGauges::BrokerOutboundBufferRequests => "kafka.stats.broker.outbuf.requests",
+            KafkaGauges::BrokerOutboundBufferMessages => "kafka.stats.broker.outbuf.messages",
+            KafkaGauges::BrokerConnects => "kafka.stats.broker.connects",
+            KafkaGauges::BrokerDisconnects => "kafka.stats.broker.disconnects",
             KafkaGauges::BrokerIntLatencyAvg => "kafka.stats.broker.int_latency.avg",
             KafkaGauges::BrokerIntLatencyP99 => "kafka.stats.broker.int_latency.p99",
             KafkaGauges::BrokerOutbufLatencyAvg => "kafka.stats.broker.outbuf_latency.avg",


### PR DESCRIPTION
Yet another metric, this will give us more insights into the actual state of the broker, which can also be used for alerts.