### PR TITLE
ref(transaction): Send transactions as events to store 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Update sentry-conventions to 0.12.0.
 - Update sentry-conventions to 0.13.0. ([#6139](https://github.com/getsentry/relay/pull/6139))
 - Upgrade release image to Debian 13. ([#6110](https://github.com/getsentry/relay/pull/6110))
+- No longer serialize transactions into envelopes when storing them. ([#6193](https://github.com/getsentry/relay/pull/6193))
 - Prefix upload location query params for forward compatibility. ([#6076](https://github.com/getsentry/relay/pull/6076))
 - Add config option to bypass the kafka fallback for objectstore uploads. ([#6127](https://github.com/getsentry/relay/pull/6127))
 - Use upstream descriptor in upload requests. ([#6128](https://github.com/getsentry/relay/pull/6128))

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -245,6 +245,11 @@ impl<T: Counted> Managed<T> {
         self.meta.scoping
     }
 
+    /// Optional remote addr from where the data was received from.
+    pub fn remote_addr(&self) -> Option<IpAddr> {
+        self.meta.remote_addr
+    }
+
     /// Updates the scoping stored in this context.
     ///
     /// Special care has to be taken when items contained in the managed instance also store a

--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -245,7 +245,7 @@ impl<T: Counted> Managed<T> {
         self.meta.scoping
     }
 
-    /// Optional remote addr from where the data was received from.
+    /// Optional remote addr from where the data was received.
     pub fn remote_addr(&self) -> Option<IpAddr> {
         self.meta.remote_addr
     }
@@ -779,7 +779,7 @@ struct Meta {
     scoping: Scoping,
     /// Optional event id associated with the contained data.
     event_id: Option<EventId>,
-    /// Optional remote addr from where the data was received from.
+    /// Optional remote addr from where the data was received.
     remote_addr: Option<IpAddr>,
 }
 

--- a/relay-server/src/processing/forward.rs
+++ b/relay-server/src/processing/forward.rs
@@ -12,7 +12,7 @@ use crate::managed::{Managed, Rejected};
 use crate::services::objectstore::Objectstore;
 use crate::services::projects::project::ProjectInfo;
 #[cfg(feature = "processing")]
-use crate::services::store::Store;
+use crate::services::store::{Store, StoreEvent};
 
 /// A transparent handle that dispatches between store-like services.
 #[cfg(feature = "processing")]
@@ -34,6 +34,31 @@ impl<'a> StoreHandle<'a> {
             store,
             objectstore,
             global_config,
+        }
+    }
+
+    /// Dispatches an event message to either the [`Objectstore`] or [`Store`] service.
+    pub fn send_event(&self, message: Managed<Box<StoreEvent>>) {
+        if message.attachments.is_empty() {
+            self.store.send(message);
+            return;
+        }
+
+        let Some(objectstore) = self.objectstore else {
+            self.store.send(message);
+            return;
+        };
+
+        let use_objectstore = crate::utils::sample(
+            self.global_config
+                .options
+                .objectstore_attachments_sample_rate,
+        )
+        .is_keep();
+
+        match use_objectstore {
+            true => objectstore.send(message),
+            false => self.store.send(message),
         }
     }
 

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -91,33 +91,28 @@ impl Forward for TransactionOutput {
         let (profile, event) = transaction.split_once(|tx, _| {
             let ExpandedTransaction {
                 headers: _,
-                event,
+                mut event,
                 flags: _,
                 attachments,
                 profile,
                 category: _,
             } = *tx;
 
-            let event = event.into_value().map(|mut event| {
-                if performance_issues_spans {
-                    event.performance_issues_spans = true.into();
-                }
+            if performance_issues_spans && let Some(event) = event.value_mut() {
+                event.performance_issues_spans = true.into();
+            }
 
-                Box::new(StoreEvent {
-                    event_category: relay_quotas::DataCategory::TransactionIndexed,
-                    event,
-                    attachments,
-                    retention_days: ctx.event_retention().standard,
-                })
+            let event = Box::new(StoreEvent {
+                event_category: relay_quotas::DataCategory::TransactionIndexed,
+                event,
+                attachments,
+                retention_days: ctx.event_retention().standard,
             });
 
             (profile, event)
         });
 
-        debug_assert!(event.is_some());
-        if let Some(event) = event.transpose() {
-            s.send_event(event);
-        }
+        s.send_event(event);
 
         if let Some(profile) = profile.transpose() {
             s.send_to_store(profile.map(|p, _| store::convert_profile(p, true, ctx)));

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -1,12 +1,5 @@
-#[cfg(feature = "processing")]
-use relay_dynamic_config::Feature;
-#[cfg(feature = "processing")]
-use relay_protocol::Annotated;
-
 use crate::Envelope;
 use crate::managed::{Managed, ManagedResult, Rejected};
-#[cfg(feature = "processing")]
-use crate::processing::StoreHandle;
 use crate::processing::spans::Indexed;
 use crate::processing::transactions::types::{
     ExpandedTransaction, ExtractedIndexedSpans, StandaloneProfile,
@@ -56,9 +49,11 @@ impl Forward for TransactionOutput {
     #[cfg(feature = "processing")]
     fn forward_store(
         self,
-        s: StoreHandle<'_>,
+        s: crate::processing::StoreHandle<'_>,
         ctx: ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
+        use crate::services::store::StoreEvent;
+
         let (spans, transaction) = match self {
             TransactionOutput::Full(managed) => {
                 return Err(managed.internal_error("only indexed transactions can be stored"));
@@ -72,7 +67,7 @@ impl Forward for TransactionOutput {
 
         let performance_issues_spans = ctx
             .project_info
-            .has_feature(Feature::PerformanceIssuesSpans);
+            .has_feature(relay_dynamic_config::Feature::PerformanceIssuesSpans);
 
         if let Some(spans) = spans {
             let event_id = transaction.headers.event_id();
@@ -93,28 +88,40 @@ impl Forward for TransactionOutput {
             }
         }
 
-        let (profile, transaction) = transaction.split_once(|mut tx, _| (tx.profile.take(), tx));
+        let (profile, event) = transaction.split_once(|tx, _| {
+            let ExpandedTransaction {
+                headers: _,
+                event,
+                flags: _,
+                attachments,
+                profile,
+                category: _,
+            } = *tx;
+
+            let event = event.into_value().map(|mut event| {
+                if performance_issues_spans {
+                    event.performance_issues_spans = true.into();
+                }
+
+                Box::new(StoreEvent {
+                    event_category: relay_quotas::DataCategory::TransactionIndexed,
+                    event,
+                    attachments,
+                    retention_days: ctx.event_retention().standard,
+                })
+            });
+
+            (profile, event)
+        });
+
+        debug_assert!(event.is_some());
+        if let Some(event) = event.transpose() {
+            s.send_event(event);
+        }
+
         if let Some(profile) = profile.transpose() {
             s.send_to_store(profile.map(|p, _| store::convert_profile(p, true, ctx)));
         }
-
-        let envelope = transaction.try_map(|mut work, record_keeper| {
-            // TODO: This should raise an error, Indexed output should go straight to Kafka
-            // instead of an envelope. As long as we have this hack, ignore bookkeeping
-            record_keeper.lenient(relay_quotas::DataCategory::Transaction);
-
-            if let Some(event) = work.event.value_mut()
-                && performance_issues_spans
-            {
-                event.performance_issues_spans = Annotated::new(true);
-            }
-
-            work.serialize_envelope()
-                .map_err(drop)
-                .with_outcome(Outcome::Invalid(DiscardReason::Internal))
-        })?;
-
-        s.send_envelope(envelope.into());
 
         Ok(())
     }

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -29,7 +29,8 @@ use crate::managed::{
 use crate::processing::utils::store::item_id_to_uuid;
 use crate::services::outcome::DiscardReason;
 use crate::services::store::{
-    ProfileAttachment, Store, StoreAttachment, StoreEnvelope, StoreProfileChunk, StoreTraceItem,
+    ProfileAttachment, Store, StoreAttachment, StoreEnvelope, StoreEvent, StoreProfileChunk,
+    StoreTraceItem,
 };
 use crate::services::upload::ByteStream;
 use crate::statsd::{RelayCounters, RelayTimers};
@@ -40,6 +41,7 @@ use super::outcome::Outcome;
 /// Messages that the objectstore service can handle.
 pub enum Objectstore {
     Envelope(StoreEnvelope),
+    Event(Managed<Box<StoreEvent>>),
     TraceAttachment(Managed<StoreTraceAttachment>),
     EventAttachment(Managed<StoreAttachment>),
     RawProfile(Managed<StoreRawProfile>),
@@ -49,7 +51,8 @@ pub enum Objectstore {
 impl Objectstore {
     fn kind(&self) -> MessageKind {
         match self {
-            Self::Envelope(_) => MessageKind::Envelope,
+            Self::Envelope(_) => MessageKind::Event,
+            Self::Event(_) => MessageKind::Event,
             Self::TraceAttachment(_) => MessageKind::TraceAttachment,
             Self::EventAttachment(_) => MessageKind::EventAttachment,
             Self::RawProfile(_) => MessageKind::RawProfile,
@@ -64,6 +67,7 @@ impl Objectstore {
                 .items()
                 .filter(|item| *item.ty() == ItemType::Attachment)
                 .count(),
+            Self::Event(e) => e.attachments.len(),
             Self::TraceAttachment(_) => 1,
             Self::EventAttachment(_) => 1,
             Self::RawProfile(_) => 1,
@@ -79,6 +83,14 @@ impl FromMessage<StoreEnvelope> for Objectstore {
 
     fn from_message(message: StoreEnvelope, _sender: ()) -> Self {
         Self::Envelope(message)
+    }
+}
+
+impl FromMessage<Managed<Box<StoreEvent>>> for Objectstore {
+    type Response = NoResponse;
+
+    fn from_message(message: Managed<Box<StoreEvent>>, _sender: ()) -> Self {
+        Self::Event(message)
     }
 }
 
@@ -110,6 +122,7 @@ impl FromMessage<Managed<StoreRawProfile>> for Objectstore {
 #[derive(Debug, Clone, Copy)]
 enum MessageKind {
     Envelope,
+    Event,
     EventAttachment,
     TraceAttachment,
     RawProfile,
@@ -120,6 +133,7 @@ impl MessageKind {
     fn as_str(&self) -> &'static str {
         match self {
             Self::Envelope => "envelope",
+            Self::Event => "envelope",
             Self::EventAttachment => "attachment",
             Self::TraceAttachment => "attachment_v2",
             Self::RawProfile => "profile_raw",
@@ -405,6 +419,12 @@ impl LoadShed<Objectstore> for ObjectstoreService {
                 }
                 self.inner.store.send(StoreEnvelope { envelope });
             }
+            Objectstore::Event(mut event) => {
+                if !self.inner.fallback_to_kafka {
+                    drop_attachments(&mut event);
+                }
+                self.inner.store.send(event);
+            }
             Objectstore::EventAttachment(message) => {
                 if self.inner.fallback_to_kafka {
                     self.inner.store.send(message);
@@ -446,6 +466,9 @@ impl ObjectstoreServiceInner {
         match message {
             Objectstore::Envelope(StoreEnvelope { envelope }) => {
                 self.handle_envelope(envelope).await;
+            }
+            Objectstore::Event(event) => {
+                self.handle_event(event).await;
             }
             Objectstore::TraceAttachment(attachment) => {
                 let result = self
@@ -531,6 +554,71 @@ impl ObjectstoreServiceInner {
 
         // last but not least, forward the envelope to the store endpoint
         self.store.send(StoreEnvelope { envelope });
+    }
+
+    async fn handle_event(&self, mut event: Managed<Box<StoreEvent>>) {
+        let scoping = event.scoping();
+        let session = self.session(
+            &self.event_attachments,
+            scoping.organization_id,
+            scoping.project_id,
+        );
+
+        let session = match session {
+            Err(error) => {
+                error
+                    .with_amount(event.attachments.len())
+                    .log(MessageKind::Event);
+                if !self.fallback_to_kafka {
+                    drop_attachments(&mut event);
+                }
+                self.store.send(event);
+                return;
+            }
+            Ok(session) => session,
+        };
+
+        let (mut event, attachments) = event.split_once(|mut e, _| {
+            let attachments = e
+                .attachments
+                .extract_if(.., |item| should_upload(item))
+                .collect::<Vec<_>>();
+
+            (e, attachments)
+        });
+
+        for mut attachment in attachments.split(|e| e) {
+            let result = self
+                .upload_bytes(
+                    MessageKind::Event,
+                    &session,
+                    attachment.payload(),
+                    event.retention_days,
+                    None,
+                    None,
+                )
+                .await;
+
+            match result {
+                Ok(stored_key) => {
+                    attachment.modify(|a, _| a.set_stored_key(stored_key.into_inner()));
+                }
+                Err(error) => {
+                    error.log(MessageKind::Event);
+                    if !self.fallback_to_kafka {
+                        let reason = Outcome::Invalid(DiscardReason::UploadFailed);
+                        let _ = attachment.reject_err(reason);
+                        continue;
+                    }
+                }
+            }
+
+            event.merge_with(attachment, |e, attachment, _| {
+                e.attachments.push(attachment)
+            });
+        }
+
+        self.store.send(event);
     }
 
     /// Uploads the attachment.
@@ -925,6 +1013,13 @@ fn should_upload(item: &Item) -> bool {
         && item.stored_key().is_none()
         && !item.is_empty()
         && !item.is_attachment_ref()
+}
+
+fn drop_attachments(event: &mut Managed<Box<StoreEvent>>) {
+    event.modify(|event, records| {
+        let reason = Outcome::Invalid(DiscardReason::UploadFailed);
+        records.reject_err(reason, std::mem::take(&mut event.attachments));
+    });
 }
 
 fn drop_failed_uploads(envelope: &mut ManagedEnvelope) {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -51,7 +51,7 @@ pub enum Objectstore {
 impl Objectstore {
     fn kind(&self) -> MessageKind {
         match self {
-            Self::Envelope(_) => MessageKind::Event,
+            Self::Envelope(_) => MessageKind::Envelope,
             Self::Event(_) => MessageKind::Event,
             Self::TraceAttachment(_) => MessageKind::TraceAttachment,
             Self::EventAttachment(_) => MessageKind::EventAttachment,

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -107,7 +107,7 @@ pub struct StoreEvent {
     /// The data category the [`Self::event`] is counted in.
     pub event_category: DataCategory,
     /// The event to be stored.
-    pub event: Event,
+    pub event: Annotated<Event>,
     /// A list of attachments associated with the event.
     pub attachments: Vec<Item>,
     /// Event retention in days.
@@ -507,10 +507,10 @@ impl StoreService {
         received_at: DateTime<Utc>,
         remote_addr: Option<String>,
     ) -> Result<(), StoreError> {
-        let event_id = store.event.id.value().copied();
+        let event_id = store.event.value().and_then(|e| e.id.value()).copied();
         let event_id = event_id.ok_or(StoreError::NoEventId)?;
 
-        let event_type = store.event.ty.value();
+        let event_type = store.event.value().and_then(|e| e.ty.value());
         let send_individual_attachments = matches!(event_type, Some(&EventType::Transaction));
 
         let mut attachments = Vec::new();
@@ -541,7 +541,7 @@ impl StoreService {
             KafkaTopic::Events
         };
 
-        let payload = Annotated::new(store.event).to_json()?.into_bytes().into();
+        let payload = store.event.to_json()?.into_bytes().into();
         self.produce(
             event_topic,
             KafkaMessage::Event(EventKafkaMessage {

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -515,7 +515,7 @@ impl StoreService {
 
         let mut attachments = Vec::new();
         for attachment in store.attachments {
-            // Note: Technically when an error occours we may have already produced some items to Kafka,
+            // Note: Technically when an error occurs we may have already produced some items to Kafka,
             // but since we don't keep track of that properly and just error out here, outcomes will
             // also report items which were already produced to Kafka as dropped.
             //

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -11,6 +11,7 @@ use std::task;
 use bytes::Bytes;
 use chrono::{DateTime, SecondsFormat, Utc};
 use prost::Message as _;
+use relay_base_schema::events::EventType;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 use serde::Serialize;
 use uuid::Uuid;
@@ -20,7 +21,7 @@ use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::ProjectId;
 use relay_common::time::UnixTimestamp;
 use relay_config::Config;
-use relay_event_schema::protocol::{EventId, SpanV2, datetime_to_timestamp};
+use relay_event_schema::protocol::{Event, EventId, SpanV2, datetime_to_timestamp};
 use relay_kafka::{ClientError, KafkaClient, KafkaTopic, Message, SerializationOutput};
 use relay_metrics::{
     Bucket, BucketView, BucketViewValue, BucketsView, ByNamespace, GaugeValue, MetricName,
@@ -54,6 +55,8 @@ pub enum StoreError {
     SendFailed(#[from] ClientError),
     #[error("failed to encode data: {0}")]
     EncodingFailed(std::io::Error),
+    #[error("failed to serialize data: {0}")]
+    Serialize(#[from] serde_json::Error),
     #[error("failed to store event because event id was missing")]
     NoEventId,
     #[error("invalid attachment reference")]
@@ -65,9 +68,10 @@ impl OutcomeError for StoreError {
 
     fn consume(self) -> (Option<Outcome>, Self::Error) {
         let outcome = match self {
-            StoreError::SendFailed(_) | StoreError::EncodingFailed(_) | StoreError::NoEventId => {
-                Some(Outcome::Invalid(DiscardReason::Internal))
-            }
+            StoreError::SendFailed(_)
+            | StoreError::EncodingFailed(_)
+            | StoreError::Serialize(_)
+            | StoreError::NoEventId => Some(Outcome::Invalid(DiscardReason::Internal)),
             StoreError::InvalidAttachmentRef => {
                 Some(Outcome::Invalid(DiscardReason::InvalidAttachmentRef))
             }
@@ -94,6 +98,27 @@ impl Producer {
         Ok(Self {
             client: client_builder.build(),
         })
+    }
+}
+
+/// Publishes an [`Event`] and its attachments to Kafka.
+#[derive(Debug)]
+pub struct StoreEvent {
+    /// The data category the [`Self::event`] is counted in.
+    pub event_category: DataCategory,
+    /// The event to be stored.
+    pub event: Event,
+    /// A list of attachments associated with the event.
+    pub attachments: Vec<Item>,
+    /// Event retention in days.
+    pub retention_days: u16,
+}
+
+impl Counted for StoreEvent {
+    fn quantities(&self) -> Quantities {
+        let mut quantities = smallvec::smallvec![(self.event_category, 1)];
+        quantities.extend(self.attachments.quantities());
+        quantities
     }
 }
 
@@ -272,6 +297,8 @@ pub enum Store {
     /// Long term this variant is going to be replaced with fully typed variants of items which can
     /// be stored instead.
     Envelope(StoreEnvelope),
+    /// An [`Event`] and its associated items.
+    Event(Managed<Box<StoreEvent>>),
     /// Aggregated generic metrics.
     Metrics(StoreMetrics),
     /// A singular [`TraceItem`].
@@ -295,6 +322,7 @@ impl Store {
     fn variant(&self) -> &'static str {
         match self {
             Store::Envelope(_) => "envelope",
+            Store::Event(_) => "event",
             Store::Metrics(_) => "metrics",
             Store::TraceItem(_) => "trace_item",
             Store::Span(_) => "span",
@@ -314,6 +342,14 @@ impl FromMessage<StoreEnvelope> for Store {
 
     fn from_message(message: StoreEnvelope, _: ()) -> Self {
         Self::Envelope(message)
+    }
+}
+
+impl FromMessage<Managed<Box<StoreEvent>>> for Store {
+    type Response = NoResponse;
+
+    fn from_message(message: Managed<Box<StoreEvent>>, _: ()) -> Self {
+        Self::Event(message)
     }
 }
 
@@ -412,6 +448,7 @@ impl StoreService {
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {
                 Store::Envelope(message) => self.handle_store_envelope(message),
+                Store::Event(message) => self.handle_store_event(message),
                 Store::Metrics(message) => {
                     self.handle_store_metrics(message);
                     Ok(())
@@ -450,6 +487,73 @@ impl StoreService {
                 Err(Managed::with_meta_from_managed_envelope(&envelope, ()).reject_err(error))
             }
         }
+    }
+
+    fn handle_store_event(
+        &self,
+        message: Managed<Box<StoreEvent>>,
+    ) -> Result<(), Rejected<StoreError>> {
+        let received_at = message.received_at();
+        let scoping = message.scoping();
+        let remote_addr = message.remote_addr().map(|ip| ip.to_string());
+
+        message.try_accept(|m| self.do_store_event(*m, scoping, received_at, remote_addr))
+    }
+
+    fn do_store_event(
+        &self,
+        store: StoreEvent,
+        scoping: Scoping,
+        received_at: DateTime<Utc>,
+        remote_addr: Option<String>,
+    ) -> Result<(), StoreError> {
+        let event_id = store.event.id.value().copied();
+        let event_id = event_id.ok_or(StoreError::NoEventId)?;
+
+        let event_type = store.event.ty.value();
+        let send_individual_attachments = matches!(event_type, Some(&EventType::Transaction));
+
+        let mut attachments = Vec::new();
+        for attachment in store.attachments {
+            // Note: Technically when an error occours we may have already produced some items to Kafka,
+            // but since we don't keep track of that properly and just error out here, outcomes will
+            // also report items which were already produced to Kafka as dropped.
+            //
+            // We specifically accept this here, since this is an extreme edge case with minimal practical
+            // consequences.
+            if let Some(attachment) = self.produce_attachment(
+                event_id,
+                scoping.project_id,
+                scoping.organization_id,
+                &attachment,
+                send_individual_attachments,
+                store.retention_days,
+            )? {
+                attachments.push(attachment);
+            }
+        }
+
+        let event_topic = if event_type == Some(&EventType::Transaction) {
+            KafkaTopic::Transactions
+        } else if !attachments.is_empty() {
+            KafkaTopic::Attachments
+        } else {
+            KafkaTopic::Events
+        };
+
+        let payload = Annotated::new(store.event).to_json()?.into_bytes().into();
+        self.produce(
+            event_topic,
+            KafkaMessage::Event(EventKafkaMessage {
+                payload,
+                start_time: safe_timestamp(received_at),
+                event_id,
+                project_id: scoping.project_id,
+                org_id: scoping.organization_id,
+                remote_addr,
+                attachments,
+            }),
+        )
     }
 
     fn store_envelope(&self, managed_envelope: &mut ManagedEnvelope) -> Result<(), StoreError> {


### PR DESCRIPTION
No longer serializes transactions into envelopes to forward them to the store.

Introduces a new `StoreEvent` message, which in a follow-up will also be used for error events, fully replacing the existing `StoreEnvelope`.