### PR TITLE
fix(eap): Port set_segment_attributes to V2 span pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,8 @@
 - Wider type support for OTel log bodies. ([#6106](https://github.com/getsentry/relay/pull/6106))
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))
 - Infer span names PII-safely. ([#6112](https://github.com/getsentry/relay/pull/6112))
-- Unset segment info for web vital spans. ([#6042](https://github.com/getsentry/relay/pull/6042))
 - Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
-- Don't modify segment information for V2 web vital spans. ([#6160](https://github.com/getsentry/relay/pull/6160))
+- Normalize segment-related fields in the experimental standalone spans pipeline. ([#6042](https://github.com/getsentry/relay/pull/6042), [#6160](https://github.com/getsentry/relay/pull/6160), [#6164](https://github.com/getsentry/relay/pull/6164))
 
 **Internal**:
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -829,12 +829,18 @@ fn normalize_http_attributes(
     }
 }
 
-/// Makes sure web vital spans are not identified with segments.
+/// Normalize segment-related fields and attributes for a span.
 ///
-/// This was ported from the legacy pipeline for behavior parity.
-/// At some point in the future, web vital spans will become metrics,
-/// and this will become academic.
-pub fn normalize_web_vital_span_segment(span: &mut SpanV2) {
+/// * Web vital spans have segment-related information deleted.
+/// * Spans are marked as segments according to whether their span
+///   ID coincides with their segment ID, if they have the latter.
+/// * Spans without a parent span are marked as segments.
+/// * Finally, if a span is a segment, its segment ID is set
+///   to its ID.
+///
+/// This was ported from the function `set_segment_attributes`
+/// in the legacy pipeline for behavior parity.
+pub fn normalize_span_segment(span: &mut SpanV2) {
     let Some(attributes) = span.attributes.value_mut() else {
         return;
     };
@@ -846,6 +852,27 @@ pub fn normalize_web_vital_span_segment(span: &mut SpanV2) {
         span.is_segment = None.into();
         span.parent_span_id = None.into();
         attributes.remove(SENTRY__SEGMENT__ID);
+        return;
+    }
+
+    let Some(span_id) = span.span_id.value() else {
+        return;
+    };
+
+    if let Some(segment_id) = attributes
+        .get_value(SENTRY__SEGMENT__ID)
+        .and_then(|value| value.as_str())
+    {
+        // The span is a segment if and only if the segment_id matches the span_id.
+        span.is_segment = (segment_id == span_id.to_string()).into();
+    } else if span.parent_span_id.is_empty() {
+        // If the span has no parent, it is automatically a segment:
+        span.is_segment = true.into();
+    }
+
+    // If the span is a segment, always set the segment_id to the current span_id:
+    if span.is_segment.value() == Some(&true) {
+        attributes.insert(SENTRY__SEGMENT__ID, span_id.to_string());
     }
 }
 

--- a/relay-server/src/processing/spans/mod.rs
+++ b/relay-server/src/processing/spans/mod.rs
@@ -385,15 +385,14 @@ struct Settings {
     /// for the benefit of standalone spans which need to have a name inferred
     /// after conversion to V2.
     infer_name: bool,
-    /// Whether to delete segment information (`is_segment`, `parent_span_id`,
-    /// [`SENTRY__SEGMENT__ID`](relay_conventions::attributes::SENTRY__SEGMENT__ID))
-    /// for web vital spans.
-    /// See [`normalize_web_vital_span_segment`](relay_event_normalization::eap::normalize_web_vital_span_segment).
+    /// Whether to normalize various segment-related fields and attributes.
+    ///
+    /// See [`normalize_span_segment`](relay_event_normalization::eap::normalize_span_segment).
     ///
     /// We want to do this for V1 standalone spans for the sake of parity
     /// with the legacy pipeline. For V2 spans, we assume the SDK is already
     /// sending the correct values.
-    clear_web_vital_segment_info: bool,
+    normalize_segment_info: bool,
 }
 
 /// Spans which have been parsed and expanded from their serialized state.

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -116,7 +116,7 @@ fn expand_span_container(item: &Item) -> Result<(Settings, ContainerItems<SpanV2
                     // We don't want to infer names for V2 spans. If an SDK sent a
                     // V2 span without a name it's just invalid.
                     infer_name: false,
-                    clear_web_vital_segment_info: false,
+                    normalize_segment_info: false,
                 },
                 // Unsupported, fall back to the safe default.
                 Some(_) => Default::default(),
@@ -154,7 +154,7 @@ fn expand_legacy_spans(
         infer_name: true,
         // We want to do this for V1 standalone spans for parity
         // with the legacy pipeline.
-        clear_web_vital_segment_info: true,
+        normalize_segment_info: true,
     };
 
     (settings, spans)
@@ -238,8 +238,8 @@ fn normalize_span(
         // because category derivation depends on having the sentry.op attribute
         // available.
         eap::normalize_sentry_op(&mut span.attributes);
-        if settings.clear_web_vital_segment_info {
-            eap::normalize_web_vital_span_segment(span);
+        if settings.normalize_segment_info {
+            eap::normalize_span_segment(span);
         }
         eap::normalize_span_category(&mut span.attributes);
         eap::normalize_received(&mut span.attributes, meta.received_at());

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -1192,5 +1192,154 @@ def test_name_inference(
     }
 
 
+@pytest.mark.parametrize("mode", ["legacy", "v2"])
+@pytest.mark.parametrize("segment_id", [None, "same", "different"])
+@pytest.mark.parametrize("has_parent_span", [False, True])
+@pytest.mark.parametrize("is_segment", [False, True])
+def test_segment_normalization(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    spans_consumer,
+    mode,
+    segment_id,
+    has_parent_span,
+    is_segment,
+):
+    """
+    Tests that (non-web-vital-related) segment fields are normalized.
+    """
+    spans_consumer = spans_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    if mode == "v2":
+        project_config["config"].setdefault("features", []).append(
+            "projects:span-v2-experimental-processing"
+        )
+
+    relay = relay(relay_with_processing())
+
+    ts = datetime.now(timezone.utc)
+
+    span_id = "9fd17741416e8e4e"
+
+    if segment_id == "same":
+        segment_id = span_id
+    elif segment_id == "different":
+        segment_id = "aaaaaaaaaaaaaaaa"
+
+    fields = {}
+    if has_parent_span:
+        fields["parent_span_id"] = "8a6626cc9bdd5d9b"
+    if segment_id:
+        fields["segment_id"] = segment_id
+
+    envelope = envelope_with_spans(
+        {
+            "op": "http.client",
+            "description": "http.client",
+            "span_id": span_id,
+            "start_timestamp": ts.timestamp() - 0.5,
+            "timestamp": ts.timestamp(),
+            "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+            "origin": "auto",
+            "exclusive_time": 0,
+            "measurements": {},
+            "is_segment": is_segment,
+            **fields,
+        },
+        trace_info={
+            "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+            "public_key": project_config["publicKeys"][0]["publicKey"],
+            "transaction": "/insights/projects/",
+        },
+    )
+
+    relay.send_envelope(project_id, envelope)
+
+    # Mirrors the logic in `set_segment_attributes`.
+    if segment_id:
+        expected_is_segment = segment_id == span_id
+    elif not has_parent_span:
+        expected_is_segment = True
+    else:
+        expected_is_segment = is_segment
+
+    if expected_is_segment:
+        expected_segment_id = span_id
+    else:
+        expected_segment_id = segment_id
+
+    assert spans_consumer.get_span() == {
+        "attributes": {
+            "client.address": {"type": "string", "value": "127.0.0.1"},
+            "browser.name": {"type": "string", "value": "Firefox"},
+            "sentry.category": {"type": "string", "value": "http"},
+            "sentry.description": {"type": "string", "value": "http.client"},
+            "sentry.dsc.transaction": {
+                "type": "string",
+                "value": "/insights/projects/",
+            },
+            "sentry.dsc.project_id": {"type": "string", "value": "42"},
+            "sentry.dsc.trace_id": {
+                "type": "string",
+                "value": "d3d20f000885466b8c8f947c9b92b8d3",
+            },
+            "sentry.exclusive_time": {"type": "double", "value": 0.0},
+            "sentry.op": {"type": "string", "value": "http.client"},
+            "sentry.origin": {"type": "string", "value": "auto"},
+            **_if_dict(
+                expected_segment_id,
+                {
+                    "sentry.segment.id": {
+                        "type": "string",
+                        "value": expected_segment_id,
+                    },
+                },
+            ),
+            "user_agent.original": {
+                "type": "string",
+                "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
+            },
+            # The V2 pipeline has some additional normalizations
+            # for segment spans specifically.
+            **_if_dict(
+                mode == "v2" and expected_is_segment,
+                {
+                    "sentry.trace.status": {
+                        "type": "string",
+                        "value": "ok",
+                    },
+                    "sentry.dsc.public_key": {
+                        "type": "string",
+                        "value": project_config["publicKeys"][0]["publicKey"],
+                    },
+                },
+            ),
+            **lcp_cls_inp_differences(mode),
+        },
+        "downsampled_retention_days": 90,
+        "end_timestamp": time_within(ts),
+        "key_id": 123,
+        "name": "HTTP",
+        "organization_id": 1,
+        "project_id": 42,
+        "received": time_within(ts),
+        "retention_days": 90,
+        "span_id": span_id,
+        "start_timestamp": time_within(ts.timestamp() - 0.5),
+        "status": "ok",
+        "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+        "is_segment": expected_is_segment,
+        **_if_dict(
+            has_parent_span,
+            {
+                "parent_span_id": "8a6626cc9bdd5d9b",
+            },
+        ),
+    }
+
+
 def _if_dict(cond, then):
     return then if cond else {}


### PR DESCRIPTION
This extends #6042 by porting the entire `set_segment_attributes` function (which contains the logic implemented in that PR) to the V2 standalone span pipeline. The normalization function and the settings flag are renamed accordingly.

I've also added a test that exercises every possible way through this function (for non-web-vital spans—those are already covered by existing tests).

ref: INGEST-943