### PR TITLE
feat(auth): Allow parsing PEM key files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Infer span descriptions via `sentry-conventions`. ([#6093](https://github.com/getsentry/relay/pull/6093))
 - Raises the size limit for the flags context to 64KiB. ([#6137](https://github.com/getsentry/relay/pull/6137))
+- Support PEM file format for signing / verification keys. ([#6155](https://github.com/getsentry/relay/pull/6155))
+
 
 **Bug Fixes**:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,13 @@ android_trace_log = { version = "0.3", features = ["serde"] }
 # Keep it pinned until it's possible to disable backtrace.
 anyhow = "=1.0.69"
 arc-swap = "1"
-async-compression = { version = "0.4", features = ["tokio", "gzip", "brotli", "deflate", "zstd"] }
+async-compression = { version = "0.4", features = [
+    "tokio",
+    "gzip",
+    "brotli",
+    "deflate",
+    "zstd",
+] }
 async-trait = "0.1"
 axum = "0.8"
 axum-extra = "0.12"
@@ -117,7 +123,7 @@ debugid = "0.8"
 dialoguer = "0.11"
 dircpy = "0.3"
 dynfmt = "0.1"
-ed25519-dalek = { version = "2", features = ["digest"] }
+ed25519-dalek = { version = "2", features = ["digest", "pem", "pkcs8"] }
 enumset = "1"
 either = "1"
 flate2 = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,13 +90,7 @@ android_trace_log = { version = "0.3", features = ["serde"] }
 # Keep it pinned until it's possible to disable backtrace.
 anyhow = "=1.0.69"
 arc-swap = "1"
-async-compression = { version = "0.4", features = [
-    "tokio",
-    "gzip",
-    "brotli",
-    "deflate",
-    "zstd",
-] }
+async-compression = { version = "0.4", features = ["tokio", "gzip", "brotli", "deflate", "zstd"] }
 async-trait = "0.1"
 axum = "0.8"
 axum-extra = "0.12"

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- (auth) Support PEM file format for signing / verification keys by @jjbayer in ([#6155](https://github.com/getsentry/relay/pull/6155))
+
 ## 0.9.27
 
 ### Bug Fixes 🐛

--- a/relay-auth/src/lib.rs
+++ b/relay-auth/src/lib.rs
@@ -28,6 +28,7 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Duration, Utc};
 use data_encoding::BASE64URL_NOPAD;
+use ed25519_dalek::pkcs8::{DecodePrivateKey as _, DecodePublicKey as _};
 use ed25519_dalek::{Digest, DigestSigner, DigestVerifier, Signer, Verifier};
 use hmac::{Hmac, Mac};
 use rand::rngs::OsRng;
@@ -321,6 +322,10 @@ impl FromStr for SecretKey {
     type Err = KeyParseError;
 
     fn from_str(s: &str) -> Result<SecretKey, KeyParseError> {
+        if let Ok(inner) = ed25519_dalek::SigningKey::from_pkcs8_pem(s) {
+            return Ok(Self { inner });
+        }
+
         let bytes = match BASE64URL_NOPAD.decode(s.as_bytes()) {
             Ok(bytes) => bytes,
             _ => return Err(KeyParseError::BadEncoding),
@@ -450,6 +455,10 @@ impl FromStr for PublicKey {
     type Err = KeyParseError;
 
     fn from_str(s: &str) -> Result<PublicKey, KeyParseError> {
+        if let Ok(inner) = ed25519_dalek::VerifyingKey::from_public_key_pem(s) {
+            return Ok(Self { inner });
+        }
+
         let Ok(bytes) = BASE64URL_NOPAD.decode(s.as_bytes()) else {
             return Err(KeyParseError::BadEncoding);
         };
@@ -1216,5 +1225,29 @@ mod tests {
                 Duration::seconds(3),
             )
             .unwrap();
+    }
+
+    #[test]
+    fn test_parse_private_pem() {
+        let s = r#"-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIPBFGz4q5QW27KNimPqb3dr9/pO4o6XR7QIKE1rxGAIK
+-----END PRIVATE KEY-----"#;
+        let key: SecretKey = s.parse().unwrap();
+        assert_eq!(
+            key.to_string(),
+            "8EUbPirlBbbso2KY-pvd2v3-k7ijpdHtAgoTWvEYAgo"
+        );
+    }
+
+    #[test]
+    fn test_parse_public_pem() {
+        let s = r#"-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEATQCO/kpf2pyVjQyTuzr2qhi8IBxmBm2apZrUjJALYeA=
+-----END PUBLIC KEY-----"#;
+        let key: PublicKey = s.parse().unwrap();
+        assert_eq!(
+            key.to_string(),
+            "TQCO_kpf2pyVjQyTuzr2qhi8IBxmBm2apZrUjJALYeA"
+        );
     }
 }


### PR DESCRIPTION
Enable deserialization of public verification / private signing keys formatted with the prefix `-----BEGIN PUBLIC KEY-----` and `-----BEGIN PRIVATE KEY-----`, respectively.

This facilitates integration with secret providers.

ref: INGEST-755