### PR TITLE
ref(kafka): Provide details on startup failure

### DIFF
--- a/relay-kafka/src/producer/mod.rs
+++ b/relay-kafka/src/producer/mod.rs
@@ -44,7 +44,7 @@ pub enum ClientError {
     InvalidTopicName,
 
     /// Failed to create a kafka producer because of the invalid configuration.
-    #[error("failed to create kafka producer: invalid kafka config")]
+    #[error("failed to create kafka producer: invalid kafka config: {0}")]
     InvalidConfig(#[source] rdkafka::error::KafkaError),
 
     /// Failed to serialize the message.


### PR DESCRIPTION
Before:

```
ERROR relay_log::utils: error=could not initialize kafka producer:
failed to create kafka producer: invalid kafka config
```

After:

```
ERROR relay_log::utils: error=could not initialize kafka producer:
failed to create kafka producer: invalid kafka config: Client creation error:
`message.timeout.ms` must be greater than `linger.ms`
```