### PR TITLE
ref(transactions): Remove metrics extracted flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Use dedicated secret to sign upload URLs. ([#6132](https://github.com/getsentry/relay/pull/6132))
 - Inline small attachments instead of uploading to objectstore. ([#6165](https://github.com/getsentry/relay/pull/6165))
 - Retry 500 responses from objectstore. ([#6162](https://github.com/getsentry/relay/pull/6162))
+- Remove the `metrics_extracted` flag from the transactions processing pipeline. ([#6190](https://github.com/getsentry/relay/pull/6190))
 
 ## 26.6.0
 

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -415,19 +415,6 @@ impl Item {
         self.headers.source_quantities = Some(source_quantities);
     }
 
-    /// Returns the metrics extracted flag.
-    pub fn metrics_extracted(&self) -> bool {
-        self.headers
-            .get(ItemHeaderKey::MetricsExtracted)
-            .unwrap_or_default()
-    }
-
-    /// Sets the metrics extracted flag.
-    pub fn set_metrics_extracted(&mut self, metrics_extracted: bool) {
-        self.headers
-            .set(ItemHeaderKey::MetricsExtracted, metrics_extracted);
-    }
-
     /// Returns the spans extracted flag.
     pub fn spans_extracted(&self) -> bool {
         self.headers
@@ -1034,13 +1021,6 @@ pub enum ItemHeaderKey {
     /// This is currently considered optional for profile chunks, but may change
     /// to required in the future.
     Platform,
-    /// Flag indicating if metrics have already been extracted from the item.
-    ///
-    /// In order to only extract metrics once from an item while through a
-    /// chain of Relays, a Relay that extracts metrics from an item (typically
-    /// the first Relay) MUST set this flat to true so that upstream Relays do
-    /// not extract the metric again causing double counting of the metric.
-    MetricsExtracted,
     /// Whether or not spans and span metrics have been extracted from a transaction.
     ///
     /// This header is set to `true` after both span extraction and span metrics extraction,

--- a/relay-server/src/processing/transactions/extraction.rs
+++ b/relay-server/src/processing/transactions/extraction.rs
@@ -8,7 +8,6 @@ use relay_sampling::DynamicSamplingContext;
 use relay_sampling::evaluation::SamplingDecision;
 
 use crate::processing::Context;
-use crate::processing::utils::event::EventMetricsExtracted;
 use crate::services::processor::ProcessingExtractedMetrics;
 
 /// Creates a span from the transaction and applies tag extraction on it.
@@ -33,7 +32,6 @@ pub struct ExtractMetricsContext<'a> {
     pub project_id: ProjectId,
     pub ctx: Context<'a>,
     pub sampling_decision: SamplingDecision,
-    pub metrics_extracted: bool,
     pub extract_span_metrics: bool,
 }
 
@@ -42,24 +40,20 @@ pub fn extract_metrics(
     event: &mut Annotated<Event>,
     extracted_metrics: &mut ProcessingExtractedMetrics,
     ctx: ExtractMetricsContext,
-) -> EventMetricsExtracted {
+) -> bool {
     let ExtractMetricsContext {
         dsc,
         project_id,
         ctx,
         sampling_decision,
-        metrics_extracted,
         extract_span_metrics,
     } = ctx;
     // TODO(follow-up): this function should always extract metrics. Dynamic sampling should validate
     // the full metrics extraction config and skip sampling if it is incomplete.
 
-    if metrics_extracted {
-        return EventMetricsExtracted(true);
-    }
     let Some(event) = event.value_mut() else {
         // Nothing to extract, but metrics extraction was called.
-        return EventMetricsExtracted(true);
+        return true;
     };
 
     // NOTE: This function requires a `metric_extraction` in the project config. Legacy configs
@@ -68,7 +62,7 @@ pub fn extract_metrics(
     let combined_config = {
         let config = match &ctx.project_info.config.metric_extraction {
             ErrorBoundary::Ok(config) if config.is_supported() => config,
-            _ => return EventMetricsExtracted(false),
+            _ => return false,
         };
         let global_config = match &ctx.global_config.metric_extraction {
             ErrorBoundary::Ok(global_config) => global_config,
@@ -83,7 +77,7 @@ pub fn extract_metrics(
                     // If there's an error with global metrics extraction, it is safe to assume that this
                     // Relay instance is not up-to-date, and we should skip extraction.
                     relay_log::debug!("Failed to parse global extraction config: {e}");
-                    return EventMetricsExtracted(false);
+                    return false;
                 }
             }
         };
@@ -106,5 +100,5 @@ pub fn extract_metrics(
     );
     extracted_metrics.extend(metrics, Some(sampling_decision));
 
-    EventMetricsExtracted(true)
+    true
 }

--- a/relay-server/src/processing/transactions/process.rs
+++ b/relay-server/src/processing/transactions/process.rs
@@ -47,13 +47,11 @@ pub fn expand(
             event.ty = EventType::Transaction.into();
         }
         let flags = Flags {
-            metrics_extracted: transaction_item.metrics_extracted(),
             spans_extracted: transaction_item.spans_extracted(),
             fully_normalized: headers.meta().request_trust().is_trusted()
                 && transaction_item.fully_normalized(),
             spans_rate_limited: false,
         };
-        validate_flags(&flags);
 
         let profile = expand_profile(profiles, record_keeper);
 
@@ -76,15 +74,6 @@ pub fn expand(
             category: TotalAndIndexed,
         }))
     })
-}
-
-/// Validates the following assumption:
-/// 1. Metrics are only extracted in non-processing relays if the sampling decision is "drop".
-/// 2. That means that if we see a new transaction, it cannot yet have metrics extracted.
-fn validate_flags(flags: &Flags) {
-    if flags.metrics_extracted {
-        relay_log::error!("Received a transaction which already had its metrics extracted.");
-    }
 }
 
 fn expand_profile(
@@ -312,13 +301,13 @@ pub fn split_indexed_and_total_with_extracted_spans(
 ) -> IndexedTransactionAndSpanAndMetrics {
     let scoping = transaction.scoping();
 
+    let mut metrics_extracted = false;
     let (transaction, metrics) = transaction.split_once(|mut tx, r| {
         r.lenient(DataCategory::MetricBucket);
 
         let mut metrics = ProcessingExtractedMetrics::new();
 
-        let had_metrics_extracted = tx.flags.metrics_extracted;
-        tx.flags.metrics_extracted = extraction::extract_metrics(
+        metrics_extracted = extraction::extract_metrics(
             &mut tx.event,
             &mut metrics,
             ExtractMetricsContext {
@@ -326,13 +315,11 @@ pub fn split_indexed_and_total_with_extracted_spans(
                 project_id: scoping.project_id,
                 ctx,
                 sampling_decision: SamplingDecision::Keep,
-                metrics_extracted: tx.flags.metrics_extracted,
                 extract_span_metrics: spans.is_some(),
             },
-        )
-        .0;
+        );
 
-        if had_metrics_extracted || !tx.flags.metrics_extracted {
+        if !metrics_extracted {
             // Invalid config or invalid original transaction
             r.lenient(DataCategory::Transaction);
             r.lenient(DataCategory::Span);
@@ -381,8 +368,9 @@ pub fn split_indexed_and_total_with_extracted_spans(
                 // "Insurance" that metrics extracted from the transaction spans match the extracted
                 // spans.
                 r.modify_by(*c, -(*q as isize));
-            } else if transaction.flags.metrics_extracted {
-                // This `metrics_extracted` flag really isn't necessary anymore and should be deleted.
+            } else if metrics_extracted {
+                // Metrics were extracted but do not contain a span quantity,
+                // be lenient about the span counts instead of failing bookkeeping.
                 r.lenient(DataCategory::Span);
             }
 
@@ -406,12 +394,12 @@ pub fn split_indexed_and_total(
 ) -> IndexedAndMetrics {
     let scoping = work.scoping();
 
-    let had_metrics_extracted = work.flags.metrics_extracted;
     let extract_span_metrics = !work.flags.spans_rate_limited;
 
     let mut metrics = ProcessingExtractedMetrics::new();
+    let mut metrics_extracted = false;
     work.modify(|work, _| {
-        work.flags.metrics_extracted = extraction::extract_metrics(
+        metrics_extracted = extraction::extract_metrics(
             &mut work.event,
             &mut metrics,
             ExtractMetricsContext {
@@ -419,16 +407,14 @@ pub fn split_indexed_and_total(
                 project_id: scoping.project_id,
                 ctx,
                 sampling_decision,
-                metrics_extracted: work.flags.metrics_extracted,
                 extract_span_metrics,
             },
-        )
-        .0;
+        );
     });
 
     work.split_once(|work, r| {
         r.lenient(DataCategory::MetricBucket);
-        if had_metrics_extracted || !work.flags.metrics_extracted {
+        if !metrics_extracted {
             // Invalid config or invalid original transaction
             r.lenient(DataCategory::Transaction);
             r.lenient(DataCategory::Span);

--- a/relay-server/src/processing/transactions/types/expanded.rs
+++ b/relay-server/src/processing/transactions/types/expanded.rs
@@ -19,11 +19,10 @@ use crate::statsd::RelayTimers;
 
 /// Flags extracted from transaction item headers.
 ///
-/// Ideally `metrics_extracted` and `spans_extracted` will not be needed in the future. Unsure
+/// Ideally `spans_extracted` will not be needed in the future. Unsure
 /// about `fully_normalized`.
 #[derive(Debug, Default)]
 pub struct Flags {
-    pub metrics_extracted: bool,
     pub spans_extracted: bool,
     pub fully_normalized: bool,
     pub spans_rate_limited: bool,
@@ -231,12 +230,10 @@ impl<T> ExpandedTransaction<T> {
         item.set_payload(ContentType::Json, data);
 
         let Flags {
-            metrics_extracted,
             spans_extracted,
             fully_normalized,
             spans_rate_limited: _,
         } = flags;
-        item.set_metrics_extracted(metrics_extracted);
         item.set_spans_extracted(spans_extracted);
         item.set_fully_normalized(fully_normalized);
 

--- a/relay-server/src/processing/utils/event.rs
+++ b/relay-server/src/processing/utils/event.rs
@@ -387,10 +387,6 @@ pub fn filter(
 #[derive(Debug, Copy, Clone)]
 pub struct EventFullyNormalized(pub bool);
 
-/// New type representing whether metrics were extracted from transactions/spans.
-#[derive(Debug, Copy, Clone)]
-pub struct EventMetricsExtracted(pub bool);
-
 /// Checks if the Event includes unprintable fields.
 fn has_unprintable_fields(event: &Annotated<Event>) -> bool {
     fn is_unprintable(value: &&str) -> bool {

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -696,15 +696,7 @@ def test_session_metrics_processing(
     }
 
 
-@pytest.mark.parametrize("send_extracted_header", [False, True])
-def test_transaction_metrics_extraction_external_relays(
-    mini_sentry, relay, send_extracted_header
-):
-    if send_extracted_header:
-        item_headers = {"metrics_extracted": True}
-    else:
-        item_headers = None
-
+def test_transaction_metrics_extraction_external_relays(mini_sentry, relay):
     project_id = 42
     mini_sentry.add_full_project_config(project_id)
     config = mini_sentry.project_configs[project_id]["config"]
@@ -732,44 +724,25 @@ def test_transaction_metrics_extraction_external_relays(
         "public_key": mini_sentry.get_dsn_public_key(project_id),
         "transaction": "root_transaction",
     }
-    external.send_transaction(project_id, tx, item_headers, trace_info)
+    external.send_transaction(project_id, tx, None, trace_info)
 
-    if send_extracted_header:
-        _, error = mini_sentry.test_failures.get()
-        assert (
-            str(error)
-            == "Relay sent us event: Received a transaction which already had its metrics extracted."
-        )
-    else:
-        payload = mini_sentry.get_metrics()
-        assert len(payload) == 4
+    payload = mini_sentry.get_metrics()
+    assert len(payload) == 4
 
-        by_name = {m["name"]: m for m in payload}
-        count_metric = by_name["c:spans/count_per_root_project@none"]
-        assert count_metric["tags"]["transaction"] == "root_transaction"
-        assert count_metric["value"] == 1.0
-        usage_metric = by_name["c:spans/usage@none"]
-        assert usage_metric["value"] == 1.0
+    by_name = {m["name"]: m for m in payload}
+    count_metric = by_name["c:spans/count_per_root_project@none"]
+    assert count_metric["tags"]["transaction"] == "root_transaction"
+    assert count_metric["value"] == 1.0
+    usage_metric = by_name["c:spans/usage@none"]
+    assert usage_metric["value"] == 1.0
 
 
-@pytest.mark.parametrize(
-    "send_extracted_header,expect_metrics_extraction",
-    [(False, True), (True, False)],
-    ids=["must extract metrics", "must not extract metrics"],
-)
 def test_transaction_metrics_extraction_processing_relays(
     transactions_consumer,
     metrics_consumer,
     mini_sentry,
     relay_with_processing,
-    send_extracted_header,
-    expect_metrics_extraction,
 ):
-    if send_extracted_header:
-        item_headers = {"metrics_extracted": True}
-    else:
-        item_headers = None
-
     project_id = 42
     mini_sentry.add_full_project_config(project_id)
     mini_sentry.project_configs[project_id]["config"]
@@ -780,23 +753,17 @@ def test_transaction_metrics_extraction_processing_relays(
     metrics_consumer = metrics_consumer()
     tx_consumer = transactions_consumer()
     processing = relay_with_processing(options=TEST_CONFIG)
-    processing.send_transaction(project_id, tx, item_headers)
+    processing.send_transaction(project_id, tx)
 
     tx, _ = tx_consumer.get_event()
     assert tx["transaction"] == "/organizations/:orgId/performance/:eventSlug/"
     tx_consumer.assert_empty()
 
-    if expect_metrics_extraction:
-        metrics = metrics_by_name(metrics_consumer, 4)
-        metric_usage = metrics["c:spans/usage@none"]
-        assert metric_usage["value"] == 1.0
-        metric_count_per_project = metrics["c:spans/count_per_root_project@none"]
-        assert metric_count_per_project["value"] == 1.0
-    else:
-        assert (
-            str(mini_sentry.test_failures.get(timeout=5)[1])
-            == "Relay sent us event: Received a transaction which already had its metrics extracted."
-        )
+    metrics = metrics_by_name(metrics_consumer, 4)
+    metric_usage = metrics["c:spans/usage@none"]
+    assert metric_usage["value"] == 1.0
+    metric_count_per_project = metrics["c:spans/count_per_root_project@none"]
+    assert metric_count_per_project["value"] == 1.0
 
     metrics_consumer.assert_empty()
 

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -489,9 +489,7 @@ def test_span_extraction_mobile_app_start_backfill(
         assert key not in attrs
 
 
-def envelope_with_spans(
-    start: datetime, end: datetime, metrics_extracted: bool = False
-) -> Envelope:
+def envelope_with_spans(start: datetime, end: datetime) -> Envelope:
     envelope = Envelope()
     envelope.add_item(
         Item(


### PR DESCRIPTION
Refs: INGEST-704
Fixes: INGEST-1007

This flag isn't necessary as the presence of the envelope already tells us metrics have not been extracted. We delay metrics extraction until the very end of the pipeline.