### PR TITLE
feat(objectstore): Retry 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add config option to bypass the kafka fallback for objectstore uploads. ([#6127](https://github.com/getsentry/relay/pull/6127))
 - Use upstream descriptor in upload requests. ([#6128](https://github.com/getsentry/relay/pull/6128))
 - Use dedicated secret to sign upload URLs. ([#6132](https://github.com/getsentry/relay/pull/6132))
+- Retry 500 responses from objectstore. ([#6162](https://github.com/getsentry/relay/pull/6162))
 
 ## 26.6.0
 

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -905,6 +905,7 @@ fn is_retryable(error: &objectstore_client::Error) -> bool {
                             | StatusCode::BAD_GATEWAY
                             | StatusCode::SERVICE_UNAVAILABLE
                             | StatusCode::GATEWAY_TIMEOUT
+                            | StatusCode::INTERNAL_SERVER_ERROR
                     )
                 )
         }


### PR DESCRIPTION
Objectstore translates transient 503s from its backends to 500 responses, so chances are high that a 500 response from Objectstore is actually not deterministic (based on input), but rather retryable.

Fixes [RELAY-6E](https://sentry-s4s2.sentry.io/issues/26271/events/3a2bc7d5e126473aaaa4408dcdb2334c/)