### PR TITLE
feat(ai): Attach granular cost data to spans

### DIFF
--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -206,9 +206,6 @@ fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&Model
 
     // Overwrite all values, the attributes should reflect the values we used to calculate the total.
     attributes.insert(GEN_AI__COST__INPUT_TOKENS, costs.input);
-    attributes.insert(GEN_AI__COST__OUTPUT_TOKENS, costs.output);
-    attributes.insert(GEN_AI__COST__TOTAL_TOKENS, costs.total());
-
     attributes.insert(
         GEN_AI__COST__CACHE_READ__INPUT_TOKENS,
         costs.cache_read_input,
@@ -217,10 +214,14 @@ fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&Model
         GEN_AI__COST__CACHE_CREATION__INPUT_TOKENS,
         costs.cache_creation_input,
     );
+
+    attributes.insert(GEN_AI__COST__OUTPUT_TOKENS, costs.output);
     attributes.insert(
         GEN_AI__COST__REASONING__OUTPUT_TOKENS,
         costs.reasoning_output,
     );
+
+    attributes.insert(GEN_AI__COST__TOTAL_TOKENS, costs.total());
 }
 
 fn extract_string_value<'a>(attributes: &'a Attributes, key: &str) -> Option<&'a str> {

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -208,6 +208,19 @@ fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&Model
     attributes.insert(GEN_AI__COST__INPUT_TOKENS, costs.input);
     attributes.insert(GEN_AI__COST__OUTPUT_TOKENS, costs.output);
     attributes.insert(GEN_AI__COST__TOTAL_TOKENS, costs.total());
+
+    attributes.insert(
+        GEN_AI__COST__CACHE_READ__INPUT_TOKENS,
+        costs.cache_read_input,
+    );
+    attributes.insert(
+        GEN_AI__COST__CACHE_CREATION__INPUT_TOKENS,
+        costs.cache_creation_input,
+    );
+    attributes.insert(
+        GEN_AI__COST__REASONING__OUTPUT_TOKENS,
+        costs.reasoning_output,
+    );
 }
 
 fn extract_string_value<'a>(attributes: &'a Attributes, key: &str) -> Option<&'a str> {
