### PR TITLE
fix(spans): Don't modify segment information for V2 spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Infer span names PII-safely. ([#6112](https://github.com/getsentry/relay/pull/6112))
 - Unset segment info for web vital spans. ([#6042](https://github.com/getsentry/relay/pull/6042))
 - Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
+- Don't modify segment information for V2 web vital spans. ([#6160](https://github.com/getsentry/relay/pull/6160))
 
 **Internal**:
 

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -385,6 +385,15 @@ struct Settings {
     /// for the benefit of standalone spans which need to have a name inferred
     /// after conversion to V2.
     infer_name: bool,
+    /// Whether to delete segment information (`is_segment`, `parent_span_id`,
+    /// [`SENTRY__SEGMENT__ID`](relay_conventions::attributes::SENTRY__SEGMENT__ID))
+    /// for web vital spans.
+    /// See [`normalize_web_vital_span_segment`](relay_event_normalization::eap::normalize_web_vital_span_segment).
+    ///
+    /// We want to do this for V1 standalone spans for the sake of parity
+    /// with the legacy pipeline. For V2 spans, we assume the SDK is already
+    /// sending the correct values.
+    clear_web_vital_segment_info: bool,
 }
 
 /// Spans which have been parsed and expanded from their serialized state.

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -116,6 +116,7 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
                     // We don't want to infer names for V2 spans. If an SDK sent a
                     // V2 span without a name it's just invalid.
                     infer_name: false,
+                    clear_web_vital_segment_info: false,
                 },
                 // Unsupported, fall back to the safe default.
                 Some(_) => Default::default(),
@@ -151,6 +152,9 @@ fn expand_legacy_spans(
         // The inference can't happen during the conversion
         // because PII scrubbing needs to run first.
         infer_name: true,
+        // We want to do this for V1 standalone spans for parity
+        // with the legacy pipeline.
+        clear_web_vital_segment_info: false,
     };
 
     (settings, spans)
@@ -234,7 +238,9 @@ fn normalize_span(
         // because category derivation depends on having the sentry.op attribute
         // available.
         eap::normalize_sentry_op(&mut span.attributes);
-        eap::normalize_web_vital_span_segment(span);
+        if settings.clear_web_vital_segment_info {
+            eap::normalize_web_vital_span_segment(span);
+        }
         eap::normalize_span_category(&mut span.attributes);
         eap::normalize_received(&mut span.attributes, meta.received_at());
         eap::normalize_client_address(&mut span.attributes, meta.client_addr());

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -154,7 +154,7 @@ fn expand_legacy_spans(
         infer_name: true,
         // We want to do this for V1 standalone spans for parity
         // with the legacy pipeline.
-        clear_web_vital_segment_info: false,
+        clear_web_vital_segment_info: true,
     };
 
     (settings, spans)

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1904,3 +1904,114 @@ def test_spansv2_ingestion_with_performance_scores(
     for span, scores in zip(spans, expected_scores):
         for key, score in scores.items():
             assert span["attributes"][key]["value"] == score
+
+
+def test_spansv2_lcp_segment(mini_sentry, relay_with_processing, spans_consumer):
+    """Tests that segment information is left in place for
+    V2 web vital spans."""
+
+    spans_consumer = spans_consumer()
+    relay = relay_with_processing()
+
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+
+    ts = datetime.now(timezone.utc)
+
+    envelope = envelope_with_spans(
+        {
+            "name": "StreamGroup > GroupSummary > GroupHeaderRow > EventMessage > Message",
+            "span_id": "9b2fc21fec8336be",
+            "trace_id": "60af731187e44081a96d22205ab97561",
+            "parent_span_id": "a84cb30362883928",
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.5,
+            "is_segment": False,
+            "status": "ok",
+            "attributes": {
+                "sentry.origin": {"value": "auto.http.browser.lcp", "type": "string"},
+                "sentry.op": {"value": "ui.webvital.lcp", "type": "string"},
+                "sentry.segment.name": {"value": "/issues/", "type": "string"},
+                "sentry.segment.id": {"value": "a84cb30362883928", "type": "string"},
+            },
+        },
+        metadata={
+            "version": 2,
+            "ingest_settings": {
+                "infer_user_agent": "auto",
+            },
+        },
+        trace_info={
+            "trace_id": "60af731187e44081a96d22205ab97561",
+            "environment": "control",
+            "release": "backend@edca71dbf71173e6436087b69a110538b0f02a04",
+            "public_key": "98443d956c9e40989a0139756c121c34",
+            "transaction": "/issues/",
+        },
+    )
+    relay.send_envelope(project_id, envelope)
+
+    span = spans_consumer.get_span()
+
+    assert span == {
+        "name": "StreamGroup > GroupSummary > GroupHeaderRow > EventMessage > Message",
+        "span_id": "9b2fc21fec8336be",
+        "trace_id": "60af731187e44081a96d22205ab97561",
+        "parent_span_id": "a84cb30362883928",
+        "start_timestamp": time_is(ts.timestamp()),
+        "end_timestamp": time_is(ts.timestamp() + 0.5),
+        "is_segment": False,
+        "status": "ok",
+        "received": time_within(ts),
+        "downsampled_retention_days": 90,
+        "retention_days": 90,
+        "key_id": 123,
+        "organization_id": 1,
+        "project_id": 42,
+        "attributes": {
+            "browser.name": {
+                "type": "string",
+                "value": "Firefox",
+            },
+            "browser.version": {
+                "type": "string",
+                "value": "42.0",
+            },
+            "sentry.dsc.project_id": {
+                "type": "string",
+                "value": "42",
+            },
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "60af731187e44081a96d22205ab97561",
+            },
+            "sentry.observed_timestamp_nanos": {
+                "type": "string",
+                "value": time_within(ts, expect_resolution="ns"),
+            },
+            "sentry.origin": {
+                "type": "string",
+                "value": "auto.http.browser.lcp",
+            },
+            "sentry.op": {
+                "type": "string",
+                "value": "ui.webvital.lcp",
+            },
+            "sentry.segment.name": {
+                "type": "string",
+                "value": "/issues/",
+            },
+            "sentry.segment.id": {
+                "type": "string",
+                "value": "a84cb30362883928",
+            },
+            "sentry.transaction": {
+                "type": "string",
+                "value": "/issues/",
+            },
+            "user_agent.original": {
+                "type": "string",
+                "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+            },
+        },
+    }


### PR DESCRIPTION
PR https://github.com/getsentry/relay/pull/6042 added a normalization to the V2 span pipeline that clears out segment information for web vital spans. This was added for feature parity with the legacy V1 standalone span pipeline. However, this normalization is actually undesired for genuine V2 spans. Therefore we conditionally enable it only for V1 standalone spans going through the V2 pipeline.