### PR TITLE
ref(transactions): Remove obsolete spans rate limited flag

### DIFF
--- a/relay-server/src/processing/transactions/process.rs
+++ b/relay-server/src/processing/transactions/process.rs
@@ -49,7 +49,6 @@ pub fn expand(
         let flags = Flags {
             fully_normalized: headers.meta().request_trust().is_trusted()
                 && transaction_item.fully_normalized(),
-            spans_rate_limited: false,
         };
 
         let profile = expand_profile(profiles, record_keeper);
@@ -393,8 +392,6 @@ pub fn split_indexed_and_total(
 ) -> IndexedAndMetrics {
     let scoping = work.scoping();
 
-    let extract_span_metrics = !work.flags.spans_rate_limited;
-
     let mut metrics = ProcessingExtractedMetrics::new();
     let mut metrics_extracted = false;
     work.modify(|work, _| {
@@ -406,7 +403,7 @@ pub fn split_indexed_and_total(
                 project_id: scoping.project_id,
                 ctx,
                 sampling_decision,
-                extract_span_metrics,
+                extract_span_metrics: true,
             },
         );
     });
@@ -417,20 +414,6 @@ pub fn split_indexed_and_total(
             // Invalid config or invalid original transaction
             r.lenient(DataCategory::Transaction);
             r.lenient(DataCategory::Span);
-        }
-        if work.flags.spans_rate_limited {
-            // This really is a bug, we ignore here.
-            //
-            // Transactions are counted using a span metric, as transaction payloads should
-            // eventually be fully transformed into spans. But this is for now only the case for
-            // metrics, the payloads are lagging behind.
-            //
-            // If spans are rate limited, there is no metric to attach the transaction to ->
-            // we're losing a transaction here.
-            //
-            //  If and once we apply span rate limits to transactions this case will also be fixed,
-            //  as it can no longer happen.
-            r.lenient(DataCategory::Transaction);
         }
 
         (Box::new(work.into_indexed()), metrics.into_inner())

--- a/relay-server/src/processing/transactions/types/expanded.rs
+++ b/relay-server/src/processing/transactions/types/expanded.rs
@@ -23,7 +23,6 @@ use crate::statsd::RelayTimers;
 #[derive(Debug, Default)]
 pub struct Flags {
     pub fully_normalized: bool,
-    pub spans_rate_limited: bool,
 }
 
 /// Whether spans embedded in a transaction have been extracted into standalone spans.
@@ -260,10 +259,7 @@ impl ExpandedTransaction<TotalAndIndexed, SpansEmbedded> {
         let mut item = Item::new(ItemType::Transaction);
         item.set_payload(ContentType::Json, data);
 
-        let Flags {
-            fully_normalized,
-            spans_rate_limited: _,
-        } = flags;
+        let Flags { fully_normalized } = flags;
         item.set_fully_normalized(fully_normalized);
 
         item.set_span_count(Some(span_count));


### PR DESCRIPTION
This was always only set to `false`.