### PR TITLE
fix(profiling): Fix accidentally correct Android profile chunk parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
 - Don't modify segment information for V2 web vital spans. ([#6160](https://github.com/getsentry/relay/pull/6160))
 - Support compressed minidumps when the `relay-minidump-uploads` feature is enabled. ([#6151](https://github.com/getsentry/relay/pull/6151))
+- Fix Android trace and ANR profile parsing. Serialize Android trace chunks with `version: "2.android-trace"`. Custom
+  Android trace `profile_chunk` producers must send `version: "2"` or `version: "2.android-trace"`; versionless Android
+  trace chunks are rejected. ([#6183](https://github.com/getsentry/relay/pull/6183))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 **Bug Fixes**:
 
+- Fix Android trace and ANR profile parsing. Serialize Android trace chunks with `version: "2.android-trace"`. Custom
+  Android trace `profile_chunk` producers must send `version: "2"` or `version: "2.android-trace"`; `version: "1"` and
+  versionless Android trace chunks are rejected. ([#6183](https://github.com/getsentry/relay/pull/6183))
 - Defer dynamic sampling until metrics config is valid. ([#6246](https://github.com/getsentry/relay/pull/6246))
 
 ## 26.7.1
@@ -46,7 +49,6 @@
 - Unset segment info for web vital spans. ([#6042](https://github.com/getsentry/relay/pull/6042))
 - Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
 - Don't modify segment information for V2 web vital spans. ([#6160](https://github.com/getsentry/relay/pull/6160))
-
 
 - Support compressed minidumps when the `relay-minidump-uploads` feature is enabled. ([#6151](https://github.com/getsentry/relay/pull/6151))
 - Make `--log-level` and `--log-format` take effect again and accept them on all subcommands. ([#6198](https://github.com/getsentry/relay/pull/6198))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 **Bug Fixes**:
 
 - Fix Android trace and ANR profile parsing. Serialize Android trace chunks with `version: "2.android-trace"`. Custom
-  Android trace `profile_chunk` producers must send `version: "2"` or `version: "2.android-trace"`; `version: "1"` and
-  versionless Android trace chunks are rejected. ([#6183](https://github.com/getsentry/relay/pull/6183))
+  Android trace `profile_chunk` producers should send `version: "2.android-trace"`; legacy `version: "2"` is accepted
+  only for Android `sampled_profile` payloads. `version: "1"` and versionless Android trace chunks are rejected.
+  ([#6183](https://github.com/getsentry/relay/pull/6183))
 - Defer dynamic sampling until metrics config is valid. ([#6246](https://github.com/getsentry/relay/pull/6246))
 
 ## 26.7.1
@@ -49,6 +50,7 @@
 - Unset segment info for web vital spans. ([#6042](https://github.com/getsentry/relay/pull/6042))
 - Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
 - Don't modify segment information for V2 web vital spans. ([#6160](https://github.com/getsentry/relay/pull/6160))
+
 
 - Support compressed minidumps when the `relay-minidump-uploads` feature is enabled. ([#6151](https://github.com/getsentry/relay/pull/6151))
 - Make `--log-level` and `--log-format` take effect again and accept them on all subcommands. ([#6198](https://github.com/getsentry/relay/pull/6198))

--- a/relay-profiling/src/android/chunk.rs
+++ b/relay-profiling/src/android/chunk.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::debug_image::get_proguard_image;
 use crate::measurements::ChunkMeasurement;
+use crate::sample::Version;
 use crate::sample::v2::ProfileData;
 use crate::types::{ClientSdk, DebugMeta};
 use crate::{MAX_PROFILE_CHUNK_DURATION, ProfileError};
@@ -34,6 +35,9 @@ pub struct Metadata {
     environment: String,
     platform: String,
     release: String,
+
+    #[serde(default)]
+    version: Version,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     debug_meta: Option<DebugMeta>,
@@ -114,6 +118,11 @@ impl Chunk {
         // Use duration given by the profiler and not reported by the SDK.
         profile.metadata.duration_ns = profile.profile.elapsed_time.as_nanos() as u64;
 
+        // Convert the accepted legacy Android trace version ("2") to the new wire version
+        // ("2.android-trace"). We do so during parsing rather than when serializing because raw
+        // serde doesn't validate the trace payload.
+        profile.metadata.version = Version::V2AndroidTrace;
+
         // If build_id is not empty but we don't have any DebugImage set,
         // we create the proper Proguard image and set the uuid.
         if !profile.metadata.build_id.is_empty() && profile.metadata.debug_meta.is_none() {
@@ -175,8 +184,26 @@ mod tests {
     fn test_roundtrip_react_native() {
         let payload = include_bytes!("../../tests/fixtures/android/chunk/valid-rn.json");
         let profile = Chunk::parse(payload).unwrap();
-        let data = serde_json::to_vec(&profile);
-        assert!(Chunk::parse(&(data.unwrap())[..]).is_ok());
+        let data = serde_json::to_vec(&profile).unwrap();
+        let output: serde_json::Value = serde_json::from_slice(&data).unwrap();
+
+        assert_eq!(output["version"], "2.android-trace");
+        assert!(Chunk::parse(&data).is_ok());
+    }
+
+    #[test]
+    fn test_parse_canonicalizes_android_trace_profile_version() {
+        let payload = include_bytes!("../../tests/fixtures/android/chunk/valid.json");
+        let input: serde_json::Value = serde_json::from_slice(payload).unwrap();
+        assert_eq!(input["version"], "2");
+
+        let profile = Chunk::parse(payload).unwrap();
+        assert_eq!(profile.metadata.version, Version::V2AndroidTrace);
+
+        let output = serde_json::to_value(&profile).unwrap();
+
+        assert_eq!(output["version"], "2.android-trace");
+        assert!(output.get("sampled_profile").is_none());
     }
 
     #[test]

--- a/relay-profiling/src/android/chunk.rs
+++ b/relay-profiling/src/android/chunk.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::debug_image::get_proguard_image;
 use crate::measurements::ChunkMeasurement;
+use crate::sample::Version;
 use crate::sample::v2::ProfileData;
 use crate::types::{ClientSdk, DebugMeta};
 use crate::{MAX_PROFILE_CHUNK_DURATION, ProfileError};
@@ -34,6 +35,9 @@ pub struct Metadata {
     environment: String,
     platform: String,
     release: String,
+
+    #[serde(default)]
+    version: Version,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     debug_meta: Option<DebugMeta>,
@@ -114,6 +118,11 @@ impl Chunk {
         // Use duration given by the profiler and not reported by the SDK.
         profile.metadata.duration_ns = profile.profile.elapsed_time.as_nanos() as u64;
 
+        // Convert legacy Android trace version ("2") to the new wire version
+        // ("2.android-trace"). We do so during parsing rather than
+        // serialization because raw serde doesn't validate the trace payload.
+        profile.metadata.version = Version::V2AndroidTrace;
+
         // If build_id is not empty but we don't have any DebugImage set,
         // we create the proper Proguard image and set the uuid.
         if !profile.metadata.build_id.is_empty() && profile.metadata.debug_meta.is_none() {
@@ -177,6 +186,21 @@ mod tests {
         let profile = Chunk::parse(payload).unwrap();
         let data = serde_json::to_vec(&profile);
         assert!(Chunk::parse(&(data.unwrap())[..]).is_ok());
+    }
+
+    #[test]
+    fn test_parse_canonicalizes_android_trace_profile_version() {
+        let payload = include_bytes!("../../tests/fixtures/android/chunk/valid.json");
+        let input: serde_json::Value = serde_json::from_slice(payload).unwrap();
+        assert_eq!(input["version"], "2");
+
+        let profile = Chunk::parse(payload).unwrap();
+        assert_eq!(profile.metadata.version, Version::V2AndroidTrace);
+
+        let output = serde_json::to_value(&profile).unwrap();
+
+        assert_eq!(output["version"], "2.android-trace");
+        assert!(output.get("sampled_profile").is_none());
     }
 
     #[test]

--- a/relay-profiling/src/android/chunk.rs
+++ b/relay-profiling/src/android/chunk.rs
@@ -118,7 +118,7 @@ impl Chunk {
         // Use duration given by the profiler and not reported by the SDK.
         profile.metadata.duration_ns = profile.profile.elapsed_time.as_nanos() as u64;
 
-        // Convert legacy Android trace version ("2") to the new wire version
+        // Convert legacy Android trace version ("2") to the corrected version
         // ("2.android-trace"). We do so during parsing rather than
         // serialization because raw serde doesn't validate the trace payload.
         profile.metadata.version = Version::V2AndroidTrace;
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_canonicalizes_android_trace_profile_version() {
+    fn test_parse_corrects_android_trace_profile_version() {
         let payload = include_bytes!("../../tests/fixtures/android/chunk/valid.json");
         let input: serde_json::Value = serde_json::from_slice(payload).unwrap();
         assert_eq!(input["version"], "2");

--- a/relay-profiling/src/lib.rs
+++ b/relay-profiling/src/lib.rs
@@ -33,7 +33,7 @@
 //! Each item type expects a different format.
 //!
 //! For `Profile` item type, we expect the Sample format v1 or Android format.
-//! For `ProfileChunk` item type, we expect the Sample format v2.
+//! For `ProfileChunk` item type, we expect the Sample format v2 or Android trace chunk format.
 //!
 //! # Ingestion
 //!

--- a/relay-profiling/src/profile_chunk.rs
+++ b/relay-profiling/src/profile_chunk.rs
@@ -94,6 +94,7 @@ impl relay_filter::Filterable for AnyProfileChunk {
 }
 
 /// Either an [`AndroidProfileChunk`] or a [`V2ProfileChunk`].
+#[derive(Debug)]
 pub enum AndroidOrV2ProfileChunk {
     Android(Box<AndroidProfileChunk>),
     V2(Box<V2ProfileChunk>),
@@ -123,6 +124,8 @@ impl AndroidOrV2ProfileChunk {
             platform: String,
             #[serde(default)]
             version: sample::Version,
+            #[serde(default)]
+            sampled_profile: Option<serde::de::IgnoredAny>,
         }
 
         let minimal: MinimalProfile = {
@@ -130,16 +133,179 @@ impl AndroidOrV2ProfileChunk {
             serde_path_to_error::deserialize(d)
         }?;
 
-        match (minimal.platform.as_str(), minimal.version) {
-            // This has always been parsed with higher priority than `v2`, so this was kept as-is
-            // when refactoring, but from the looks of it, this may cause issues with v2 profiles
-            // which happen to be sent from android.
-            ("android", _) => AndroidProfileChunk::parse(data)
+        let is_android_trace_profile = minimal.platform == "android"
+            && matches!(
+                minimal.version,
+                sample::Version::V2 | sample::Version::V2AndroidTrace
+            )
+            && minimal.sampled_profile.is_some();
+
+        match (minimal.version, is_android_trace_profile) {
+            // Android SDKs produce two profile_chunk types that pass through this method: trace
+            // profiles and Application-Not-Responding (ANR) profiles. They come in multiple
+            // varieties, each of which needs to be accounted for.
+
+            // Trace profiles:
+            // ---------------
+            // Versions: 2 (incorrect), 2.android-trace (corrected)
+            // Platform: android
+            // Content field: sampled_profile (i.e., Android Runtime's event-based format, aka
+            //   "traces")
+            // Destination type: AndroidProfileChunk
+
+            // ANR profiles:
+            // ---------------
+            // Version: 2
+            // Platform: java (incorrect), android (corrected)
+            // Content field: profile (i.e., standardized stacks/frames/samples format)
+            // Destination type: V2ProfileChunk
+
+            // First handle Android trace profiles...
+            (_, true) => AndroidProfileChunk::parse(data)
                 .map(Box::new)
                 .map(Self::Android),
-            (_, sample::Version::V2) => V2ProfileChunk::parse(data).map(Box::new).map(Self::V2),
-            (_, sample::Version::V1) => Err(ProfileError::PlatformNotSupported),
-            (_, sample::Version::Unknown) => Err(ProfileError::PlatformNotSupported),
+
+            // ...then handle everything else (Android ANRs, Cocoa profiles, etc.).
+            (sample::Version::V2, _) => V2ProfileChunk::parse(data).map(Box::new).map(Self::V2),
+            (
+                sample::Version::V2AndroidTrace | sample::Version::V1 | sample::Version::Unknown,
+                _,
+            ) => Err(ProfileError::PlatformNotSupported),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    #[test]
+    fn test_parse_android_trace_profile_into_android_profile_chunk() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/android/chunk/valid.json"))
+                .unwrap();
+
+        for version in ["2", "2.android-trace"] {
+            let mut payload = base_payload.clone();
+            payload["version"] = json!(version);
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
+
+            assert!(
+                matches!(chunk, AndroidOrV2ProfileChunk::Android(_)),
+                "expected Android profile chunk for version {version:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_return_error_for_android_trace_profile_without_version() {
+        for (fixture, payload) in [
+            (
+                "android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
+            ),
+            (
+                "react native android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
+            ),
+        ] {
+            let mut payload: Value = serde_json::from_slice(payload).unwrap();
+            payload.as_object_mut().unwrap().remove("version");
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
+            assert!(
+                matches!(err, ProfileError::PlatformNotSupported),
+                "expected unsupported platform error for {fixture}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_sample_v2_profile_into_v2_profile_chunk() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/sample/v2/valid.json"))
+                .unwrap();
+
+        for platform in ["android", "cocoa"] {
+            let mut payload = base_payload.clone();
+            payload["platform"] = json!(platform);
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
+
+            assert!(
+                matches!(chunk, AndroidOrV2ProfileChunk::V2(_)),
+                "expected v2 profile chunk for platform {platform:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_return_error_for_android_trace_version_without_android_trace_payload() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/sample/v2/valid.json"))
+                .unwrap();
+
+        for platform in ["android", "cocoa"] {
+            let mut payload = base_payload.clone();
+            payload["platform"] = json!(platform);
+            payload["version"] = json!("2.android-trace");
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
+            assert!(
+                matches!(err, ProfileError::PlatformNotSupported),
+                "expected unsupported platform error for platform {platform:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_return_error_for_version_1_profile() {
+        for (fixture, payload) in [
+            (
+                "sample v2 format",
+                &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
+            ),
+            (
+                "android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
+            ),
+        ] {
+            let mut payload: Value = serde_json::from_slice(payload).unwrap();
+            payload["version"] = json!("1");
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
+            assert!(
+                matches!(err, ProfileError::PlatformNotSupported),
+                "expected unsupported platform error for {fixture}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_return_error_for_unknown_version_profile() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/sample/v2/valid.json"))
+                .unwrap();
+
+        for platform in ["android", "cocoa"] {
+            let mut payload = base_payload.clone();
+            payload["platform"] = json!(platform);
+            payload.as_object_mut().unwrap().remove("version");
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
+            assert!(
+                matches!(err, ProfileError::PlatformNotSupported),
+                "expected unsupported platform error for platform {platform:?}"
+            );
         }
     }
 }

--- a/relay-profiling/src/profile_chunk.rs
+++ b/relay-profiling/src/profile_chunk.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
 
 use crate::{
-    AndroidProfileChunk, PerfettoProfileChunk, ProfileError, ProfileType, V2ProfileChunk, sample,
+    AndroidProfileChunk, PerfettoProfileChunk, ProfileError, ProfileType, V2ProfileChunk,
+    sample::Version,
 };
 
 /// Minimum interface all profile chunk types must implement.
@@ -123,7 +124,7 @@ impl AndroidOrV2ProfileChunk {
         struct MinimalProfile {
             platform: String,
             #[serde(default)]
-            version: sample::Version,
+            version: Version,
             #[serde(default)]
             sampled_profile: Option<serde::de::IgnoredAny>,
         }
@@ -161,48 +162,42 @@ impl AndroidOrV2ProfileChunk {
         // Content field: profile (i.e., standardized stacks/frames/samples format)
         // Destination type: V2ProfileChunk
 
-        let is_android_trace_profile = minimal.version == sample::Version::V2AndroidTrace
-            // Account for legacy submissions that don't use the 2.android-trace version.
-            || (minimal.platform == "android"
-                && minimal.version == sample::Version::V2
-                && minimal.sampled_profile.is_some());
+        let is_android_trace_profile =
+            minimal.platform == "android" && minimal.sampled_profile.is_some();
 
-        if is_android_trace_profile {
-            AndroidProfileChunk::parse(data)
+        match minimal.version {
+            Version::V2AndroidTrace => AndroidProfileChunk::parse(data)
                 .map(Box::new)
-                .map(Self::Android)
-        } else {
-            match minimal.version {
-                sample::Version::V2 => V2ProfileChunk::parse(data).map(Box::new).map(Self::V2),
-                sample::Version::V2AndroidTrace
-                | sample::Version::V1
-                | sample::Version::Unknown => Err(ProfileError::PlatformNotSupported),
-            }
+                .map(Self::Android),
+            // Account for legacy submissions that don't use the 2.android-trace version.
+            Version::V2 if is_android_trace_profile => AndroidProfileChunk::parse(data)
+                .map(Box::new)
+                .map(Self::Android),
+            Version::V2 => V2ProfileChunk::parse(data).map(Box::new).map(Self::V2),
+            Version::V1 | Version::Unknown => Err(ProfileError::PlatformNotSupported),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use serde_json::{Value, json};
 
     use super::*;
 
     #[test]
-    fn test_parse_properly_versioned_android_trace_profile_into_android_profile_chunk() {
-        let base_payload: Value =
+    fn test_parse_correctly_versioned_android_trace_profile_into_android_profile_chunk() {
+        let mut payload: Value =
             serde_json::from_slice(include_bytes!("../tests/fixtures/android/chunk/valid.json"))
                 .unwrap();
-        let mut payload = base_payload;
         payload["version"] = json!("2.android-trace");
         let data = serde_json::to_vec(&payload).unwrap();
 
         // 1. Fresh SDK-shaped payload: `sampled_profile` populated, `profile` absent.
         let sdk_chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
-        assert!(
-            matches!(sdk_chunk, AndroidOrV2ProfileChunk::Android(_)),
-            "expected Android profile chunk when sampled_profile is populated"
-        );
+        assert_matches!(sdk_chunk, AndroidOrV2ProfileChunk::Android(_));
 
         // 2. Relay's own re-serialized shape: `sampled_profile` absent, `profile` populated.
         let AndroidOrV2ProfileChunk::Android(android_chunk) = sdk_chunk else {
@@ -214,26 +209,19 @@ mod tests {
         assert!(value.get("profile").is_some());
 
         let round_tripped = AndroidOrV2ProfileChunk::parse(&reserialized).unwrap();
-        assert!(
-            matches!(round_tripped, AndroidOrV2ProfileChunk::Android(_)),
-            "expected Android profile chunk when profile is populated"
-        );
+        assert_matches!(round_tripped, AndroidOrV2ProfileChunk::Android(_));
     }
 
     #[test]
     fn test_parse_legacy_versioned_android_trace_profile_into_android_profile_chunk() {
-        let base_payload: Value =
+        let mut payload: Value =
             serde_json::from_slice(include_bytes!("../tests/fixtures/android/chunk/valid.json"))
                 .unwrap();
-        let mut payload = base_payload;
         payload["version"] = json!("2");
         let data = serde_json::to_vec(&payload).unwrap();
 
         let chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
-        assert!(
-            matches!(chunk, AndroidOrV2ProfileChunk::Android(_)),
-            "expected Android profile chunk for legacy version 2 payload"
-        );
+        assert_matches!(chunk, AndroidOrV2ProfileChunk::Android(_));
     }
 
     #[test]
@@ -249,66 +237,39 @@ mod tests {
 
             let chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
 
-            assert!(
-                matches!(chunk, AndroidOrV2ProfileChunk::V2(_)),
-                "expected v2 profile chunk for platform {platform:?}"
-            );
+            assert_matches!(chunk, AndroidOrV2ProfileChunk::V2(_));
         }
     }
 
     #[test]
     fn test_return_error_for_version_1_profile() {
-        for (fixture, payload) in [
-            (
-                "sample v2 format",
-                &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
-            ),
-            (
-                "android trace format",
-                &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
-            ),
-            (
-                "react native android trace format",
-                &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
-            ),
+        for payload in [
+            &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
+            &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
+            &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
         ] {
             let mut payload: Value = serde_json::from_slice(payload).unwrap();
             payload["version"] = json!("1");
             let data = serde_json::to_vec(&payload).unwrap();
 
             let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
-            assert!(
-                matches!(err, ProfileError::PlatformNotSupported),
-                "expected unsupported platform error for {fixture}"
-            );
+            assert_matches!(err, ProfileError::PlatformNotSupported);
         }
     }
 
     #[test]
     fn test_return_error_for_unknown_version_profile() {
-        for (fixture, payload) in [
-            (
-                "sample v2 format",
-                &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
-            ),
-            (
-                "android trace format",
-                &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
-            ),
-            (
-                "react native android trace format",
-                &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
-            ),
+        for payload in [
+            &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
+            &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
+            &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
         ] {
             let mut payload: Value = serde_json::from_slice(payload).unwrap();
             payload.as_object_mut().unwrap().remove("version");
             let data = serde_json::to_vec(&payload).unwrap();
 
             let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
-            assert!(
-                matches!(err, ProfileError::PlatformNotSupported),
-                "expected unsupported platform error for {fixture}"
-            );
+            assert_matches!(err, ProfileError::PlatformNotSupported);
         }
     }
 }

--- a/relay-profiling/src/profile_chunk.rs
+++ b/relay-profiling/src/profile_chunk.rs
@@ -94,6 +94,7 @@ impl relay_filter::Filterable for AnyProfileChunk {
 }
 
 /// Either an [`AndroidProfileChunk`] or a [`V2ProfileChunk`].
+#[derive(Debug)]
 pub enum AndroidOrV2ProfileChunk {
     Android(Box<AndroidProfileChunk>),
     V2(Box<V2ProfileChunk>),
@@ -123,6 +124,8 @@ impl AndroidOrV2ProfileChunk {
             platform: String,
             #[serde(default)]
             version: sample::Version,
+            #[serde(default)]
+            sampled_profile: Option<serde::de::IgnoredAny>,
         }
 
         let minimal: MinimalProfile = {
@@ -130,16 +133,182 @@ impl AndroidOrV2ProfileChunk {
             serde_path_to_error::deserialize(d)
         }?;
 
-        match (minimal.platform.as_str(), minimal.version) {
-            // This has always been parsed with higher priority than `v2`, so this was kept as-is
-            // when refactoring, but from the looks of it, this may cause issues with v2 profiles
-            // which happen to be sent from android.
-            ("android", _) => AndroidProfileChunk::parse(data)
+        // Android SDKs produce two profile_chunk types that pass through this method: trace
+        // profiles and Application-Not-Responding (ANR) profiles. They come in multiple
+        // varieties, each of which needs to be accounted for.
+
+        // Android trace profiles:
+        // ---------------
+        // Version: 2 (incorrect), 2.android-trace (corrected)
+        // Platform: android
+        // Content field: sampled_profile (i.e., Android Runtime's event-based format, aka
+        //   "traces")
+        // Destination type: AndroidProfileChunk
+
+        // Android ANR profiles:
+        // ---------------
+        // Version: 2
+        // Platform: java (incorrect), android (corrected)
+        // Content field: profile (i.e., standardized stacks/frames/samples format)
+        // Destination type: V2ProfileChunk
+
+        // We also need to handle non-Android profile chunks.
+
+        // Non-Android profiles:
+        // ---------------
+        // Version: 2
+        // Platform: cocoa, javascript, etc.
+        // Content field: profile (i.e., standardized stacks/frames/samples format)
+        // Destination type: V2ProfileChunk
+
+        let is_android_trace_profile = minimal.version == sample::Version::V2AndroidTrace
+            // Account for legacy submissions that don't use the 2.android-trace version.
+            || (minimal.platform == "android"
+                && minimal.version == sample::Version::V2
+                && minimal.sampled_profile.is_some());
+
+        if is_android_trace_profile {
+            AndroidProfileChunk::parse(data)
                 .map(Box::new)
-                .map(Self::Android),
-            (_, sample::Version::V2) => V2ProfileChunk::parse(data).map(Box::new).map(Self::V2),
-            (_, sample::Version::V1) => Err(ProfileError::PlatformNotSupported),
-            (_, sample::Version::Unknown) => Err(ProfileError::PlatformNotSupported),
+                .map(Self::Android)
+        } else {
+            match minimal.version {
+                sample::Version::V2 => V2ProfileChunk::parse(data).map(Box::new).map(Self::V2),
+                sample::Version::V2AndroidTrace
+                | sample::Version::V1
+                | sample::Version::Unknown => Err(ProfileError::PlatformNotSupported),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    #[test]
+    fn test_parse_properly_versioned_android_trace_profile_into_android_profile_chunk() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/android/chunk/valid.json"))
+                .unwrap();
+        let mut payload = base_payload;
+        payload["version"] = json!("2.android-trace");
+        let data = serde_json::to_vec(&payload).unwrap();
+
+        // 1. Fresh SDK-shaped payload: `sampled_profile` populated, `profile` absent.
+        let sdk_chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
+        assert!(
+            matches!(sdk_chunk, AndroidOrV2ProfileChunk::Android(_)),
+            "expected Android profile chunk when sampled_profile is populated"
+        );
+
+        // 2. Relay's own re-serialized shape: `sampled_profile` absent, `profile` populated.
+        let AndroidOrV2ProfileChunk::Android(android_chunk) = sdk_chunk else {
+            unreachable!()
+        };
+        let reserialized = serde_json::to_vec(&android_chunk).unwrap();
+        let value: Value = serde_json::from_slice(&reserialized).unwrap();
+        assert!(value.get("sampled_profile").is_none());
+        assert!(value.get("profile").is_some());
+
+        let round_tripped = AndroidOrV2ProfileChunk::parse(&reserialized).unwrap();
+        assert!(
+            matches!(round_tripped, AndroidOrV2ProfileChunk::Android(_)),
+            "expected Android profile chunk when profile is populated"
+        );
+    }
+
+    #[test]
+    fn test_parse_legacy_versioned_android_trace_profile_into_android_profile_chunk() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/android/chunk/valid.json"))
+                .unwrap();
+        let mut payload = base_payload;
+        payload["version"] = json!("2");
+        let data = serde_json::to_vec(&payload).unwrap();
+
+        let chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
+        assert!(
+            matches!(chunk, AndroidOrV2ProfileChunk::Android(_)),
+            "expected Android profile chunk for legacy version 2 payload"
+        );
+    }
+
+    #[test]
+    fn test_parse_sample_v2_profile_into_v2_profile_chunk() {
+        let base_payload: Value =
+            serde_json::from_slice(include_bytes!("../tests/fixtures/sample/v2/valid.json"))
+                .unwrap();
+
+        for platform in ["android", "cocoa", "javascript", "python"] {
+            let mut payload = base_payload.clone();
+            payload["platform"] = json!(platform);
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let chunk = AndroidOrV2ProfileChunk::parse(&data).unwrap();
+
+            assert!(
+                matches!(chunk, AndroidOrV2ProfileChunk::V2(_)),
+                "expected v2 profile chunk for platform {platform:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_return_error_for_version_1_profile() {
+        for (fixture, payload) in [
+            (
+                "sample v2 format",
+                &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
+            ),
+            (
+                "android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
+            ),
+            (
+                "react native android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
+            ),
+        ] {
+            let mut payload: Value = serde_json::from_slice(payload).unwrap();
+            payload["version"] = json!("1");
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
+            assert!(
+                matches!(err, ProfileError::PlatformNotSupported),
+                "expected unsupported platform error for {fixture}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_return_error_for_unknown_version_profile() {
+        for (fixture, payload) in [
+            (
+                "sample v2 format",
+                &include_bytes!("../tests/fixtures/sample/v2/valid.json")[..],
+            ),
+            (
+                "android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid.json")[..],
+            ),
+            (
+                "react native android trace format",
+                &include_bytes!("../tests/fixtures/android/chunk/valid-rn.json")[..],
+            ),
+        ] {
+            let mut payload: Value = serde_json::from_slice(payload).unwrap();
+            payload.as_object_mut().unwrap().remove("version");
+            let data = serde_json::to_vec(&payload).unwrap();
+
+            let err = AndroidOrV2ProfileChunk::parse(&data).unwrap_err();
+            assert!(
+                matches!(err, ProfileError::PlatformNotSupported),
+                "expected unsupported platform error for {fixture}"
+            );
         }
     }
 }

--- a/relay-profiling/src/sample/mod.rs
+++ b/relay-profiling/src/sample/mod.rs
@@ -15,6 +15,9 @@ pub enum Version {
     V1,
     #[serde(rename = "2")]
     V2,
+    /// Special-cased chunk format for Android trace profiles, distinct from sample-format v2.
+    #[serde(rename = "2.android-trace")]
+    V2AndroidTrace,
 }
 
 /// Holds information about a single stacktrace frame.

--- a/relay-profiling/src/sample/mod.rs
+++ b/relay-profiling/src/sample/mod.rs
@@ -15,6 +15,9 @@ pub enum Version {
     V1,
     #[serde(rename = "2")]
     V2,
+    /// Special-cased chunk format for Android trace profiles, distinct from sample v2 format.
+    #[serde(rename = "2.android-trace")]
+    V2AndroidTrace,
 }
 
 /// Holds information about a single stacktrace frame.

--- a/relay-profiling/src/sample/mod.rs
+++ b/relay-profiling/src/sample/mod.rs
@@ -6,7 +6,7 @@ use relay_event_schema::protocol::Addr;
 pub mod v1;
 pub mod v2;
 
-/// Possible values for the version field of the Sample Format.
+/// Possible values for profile payload versions.
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, Default, PartialEq, Eq)]
 pub enum Version {
     #[default]
@@ -15,7 +15,7 @@ pub enum Version {
     V1,
     #[serde(rename = "2")]
     V2,
-    /// Special-cased chunk format for Android trace profiles, distinct from sample v2 format.
+    /// Special-cased chunk format for Android trace profiles, distinct from Sample Format V2.
     #[serde(rename = "2.android-trace")]
     V2AndroidTrace,
 }

--- a/tests/integration/test_profile_chunks.py
+++ b/tests/integration/test_profile_chunks.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from copy import deepcopy
 from pathlib import Path
@@ -319,6 +320,41 @@ def test_profile_chunk_outcomes_rate_limited_fast(
             {"category": category, "quantity": 1, "reason": "profile_chunks_exceeded"}
         ]
         assert mini_sentry.captured_envelopes.empty()
+
+
+@pytest.mark.parametrize(
+    ["envelope_factory", "expected_version"],
+    [
+        pytest.param(sample_profile_v2_envelope, "2", id="profile v2"),
+        pytest.param(
+            android_profile_chunk_envelope,
+            "2.android-trace",
+            id="android chunk",
+        ),
+    ],
+)
+def test_profile_chunk_version_is_forwarded(
+    mini_sentry,
+    relay_with_processing,
+    profiles_consumer,
+    envelope_factory,
+    expected_version,
+):
+    profiles_consumer = profiles_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)["config"]
+
+    project_config.setdefault("features", []).append(
+        "organizations:continuous-profiling"
+    )
+
+    upstream = relay_with_processing(TEST_CONFIG)
+    upstream.send_envelope(project_id, envelope_factory())
+
+    profile, headers = profiles_consumer.get_profile()
+    assert headers == [("project_id", b"42")]
+    assert json.loads(profile["payload"])["version"] == expected_version
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Overview

Fixes logic for handling Android profile chunks that pass through AndroidOrV2ProfileChunk::parse (viz., Android trace profiles and Android ANR profiles). Prior to this PR, the ::parse implementation worked only because it had been tailored to the quirks of existing Android trace + ANR profiles. But that special-casing will break once the updates to ANR billing under [JAVA-548](https://linear.app/getsentry/issue/JAVA-548/bill-anr-profiles-as-ui-profile-hours-instead-of-continuous-profile0) are complete.

**This PR anticipates JAVA-548 by:**

 1. routing Android trace profile chunks by their payload shape, and allowing all ANR profiles to (rightly) be parsed as V2ProfileChunk's; and

 2. parsing + serializing Android trace chunks with a new 2.android-trace version so downstream consumers can distinguish them from sample v2 chunks.

Note: we now reject v1 and version-less Android trace profile chunks. Sentry's Android SDK implementation suggests they were always unwanted, but this PR makes that explicit. (But see the comment [here](https://github.com/getsentry/relay/pull/6183#discussion_r3530160533).)

[JAVA-634](https://linear.app/getsentry/issue/JAVA-634/update-relay-anr-profile-routing)

### ⚠️ Callouts

**[1]** See my comment [here](https://github.com/getsentry/relay/pull/6183#discussion_r3646021227).

~~**[2]** I don't plan to update [our profiling docs](https://develop.sentry.dev/sdk/telemetry/profiles/).~~

~~Those docs don't mention the already special-cased Android trace payloads currently sent under `version: 2`. I'm assuming that means we're deliberately not advertising them. (This PR now lets those profiles be marked as `version: 2.android-trace`, but the payloads otherwise remain the same.)~~

~~Let me know if I'm wrong about that^^, and I can update the docs to discuss Android trace payloads + `2.android-trace`.~~

Discussed with @Dav1dde offline, and we decided to update the docs on the assumption that they were simply overlooked when Android special-casing was introduced. I'll post a follow-on PR in the sentry-docs repo.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
