### PR TITLE
ref(upload): Naming consistency

### DIFF
--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -1291,7 +1291,7 @@ pub struct ObjectstoreServiceConfig {
 
     /// Whether event attachment payloads may be sent through Kafka if objectstore upload fails.
     ///
-    /// When disabled, failed event attachments are dropped with an `objectstore_upload_failed`
+    /// When disabled, failed event attachments are dropped with an `upload_failed`
     /// outcome instead of falling back to Store's Kafka attachment path.
     pub fallback_to_kafka: bool,
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -120,7 +120,7 @@ pub enum BadStoreRequest {
     #[error("project not available")]
     ProjectUnavailable,
 
-    #[error("failed to upload to objectstore")]
+    #[error("failed to upload file")]
     UploadFailed,
 }
 

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -121,7 +121,7 @@ pub enum BadStoreRequest {
     ProjectUnavailable,
 
     #[error("failed to upload to objectstore")]
-    ObjectstoreUploadFailed,
+    UploadFailed,
 }
 
 impl BadStoreRequest {
@@ -149,7 +149,7 @@ impl BadStoreRequest {
             Self::RateLimited(_) => DiscardReason::RateLimited,
             Self::EventRejected(discard_reason) => *discard_reason,
             Self::ProjectUnavailable => DiscardReason::ProjectUnavailable,
-            Self::ObjectstoreUploadFailed => DiscardReason::ObjectstoreUploadFailed,
+            Self::UploadFailed => DiscardReason::UploadFailed,
         };
         Some(Outcome::Invalid(discard_reason))
     }
@@ -226,7 +226,7 @@ impl IntoResponse for BadStoreRequest {
             BadStoreRequest::ItemTooLarge(_) | BadStoreRequest::RequestTooLarge => {
                 (StatusCode::PAYLOAD_TOO_LARGE, body).into_response()
             }
-            BadStoreRequest::ObjectstoreUploadFailed => {
+            BadStoreRequest::UploadFailed => {
                 (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
             }
             BadStoreRequest::InvalidMultipart(multer::Error::LockFailure) => {
@@ -545,9 +545,9 @@ fn emit_envelope_metrics(envelope: &Envelope) {
     }
 }
 
-/// Uploads the content of `field` to the objectstore and returns an [Item] with an
+/// Uploads the content of `field` to the upload service and returns an [Item] with an
 /// [AttachmentPlaceholder] as payload.
-pub async fn upload_to_objectstore<S, E>(
+pub async fn upload_stream<S, E>(
     stream: S,
     content_type: Option<String>,
     mut item: Managed<Item>,
@@ -560,7 +560,7 @@ where
     S: futures::Stream<Item = Result<Bytes, E>> + Send + 'static,
     E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
-    let res = upload_to_objectstore_inner(
+    let res = upload_stream_inner(
         stream,
         content_type,
         &mut item,
@@ -576,7 +576,7 @@ where
     }
 }
 
-async fn upload_to_objectstore_inner<S, E>(
+async fn upload_stream_inner<S, E>(
     stream: S,
     content_type: Option<String>,
     item: &mut Managed<Item>,

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -22,7 +22,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 use zstd::stream::Decoder as ZstdDecoder;
 
 use crate::constants::{ITEM_NAME_BREADCRUMBS1, ITEM_NAME_BREADCRUMBS2, ITEM_NAME_EVENT};
-use crate::endpoints::common::{self, BadStoreRequest, TextResponse, upload_to_objectstore};
+use crate::endpoints::common::{self, BadStoreRequest, TextResponse, upload_stream};
 use crate::envelope::{AttachmentType, ContentType, Envelope, Item, ItemType, Items};
 use crate::extractors::{RawContentType, RequestMeta};
 use crate::managed::{Managed, ManagedResult};
@@ -273,7 +273,7 @@ impl<'a> AttachmentStrategy for MinidumpAttachmentStrategy<'a> {
             UploadDecision::Upload => {
                 let is_minidump = matches!(item.attachment_type(), Some(AttachmentType::Minidump));
                 let content_type = field.content_type().map(ToString::to_string);
-                match upload_to_objectstore_checked(
+                match upload_stream_checked(
                     field,
                     content_type,
                     item,
@@ -315,8 +315,8 @@ impl<'a> AttachmentStrategy for MinidumpAttachmentStrategy<'a> {
     }
 }
 
-/// Wrapper around [`upload_to_objectstore`] that enforces that minidumps are not compressed.
-pub async fn upload_to_objectstore_checked<S, E>(
+/// Wrapper around [`upload_stream`] that enforces that minidumps are not compressed.
+pub async fn upload_stream_checked<S, E>(
     stream: S,
     content_type: Option<String>,
     item: Managed<Item>,
@@ -330,7 +330,7 @@ where
     E: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
 {
     if !matches!(item.attachment_type(), Some(AttachmentType::Minidump)) {
-        return upload_to_objectstore(
+        return upload_stream(
             stream,
             content_type,
             item,
@@ -340,7 +340,7 @@ where
             referrer,
         )
         .await
-        .map_err(|_| BadStoreRequest::ObjectstoreUploadFailed);
+        .map_err(|_| BadStoreRequest::UploadFailed);
     }
 
     let stream = match reject_if_compressed(stream).await {
@@ -351,7 +351,7 @@ where
         }
     };
 
-    upload_to_objectstore(
+    upload_stream(
         stream,
         content_type,
         item,
@@ -361,7 +361,7 @@ where
         referrer,
     )
     .await
-    .map_err(|_| BadStoreRequest::ObjectstoreUploadFailed)
+    .map_err(|_| BadStoreRequest::UploadFailed)
 }
 
 async fn multipart_to_items(
@@ -515,7 +515,7 @@ async fn raw_minidump_to_item(
             .await
             .map_err(|_| BadStoreRequest::InvalidMinidump)?;
 
-        item = upload_to_objectstore(
+        item = upload_stream(
             stream,
             Some(content_type.to_string()).filter(|s| !s.is_empty()),
             item,
@@ -525,7 +525,7 @@ async fn raw_minidump_to_item(
             "minidump",
         )
         .await
-        .map_err(|_| BadStoreRequest::ObjectstoreUploadFailed)?;
+        .map_err(|_| BadStoreRequest::UploadFailed)?;
     } else {
         let minidump_data = request.extract().await?;
         item.try_modify(|inner, records| -> Result<(), BadStoreRequest> {

--- a/relay-server/src/endpoints/playstation.rs
+++ b/relay-server/src/endpoints/playstation.rs
@@ -147,7 +147,7 @@ impl<'a> AttachmentStrategy for PlaystationAttachmentStrategy<'a> {
         match &self.upload_context {
             Some(upload_context) if self.infer_type(&field) != AttachmentType::Prosperodump => {
                 let content_type = field.content_type().map(ToString::to_string);
-                Ok(common::upload_to_objectstore(
+                Ok(common::upload_stream(
                     field,
                     content_type,
                     item,

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -409,8 +409,7 @@ impl LoadShed<Objectstore> for ObjectstoreService {
                 if self.inner.fallback_to_kafka {
                     self.inner.store.send(message);
                 } else {
-                    let _ = message
-                        .reject_err(Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed));
+                    let _ = message.reject_err(Outcome::Invalid(DiscardReason::UploadFailed));
                 }
             }
             Objectstore::TraceAttachment(managed) => {
@@ -580,8 +579,7 @@ impl ObjectstoreServiceInner {
                 if self.fallback_to_kafka {
                     self.store.send(attachment)
                 } else {
-                    let _ = attachment
-                        .reject_err(Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed));
+                    let _ = attachment.reject_err(Outcome::Invalid(DiscardReason::UploadFailed));
                 }
             }
         };
@@ -931,7 +929,7 @@ fn should_upload(item: &Item) -> bool {
 fn drop_failed_uploads(envelope: &mut ManagedEnvelope) {
     envelope.retain_items(|item| {
         if should_upload(item) {
-            ItemAction::Drop(Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed))
+            ItemAction::Drop(Outcome::Invalid(DiscardReason::UploadFailed))
         } else {
             ItemAction::Keep
         }
@@ -1033,7 +1031,7 @@ mod tests {
         let outcome = outcome_rx.try_recv().unwrap();
         assert_eq!(
             outcome.outcome,
-            Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed)
+            Outcome::Invalid(DiscardReason::UploadFailed)
         );
         assert_eq!(outcome.category, DataCategory::Attachment);
         assert_eq!(outcome.quantity, 5);
@@ -1041,7 +1039,7 @@ mod tests {
         let outcome = outcome_rx.try_recv().unwrap();
         assert_eq!(
             outcome.outcome,
-            Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed)
+            Outcome::Invalid(DiscardReason::UploadFailed)
         );
         assert_eq!(outcome.category, DataCategory::AttachmentItem);
         assert_eq!(outcome.quantity, 1);
@@ -1080,7 +1078,7 @@ mod tests {
         let outcome = outcome_rx.try_recv().unwrap();
         assert_eq!(
             outcome.outcome,
-            Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed)
+            Outcome::Invalid(DiscardReason::UploadFailed)
         );
         assert_eq!(outcome.category, DataCategory::Attachment);
         assert_eq!(outcome.quantity, 5);
@@ -1088,7 +1086,7 @@ mod tests {
         let outcome = outcome_rx.try_recv().unwrap();
         assert_eq!(
             outcome.outcome,
-            Outcome::Invalid(DiscardReason::ObjectstoreUploadFailed)
+            Outcome::Invalid(DiscardReason::UploadFailed)
         );
         assert_eq!(outcome.category, DataCategory::AttachmentItem);
         assert_eq!(outcome.quantity, 1);

--- a/relay-server/src/services/outcome/mod.rs
+++ b/relay-server/src/services/outcome/mod.rs
@@ -407,7 +407,7 @@ pub enum DiscardReason {
     InvalidDynamicSamplingContext,
 
     /// (Relay) Failed to upload to objectstore.
-    ObjectstoreUploadFailed,
+    UploadFailed,
 }
 
 impl DiscardReason {
@@ -475,7 +475,7 @@ impl DiscardReason {
             DiscardReason::InvalidCheckIn => "invalid_check_in",
             DiscardReason::MissingDynamicSamplingContext => "missing_dsc",
             DiscardReason::InvalidDynamicSamplingContext => "invalid_dsc",
-            DiscardReason::ObjectstoreUploadFailed => "objectstore_upload_failed",
+            DiscardReason::UploadFailed => "upload_failed",
         }
     }
 }

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -1723,7 +1723,7 @@ def test_minidump_upload_failure_bubbles_up(mini_sentry, relay):
         {
             "category": DataCategory.ERROR,
             "outcome": 3,  # invalid
-            "reason": "objectstore_upload_failed",
+            "reason": "upload_failed",
             "quantity": 1,
         },
         {


### PR DESCRIPTION
Just some renames for consistency: Uploads go to the `Upload` service, of which `Objectstore` is an implementation detail. When an upload fails, it is not necessarily an objectstore problem.