### PR TITLE
fix(cli): Env var overrides from cli work now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Set sentry.trace.status on segment spans. ([#6140](https://github.com/getsentry/relay/pull/6140))
 - Don't modify segment information for V2 web vital spans. ([#6160](https://github.com/getsentry/relay/pull/6160))
 - Support compressed minidumps when the `relay-minidump-uploads` feature is enabled. ([#6151](https://github.com/getsentry/relay/pull/6151))
+- Make `--log-level` and `--log-format` take effect again and accept them on all subcommands. ([#6198](https://github.com/getsentry/relay/pull/6198))
 
 **Internal**:
 

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -53,6 +53,9 @@ pub fn execute() -> Result<()> {
     // override file config with environment variables
     let env_config = extract_config_env_vars();
     config.apply_override(env_config)?;
+    // override config with global command line arguments
+    let global_config = extract_global_config_args(&matches);
+    config.apply_override(global_config)?;
 
     // SAFETY: The function cannot be called from a multi threaded environment,
     // this is the main entry point where no other threads have been spawned yet.
@@ -76,7 +79,16 @@ pub fn execute() -> Result<()> {
     }
 }
 
-/// Extract config arguments from a parsed command line arguments object
+/// Extract config arguments from the global command line arguments.
+pub fn extract_global_config_args(matches: &ArgMatches) -> OverridableConfig {
+    OverridableConfig {
+        log_level: matches.get_one("log_level").cloned(),
+        log_format: matches.get_one("log_format").cloned(),
+        ..Default::default()
+    }
+}
+
+/// Extract config arguments from a parsed command line arguments object.
 pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
     let processing = if matches.get_flag("processing") {
         Some("true".to_owned())
@@ -88,8 +100,8 @@ pub fn extract_config_args(matches: &ArgMatches) -> OverridableConfig {
 
     OverridableConfig {
         mode: matches.get_one("mode").cloned(),
-        log_level: matches.get_one("log_level").cloned(),
-        log_format: matches.get_one("log_format").cloned(),
+        log_level: None,
+        log_format: None,
         upstream: matches.get_one("upstream").cloned(),
         upstream_dsn: matches.get_one("upstream_dsn").cloned(),
         host: matches.get_one("host").cloned(),

--- a/relay/src/cliapp.rs
+++ b/relay/src/cliapp.rs
@@ -26,6 +26,20 @@ pub fn make_app() -> Command {
                 .value_parser(ValueParser::path_buf())
                 .help("The path to the config folder."),
         )
+        .arg(
+            Arg::new("log_level")
+                .long("log-level")
+                .global(true)
+                .help("The relay log level")
+                .value_parser(["info", "warn", "error", "debug", "trace"]),
+        )
+        .arg(
+            Arg::new("log_format")
+                .long("log-format")
+                .global(true)
+                .help("The relay log format")
+                .value_parser(["auto", "pretty", "simplified", "json"]),
+        )
         .subcommand(
             Command::new("run")
                 .about("Run the relay")
@@ -38,18 +52,6 @@ pub fn make_app() -> Command {
                         .long("mode")
                         .help("The relay mode to set")
                         .value_parser(["managed", "proxy", "static"]),
-                )
-                .arg(
-                    Arg::new("log_level")
-                        .long("log-level")
-                        .help("The relay log level")
-                        .value_parser(["info", "warn", "error", "debug", "trace"]),
-                )
-                .arg(
-                    Arg::new("log_format")
-                        .long("log-format")
-                        .help("The relay log format")
-                        .value_parser(["auto", "pretty", "simplified", "json"]),
                 )
                 .arg(
                     Arg::new("secret_key")


### PR DESCRIPTION
The overrides were applied to late, it's global now and works for all commands.

Fixes: #4485