### PR TITLE
fix(otlp): Fix OTLP endpoints to return spec conform messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Bug Fixes**:
 
 - Wider type support for OTel log bodies. ([#6106](https://github.com/getsentry/relay/pull/6106))
+- Align OTLP endpoint responses with the specification. ([#6182](https://github.com/getsentry/relay/pull/6182))
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))
 - Infer span names PII-safely. ([#6112](https://github.com/getsentry/relay/pull/6112))
 - Unset segment info for web vital spans. ([#6042](https://github.com/getsentry/relay/pull/6042))

--- a/relay-server/src/endpoints/integrations/otlp.rs
+++ b/relay-server/src/endpoints/integrations/otlp.rs
@@ -1,14 +1,18 @@
 use axum::extract::DefaultBodyLimit;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{MethodRouter, post};
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceResponse;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceResponse;
 use relay_config::Config;
 use relay_dynamic_config::Feature;
 
 use crate::endpoints::common;
 use crate::envelope::ContentType;
+use crate::extractors::IntegrationBuilderRejection;
 use crate::extractors::{IntegrationBuilder, RawContentType};
 use crate::integrations::{LogsIntegration, OtelFormat, SpansIntegration};
+use crate::managed::Rejected;
 use crate::service::ServiceState;
 
 /// All routes configured for the OTLP integration.
@@ -30,23 +34,26 @@ mod traces {
     async fn handle(
         content_type: RawContentType,
         state: ServiceState,
-        builder: IntegrationBuilder,
-    ) -> axum::response::Result<impl IntoResponse> {
+        builder: Result<IntegrationBuilder, IntegrationBuilderRejection>,
+    ) -> Result<SuccessResponse<ExportTraceServiceResponse>, OtlpError> {
         let format = match content_type.as_ref().parse::<ContentType>() {
             Ok(ContentType::Json) => OtelFormat::Json,
             Ok(ContentType::Protobuf) => OtelFormat::Protobuf,
-            _ => return Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            _ => return Err(OtlpError::unsupported_content_type(content_type)),
         };
 
         let envelope = builder
+            .map_err(|err| OtlpError::from_err(format, err))?
             .with_type(SpansIntegration::OtelV1 { format })
             .build();
 
         common::handle_envelope(&state, envelope)
-            .await?
-            .check_rate_limits()?;
+            .await
+            .map_err(Rejected::into_inner)
+            .and_then(|r| r.check_rate_limits())
+            .map_err(|err| OtlpError::from_err(format, err))?;
 
-        Ok(StatusCode::OK)
+        Ok(SuccessResponse::new(format))
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
@@ -60,27 +67,176 @@ mod logs {
     async fn handle(
         content_type: RawContentType,
         state: ServiceState,
-        builder: IntegrationBuilder,
-    ) -> axum::response::Result<impl IntoResponse> {
+        builder: Result<IntegrationBuilder, IntegrationBuilderRejection>,
+    ) -> Result<SuccessResponse<ExportLogsServiceResponse>, OtlpError> {
         let format = match content_type.as_ref().parse::<ContentType>() {
             Ok(ContentType::Json) => OtelFormat::Json,
             Ok(ContentType::Protobuf) => OtelFormat::Protobuf,
-            _ => return Ok(StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            _ => return Err(OtlpError::unsupported_content_type(content_type)),
         };
 
         let envelope = builder
+            .map_err(|err| OtlpError::from_err(format, err))?
             .with_type(LogsIntegration::OtelV1 { format })
             .with_required_feature(Feature::OurLogsIngestion)
             .build();
 
         common::handle_envelope(&state, envelope)
-            .await?
-            .check_rate_limits()?;
+            .await
+            .map_err(Rejected::into_inner)
+            .and_then(|r| r.check_rate_limits())
+            .map_err(|err| OtlpError::from_err(format, err))?;
 
-        Ok(StatusCode::OK)
+        Ok(SuccessResponse::new(format))
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
         post(handle).route_layer(DefaultBodyLimit::max(config.max_logs_integration_size()))
+    }
+}
+
+struct SuccessResponse<T> {
+    format: OtelFormat,
+    _proto: std::marker::PhantomData<T>,
+}
+
+impl<T> SuccessResponse<T> {
+    fn new(format: OtelFormat) -> Self {
+        Self {
+            format,
+            _proto: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> IntoResponse for SuccessResponse<T>
+where
+    T: prost::Message,
+    T: Default,
+{
+    fn into_response(self) -> Response {
+        match self.format {
+            OtelFormat::Json => {
+                let empty = serde_json::Value::Object(Default::default());
+                axum::Json(empty).into_response()
+            }
+            OtelFormat::Protobuf => Protobuf(T::default()).into_response(),
+        }
+    }
+}
+
+/// Protobuf-compatible subset of `google.rpc.Status`.
+#[derive(Clone, PartialEq, Eq, serde::Serialize, prost::Message)]
+#[serde(rename_all = "camelCase")]
+struct OtlpStatus {
+    #[prost(int32, tag = "1")]
+    code: i32,
+    #[prost(string, tag = "2")]
+    message: String,
+}
+
+#[repr(i32)]
+#[derive(Clone, Copy, Debug)]
+enum GrpcStatusCode {
+    Unknown = 2,
+    InvalidArgument = 3,
+    DeadlineExceeded = 4,
+    NotFound = 5,
+    PermissionDenied = 7,
+    ResourceExhausted = 8,
+    Unimplemented = 12,
+    Internal = 13,
+    Unavailable = 14,
+    Unauthenticated = 16,
+}
+
+impl GrpcStatusCode {
+    fn from_http_status(status: StatusCode) -> Self {
+        match status {
+            StatusCode::BAD_REQUEST | StatusCode::UNSUPPORTED_MEDIA_TYPE => Self::InvalidArgument,
+            StatusCode::UNAUTHORIZED => Self::Unauthenticated,
+            StatusCode::FORBIDDEN => Self::PermissionDenied,
+            StatusCode::NOT_FOUND => Self::NotFound,
+            StatusCode::PAYLOAD_TOO_LARGE | StatusCode::TOO_MANY_REQUESTS => {
+                Self::ResourceExhausted
+            }
+            StatusCode::NOT_IMPLEMENTED => Self::Unimplemented,
+            StatusCode::BAD_GATEWAY | StatusCode::SERVICE_UNAVAILABLE => Self::Unavailable,
+            StatusCode::GATEWAY_TIMEOUT => Self::DeadlineExceeded,
+            status if status.is_server_error() => Self::Internal,
+            _ => Self::Unknown,
+        }
+    }
+}
+struct OtlpError {
+    format: OtelFormat,
+    status: StatusCode,
+    headers: header::HeaderMap,
+    message: String,
+}
+
+impl OtlpError {
+    fn unsupported_content_type(content_type: RawContentType) -> Self {
+        Self {
+            format: OtelFormat::Json,
+            status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            headers: Default::default(),
+            message: format!("unsupported content type: {content_type}"),
+        }
+    }
+
+    fn from_err<E>(format: OtelFormat, err: E) -> Self
+    where
+        E: IntoResponse,
+        E: std::fmt::Display,
+    {
+        let message = err.to_string();
+        let (parts, _) = err.into_response().into_parts();
+
+        Self {
+            format,
+            status: parts.status,
+            headers: parts.headers,
+            message,
+        }
+    }
+}
+
+impl IntoResponse for OtlpError {
+    fn into_response(mut self) -> Response {
+        let status = OtlpStatus {
+            code: GrpcStatusCode::from_http_status(self.status) as i32,
+            message: self.message,
+        };
+
+        let mut response = match self.format {
+            OtelFormat::Json => axum::Json(status).into_response(),
+            OtelFormat::Protobuf => Protobuf(status).into_response(),
+        };
+
+        *response.status_mut() = self.status;
+
+        self.headers.remove(header::CONTENT_LENGTH);
+        self.headers.remove(header::CONTENT_TYPE);
+        response.headers_mut().extend(self.headers);
+
+        response
+    }
+}
+
+struct Protobuf<T>(T);
+
+impl<T> IntoResponse for Protobuf<T>
+where
+    T: prost::Message,
+{
+    fn into_response(self) -> Response {
+        let body = self.0.encode_to_vec();
+        let mut res = axum::body::Body::from(body).into_response();
+        res.headers_mut().insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/x-protobuf"),
+        );
+        res
     }
 }

--- a/relay-server/src/extractors/integration_builder.rs
+++ b/relay-server/src/extractors/integration_builder.rs
@@ -87,7 +87,7 @@ impl FromRequest<ServiceState> for IntegrationBuilder {
 
 #[derive(Debug, thiserror::Error)]
 pub enum IntegrationBuilderRejection {
-    #[error("bad event meta: {0}")]
+    #[error(transparent)]
     BadEventMeta(#[from] BadEventMeta),
     #[error("unable to read body: {0}")]
     Body(#[from] BytesRejection),

--- a/tests/integration/fixtures/__init__.py
+++ b/tests/integration/fixtures/__init__.py
@@ -210,6 +210,7 @@ class SentryLike:
         headers=None,
         dsn_key_idx=0,
         dsn_key=None,
+        raise_for_status=True,
     ):
 
         if dsn_key is None:
@@ -227,7 +228,9 @@ class SentryLike:
         else:
             response = self.post(url, headers=headers, data=bytes)
 
-        response.raise_for_status()
+        if raise_for_status:
+            response.raise_for_status()
+        return response
 
     def send_otel_logs(
         self,
@@ -237,6 +240,7 @@ class SentryLike:
         headers=None,
         dsn_key_idx=0,
         dsn_key=None,
+        raise_for_status=True,
     ):
 
         if dsn_key is None:
@@ -254,7 +258,9 @@ class SentryLike:
         else:
             response = self.post(url, headers=headers, data=bytes)
 
-        response.raise_for_status()
+        if raise_for_status:
+            response.raise_for_status()
+        return response
 
     def send_vercel_logs(
         self,

--- a/tests/integration/test_otlp_logs.py
+++ b/tests/integration/test_otlp_logs.py
@@ -1,7 +1,11 @@
 from datetime import datetime, timezone, timedelta
 
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceResponse,
+)
 from sentry_relay.consts import DataCategory
 
+from .test_spansv2_otel import parse_google_rpc_status
 from .asserts import matches_any, time_within_delta, time_within, only_items
 
 TEST_CONFIG = {
@@ -9,6 +13,127 @@ TEST_CONFIG = {
         "emit_outcomes": True,
     },
 }
+
+GRPC_INVALID_ARGUMENT = 3
+GRPC_RESOURCE_EXHAUSTED = 8
+GRPC_UNAUTHENTICATED = 16
+
+
+def test_otlp_logs_protobuf_success_response(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:ourlogs-ingestion",
+    ]
+    relay = relay(mini_sentry)
+
+    response = relay.send_otel_logs(
+        project_id,
+        headers={"Content-Type": "application/x-protobuf"},
+        bytes=b"",
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/x-protobuf"
+    assert ExportLogsServiceResponse.FromString(response.content) == (
+        ExportLogsServiceResponse()
+    )
+
+
+def test_otlp_logs_unsupported_media_type_returns_status(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:ourlogs-ingestion",
+    ]
+    relay = relay(mini_sentry)
+
+    response = relay.send_otel_logs(
+        project_id,
+        headers={"Content-Type": "text/plain"},
+        bytes=b"",
+        raise_for_status=False,
+    )
+
+    assert response.status_code == 415
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["code"] == GRPC_INVALID_ARGUMENT
+
+
+def test_otlp_logs_missing_auth_returns_status(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:ourlogs-ingestion",
+    ]
+    relay = relay(mini_sentry)
+
+    response = relay.post(
+        f"/api/{project_id}/integration/otlp/v1/logs",
+        headers={"Content-Type": "application/x-protobuf"},
+        json={"resourceLogs": []},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["content-type"] == "application/x-protobuf"
+    status = parse_google_rpc_status(response.content)
+    assert status.code == GRPC_UNAUTHENTICATED
+    assert status.message == "missing authorization information"
+
+
+def test_otlp_logs_rate_limit_returns_status_and_retry_headers(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:ourlogs-ingestion",
+    ]
+    project_config["config"]["quotas"] = [
+        {
+            "id": "test_otlp_logs_rate_limit",
+            "categories": ["log_item"],
+            "limit": 0,
+            "window": 60,
+            "reasonCode": "otlp_rate_limited",
+        }
+    ]
+    relay = relay(mini_sentry)
+
+    # Make sure project config is available.
+    relay.send_event(project_id, {"message": "warm project cache"})
+    _ = mini_sentry.get_captured_envelope().get_event()
+
+    response = relay.send_otel_logs(
+        project_id,
+        headers={"Content-Type": "application/json"},
+        json={"resourceLogs": []},
+        raise_for_status=False,
+    )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"]
+    assert response.headers["x-sentry-rate-limits"]
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["code"] == GRPC_RESOURCE_EXHAUSTED
+
+
+def test_otlp_logs_oversized_body_returns_status(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "organizations:ourlogs-ingestion",
+    ]
+    relay = relay(mini_sentry, options={"limits": {"max_container_size": 1}})
+
+    response = relay.send_otel_logs(
+        project_id,
+        headers={"Content-Type": "application/json"},
+        bytes=b"{}",
+        raise_for_status=False,
+    )
+
+    assert response.status_code == 413
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["code"] == GRPC_RESOURCE_EXHAUSTED
 
 
 def test_otlp_logs_conversion(

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -1,5 +1,9 @@
 from datetime import datetime, timezone
 
+from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceResponse,
+)
 from opentelemetry.proto.common.v1.common_pb2 import (
     AnyValue,
     InstrumentationScope,
@@ -16,6 +20,155 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 from sentry_relay.consts import DataCategory
 
 from .asserts import time_within_delta, time_within
+
+GRPC_INVALID_ARGUMENT = 3
+GRPC_RESOURCE_EXHAUSTED = 8
+GRPC_UNAUTHENTICATED = 16
+
+
+def parse_google_rpc_status(data):
+    file_descriptor = descriptor_pb2.FileDescriptorProto(
+        name="google/rpc/status.proto",
+        package="google.rpc",
+        message_type=[
+            descriptor_pb2.DescriptorProto(
+                name="Status",
+                field=[
+                    descriptor_pb2.FieldDescriptorProto(
+                        name="code",
+                        number=1,
+                        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+                        type=descriptor_pb2.FieldDescriptorProto.TYPE_INT32,
+                    ),
+                    descriptor_pb2.FieldDescriptorProto(
+                        name="message",
+                        number=2,
+                        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+                        type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+                    ),
+                ],
+            )
+        ],
+    )
+    pool = descriptor_pool.DescriptorPool()
+    pool.Add(file_descriptor)
+    status_cls = message_factory.GetMessageClass(
+        pool.FindMessageTypeByName("google.rpc.Status")
+    )
+    status = status_cls()
+    status.ParseFromString(data)
+    return status
+
+
+def warm_project_cache(relay, mini_sentry, project_id):
+    relay.send_event(project_id, {"message": "warm project cache"})
+
+    while True:
+        event = mini_sentry.get_captured_envelope().get_event()
+        if event.get("logentry", {}).get("formatted") == "warm project cache":
+            break
+
+
+def test_otlp_traces_protobuf_success_response(mini_sentry, relay):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(mini_sentry)
+
+    response = relay.send_otel_span(
+        project_id,
+        headers={"Content-Type": "application/x-protobuf"},
+        bytes=TracesData().SerializeToString(),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/x-protobuf"
+    assert ExportTraceServiceResponse.FromString(response.content) == (
+        ExportTraceServiceResponse()
+    )
+
+
+def test_otlp_traces_unsupported_media_type_returns_status(mini_sentry, relay):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(mini_sentry)
+
+    response = relay.send_otel_span(
+        project_id,
+        headers={"Content-Type": "text/plain"},
+        bytes=b"",
+        raise_for_status=False,
+    )
+
+    assert response.status_code == 415
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["code"] == GRPC_INVALID_ARGUMENT
+
+
+def test_otlp_traces_missing_auth_returns_protobuf_status(mini_sentry, relay):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(mini_sentry)
+
+    response = relay.post(
+        f"/api/{project_id}/integration/otlp/v1/traces",
+        headers={"Content-Type": "application/x-protobuf"},
+        data=TracesData().SerializeToString(),
+    )
+
+    assert response.status_code == 401
+    assert response.headers["content-type"] == "application/x-protobuf"
+    status = parse_google_rpc_status(response.content)
+    assert status.code == GRPC_UNAUTHENTICATED
+    assert status.message == "missing authorization information"
+
+
+def test_otlp_traces_rate_limit_returns_status_and_retry_headers(mini_sentry, relay):
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["quotas"] = [
+        {
+            "id": "test_otlp_traces_rate_limit",
+            "categories": ["span"],
+            "limit": 0,
+            "window": 60,
+            "reasonCode": "otlp_rate_limited",
+        }
+    ]
+    relay = relay(mini_sentry)
+
+    # Make sure project cache is loaded:
+    relay.send_event(project_id, {"message": "warm project cache"})
+    _ = mini_sentry.get_captured_envelope().get_event()
+
+    response = relay.send_otel_span(
+        project_id,
+        headers={"Content-Type": "application/json"},
+        json={"resourceSpans": []},
+        raise_for_status=False,
+    )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"]
+    assert response.headers["x-sentry-rate-limits"]
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["code"] == GRPC_RESOURCE_EXHAUSTED
+
+
+def test_otlp_traces_oversized_body_returns_status(mini_sentry, relay):
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+    relay = relay(mini_sentry, options={"limits": {"max_container_size": 1}})
+
+    response = relay.send_otel_span(
+        project_id,
+        headers={"Content-Type": "application/json"},
+        bytes=b"{}",
+        raise_for_status=False,
+    )
+
+    assert response.status_code == 413
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["code"] == GRPC_RESOURCE_EXHAUSTED
 
 
 def test_span_ingestion(


### PR DESCRIPTION
[Specification](https://opentelemetry.io/docs/specs/otlp/#otlphttp-response).

Summary:
- Protobuf needs to return protobuf
- Json returns an empty object on success
- Errors return proper error responses

Fixes: #6181 