### PR TITLE
ref(minidump): Add status tag to attachment scrubbing metric

### DIFF
--- a/relay-server/src/processing/trace_attachments/process.rs
+++ b/relay-server/src/processing/trace_attachments/process.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use bytes::Bytes;
 use relay_event_schema::processor::{ProcessingAction, ValueType};
 use relay_pii::PiiAttachmentsProcessor;
@@ -144,15 +146,16 @@ pub fn scrub_attachment<'a>(
         let processor = PiiAttachmentsProcessor::new(config.compiled());
         let mut payload = body.to_vec();
 
+        let start = Instant::now();
+        let modified = processor.scrub_attachment(filename, &mut payload);
         metric!(
-            timer(RelayTimers::AttachmentScrubbing),
+            timer(RelayTimers::AttachmentScrubbing) = start.elapsed(),
             attachment_type = "trace_attachment",
-            {
-                if processor.scrub_attachment(filename, &mut payload) {
-                    *body = Bytes::from(payload);
-                };
-            }
+            status = if modified { "ok" } else { "n/a" },
         );
+        if modified {
+            *body = Bytes::from(payload);
+        }
     }
 
     Ok(())

--- a/relay-server/src/processing/utils/attachments.rs
+++ b/relay-server/src/processing/utils/attachments.rs
@@ -140,12 +140,12 @@ fn scrub_minidump(item: &mut crate::envelope::Item, config: &relay_pii::PiiConfi
                 error = &scrub_error as &dyn Error,
                 "failed to scrub minidump",
             );
+            let start = Instant::now();
+            let modified = processor.scrub_attachment(filename, &mut payload);
             metric!(
-                timer(RelayTimers::AttachmentScrubbing),
+                timer(RelayTimers::AttachmentScrubbing) = start.elapsed(),
                 attachment_type = "minidump",
-                {
-                    processor.scrub_attachment(filename, &mut payload);
-                }
+                status = if modified { "ok" } else { "n/a" },
             )
         }
     }

--- a/relay-server/src/processing/utils/attachments.rs
+++ b/relay-server/src/processing/utils/attachments.rs
@@ -205,12 +205,12 @@ fn scrub_attachment(item: &mut crate::envelope::Item, config: &relay_pii::PiiCon
         Some(t) => t.to_string(),
         None => "".to_owned(),
     };
+    let start = Instant::now();
+    let modified = processor.scrub_attachment(filename, &mut payload);
     metric!(
-        timer(RelayTimers::AttachmentScrubbing),
-        attachment_type = &attachment_type_tag,
-        {
-            processor.scrub_attachment(filename, &mut payload);
-        }
+        timer(RelayTimers::AttachmentScrubbing) = start.elapsed(),
+        attachment_type = attachment_type_tag,
+        status = if modified { "ok" } else { "n/a" },
     );
 
     item.set_payload_without_content_type(payload);

--- a/relay-server/src/processing/utils/attachments.rs
+++ b/relay-server/src/processing/utils/attachments.rs
@@ -163,7 +163,7 @@ fn scrub_view_hierarchy(item: &mut crate::envelope::Item, config: &relay_pii::Pi
         Ok(output) => {
             metric!(
                 timer(RelayTimers::ViewHierarchyScrubbing) = start.elapsed(),
-                status = "ok"
+                status = if output != payload { "ok" } else { "n/a" }
             );
             item.set_default_content_type(ContentType::Json);
             item.set_payload_without_content_type(output);

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -482,7 +482,7 @@ pub enum RelayTimers {
     ///
     /// - `status`: Scrubbing status: "ok" means successful scrubbed, "error" means there
     ///   was an error during scrubbing and finally "n/a" means scrubbing was successful
-    ///   but no scurbbing rules applied.
+    ///   but no scrubbing rules applied.
     MinidumpScrubbing,
     /// Time spent on view hierarchy scrubbing.
     ///
@@ -491,7 +491,7 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     ///
     /// - `status`: "ok" means successful scrubbed, "error" means there was an error during
-    ///   scrubbing. "n/a" means not changed.
+    ///   scrubbing.
     ViewHierarchyScrubbing,
     /// Time spend on attachment scrubbing.
     ///

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -491,7 +491,7 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     ///
     /// - `status`: "ok" means successful scrubbed, "error" means there was an error during
-    ///   scrubbing
+    ///   scrubbing. "n/a" means not changed.
     ViewHierarchyScrubbing,
     /// Time spend on attachment scrubbing.
     ///
@@ -504,6 +504,7 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     ///
     ///   - `attachment_type`: The type of attachment, e.g. "minidump".
+    ///   - `status`: "ok" means successful scrubbed. "n/a" means not changed.
     AttachmentScrubbing,
     /// Total time spent to send request to upstream Relay and handle the response.
     ///

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -491,7 +491,7 @@ pub enum RelayTimers {
     /// This metric is tagged with:
     ///
     /// - `status`: "ok" means successful scrubbed, "error" means there was an error during
-    ///   scrubbing.
+    ///   scrubbing. "n/a" means unchanged.
     ViewHierarchyScrubbing,
     /// Time spend on attachment scrubbing.
     ///


### PR DESCRIPTION
The `MinidumpScrubbing` metric has a status tag to indicate whether anything was changed. Add the same tag to the `AttachmentScrubbing` metric.

ref: INGEST-869