@@ -305,6 +318,14 @@ mod tests {
 
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
+          "gen_ai.cost.cache_read.input_tokens": {
+            "type": "double",
+            "value": 20.0
+          },
           "gen_ai.cost.input_tokens": {
             "type": "double",
             "value": 25.0
@@ -312,6 +333,10 @@ mod tests {
           "gen_ai.cost.output_tokens": {
             "type": "double",
             "value": 50.0
+          },
+          "gen_ai.cost.reasoning.output_tokens": {
+            "type": "double",
+            "value": 30.0
           },
           "gen_ai.cost.total_tokens": {
             "type": "double",
@@ -374,6 +399,14 @@ mod tests {
 
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
+          "gen_ai.cost.cache_read.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
           "gen_ai.cost.input_tokens": {
             "type": "double",
             "value": 90.0
@@ -381,6 +414,10 @@ mod tests {
           "gen_ai.cost.output_tokens": {
             "type": "double",
             "value": 100.0
+          },
+          "gen_ai.cost.reasoning.output_tokens": {
+            "type": "double",
+            "value": 0.0
           },
           "gen_ai.cost.total_tokens": {
             "type": "double",
@@ -483,6 +520,14 @@ mod tests {
 
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
+          "gen_ai.cost.cache_read.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
           "gen_ai.cost.input_tokens": {
             "type": "double",
             "value": 90.0
@@ -490,6 +535,10 @@ mod tests {
           "gen_ai.cost.output_tokens": {
             "type": "double",
             "value": 100.0
+          },
+          "gen_ai.cost.reasoning.output_tokens": {
+            "type": "double",
+            "value": 0.0
           },
           "gen_ai.cost.total_tokens": {
             "type": "double",
@@ -552,6 +601,14 @@ mod tests {
 
         assert_annotated_snapshot!(attributes, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
+          "gen_ai.cost.cache_read.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
           "gen_ai.cost.input_tokens": {
             "type": "double",
             "value": 90.0
@@ -559,6 +616,10 @@ mod tests {
           "gen_ai.cost.output_tokens": {
             "type": "double",
             "value": 100.0
+          },
+          "gen_ai.cost.reasoning.output_tokens": {
+            "type": "double",
+            "value": 0.0
           },
           "gen_ai.cost.total_tokens": {
             "type": "double",
@@ -683,6 +744,14 @@ mod tests {
             "type": "integer",
             "value": 100000
           },
+          "gen_ai.cost.cache_creation.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
+          "gen_ai.cost.cache_read.input_tokens": {
+            "type": "double",
+            "value": 0.0
+          },
           "gen_ai.cost.input_tokens": {
             "type": "double",
             "value": 300.0
@@ -690,6 +759,10 @@ mod tests {
           "gen_ai.cost.output_tokens": {
             "type": "double",
             "value": 240.0
+          },
+          "gen_ai.cost.reasoning.output_tokens": {
+            "type": "double",
+            "value": 0.0
           },
           "gen_ai.cost.total_tokens": {
             "type": "double",

--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -2566,8 +2566,11 @@ mod tests {
 
         assert_annotated_snapshot!(span1, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 0.0,
           "gen_ai.cost.input_tokens": 10.0,
           "gen_ai.cost.output_tokens": 40.0,
+          "gen_ai.cost.reasoning.output_tokens": 0.0,
           "gen_ai.cost.total_tokens": 50.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.request.model": "claude-2.1",
@@ -2580,8 +2583,11 @@ mod tests {
         "#);
         assert_annotated_snapshot!(span2, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 0.0,
           "gen_ai.cost.input_tokens": 20.0,
           "gen_ai.cost.output_tokens": 60.0,
+          "gen_ai.cost.reasoning.output_tokens": 0.0,
           "gen_ai.cost.total_tokens": 80.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.request.model": "gpt4-21-04",
@@ -2691,8 +2697,11 @@ mod tests {
 
         assert_annotated_snapshot!(span1, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 20.0,
           "gen_ai.cost.input_tokens": 25.0,
           "gen_ai.cost.output_tokens": 50.0,
+          "gen_ai.cost.reasoning.output_tokens": 30.0,
           "gen_ai.cost.total_tokens": 75.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.request.model": "claude-2.1",
@@ -2707,8 +2716,11 @@ mod tests {
         "#);
         assert_annotated_snapshot!(span2, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 0.0,
           "gen_ai.cost.input_tokens": 90.0,
           "gen_ai.cost.output_tokens": 100.0,
+          "gen_ai.cost.reasoning.output_tokens": 0.0,
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.request.model": "gpt4-21-04",
@@ -2721,8 +2733,11 @@ mod tests {
         "#);
         assert_annotated_snapshot!(span3, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 0.0,
           "gen_ai.cost.input_tokens": 90.0,
           "gen_ai.cost.output_tokens": 100.0,
+          "gen_ai.cost.reasoning.output_tokens": 0.0,
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.response.model": "gpt4-21-04",
@@ -2874,8 +2889,11 @@ mod tests {
 
         assert_annotated_snapshot!(span1, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 20.0,
           "gen_ai.cost.input_tokens": 25.0,
           "gen_ai.cost.output_tokens": 40.0,
+          "gen_ai.cost.reasoning.output_tokens": 20.0,
           "gen_ai.cost.total_tokens": 65.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.request.model": "claude-2.1",
@@ -2890,8 +2908,11 @@ mod tests {
         "#);
         assert_annotated_snapshot!(span2, @r#"
         {
+          "gen_ai.cost.cache_creation.input_tokens": 0.0,
+          "gen_ai.cost.cache_read.input_tokens": 0.0,
           "gen_ai.cost.input_tokens": 90.0,
           "gen_ai.cost.output_tokens": 100.0,
+          "gen_ai.cost.reasoning.output_tokens": 0.0,
           "gen_ai.cost.total_tokens": 190.0,
           "gen_ai.operation.type": "ai_client",
           "gen_ai.request.model": "gpt4-21-04",

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -236,11 +236,6 @@ fn extract_ai_model_cost_data(
         .or_default()
         .set_value(Value::F64(costs.input).into());
     data.other
-        .entry(GEN_AI__COST__OUTPUT_TOKENS.to_owned())
-        .or_default()
-        .set_value(Value::F64(costs.output).into());
-
-    data.other
         .entry(GEN_AI__COST__CACHE_READ__INPUT_TOKENS.to_owned())
         .or_default()
         .set_value(Value::F64(costs.cache_read_input).into());
@@ -248,6 +243,12 @@ fn extract_ai_model_cost_data(
         .entry(GEN_AI__COST__CACHE_CREATION__INPUT_TOKENS.to_owned())
         .or_default()
         .set_value(Value::F64(costs.cache_creation_input).into());
+
+    data.other
+        .entry(GEN_AI__COST__OUTPUT_TOKENS.to_owned())
+        .or_default()
+        .set_value(Value::F64(costs.output).into());
+
     data.other
         .entry(GEN_AI__COST__REASONING__OUTPUT_TOKENS.to_owned())
         .or_default()

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -73,10 +73,16 @@ impl UsedTokens {
 /// Calculated model call costs.
 #[derive(Debug, Copy, Clone)]
 pub struct CalculatedCost {
-    /// The cost of input tokens used.
+    /// The total cost of all input tokens (raw + cached + cache_write).
     pub input: f64,
-    /// The cost of output tokens used.
+    /// The total cost of all output tokens (raw + reasoning).
     pub output: f64,
+    /// The cost of cached input tokens only (subset of `input`).
+    pub cache_read_input: f64,
+    /// The cost of cache-write input tokens only (subset of `input`).
+    pub cache_creation_input: f64,
+    /// The cost of reasoning output tokens only (subset of `output`).
+    pub reasoning_output: f64,
 }
 
 impl CalculatedCost {
@@ -105,19 +111,21 @@ pub fn calculate_costs(
         return None;
     }
 
+    let cache_read_input = tokens.input_cached_tokens * model_cost.input_cached_per_token;
+    let cache_creation_input =
+        tokens.input_cache_write_tokens * model_cost.input_cache_write_per_token;
     let input = (tokens.raw_input_tokens() * model_cost.input_per_token)
-        + (tokens.input_cached_tokens * model_cost.input_cached_per_token)
-        + (tokens.input_cache_write_tokens * model_cost.input_cache_write_per_token);
+        + cache_read_input
+        + cache_creation_input;
 
     // For now most of the models do not differentiate between reasoning and output token cost,
     // it costs the same.
-    let reasoning_cost = match model_cost.output_reasoning_per_token {
-        reasoning_cost if reasoning_cost > 0.0 => reasoning_cost,
+    let reasoning_per_token = match model_cost.output_reasoning_per_token {
+        r if r > 0.0 => r,
         _ => model_cost.output_per_token,
     };
-
-    let output = (tokens.raw_output_tokens() * model_cost.output_per_token)
-        + (tokens.output_reasoning_tokens * reasoning_cost);
+    let reasoning_output = tokens.output_reasoning_tokens * reasoning_per_token;
+    let output = (tokens.raw_output_tokens() * model_cost.output_per_token) + reasoning_output;
 
     let metric_label = match (input, output) {
         (x, y) if x < 0.0 || y < 0.0 => "calculation_negative",
@@ -132,7 +140,13 @@ pub fn calculate_costs(
         platform = platform,
     );
 
-    Some(CalculatedCost { input, output })
+    Some(CalculatedCost {
+        input,
+        output,
+        cache_read_input,
+        cache_creation_input,
+        reasoning_output,
+    })
 }
 
 /// Default AI operation stored in [`GEN_AI__OPERATION__TYPE`]
@@ -225,6 +239,19 @@ fn extract_ai_model_cost_data(
         .entry(GEN_AI__COST__OUTPUT_TOKENS.to_owned())
         .or_default()
         .set_value(Value::F64(costs.output).into());
+
+    data.other
+        .entry(GEN_AI__COST__CACHE_READ__INPUT_TOKENS.to_owned())
+        .or_default()
+        .set_value(Value::F64(costs.cache_read_input).into());
+    data.other
+        .entry(GEN_AI__COST__CACHE_CREATION__INPUT_TOKENS.to_owned())
+        .or_default()
+        .set_value(Value::F64(costs.cache_creation_input).into());
+    data.other
+        .entry(GEN_AI__COST__REASONING__OUTPUT_TOKENS.to_owned())
+        .or_default()
+        .set_value(Value::F64(costs.reasoning_output).into());
 }
 
 /// Maps AI-related measurements (legacy) to span data.
@@ -556,6 +583,9 @@ mod tests {
         CalculatedCost {
             input: 5.5,
             output: 39.0,
+            cache_read_input: 2.5,
+            cache_creation_input: 0.0,
+            reasoning_output: 27.0,
         }
         ");
     }
@@ -587,6 +617,9 @@ mod tests {
         CalculatedCost {
             input: 5.5,
             output: 30.0,
+            cache_read_input: 2.5,
+            cache_creation_input: 0.0,
+            reasoning_output: 18.0,
         }
         ");
     }
@@ -620,6 +653,9 @@ mod tests {
         CalculatedCost {
             input: -9.0,
             output: -7.0,
+            cache_read_input: 11.0,
+            cache_creation_input: 0.0,
+            reasoning_output: 9.0,
         }
         ");
     }
@@ -653,6 +689,9 @@ mod tests {
         CalculatedCost {
             input: 82.5,
             output: 110.0,
+            cache_read_input: 10.0,
+            cache_creation_input: 22.5,
+            reasoning_output: 30.0,
         }
         ");
     }
@@ -701,6 +740,9 @@ mod tests {
         CalculatedCost {
             input: 90.0,
             output: 100.0,
+            cache_read_input: 10.0,
+            cache_creation_input: 0.0,
+            reasoning_output: 0.0,
         }
         ");
     }

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -383,8 +383,20 @@ def test_ai_spans_example_transaction(
                     "value": matches_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
+                "gen_ai.cost.cache_creation.input_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
+                "gen_ai.cost.cache_read.input_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.45},
                 "gen_ai.cost.output_tokens": {"type": "double", "value": 1.3},
+                "gen_ai.cost.reasoning.output_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
                 "gen_ai.cost.total_tokens": {"type": "double", "value": 3.75},
                 "gen_ai.agent.name": {"type": "string", "value": "weather-chat"},
                 "gen_ai.function_id": {"type": "string", "value": "weather-chat"},
@@ -489,8 +501,20 @@ def test_ai_spans_example_transaction(
                     "value": matches_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
+                "gen_ai.cost.cache_creation.input_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
+                "gen_ai.cost.cache_read.input_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 0.37},
                 "gen_ai.cost.output_tokens": {"type": "double", "value": 0.92},
+                "gen_ai.cost.reasoning.output_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
                 "gen_ai.cost.total_tokens": {"type": "double", "value": 1.29},
                 "gen_ai.agent.name": {"type": "string", "value": "weather-chat"},
                 "gen_ai.function_id": {"type": "string", "value": "weather-chat"},
@@ -1044,8 +1068,20 @@ def test_ai_spans_example_transaction(
                     "value": matches_any(),
                 },
                 "gen_ai.context.window_size": {"type": "integer", "value": 128000},
+                "gen_ai.cost.cache_creation.input_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
+                "gen_ai.cost.cache_read.input_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
                 "gen_ai.cost.input_tokens": {"type": "double", "value": 2.08},
                 "gen_ai.cost.output_tokens": {"type": "double", "value": 0.38},
+                "gen_ai.cost.reasoning.output_tokens": {
+                    "type": "double",
+                    "value": 0.0,
+                },
                 "gen_ai.cost.total_tokens": {"type": "double", "value": 2.46},
                 "gen_ai.agent.name": {"type": "string", "value": "weather-chat"},
                 "gen_ai.function_id": {"type": "string", "value": "weather-chat"},


### PR DESCRIPTION
Since we introduced cost calculation we were correctly calculating the cost by taking into account input, cached, output and reasoning tokens, but we have never attached that information to spans.

We already have this attributes in our conventions since forever, this PR just adds the better cost breakdown to spans