### PR TITLE
build(deps): Update minidumper 0.4.1 to fix socket path issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "minidumper-child"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7615d83d636600b331883635f136665b4a75cf8031e29be1521bb271325dfc3"
+checksum = "8a3d61b83164dfe719396921156c6bb01fe59e7cf03a3176322d334cbaea2509"
 dependencies = [
  "crash-handler",
  "minidumper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ memchr = "2"
 mimalloc = { version = "0.1", features = ["v3"] }
 mime = "0.3"
 minidump = "0.26"
-minidumper-child = "0.4" 
+minidumper-child = "0.4.1" 
 multer = "3"
 metrics = "0.24"
 metrics-exporter-dogstatsd = "0.9"


### PR DESCRIPTION
This will always create the socket path in the `/tmp` directory, addressing an issue where it would fail when the process doesn't have write permissions in the current dir.

See also: https://github.com/timfish/minidumper-child/pull/8