### PR TITLE
test(timeouts): Custom timeouts are bad

### DIFF
--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -279,7 +279,7 @@ def test_proxy_rate_limit_passthrough(relay, mini_sentry, behavior: RateLimitBeh
 
         rate_limited_events = []
         for _ in range(len(behavior.expected_outcomes)):
-            client_report = mini_sentry.get_client_report(timeout=1)
+            client_report = mini_sentry.get_client_report()
             rate_limited_events.extend(client_report["rate_limited_events"])
         rate_limited_events.sort(key=lambda x: x["category"])
         assert rate_limited_events == behavior.expected_outcomes

--- a/tests/integration/test_trusted_relay.py
+++ b/tests/integration/test_trusted_relay.py
@@ -65,7 +65,7 @@ def test_send_directly(mini_sentry, relay, relay_credentials):
     with pytest.raises(HTTPError, match="403 Client Error"):
         managed_relay.send_event(project_id, {"message": "trusted event"})
 
-    outcome = mini_sentry.get_client_report(timeout=1)
+    outcome = mini_sentry.get_client_report()
     assert outcome["discarded_events"] == [
         {"reason": "missing_signature", "category": "error", "quantity": 1}
     ]
@@ -90,7 +90,7 @@ def test_expired_signature(mini_sentry, relay):
 
     relay.send_event(project_id, {"message": "expired signature"}, headers=headers)
 
-    outcome = mini_sentry.get_client_report(timeout=1)
+    outcome = mini_sentry.get_client_report()
     assert outcome["discarded_events"] == [
         {"reason": "invalid_signature", "category": "error", "quantity": 1}
     ]
@@ -206,7 +206,7 @@ def test_invalid_signature(mini_sentry, relay, relay_credentials):
     )
 
     # Wait a bit for the project config fetch
-    outcome = mini_sentry.get_client_report(timeout=1)
+    outcome = mini_sentry.get_client_report()
     assert outcome["discarded_events"] == [
         {"reason": "invalid_signature", "category": "error", "quantity": 1}
     ]
@@ -234,7 +234,7 @@ def test_not_trusted_relay(mini_sentry, relay, relay_credentials):
     relay.send_event(project_id)
 
     # once the project config is fetched we can check the outcome
-    outcome = mini_sentry.get_client_report(timeout=1)
+    outcome = mini_sentry.get_client_report()
     assert outcome["discarded_events"] == [
         {"reason": "missing_signature", "category": "error", "quantity": 1}
     ]


### PR DESCRIPTION
```
____________________________ test_not_trusted_relay ____________________________
[gw5] linux -- Python 3.14.6 /home/runner/work/relay/relay/.venv/bin/python3
Traceback (most recent call last):
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/runner.py", line 353, in from_call
    result: TResult | None = func()
                             ~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/runner.py", line 245, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/logging.py", line 850, in pytest_runtest_call
    yield
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/capture.py", line 900, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/skipping.py", line 268, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/runner.py", line 179, in pytest_runtest_call
    item.runtest()
    ~~~~~~~~~~~~^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/relay/relay/.venv/lib/python3.14/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/runner/work/relay/relay/tests/integration/test_trusted_relay.py", line 237, in test_not_trusted_relay
    outcome = mini_sentry.get_client_report(timeout=1)
  File "/home/runner/work/relay/relay/tests/integration/fixtures/mini_sentry.py", line 222, in get_client_report
    envelope = self.get_captured_envelope(timeout=timeout)
  File "/home/runner/work/relay/relay/tests/integration/fixtures/mini_sentry.py", line 219, in get_captured_envelope
    return self.captured_envelopes.get(timeout=timeout or self.timeout)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/queue.py", line 209, in get
    raise Empty
_queue.Empty
```