### PR TITLE
ref(upstream): Make upstream required for upstream requests sent to upstream

### DIFF
--- a/relay-server/src/services/upstream.rs
+++ b/relay-server/src/services/upstream.rs
@@ -370,9 +370,7 @@ pub trait UpstreamRequest: Send + Sync + fmt::Debug {
     ///
     /// Requests may override the default upstream descriptor with a different upstream descriptor
     /// to influence routing.
-    fn upstream(&self) -> Option<&UpstreamDescriptor> {
-        None
-    }
+    fn upstream(&self) -> Option<&UpstreamDescriptor>;
 
     /// The HTTP method of the request.
     fn method(&self) -> Method;


### PR DESCRIPTION
Every new upstream request needs to make an explicit decision what they want to do.