### PR TITLE
ref(events): Send errors as items to store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Upgrade release image to Debian 13. ([#6110](https://github.com/getsentry/relay/pull/6110))
 - No longer serialize transactions into envelopes when storing them. ([#6193](https://github.com/getsentry/relay/pull/6193))
 - No longer serialize check-ins into envelopes when storing them. ([#6196](https://github.com/getsentry/relay/pull/6196))
+- No longer serialize errors into envelopes when storing them. ([#6194](https://github.com/getsentry/relay/pull/6194))
 - Prefix upload location query params for forward compatibility. ([#6076](https://github.com/getsentry/relay/pull/6076))
 - Add config option to bypass the kafka fallback for objectstore uploads. ([#6127](https://github.com/getsentry/relay/pull/6127))
 - Use upstream descriptor in upload requests. ([#6128](https://github.com/getsentry/relay/pull/6128))

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -124,10 +124,13 @@ impl Item {
                 smallvec![(DataCategory::Security, item_count)]
             }
             ItemType::UnrealReport => smallvec![(DataCategory::Error, item_count)],
-            ItemType::Attachment => smallvec![
-                (DataCategory::Attachment, self.attachment_body_size()),
-                (DataCategory::AttachmentItem, item_count),
-            ],
+            ItemType::Attachment => match self.rate_limited() {
+                true => smallvec![],
+                false => smallvec![
+                    (DataCategory::Attachment, self.attachment_body_size()),
+                    (DataCategory::AttachmentItem, item_count),
+                ],
+            },
             ItemType::Session | ItemType::Sessions => {
                 smallvec![(DataCategory::Session, item_count)]
             }

--- a/relay-server/src/processing/errors/mod.rs
+++ b/relay-server/src/processing/errors/mod.rs
@@ -353,8 +353,42 @@ impl Forward for ErrorOutput {
         s: processing::StoreHandle<'_>,
         ctx: processing::ForwardContext<'_>,
     ) -> Result<(), Rejected<()>> {
-        let envelope = self.serialize_envelope(ctx)?;
-        s.send_envelope(ManagedEnvelope::from(envelope));
+        use crate::services::store::StoreEvent;
+
+        let ErrorOutput(event) = self;
+
+        let event = event
+            .try_map(|errors, _| -> Result<_> {
+                let ExpandedError {
+                    headers: _,
+                    fully_normalized: _,
+                    metrics: _,
+                    event,
+                    mut attachments,
+                    user_reports,
+                    data,
+                    other,
+                } = errors;
+
+                // A processing Relay must know about all item types in use, unknown items are
+                // already discarded during expansion.
+                debug_assert!(other.is_empty());
+
+                let event_category = data.event_category();
+                data.serialize_into(&mut attachments, ctx)?;
+
+                Ok(Box::new(StoreEvent {
+                    event_category,
+                    event: *event,
+                    attachments,
+                    user_reports,
+                    retention_days: ctx.event_retention().standard,
+                }))
+            })
+            .map_err(|err| err.map(|_| ()))?;
+
+        s.send_event(event);
+
         Ok(())
     }
 }

--- a/relay-server/src/processing/forward.rs
+++ b/relay-server/src/processing/forward.rs
@@ -5,8 +5,6 @@ use relay_dynamic_config::{RetentionConfig, RetentionsConfig};
 use relay_system::{Addr, FromMessage};
 
 use crate::Envelope;
-#[cfg(feature = "processing")]
-use crate::managed::ManagedEnvelope;
 use crate::managed::{Managed, Rejected};
 #[cfg(feature = "processing")]
 use crate::services::objectstore::Objectstore;
@@ -79,36 +77,6 @@ impl<'a> StoreHandle<'a> {
             objectstore.send(message);
         } else {
             relay_log::error!("Objectstore service not configured. Dropping message.");
-        }
-    }
-
-    /// Dispatches an envelopes to either the [`Objectstore`] or [`Store`] service.
-    pub fn send_envelope(&self, envelope: ManagedEnvelope) {
-        use crate::services::store::StoreEnvelope;
-
-        let Some(objectstore) = self.objectstore else {
-            self.store.send(StoreEnvelope { envelope });
-            return;
-        };
-
-        let has_attachments = envelope
-            .envelope()
-            .items()
-            .any(|item| item.ty() == &crate::envelope::ItemType::Attachment);
-
-        let use_objectstore = || {
-            crate::utils::sample(
-                self.global_config
-                    .options
-                    .objectstore_attachments_sample_rate,
-            )
-            .is_keep()
-        };
-
-        if has_attachments && use_objectstore() {
-            objectstore.send(StoreEnvelope { envelope })
-        } else {
-            self.store.send(StoreEnvelope { envelope });
         }
     }
 }

--- a/relay-server/src/processing/transactions/types/output.rs
+++ b/relay-server/src/processing/transactions/types/output.rs
@@ -106,6 +106,7 @@ impl Forward for TransactionOutput {
                 event_category: relay_quotas::DataCategory::TransactionIndexed,
                 event,
                 attachments,
+                user_reports: Vec::new(),
                 retention_days: ctx.event_retention().standard,
             });
 

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -22,15 +22,11 @@ use sentry_protos::snuba::v1::TraceItem;
 
 use crate::constants::DEFAULT_ATTACHMENT_RETENTION;
 use crate::envelope::{ContentType, Item, ItemType};
-use crate::managed::{
-    Counted, ItemAction, Managed, ManagedEnvelope, ManagedResult, OutcomeError, Quantities,
-    Rejected,
-};
+use crate::managed::{Counted, Managed, ManagedResult, OutcomeError, Quantities, Rejected};
 use crate::processing::utils::store::item_id_to_uuid;
 use crate::services::outcome::DiscardReason;
 use crate::services::store::{
-    ProfileAttachment, Store, StoreAttachment, StoreEnvelope, StoreEvent, StoreProfileChunk,
-    StoreTraceItem,
+    ProfileAttachment, Store, StoreAttachment, StoreEvent, StoreProfileChunk, StoreTraceItem,
 };
 use crate::services::upload::ByteStream;
 use crate::statsd::{RelayCounters, RelayTimers};
@@ -40,7 +36,6 @@ use super::outcome::Outcome;
 
 /// Messages that the objectstore service can handle.
 pub enum Objectstore {
-    Envelope(StoreEnvelope),
     Event(Managed<Box<StoreEvent>>),
     TraceAttachment(Managed<StoreTraceAttachment>),
     EventAttachment(Managed<StoreAttachment>),
@@ -51,7 +46,6 @@ pub enum Objectstore {
 impl Objectstore {
     fn kind(&self) -> MessageKind {
         match self {
-            Self::Envelope(_) => MessageKind::Envelope,
             Self::Event(_) => MessageKind::Event,
             Self::TraceAttachment(_) => MessageKind::TraceAttachment,
             Self::EventAttachment(_) => MessageKind::EventAttachment,
@@ -62,11 +56,6 @@ impl Objectstore {
 
     fn attachment_count(&self) -> usize {
         match self {
-            Self::Envelope(StoreEnvelope { envelope }) => envelope
-                .envelope()
-                .items()
-                .filter(|item| *item.ty() == ItemType::Attachment)
-                .count(),
             Self::Event(e) => e.attachments.len(),
             Self::TraceAttachment(_) => 1,
             Self::EventAttachment(_) => 1,
@@ -77,14 +66,6 @@ impl Objectstore {
 }
 
 impl Interface for Objectstore {}
-
-impl FromMessage<StoreEnvelope> for Objectstore {
-    type Response = NoResponse;
-
-    fn from_message(message: StoreEnvelope, _sender: ()) -> Self {
-        Self::Envelope(message)
-    }
-}
 
 impl FromMessage<Managed<Box<StoreEvent>>> for Objectstore {
     type Response = NoResponse;
@@ -121,7 +102,6 @@ impl FromMessage<Managed<StoreRawProfile>> for Objectstore {
 /// A type tag used for logging.
 #[derive(Debug, Clone, Copy)]
 enum MessageKind {
-    Envelope,
     Event,
     EventAttachment,
     TraceAttachment,
@@ -132,7 +112,6 @@ enum MessageKind {
 impl MessageKind {
     fn as_str(&self) -> &'static str {
         match self {
-            Self::Envelope => "envelope",
             Self::Event => "envelope",
             Self::EventAttachment => "attachment",
             Self::TraceAttachment => "attachment_v2",
@@ -412,13 +391,6 @@ impl LoadShed<Objectstore> for ObjectstoreService {
         let error = Error::from(ErrorKind::LoadShed).with_amount(message.attachment_count());
         error.log(message.kind());
         match message {
-            Objectstore::Envelope(envelope) => {
-                let StoreEnvelope { mut envelope } = envelope;
-                if !self.inner.fallback_to_kafka {
-                    drop_failed_uploads(&mut envelope);
-                }
-                self.inner.store.send(StoreEnvelope { envelope });
-            }
             Objectstore::Event(mut event) => {
                 if !self.inner.fallback_to_kafka {
                     drop_attachments(&mut event);
@@ -464,9 +436,6 @@ struct ObjectstoreServiceInner {
 impl ObjectstoreServiceInner {
     async fn handle_message(&self, message: Objectstore) {
         match message {
-            Objectstore::Envelope(StoreEnvelope { envelope }) => {
-                self.handle_envelope(envelope).await;
-            }
             Objectstore::Event(event) => {
                 self.handle_event(event).await;
             }
@@ -493,67 +462,6 @@ impl ObjectstoreServiceInner {
                 sender.send(result);
             }
         };
-    }
-
-    /// Uploads all attachments belonging to the given envelope.
-    ///
-    /// This mutates the attachment items in-place, setting their `stored_key` field to the key
-    /// in objectstore.
-    async fn handle_envelope(&self, mut envelope: ManagedEnvelope) {
-        let scoping = envelope.scoping();
-        let session = self.session(
-            &self.event_attachments,
-            scoping.organization_id,
-            scoping.project_id,
-        );
-        let retention = envelope.envelope().retention();
-
-        let attachments = envelope
-            .envelope_mut()
-            .items_mut()
-            .filter(|item| should_upload(item));
-
-        match session {
-            Err(error) => {
-                error
-                    .with_amount(attachments.count())
-                    .log(MessageKind::Envelope);
-
-                if !self.fallback_to_kafka {
-                    drop_failed_uploads(&mut envelope);
-                }
-            }
-            Ok(session) => {
-                for attachment in attachments {
-                    let result = self
-                        .upload_bytes(
-                            MessageKind::Envelope,
-                            &session,
-                            attachment.payload(),
-                            retention,
-                            None,
-                            None,
-                        )
-                        .await;
-
-                    match result {
-                        Ok(stored_key) => {
-                            attachment.set_stored_key(stored_key.into_inner());
-                        }
-                        Err(error) => {
-                            error.log(MessageKind::Envelope);
-                        }
-                    }
-                }
-
-                if !self.fallback_to_kafka {
-                    drop_failed_uploads(&mut envelope);
-                }
-            }
-        }
-
-        // last but not least, forward the envelope to the store endpoint
-        self.store.send(StoreEnvelope { envelope });
     }
 
     async fn handle_event(&self, mut event: Managed<Box<StoreEvent>>) {
@@ -1018,19 +926,12 @@ fn should_upload(item: &Item) -> bool {
 fn drop_attachments(event: &mut Managed<Box<StoreEvent>>) {
     event.modify(|event, records| {
         let reason = Outcome::Invalid(DiscardReason::UploadFailed);
-        records.reject_err(reason, std::mem::take(&mut event.attachments));
+        let attachments = event
+            .attachments
+            .extract_if(.., |item| should_upload(item))
+            .collect::<Vec<_>>();
+        records.reject_err(reason, attachments);
     });
-}
-
-fn drop_failed_uploads(envelope: &mut ManagedEnvelope) {
-    envelope.retain_items(|item| {
-        if should_upload(item) {
-            ItemAction::Drop(Outcome::Invalid(DiscardReason::UploadFailed))
-        } else {
-            ItemAction::Keep
-        }
-    });
-    envelope.update();
 }
 
 #[cfg(test)]
@@ -1041,6 +942,7 @@ mod tests {
     use relay_system::Service;
 
     use crate::Envelope;
+    use crate::managed::{ManagedEnvelope, ManagedTestHandle};
 
     use super::*;
 
@@ -1072,75 +974,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn envelope_falls_back_to_kafka_by_default() {
+    async fn event_falls_back_to_kafka_by_default() {
         let (store, mut store_rx) = Addr::custom();
-        let (outcomes, mut outcome_rx) = Addr::custom();
         let service = ObjectstoreService::new(&test_config(), Some(store))
             .unwrap()
             .unwrap();
 
-        service
-            .inner
-            .handle_envelope(ManagedEnvelope::new(test_envelope(), outcomes))
-            .await;
+        let (event, _handle) = test_event();
+        service.inner.handle_event(event).await;
 
-        let Store::Envelope(StoreEnvelope { envelope }) = store_rx.try_recv().unwrap() else {
-            panic!("expected envelope");
+        let Store::Event(event) = store_rx.try_recv().unwrap() else {
+            panic!("expected event");
         };
         {
-            let items = envelope.envelope().items().collect::<Vec<_>>();
-            assert_eq!(items.len(), 2);
-            assert_eq!(items[0].ty(), &ItemType::Event);
-            assert_eq!(items[1].ty(), &ItemType::Attachment);
-            assert_eq!(items[1].stored_key(), None);
+            assert_eq!(event.attachments.len(), 1);
+            assert_eq!(event.attachments[0].ty(), &ItemType::Attachment);
+            assert_eq!(event.attachments[0].stored_key(), None);
         }
-        envelope.accept();
-
-        assert!(outcome_rx.try_recv().is_err());
+        event.accept(|_| ());
     }
 
     #[tokio::test]
-    async fn envelope_rejects_failed_attachments_without_fallback() {
+    async fn event_rejects_failed_attachments_without_fallback() {
         let (store, mut store_rx) = Addr::custom();
-        let (outcomes, mut outcome_rx) = Addr::custom();
         let mut config = test_config();
         config.fallback_to_kafka = false;
         let service = ObjectstoreService::new(&config, Some(store))
             .unwrap()
             .unwrap();
 
-        service
-            .inner
-            .handle_envelope(ManagedEnvelope::new(test_envelope(), outcomes))
-            .await;
+        let (event, mut handle) = test_event();
+        service.inner.handle_event(event).await;
 
-        let Store::Envelope(StoreEnvelope { envelope }) = store_rx.try_recv().unwrap() else {
-            panic!("expected envelope");
+        let Store::Event(event) = store_rx.try_recv().unwrap() else {
+            panic!("expected event");
         };
-        {
-            let items = envelope.envelope().items().collect::<Vec<_>>();
-            assert_eq!(items.len(), 1);
-            assert_eq!(items[0].ty(), &ItemType::Event);
-        }
-        envelope.accept();
+        assert!(event.attachments.is_empty());
+        event.accept(|_| ());
 
-        let outcome = outcome_rx.try_recv().unwrap();
-        assert_eq!(
-            outcome.outcome,
-            Outcome::Invalid(DiscardReason::UploadFailed)
+        handle.assert_outcome(
+            &Outcome::Invalid(DiscardReason::UploadFailed),
+            DataCategory::Attachment,
+            5,
         );
-        assert_eq!(outcome.category, DataCategory::Attachment);
-        assert_eq!(outcome.quantity, 5);
-
-        let outcome = outcome_rx.try_recv().unwrap();
-        assert_eq!(
-            outcome.outcome,
-            Outcome::Invalid(DiscardReason::UploadFailed)
+        handle.assert_outcome(
+            &Outcome::Invalid(DiscardReason::UploadFailed),
+            DataCategory::AttachmentItem,
+            1,
         );
-        assert_eq!(outcome.category, DataCategory::AttachmentItem);
-        assert_eq!(outcome.quantity, 1);
-
-        assert!(outcome_rx.try_recv().is_err());
     }
 
     #[tokio::test]
@@ -1199,6 +1080,20 @@ mod tests {
               hello\n",
         ))
         .unwrap()
+    }
+
+    fn test_event() -> (Managed<Box<StoreEvent>>, ManagedTestHandle) {
+        let mut attachment = Item::new(ItemType::Attachment);
+        attachment.set_payload(ContentType::Text, "hello");
+
+        Managed::for_test(Box::new(StoreEvent {
+            event_category: DataCategory::Error,
+            event: Default::default(),
+            attachments: vec![attachment],
+            user_reports: Vec::new(),
+            retention_days: 90,
+        }))
+        .build()
     }
 
     fn test_config() -> ObjectstoreServiceConfig {

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -936,13 +936,11 @@ fn drop_attachments(event: &mut Managed<Box<StoreEvent>>) {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
     use relay_event_schema::protocol::EventId;
     use relay_quotas::DataCategory;
     use relay_system::Service;
 
-    use crate::Envelope;
-    use crate::managed::{ManagedEnvelope, ManagedTestHandle};
+    use crate::managed::ManagedTestHandle;
 
     use super::*;
 
@@ -1027,59 +1025,37 @@ mod tests {
     #[tokio::test]
     async fn event_attachment_rejects_without_fallback() {
         let (store, mut store_rx) = Addr::custom();
-        let (outcomes, mut outcome_rx) = Addr::custom();
         let mut config = test_config();
         config.fallback_to_kafka = false;
         let service = ObjectstoreService::new(&config, Some(store))
             .unwrap()
             .unwrap();
 
-        let envelope = ManagedEnvelope::untracked(test_envelope(), outcomes.clone());
         let mut item = Item::new(ItemType::Attachment);
         item.set_payload(ContentType::Text, "hello");
         let quantities = item.quantities();
-        let attachment = Managed::with_meta_from_managed_envelope(
-            &envelope,
-            StoreAttachment {
-                event_id: EventId::new(),
-                attachment: item,
-                quantities,
-                retention: 90,
-            },
-        );
+        let (attachment, mut handle) = Managed::for_test(StoreAttachment {
+            event_id: EventId::new(),
+            attachment: item,
+            quantities,
+            retention: 90,
+        })
+        .build();
 
         service.inner.handle_event_attachment(attachment).await;
 
         assert!(store_rx.try_recv().is_err());
 
-        let outcome = outcome_rx.try_recv().unwrap();
-        assert_eq!(
-            outcome.outcome,
-            Outcome::Invalid(DiscardReason::UploadFailed)
+        handle.assert_outcome(
+            &Outcome::Invalid(DiscardReason::UploadFailed),
+            DataCategory::Attachment,
+            5,
         );
-        assert_eq!(outcome.category, DataCategory::Attachment);
-        assert_eq!(outcome.quantity, 5);
-
-        let outcome = outcome_rx.try_recv().unwrap();
-        assert_eq!(
-            outcome.outcome,
-            Outcome::Invalid(DiscardReason::UploadFailed)
+        handle.assert_outcome(
+            &Outcome::Invalid(DiscardReason::UploadFailed),
+            DataCategory::AttachmentItem,
+            1,
         );
-        assert_eq!(outcome.category, DataCategory::AttachmentItem);
-        assert_eq!(outcome.quantity, 1);
-
-        assert!(outcome_rx.try_recv().is_err());
-    }
-
-    fn test_envelope() -> Box<Envelope> {
-        Envelope::parse_bytes(Bytes::from_static(
-            b"{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"dsn\":\"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42\"}\n\
-              {\"type\":\"event\",\"length\":2}\n\
-              {}\n\
-              {\"type\":\"attachment\",\"length\":5,\"filename\":\"hello.txt\"}\n\
-              hello\n",
-        ))
-        .unwrap()
     }
 
     fn test_event() -> (Managed<Box<StoreEvent>>, ManagedTestHandle) {

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -33,8 +33,8 @@ use relay_statsd::metric;
 use relay_system::{FromMessage, Interface, NoResponse, Service};
 use relay_threading::AsyncPool;
 
-use crate::envelope::{AttachmentPlaceholder, AttachmentType, ContentType, Item, ItemType};
-use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities, Rejected};
+use crate::envelope::{AttachmentPlaceholder, AttachmentType, ContentType, Item};
+use crate::managed::{Counted, Managed, OutcomeError, Quantities, Rejected};
 use crate::metrics::{ArrayEncoding, BucketEncoder, MetricOutcomes};
 use crate::service::ServiceError;
 use crate::services::global_config::GlobalConfigHandle;
@@ -42,7 +42,7 @@ use crate::services::objectstore::ObjectstoreKey;
 use crate::services::outcome::{self, DiscardReason, Outcome, OutcomeId};
 use crate::services::upload::{Final, SignedLocation};
 use crate::statsd::{RelayCounters, RelayGauges, RelayTimers};
-use crate::utils::{self, FormDataIter};
+use crate::utils;
 
 mod sessions;
 
@@ -110,6 +110,8 @@ pub struct StoreEvent {
     pub event: Annotated<Event>,
     /// A list of attachments associated with the event.
     pub attachments: Vec<Item>,
+    /// A list of user reports associated with the event.
+    pub user_reports: Vec<Item>,
     /// Event retention in days.
     pub retention_days: u16,
 }
@@ -118,14 +120,9 @@ impl Counted for StoreEvent {
     fn quantities(&self) -> Quantities {
         let mut quantities = smallvec::smallvec![(self.event_category, 1)];
         quantities.extend(self.attachments.quantities());
+        quantities.extend(self.user_reports.quantities());
         quantities
     }
-}
-
-/// Publishes an [`Envelope`](crate::envelope::Envelope) to the Sentry core application through Kafka topics.
-#[derive(Debug)]
-pub struct StoreEnvelope {
-    pub envelope: ManagedEnvelope,
 }
 
 /// Publishes a list of [`Bucket`]s to the Sentry core application through Kafka topics.
@@ -303,17 +300,9 @@ impl Counted for StoreCheckIn {
 /// The asynchronous thread pool used for scheduling storing tasks in the envelope store.
 pub type StoreServicePool = AsyncPool<StoreTask>;
 
-/// Service interface for the [`StoreEnvelope`] message.
+/// Service interface for storing items in Kafka.
 #[derive(Debug)]
 pub enum Store {
-    /// An envelope containing a mixture of items.
-    ///
-    /// Note: Some envelope items are not supported to be submitted at all or through an envelope,
-    /// for example logs must be submitted via [`Self::TraceItem`] instead.
-    ///
-    /// Long term this variant is going to be replaced with fully typed variants of items which can
-    /// be stored instead.
-    Envelope(StoreEnvelope),
     /// An [`Event`] and its associated items.
     Event(Managed<Box<StoreEvent>>),
     /// Aggregated generic metrics.
@@ -340,7 +329,6 @@ impl Store {
     /// Returns the name of the message variant.
     fn variant(&self) -> &'static str {
         match self {
-            Store::Envelope(_) => "envelope",
             Store::Event(_) => "event",
             Store::Metrics(_) => "metrics",
             Store::TraceItem(_) => "trace_item",
@@ -356,14 +344,6 @@ impl Store {
 }
 
 impl Interface for Store {}
-
-impl FromMessage<StoreEnvelope> for Store {
-    type Response = NoResponse;
-
-    fn from_message(message: StoreEnvelope, _: ()) -> Self {
-        Self::Envelope(message)
-    }
-}
 
 impl FromMessage<Managed<Box<StoreEvent>>> for Store {
     type Response = NoResponse;
@@ -475,7 +455,6 @@ impl StoreService {
         let ty = message.variant();
         relay_statsd::metric!(timer(RelayTimers::StoreServiceDuration), message = ty, {
             let result = match message {
-                Store::Envelope(message) => self.handle_store_envelope(message),
                 Store::Event(message) => self.handle_store_event(message),
                 Store::Metrics(message) => {
                     self.handle_store_metrics(message);
@@ -500,24 +479,6 @@ impl StoreService {
         })
     }
 
-    fn handle_store_envelope(&self, message: StoreEnvelope) -> Result<(), Rejected<StoreError>> {
-        let StoreEnvelope { mut envelope } = message;
-
-        match self.store_envelope(&mut envelope) {
-            Ok(()) => {
-                envelope.accept();
-                Ok(())
-            }
-            Err(error) => {
-                // The envelope is now empty. `ManagedEnvelope` still counts items correctly
-                // through `EnvelopeSummary`, but `Managed<Box<Envelope>>` does not.
-                // -> Reject the old way and return a dummy item.
-                envelope.reject(Outcome::Invalid(DiscardReason::Internal));
-                Err(Managed::with_meta_from_managed_envelope(&envelope, ()).reject_err(error))
-            }
-        }
-    }
-
     fn handle_store_event(
         &self,
         message: Managed<Box<StoreEvent>>,
@@ -540,7 +501,10 @@ impl StoreService {
         let event_id = event_id.ok_or(StoreError::NoEventId)?;
 
         let event_type = store.event.value().and_then(|e| e.ty.value());
-        let send_individual_attachments = matches!(event_type, Some(&EventType::Transaction));
+        let send_individual_attachments = matches!(
+            event_type,
+            Some(&EventType::Transaction) | Some(&EventType::UserReportV2)
+        );
 
         let mut attachments = Vec::new();
         for attachment in store.attachments {
@@ -562,9 +526,21 @@ impl StoreService {
             }
         }
 
+        for user_report in &store.user_reports {
+            self.produce_user_report(
+                event_id,
+                scoping.project_id,
+                scoping.organization_id,
+                received_at,
+                user_report,
+            )?;
+        }
+
         let event_topic = if event_type == Some(&EventType::Transaction) {
             KafkaTopic::Transactions
-        } else if !attachments.is_empty() {
+        } else if event_type == Some(&EventType::UserReportV2) {
+            KafkaTopic::Feedback
+        } else if !attachments.is_empty() || !store.user_reports.is_empty() {
             KafkaTopic::Attachments
         } else {
             KafkaTopic::Events
@@ -583,154 +559,6 @@ impl StoreService {
                 attachments,
             }),
         )
-    }
-
-    fn store_envelope(&self, managed_envelope: &mut ManagedEnvelope) -> Result<(), StoreError> {
-        let mut envelope = managed_envelope.take_envelope();
-        let received_at = managed_envelope.received_at();
-        let scoping = managed_envelope.scoping();
-
-        let retention = envelope.retention();
-
-        let event_id = envelope.event_id();
-        let event_item = envelope.as_mut().take_item_by(|item| {
-            matches!(
-                item.ty(),
-                ItemType::Event | ItemType::Transaction | ItemType::Security
-            )
-        });
-        let event_type = event_item.as_ref().map(|item| item.ty());
-
-        // Some error events like minidumps need all attachment chunks to be processed _before_
-        // the event payload on the consumer side. Transaction attachments do not require this ordering
-        // guarantee, so they do not have to go to the same topic as their event payload.
-        let event_topic = if event_item.as_ref().map(|x| x.ty()) == Some(&ItemType::Transaction) {
-            KafkaTopic::Transactions
-        } else if envelope.get_item_by(is_slow_item).is_some() {
-            KafkaTopic::Attachments
-        } else {
-            KafkaTopic::Events
-        };
-
-        let send_individual_attachments = matches!(event_type, None | Some(&ItemType::Transaction));
-
-        let mut attachments = Vec::new();
-
-        for item in envelope.items() {
-            match item.ty() {
-                ItemType::Attachment => {
-                    if let Some(attachment) = self.produce_attachment(
-                        event_id.ok_or(StoreError::NoEventId)?,
-                        scoping.project_id,
-                        scoping.organization_id,
-                        item,
-                        send_individual_attachments,
-                        retention,
-                    )? {
-                        attachments.push(attachment);
-                    }
-                }
-                ItemType::UserReport => {
-                    debug_assert!(event_topic == KafkaTopic::Attachments);
-                    self.produce_user_report(
-                        event_id.ok_or(StoreError::NoEventId)?,
-                        scoping.project_id,
-                        scoping.organization_id,
-                        received_at,
-                        item,
-                    )?;
-                }
-                ItemType::UserReportV2 => {
-                    let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
-                    self.produce_user_report_v2(
-                        event_id.ok_or(StoreError::NoEventId)?,
-                        scoping.project_id,
-                        scoping.organization_id,
-                        received_at,
-                        item,
-                        remote_addr,
-                    )?;
-                }
-                ItemType::Profile => self.produce_profile(
-                    scoping.organization_id,
-                    scoping.project_id,
-                    scoping.key_id,
-                    received_at,
-                    retention,
-                    item,
-                )?,
-                ty @ (ItemType::Log | ItemType::Span | ItemType::CheckIn) => {
-                    debug_assert!(
-                        false,
-                        "received {ty} through an envelope, \
-                        this item must be submitted via a specific store message instead"
-                    );
-                    relay_log::error!(
-                        tags.project_key = %scoping.project_key,
-                        "StoreService received unsupported item type '{ty}' in envelope"
-                    );
-                }
-                other => {
-                    let event_type = event_item.as_ref().map(|item| item.ty().as_str());
-                    let item_types = envelope
-                        .items()
-                        .map(|item| item.ty().as_str())
-                        .collect::<Vec<_>>();
-                    let attachment_types = envelope
-                        .items()
-                        .map(|item| {
-                            item.attachment_type()
-                                .map(|t| t.to_string())
-                                .unwrap_or_default()
-                        })
-                        .collect::<Vec<_>>();
-
-                    relay_log::with_scope(
-                        |scope| {
-                            scope.set_extra("item_types", item_types.into());
-                            scope.set_extra("attachment_types", attachment_types.into());
-                            if other == &ItemType::FormData {
-                                let payload = item.payload();
-                                let form_data_keys = FormDataIter::new(&payload)
-                                    .map(|entry| entry.key())
-                                    .collect::<Vec<_>>();
-                                scope.set_extra("form_data_keys", form_data_keys.into());
-                            }
-                        },
-                        || {
-                            relay_log::error!(
-                                tags.project_key = %scoping.project_key,
-                                tags.event_type = event_type.unwrap_or("none"),
-                                "StoreService received unexpected item type: {other}"
-                            )
-                        },
-                    )
-                }
-            }
-        }
-
-        if let Some(event_item) = event_item {
-            let event_id = event_id.ok_or(StoreError::NoEventId)?;
-            let project_id = scoping.project_id;
-            let remote_addr = envelope.meta().client_addr().map(|addr| addr.to_string());
-
-            self.produce(
-                event_topic,
-                KafkaMessage::Event(EventKafkaMessage {
-                    payload: event_item.payload(),
-                    start_time: safe_timestamp(received_at),
-                    event_id,
-                    project_id,
-                    remote_addr,
-                    attachments,
-                    org_id: scoping.organization_id,
-                }),
-            )?;
-        } else {
-            debug_assert!(attachments.is_empty());
-        }
-
-        Ok(())
     }
 
     fn handle_store_metrics(&self, message: StoreMetrics) {
@@ -1272,27 +1100,6 @@ impl StoreService {
         });
 
         self.produce(KafkaTopic::Attachments, message)
-    }
-
-    fn produce_user_report_v2(
-        &self,
-        event_id: EventId,
-        project_id: ProjectId,
-        org_id: OrganizationId,
-        received_at: DateTime<Utc>,
-        item: &Item,
-        remote_addr: Option<String>,
-    ) -> Result<(), StoreError> {
-        let message = KafkaMessage::Event(EventKafkaMessage {
-            project_id,
-            event_id,
-            payload: item.payload(),
-            start_time: safe_timestamp(received_at),
-            remote_addr,
-            attachments: vec![],
-            org_id,
-        });
-        self.produce(KafkaTopic::Feedback, message)
     }
 
     fn send_metric_message(
@@ -1966,13 +1773,6 @@ fn serialize_as_json<T: serde::Serialize>(
         Ok(vec) => Ok(SerializationOutput::Json(Cow::Owned(vec))),
         Err(err) => Err(ClientError::InvalidJson(err)),
     }
-}
-
-/// Determines if the given item is considered slow.
-///
-/// Slow items must be routed to the `Attachments` topic.
-fn is_slow_item(item: &Item) -> bool {
-    item.ty() == &ItemType::Attachment || item.ty() == &ItemType::UserReport
 }
 
 fn bool_to_str(value: bool) -> &'static str {


### PR DESCRIPTION
Quantities change in `Item` is already what we're doing in the even processing, this just aligns it with what we do in the `EnvelopeSummary`.

Sends errors/events also with the `StoreEvent` message which means the `StoreEnvelope` message is now unused.