### PR TITLE
fix(instr): Fix Kafka state gauge emission

### DIFF
--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -87,6 +87,51 @@ impl Context {
     pub fn producer_name(&self) -> &str {
         &self.producer_name
     }
+
+    /// A helper to emit a broker state gauge.
+    ///
+    /// Each state is represented as a distinct gauge with a specific state tag,
+    /// since gauges do not self-clear this helper resets all known states to zero
+    /// on every emission.
+    ///
+    /// Note:
+    ///  - This implementation does relay on the list of brokers being static.
+    ///  - This implementation only considers known broker state values.
+    fn emit_broker_state(&self, broker: &rdkafka::statistics::Broker) {
+        const KAFKA_BROKER_STATES: &[&str] = &[
+            // Documented in the `rdkafka` crate:
+            "INIT",
+            "DOWN",
+            "CONNECT",
+            "AUTH",
+            "APIVERSION_QUERY",
+            "AUTH_HANDSHAKE",
+            "UP",
+            "UPDATE",
+            // In the C `rdkafka` source:
+            "TRY_CONNECT",
+            "SSL_HANDSHAKE",
+            "AUTH_LEGACY",
+            "AUTH_REQ",
+            "REAUTH",
+        ];
+
+        // Not gonna catch all cases, but better than nothing and shows the intention,
+        // all possible states must be defined in `KAFKA_BROKER_STATES`.
+        debug_assert!(
+            KAFKA_BROKER_STATES.contains(&broker.state.as_str()),
+            "Kafka broker state not in known list of states"
+        );
+
+        for state in KAFKA_BROKER_STATES {
+            relay_statsd::metric!(
+                gauge(KafkaGauges::BrokerState) = u64::from(*state == broker.state),
+                broker_name = &broker.name,
+                producer_name = &self.producer_name,
+                state = *state
+            );
+        }
+    }
 }
 
 impl ClientContext for Context {
@@ -118,13 +163,8 @@ impl ClientContext for Context {
         );
 
         for (_, broker) in statistics.brokers {
-            relay_statsd::metric!(
-                gauge(KafkaGauges::BrokerState) = 1,
-                broker_name = &broker.name,
-                producer_name = producer_name,
-                source = broker.source,
-                state = broker.state
-            );
+            self.emit_broker_state(&broker);
+
             relay_statsd::metric!(
                 gauge(KafkaGauges::BrokerOutboundBufferRequests) = broker.outbuf_cnt as u64,
                 broker_name = &broker.name,

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -145,14 +145,15 @@ pub enum KafkaGauges {
     /// - `producer_name`: The configured producer name/deployment identifier.
     TxMsgs,
 
-    /// The current state of the broker.
+    /// A snapshot of the broker state.
     ///
-    /// The metric is always emitted with the value `1` - the state is available as a tag.
+    /// All broker states are emitted as a separate series tagged with `state`.
+    /// The current state is emitted with value `1`, and all other states are emitted
+    /// with value `0`.
     ///
     /// This metric is tagged with:
     /// - `broker_name`: The broker hostname, port, and ID, in the form HOSTNAME:PORT/ID.
     /// - `producer_name`: The configured producer name/deployment identifier.
-    /// - `source`: The [`rdkafka::statistics::Broker::source`] of the broker.
     /// - `state`: The current [`rdkafka::statistics::Broker::state`] of the broker.
     BrokerState,
 


### PR DESCRIPTION
Our current metrics backend doesn't actually stop emitting gauges, it continuous to emit gauges with the last seen value (which is good), this breaks the intent of the metric.

This fixes the gauge, but has some caveats (like brokers can't disappear and it doesn't handle unknown states), but I think these are acceptable compromises for this metric, as practically these things never happen and the alternatives are much more complicated.