### PR TITLE
fix(parse): Prevent panic through item size overflow

### DIFF
--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -71,7 +71,10 @@ impl Item {
             .map_err(EnvelopeError::InvalidItemHeader)?;
         let payload_end = match length {
             Some(len) => {
-                let payload_end = payload_start + len;
+                let payload_end = payload_start
+                    .checked_add(len)
+                    .ok_or(EnvelopeError::UnexpectedEof)?;
+
                 if bytes.len() < payload_end {
                     // NB: `Bytes::slice` panics if the indices are out of range.
                     return Err(EnvelopeError::UnexpectedEof);

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -1395,6 +1395,17 @@ mod tests {
     }
 
     #[test]
+    fn test_item_parse_length_overflow_does_not_panic() {
+        let header = format!(r#"{{"type":"attachment","length":{}}}"#, usize::MAX)
+            .into_bytes()
+            .into();
+
+        let err = Item::parse(header).unwrap_err();
+
+        std::assert_matches!(err, EnvelopeError::UnexpectedEof);
+    }
+
+    #[test]
     fn test_item_type_names() {
         assert_eq!(ItemType::Span.name(), "span");
         assert_eq!(ItemType::Unknown("test".to_owned()).name(), "unknown");


### PR DESCRIPTION
Fixes a potential overflow where an item header length is parsed as `usize` and added to the `payload_start` which can cause on overflow creating a situation where the `payload_end` is smaller than `payload_start`, using start and end to create a range will then cause a panic.