### PR TITLE
test(trace-metrics): Fix lower bound too small in test under certain conditions

### DIFF
--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -85,7 +85,7 @@ def test_trace_metric_multiple_containers_not_allowed(
             "category": DataCategory.TRACE_METRIC_BYTE.value,
             "timestamp": time_within_delta(),
             "outcome": 3,  # Invalid
-            "quantity": matches(lambda x: 400 < x < 500),
+            "quantity": matches(lambda x: 300 < x < 500),
             "reason": "duplicate_item",
         },
     ]


### PR DESCRIPTION
Under normal conditions this payload is 406 bytes, but when the time just hits right, the timestamp will be short enough to dip below 400.


```
At index 1 diff: {'timestamp': 1783674043, 'outcome': 3, 'category': 37, 'quantity': 400, 'reason': 'duplicate_item'} != {'category': 37, 'timestamp': 2026-07-10 09:00:13.504428+00:00 (1783674013.504428) <= x <= 2026-07-10 09:01:13.504429+00:00 (1783674073.504429), 'outcome': 3, 'quantity': matches<<function test_trace_metric_multiple_containers_not_allowed.<locals>.<lambda> at 0x11595a020>>, 'reason': 'duplicate_item'}
  
  Full diff:
    [
        {
            'category': 33,
            'outcome': 3,
            'quantity': 3,
            'reason': 'duplicate_item',
            'timestamp': 1783674043,
        },
        {
            'category': 37,
            'outcome': 3,
  -         'quantity': matches<<function test_trace_metric_multiple_containers_not_allowed.<locals>.<lambda> at 0x11595a020>>,
  +         'quantity': 400,
            'reason': 'duplicate_item',
            'timestamp': 1783674043,
        },
    ]
```