### PR TITLE
fix(msgpack): Recursion limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 **Bug Fixes**:
 
-- Bound the recursion depth when deserializing MessagePack payloads (attachments, replay videos, event ids) to prevent stack overflows from maliciously nested input. ([#XXXX](https://github.com/getsentry/relay/pull/XXXX))
+- Bound the recursion depth when deserializing MessagePack payloads to prevent stack overflows. ([#6212](https://github.com/getsentry/relay/pull/6212))
 - Wider type support for OTel log bodies. ([#6106](https://github.com/getsentry/relay/pull/6106))
 - Align OTLP endpoint responses with the specification. ([#6182](https://github.com/getsentry/relay/pull/6182))
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 **Bug Fixes**:
 
+- Bound the recursion depth when deserializing MessagePack payloads (attachments, replay videos, event ids) to prevent stack overflows from maliciously nested input. ([#XXXX](https://github.com/getsentry/relay/pull/XXXX))
 - Wider type support for OTel log bodies. ([#6106](https://github.com/getsentry/relay/pull/6106))
 - Align OTLP endpoint responses with the specification. ([#6182](https://github.com/getsentry/relay/pull/6182))
 - Don't reject attributes that don't have values, but do have metadata. ([#6098](https://github.com/getsentry/relay/pull/6098))

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,8 @@
 disallowed-methods = [
     { path = "tokio::spawn", reason = "use `relay_system::spawn!` instead" },
+    { path = "rmp_serde::from_slice", reason = "use relay_server::utils::msgpack_deserializer instead" },
+    { path = "rmp_serde::from_read", reason = "use relay_server::utils::msgpack_deserializer instead" },
+    { path = "rmp_serde::from_read_ref", reason = "use relay_server::utils::msgpack_deserializer instead" },
 ]
 disallowed-types = [
     { path = "rmp_serde::Deserializer", reason = "use `relay_server::utils::msgpack_deserializer` instead" },

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,6 @@
 disallowed-methods = [
     { path = "tokio::spawn", reason = "use `relay_system::spawn!` instead" },
 ]
+disallowed-types = [
+    { path = "rmp_serde::Deserializer", reason = "use `relay_server::utils::msgpack_deserializer` instead" },
+]

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -28,7 +28,7 @@ use crate::services::upload::{Create, ProjectContext, Stream, Upload};
 use crate::statsd::{RelayCounters, RelayDistributions};
 use crate::utils::{
     self, ApiErrorResponse, BoundedStream, FormDataIter, MeteredStream, find_error_source,
-    is_length_limit_error,
+    is_length_limit_error, rmp,
 };
 
 #[derive(Clone, Copy, Debug, thiserror::Error)]
@@ -292,7 +292,7 @@ pub fn event_id_from_json(data: &[u8]) -> Result<Option<EventId>, BadStoreReques
 /// the provided is valid and returns an `Err` on parse errors. If the event id itself is malformed,
 /// an `Err` is returned.
 pub fn event_id_from_msgpack(data: &[u8]) -> Result<Option<EventId>, BadStoreRequest> {
-    let mut deserializer = crate::utils::msgpack_deserializer(data);
+    let mut deserializer = rmp::slice_deserializer(data);
     MinimalEvent::deserialize(&mut deserializer)
         .map(|MinimalEvent { id, .. }| id)
         .map_err(BadStoreRequest::InvalidMsgpack)

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -292,7 +292,8 @@ pub fn event_id_from_json(data: &[u8]) -> Result<Option<EventId>, BadStoreReques
 /// the provided is valid and returns an `Err` on parse errors. If the event id itself is malformed,
 /// an `Err` is returned.
 pub fn event_id_from_msgpack(data: &[u8]) -> Result<Option<EventId>, BadStoreRequest> {
-    crate::utils::msgpack_from_slice(data)
+    let mut deserializer = crate::utils::msgpack_deserializer(data);
+    MinimalEvent::deserialize(&mut deserializer)
         .map(|MinimalEvent { id, .. }| id)
         .map_err(BadStoreRequest::InvalidMsgpack)
 }

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -292,7 +292,7 @@ pub fn event_id_from_json(data: &[u8]) -> Result<Option<EventId>, BadStoreReques
 /// the provided is valid and returns an `Err` on parse errors. If the event id itself is malformed,
 /// an `Err` is returned.
 pub fn event_id_from_msgpack(data: &[u8]) -> Result<Option<EventId>, BadStoreRequest> {
-    rmp_serde::from_slice(data)
+    crate::utils::msgpack_from_slice(data)
         .map(|MinimalEvent { id, .. }| id)
         .map_err(BadStoreRequest::InvalidMsgpack)
 }

--- a/relay-server/src/processing/errors/errors/utils/attachment.rs
+++ b/relay-server/src/processing/errors/errors/utils/attachment.rs
@@ -78,6 +78,9 @@ fn extract_attached_event(
 
     let payload = item.payload();
     let deserializer = &mut rmp_serde::Deserializer::from_read_ref(payload.as_ref());
+    // Bound the recursion depth to protect against stack overflows from maliciously nested
+    // payloads. rmp_serde's default limit (1024) is too high for our deeply generic types.
+    deserializer.set_max_depth(crate::utils::MSGPACK_MAX_DEPTH);
     Annotated::deserialize_with_meta(deserializer).map_err(ProcessingError::InvalidMsgpack)
 }
 
@@ -105,6 +108,9 @@ fn parse_msgpack_breadcrumbs(
 
     let payload = item.payload();
     let mut deserializer = rmp_serde::Deserializer::new(payload.as_ref());
+    // Bound the recursion depth to protect against stack overflows from maliciously nested
+    // payloads. rmp_serde's default limit (1024) is too high for our deeply generic types.
+    deserializer.set_max_depth(crate::utils::MSGPACK_MAX_DEPTH);
 
     while !deserializer.get_ref().is_empty() {
         let breadcrumb = Annotated::deserialize_with_meta(&mut deserializer)?;
@@ -257,71 +263,39 @@ mod tests {
         buf.push(0x81); // fixmap with 1 entry
         buf.push(0xa1); // fixstr of length 1
         buf.push(b'a'); //   the key "a"
-        for _ in 0..depth {
-            buf.push(0x91); // fixarray of length 1 -> one more nesting level
-        }
+        buf.resize(buf.len() + depth, 0x91); // `depth` fixarrays of length 1 (one level each)
         buf.push(0x90); // innermost: fixarray of length 0
         buf
     }
 
-    /// Proof of the unbounded-recursion vulnerability in the msgpack attachment path.
+    /// Regression test for unbounded recursion in the msgpack attachment path.
     ///
-    /// [`extract_attached_event`] deserializes an attachment with `rmp_serde`, which (unlike
-    /// `serde_json`, capped at 128 levels) enforces *no* recursion limit. A ~200 KB payload of
-    /// nested arrays therefore drives `Value` deserialization ~200k frames deep and overflows
-    /// the stack. The `config.max_event_size()` check (1 MiB by default) does not help: nesting
-    /// depth is unbounded well below the byte limit.
+    /// [`extract_attached_event`] deserializes an attachment with `rmp_serde`. Its default
+    /// recursion limit (1024) is too high for Relay's deeply generic `Value` type: each frame is
+    /// several KB, so a deeply nested payload used to overflow the stack (which aborts the
+    /// process) long before the limit tripped. The `config.max_event_size()` check (1 MiB) does
+    /// not help, as nesting depth is unbounded well below the byte limit.
     ///
-    /// A stack overflow aborts the process rather than unwinding, so it cannot be caught in this
-    /// thread. Instead we re-exec this test binary in a child process that performs the
-    /// deserialization, and assert the child was killed by a stack overflow.
+    /// We now cap the depth via `set_max_depth`, so a maliciously nested payload is rejected with
+    /// an error instead of crashing. This test builds a ~200 KB payload nested 200k levels deep
+    /// (far beyond the cap, but still under `max_event_size`) and asserts graceful rejection.
     ///
-    /// Once the deserialization path is bounded (e.g. via a depth-limited / `serde_stacker`
-    /// deserializer), the child will instead return an `Err` and exit cleanly — at which point
-    /// this test should be inverted to assert graceful rejection.
+    /// Before the fix this test would abort the whole test process with a stack overflow; if that
+    /// ever regresses, this test will take the runner down with it — which is the intended signal.
     #[test]
-    fn test_msgpack_deep_nesting_overflows_stack() {
-        const REPRO_ENV: &str = "RELAY_REPRO_MSGPACK_OVERFLOW";
+    fn test_msgpack_deep_nesting_is_rejected() {
+        // ~200 KB payload, comfortably under the 1 MiB max_event_size, but 200k levels deep.
+        let payload = deeply_nested_msgpack_event(200_000);
+        assert!(payload.len() < Config::default().max_event_size());
 
-        // Child branch: actually run the vulnerable deserialization. This overflows the stack
-        // and aborts the process on current code.
-        if std::env::var(REPRO_ENV).is_ok() {
-            // ~200 KB payload, comfortably under the 1 MiB max_event_size, but 200k levels deep.
-            let payload = deeply_nested_msgpack_event(200_000);
-            assert!(payload.len() < Config::default().max_event_size());
+        let mut item = Item::new(ItemType::Attachment);
+        item.set_payload(ContentType::MsgPack, payload);
 
-            let mut item = Item::new(ItemType::Attachment);
-            item.set_payload(ContentType::MsgPack, payload);
-
-            // On vulnerable code this never returns: it overflows the stack during recursive
-            // `Value` deserialization (or during the recursive drop of the parsed tree).
-            let _ = extract_attached_event(&Config::default(), Some(item));
-            return;
-        }
-
-        // Parent branch: re-exec this exact test in a subprocess with the repro env set.
-        let module = module_path!(); // relay_server::...::attachment::tests
-        let test_path = module.strip_prefix("relay_server::").unwrap_or(module);
-        let test_name = format!("{test_path}::test_msgpack_deep_nesting_overflows_stack");
-
-        let exe = std::env::current_exe().expect("current test executable");
-        let output = std::process::Command::new(exe)
-            .args(["--exact", "--nocapture", &test_name])
-            .env(REPRO_ENV, "1")
-            .output()
-            .expect("spawn repro subprocess");
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let result = extract_attached_event(&Config::default(), Some(item));
 
         assert!(
-            !output.status.success(),
-            "child exited successfully — the rmp_serde recursion vulnerability appears to be \
-             fixed. Update this test to assert graceful rejection instead.\nstderr:\n{stderr}"
-        );
-        assert!(
-            stderr.contains("stack overflow") || stderr.contains("overflowed its stack"),
-            "child crashed, but not from a stack overflow. status: {:?}\nstderr:\n{stderr}",
-            output.status
+            matches!(result, Err(ProcessingError::InvalidMsgpack(_))),
+            "expected the deeply nested payload to be rejected, got: {result:?}"
         );
     }
 }

--- a/relay-server/src/processing/errors/errors/utils/attachment.rs
+++ b/relay-server/src/processing/errors/errors/utils/attachment.rs
@@ -78,8 +78,7 @@ fn extract_attached_event(
 
     let payload = item.payload();
     let deserializer = &mut rmp_serde::Deserializer::from_read_ref(payload.as_ref());
-    // Bound the recursion depth to protect against stack overflows from maliciously nested
-    // payloads. rmp_serde's default limit (1024) is too high for our deeply generic types.
+    // rmp_serde's default limit (1024) is too high for our types.
     deserializer.set_max_depth(crate::utils::MSGPACK_MAX_DEPTH);
     Annotated::deserialize_with_meta(deserializer).map_err(ProcessingError::InvalidMsgpack)
 }
@@ -108,8 +107,7 @@ fn parse_msgpack_breadcrumbs(
 
     let payload = item.payload();
     let mut deserializer = rmp_serde::Deserializer::new(payload.as_ref());
-    // Bound the recursion depth to protect against stack overflows from maliciously nested
-    // payloads. rmp_serde's default limit (1024) is too high for our deeply generic types.
+    // rmp_serde's default limit (1024) is too high for our types.
     deserializer.set_max_depth(crate::utils::MSGPACK_MAX_DEPTH);
 
     while !deserializer.get_ref().is_empty() {
@@ -252,12 +250,6 @@ mod tests {
         result.expect("event_from_attachments");
     }
 
-    /// Builds a msgpack event `{"a": [[[ ... ]]]}` with `depth` levels of nested arrays.
-    ///
-    /// The top level is a map so it deserializes into an [`Event`]; the unknown key `a`
-    /// causes its deeply nested array value to be deserialized into a recursive
-    /// [`relay_protocol::Value`] (stored in `Event::other`). Each `0x91` byte is a msgpack
-    /// "fixarray of length 1", so the payload is roughly `depth` bytes for `depth` levels.
     fn deeply_nested_msgpack_event(depth: usize) -> Vec<u8> {
         let mut buf = Vec::with_capacity(depth + 8);
         buf.push(0x81); // fixmap with 1 entry
@@ -268,20 +260,7 @@ mod tests {
         buf
     }
 
-    /// Regression test for unbounded recursion in the msgpack attachment path.
-    ///
-    /// [`extract_attached_event`] deserializes an attachment with `rmp_serde`. Its default
-    /// recursion limit (1024) is too high for Relay's deeply generic `Value` type: each frame is
-    /// several KB, so a deeply nested payload used to overflow the stack (which aborts the
-    /// process) long before the limit tripped. The `config.max_event_size()` check (1 MiB) does
-    /// not help, as nesting depth is unbounded well below the byte limit.
-    ///
-    /// We now cap the depth via `set_max_depth`, so a maliciously nested payload is rejected with
-    /// an error instead of crashing. This test builds a ~200 KB payload nested 200k levels deep
-    /// (far beyond the cap, but still under `max_event_size`) and asserts graceful rejection.
-    ///
-    /// Before the fix this test would abort the whole test process with a stack overflow; if that
-    /// ever regresses, this test will take the runner down with it — which is the intended signal.
+    /// Reject event encoded as msgpack if it is too deeply nested.
     #[test]
     fn test_msgpack_deep_nesting_is_rejected() {
         // ~200 KB payload, comfortably under the 1 MiB max_event_size, but 200k levels deep.

--- a/relay-server/src/processing/errors/errors/utils/attachment.rs
+++ b/relay-server/src/processing/errors/errors/utils/attachment.rs
@@ -4,7 +4,7 @@ use relay_protocol::{Annotated, Array, Object};
 
 use crate::envelope::Item;
 use crate::services::processor::ProcessingError;
-use crate::utils::msgpack_deserializer;
+use crate::utils::rmp;
 
 pub fn event_from_attachments(
     config: &Config,
@@ -78,7 +78,7 @@ fn extract_attached_event(
     }
 
     let payload = item.payload();
-    let deserializer = &mut msgpack_deserializer(payload.as_ref());
+    let deserializer = &mut rmp::slice_deserializer(payload.as_ref());
     Annotated::deserialize_with_meta(deserializer).map_err(ProcessingError::InvalidMsgpack)
 }
 
@@ -105,7 +105,7 @@ fn parse_msgpack_breadcrumbs(
     }
 
     let payload = item.payload();
-    let mut deserializer = msgpack_deserializer(&payload);
+    let mut deserializer = rmp::stream_deserializer(&payload);
 
     while !deserializer.get_ref().is_empty() {
         let breadcrumb = Annotated::deserialize_with_meta(&mut deserializer)?;

--- a/relay-server/src/processing/errors/errors/utils/attachment.rs
+++ b/relay-server/src/processing/errors/errors/utils/attachment.rs
@@ -245,4 +245,83 @@ mod tests {
         // regression test to ensure we don't fail parsing an empty file
         result.expect("event_from_attachments");
     }
+
+    /// Builds a msgpack event `{"a": [[[ ... ]]]}` with `depth` levels of nested arrays.
+    ///
+    /// The top level is a map so it deserializes into an [`Event`]; the unknown key `a`
+    /// causes its deeply nested array value to be deserialized into a recursive
+    /// [`relay_protocol::Value`] (stored in `Event::other`). Each `0x91` byte is a msgpack
+    /// "fixarray of length 1", so the payload is roughly `depth` bytes for `depth` levels.
+    fn deeply_nested_msgpack_event(depth: usize) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(depth + 8);
+        buf.push(0x81); // fixmap with 1 entry
+        buf.push(0xa1); // fixstr of length 1
+        buf.push(b'a'); //   the key "a"
+        for _ in 0..depth {
+            buf.push(0x91); // fixarray of length 1 -> one more nesting level
+        }
+        buf.push(0x90); // innermost: fixarray of length 0
+        buf
+    }
+
+    /// Proof of the unbounded-recursion vulnerability in the msgpack attachment path.
+    ///
+    /// [`extract_attached_event`] deserializes an attachment with `rmp_serde`, which (unlike
+    /// `serde_json`, capped at 128 levels) enforces *no* recursion limit. A ~200 KB payload of
+    /// nested arrays therefore drives `Value` deserialization ~200k frames deep and overflows
+    /// the stack. The `config.max_event_size()` check (1 MiB by default) does not help: nesting
+    /// depth is unbounded well below the byte limit.
+    ///
+    /// A stack overflow aborts the process rather than unwinding, so it cannot be caught in this
+    /// thread. Instead we re-exec this test binary in a child process that performs the
+    /// deserialization, and assert the child was killed by a stack overflow.
+    ///
+    /// Once the deserialization path is bounded (e.g. via a depth-limited / `serde_stacker`
+    /// deserializer), the child will instead return an `Err` and exit cleanly — at which point
+    /// this test should be inverted to assert graceful rejection.
+    #[test]
+    fn test_msgpack_deep_nesting_overflows_stack() {
+        const REPRO_ENV: &str = "RELAY_REPRO_MSGPACK_OVERFLOW";
+
+        // Child branch: actually run the vulnerable deserialization. This overflows the stack
+        // and aborts the process on current code.
+        if std::env::var(REPRO_ENV).is_ok() {
+            // ~200 KB payload, comfortably under the 1 MiB max_event_size, but 200k levels deep.
+            let payload = deeply_nested_msgpack_event(200_000);
+            assert!(payload.len() < Config::default().max_event_size());
+
+            let mut item = Item::new(ItemType::Attachment);
+            item.set_payload(ContentType::MsgPack, payload);
+
+            // On vulnerable code this never returns: it overflows the stack during recursive
+            // `Value` deserialization (or during the recursive drop of the parsed tree).
+            let _ = extract_attached_event(&Config::default(), Some(item));
+            return;
+        }
+
+        // Parent branch: re-exec this exact test in a subprocess with the repro env set.
+        let module = module_path!(); // relay_server::...::attachment::tests
+        let test_path = module.strip_prefix("relay_server::").unwrap_or(module);
+        let test_name = format!("{test_path}::test_msgpack_deep_nesting_overflows_stack");
+
+        let exe = std::env::current_exe().expect("current test executable");
+        let output = std::process::Command::new(exe)
+            .args(["--exact", "--nocapture", &test_name])
+            .env(REPRO_ENV, "1")
+            .output()
+            .expect("spawn repro subprocess");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            !output.status.success(),
+            "child exited successfully — the rmp_serde recursion vulnerability appears to be \
+             fixed. Update this test to assert graceful rejection instead.\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("stack overflow") || stderr.contains("overflowed its stack"),
+            "child crashed, but not from a stack overflow. status: {:?}\nstderr:\n{stderr}",
+            output.status
+        );
+    }
 }

--- a/relay-server/src/processing/errors/errors/utils/attachment.rs
+++ b/relay-server/src/processing/errors/errors/utils/attachment.rs
@@ -4,6 +4,7 @@ use relay_protocol::{Annotated, Array, Object};
 
 use crate::envelope::Item;
 use crate::services::processor::ProcessingError;
+use crate::utils::msgpack_deserializer;
 
 pub fn event_from_attachments(
     config: &Config,
@@ -77,9 +78,7 @@ fn extract_attached_event(
     }
 
     let payload = item.payload();
-    let deserializer = &mut rmp_serde::Deserializer::from_read_ref(payload.as_ref());
-    // rmp_serde's default limit (1024) is too high for our types.
-    deserializer.set_max_depth(crate::utils::MSGPACK_MAX_DEPTH);
+    let deserializer = &mut msgpack_deserializer(payload.as_ref());
     Annotated::deserialize_with_meta(deserializer).map_err(ProcessingError::InvalidMsgpack)
 }
 
@@ -106,9 +105,7 @@ fn parse_msgpack_breadcrumbs(
     }
 
     let payload = item.payload();
-    let mut deserializer = rmp_serde::Deserializer::new(payload.as_ref());
-    // rmp_serde's default limit (1024) is too high for our types.
-    deserializer.set_max_depth(crate::utils::MSGPACK_MAX_DEPTH);
+    let mut deserializer = msgpack_deserializer(&payload);
 
     while !deserializer.get_ref().is_empty() {
         let breadcrumb = Annotated::deserialize_with_meta(&mut deserializer)?;

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -20,7 +20,8 @@ fn expand_video(item: &Item) -> Result<ReplayPayload, Error> {
         replay_event: event,
         replay_recording: recording,
         replay_video: video,
-    } = rmp_serde::from_slice(&item.payload()).map_err(|_| Error::InvalidReplayVideoEvent)?;
+    } = crate::utils::msgpack_from_slice(&item.payload())
+        .map_err(|_| Error::InvalidReplayVideoEvent)?;
 
     if video.is_empty() {
         return Err(Error::InvalidReplayVideoEvent);

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -15,10 +15,11 @@ use crate::processing::replays::{
 };
 use crate::processing::{Context, utils};
 use crate::statsd::RelayTimers;
+use crate::utils::rmp;
 
 fn expand_video(item: &Item) -> Result<ReplayPayload, Error> {
     let payload = item.payload();
-    let mut deserializer = crate::utils::msgpack_deserializer(&payload);
+    let mut deserializer = rmp::slice_deserializer(&payload);
     let ReplayVideoEvent {
         replay_event: event,
         replay_recording: recording,

--- a/relay-server/src/processing/replays/process.rs
+++ b/relay-server/src/processing/replays/process.rs
@@ -6,6 +6,7 @@ use relay_pii::PiiProcessor;
 use relay_protocol::Annotated;
 use relay_replays::recording::RecordingScrubber;
 use relay_statsd::metric;
+use serde::Deserialize;
 
 use crate::envelope::Item;
 use crate::managed::{Managed, Rejected};
@@ -16,11 +17,13 @@ use crate::processing::{Context, utils};
 use crate::statsd::RelayTimers;
 
 fn expand_video(item: &Item) -> Result<ReplayPayload, Error> {
+    let payload = item.payload();
+    let mut deserializer = crate::utils::msgpack_deserializer(&payload);
     let ReplayVideoEvent {
         replay_event: event,
         replay_recording: recording,
         replay_video: video,
-    } = crate::utils::msgpack_from_slice(&item.payload())
+    } = ReplayVideoEvent::deserialize(&mut deserializer)
         .map_err(|_| Error::InvalidReplayVideoEvent)?;
 
     if video.is_empty() {

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -9,6 +9,7 @@ mod pick;
 pub mod playstation;
 mod rate_limits;
 mod retry;
+pub mod rmp;
 mod scheduled;
 mod sizes;
 mod sleep_handle;

--- a/relay-server/src/utils/rmp.rs
+++ b/relay-server/src/utils/rmp.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_types)]
+
 use rmp_serde::Deserializer;
 use rmp_serde::decode::{ReadReader, ReadRefReader};
 
@@ -14,7 +16,6 @@ pub const MAX_DEPTH: usize = 128;
 ///
 /// Caps nesting at
 /// [`MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
-#[allow(clippy::disallowed_types)]
 pub fn slice_deserializer<'a>(data: &'a [u8]) -> Deserializer<ReadRefReader<'a, [u8]>> {
     let mut deserializer = Deserializer::from_read_ref(data);
     deserializer.set_max_depth(MAX_DEPTH);
@@ -27,8 +28,7 @@ pub fn slice_deserializer<'a>(data: &'a [u8]) -> Deserializer<ReadRefReader<'a, 
 /// [`MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
 ///
 /// Like `slice_deserializer`, but allows consuming multiple items from the slice.
-#[allow(clippy::disallowed_types)]
-pub fn stream_deserializer<'a>(data: &'a [u8]) -> Deserializer<ReadReader<&'a [u8]>> {
+pub fn stream_deserializer(data: &[u8]) -> Deserializer<ReadReader<&[u8]>> {
     let mut deserializer = Deserializer::new(data);
     deserializer.set_max_depth(MAX_DEPTH);
     deserializer

--- a/relay-server/src/utils/rmp.rs
+++ b/relay-server/src/utils/rmp.rs
@@ -1,0 +1,35 @@
+use rmp_serde::Deserializer;
+use rmp_serde::decode::{ReadReader, ReadRefReader};
+
+/// Maximum nesting depth allowed when deserializing MessagePack payloads.
+///
+/// `rmp_serde` default (1024) too permissive for
+/// Relay's types (e.g. `Annotated<Value>`). Each recursive deserialization frame is
+/// several kilobytes, so a payload can exhaust the thread stack well before the built-in counter
+/// trips.
+/// This limit matches the one in `serde_json`.
+pub const MAX_DEPTH: usize = 128;
+
+/// Returns a Deserializer with a bounded recursion depth.
+///
+/// Caps nesting at
+/// [`MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
+#[allow(clippy::disallowed_types)]
+pub fn slice_deserializer<'a>(data: &'a [u8]) -> Deserializer<ReadRefReader<'a, [u8]>> {
+    let mut deserializer = Deserializer::from_read_ref(data);
+    deserializer.set_max_depth(MAX_DEPTH);
+    deserializer
+}
+
+/// Returns a Deserializer with a bounded recursion depth.
+///
+/// Caps nesting at
+/// [`MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
+///
+/// Like `slice_deserializer`, but allows consuming multiple items from the slice.
+#[allow(clippy::disallowed_types)]
+pub fn stream_deserializer<'a>(data: &'a [u8]) -> Deserializer<ReadReader<&'a [u8]>> {
+    let mut deserializer = Deserializer::new(data);
+    deserializer.set_max_depth(MAX_DEPTH);
+    deserializer
+}

--- a/relay-server/src/utils/serde.rs
+++ b/relay-server/src/utils/serde.rs
@@ -3,12 +3,11 @@ use serde::{Deserialize, Deserializer, de};
 
 /// Maximum nesting depth allowed when deserializing MessagePack payloads.
 ///
-/// `rmp_serde` does enforce a recursion limit, but its default (1024) is far too permissive for
-/// Relay's deeply generic types (e.g. `Annotated<Value>`): each recursive deserialization frame is
+/// `rmp_serde` default (1024) too permissive for
+/// Relay's types (e.g. `Annotated<Value>`). Each recursive deserialization frame is
 /// several kilobytes, so a payload can exhaust the thread stack well before the built-in counter
-/// trips. We therefore cap nesting at the same depth `serde_json` enforces by default (128), which
-/// bounds the recursion long before it can overflow the stack while still accepting any realistic
-/// payload. See `set_max_depth` on [`rmp_serde::Deserializer`].
+/// trips.
+/// This limit matches the one in `serde_json`.
 pub const MSGPACK_MAX_DEPTH: usize = 128;
 
 /// Deserializes a value from MessagePack bytes with a bounded recursion depth.

--- a/relay-server/src/utils/serde.rs
+++ b/relay-server/src/utils/serde.rs
@@ -1,28 +1,5 @@
-use rmp_serde::decode::ReadRefReader;
 use serde::de::IgnoredAny;
 use serde::{Deserialize, Deserializer, de};
-
-/// Maximum nesting depth allowed when deserializing MessagePack payloads.
-///
-/// `rmp_serde` default (1024) too permissive for
-/// Relay's types (e.g. `Annotated<Value>`). Each recursive deserialization frame is
-/// several kilobytes, so a payload can exhaust the thread stack well before the built-in counter
-/// trips.
-/// This limit matches the one in `serde_json`.
-pub const MSGPACK_MAX_DEPTH: usize = 128;
-
-/// Returns a Deserializer with a bounded recursion depth.
-///
-/// Caps nesting at
-/// [`MSGPACK_MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
-#[allow(clippy::disallowed_types)]
-pub fn msgpack_deserializer<'a>(
-    data: &'a [u8],
-) -> rmp_serde::Deserializer<ReadRefReader<'a, [u8]>> {
-    let mut deserializer = rmp_serde::Deserializer::from_read_ref(data);
-    deserializer.set_max_depth(MSGPACK_MAX_DEPTH);
-    deserializer
-}
 
 /// Deserializes only the count of a sequence ignoring all individual items.
 #[derive(Clone, Copy, Debug, Default)]

--- a/relay-server/src/utils/serde.rs
+++ b/relay-server/src/utils/serde.rs
@@ -1,3 +1,4 @@
+use rmp_serde::decode::ReadRefReader;
 use serde::de::IgnoredAny;
 use serde::{Deserialize, Deserializer, de};
 
@@ -10,17 +11,17 @@ use serde::{Deserialize, Deserializer, de};
 /// This limit matches the one in `serde_json`.
 pub const MSGPACK_MAX_DEPTH: usize = 128;
 
-/// Deserializes a value from MessagePack bytes with a bounded recursion depth.
+/// Returns a Deserializer with a bounded recursion depth.
 ///
-/// This is a drop-in replacement for [`rmp_serde::from_slice`] that caps nesting at
+/// Caps nesting at
 /// [`MSGPACK_MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
-pub fn msgpack_from_slice<'a, T>(data: &'a [u8]) -> Result<T, rmp_serde::decode::Error>
-where
-    T: Deserialize<'a>,
-{
+#[allow(clippy::disallowed_types)]
+pub fn msgpack_deserializer<'a>(
+    data: &'a [u8],
+) -> rmp_serde::Deserializer<ReadRefReader<'a, [u8]>> {
     let mut deserializer = rmp_serde::Deserializer::from_read_ref(data);
     deserializer.set_max_depth(MSGPACK_MAX_DEPTH);
-    T::deserialize(&mut deserializer)
+    deserializer
 }
 
 /// Deserializes only the count of a sequence ignoring all individual items.

--- a/relay-server/src/utils/serde.rs
+++ b/relay-server/src/utils/serde.rs
@@ -1,6 +1,29 @@
 use serde::de::IgnoredAny;
 use serde::{Deserialize, Deserializer, de};
 
+/// Maximum nesting depth allowed when deserializing MessagePack payloads.
+///
+/// `rmp_serde` does enforce a recursion limit, but its default (1024) is far too permissive for
+/// Relay's deeply generic types (e.g. `Annotated<Value>`): each recursive deserialization frame is
+/// several kilobytes, so a payload can exhaust the thread stack well before the built-in counter
+/// trips. We therefore cap nesting at the same depth `serde_json` enforces by default (128), which
+/// bounds the recursion long before it can overflow the stack while still accepting any realistic
+/// payload. See `set_max_depth` on [`rmp_serde::Deserializer`].
+pub const MSGPACK_MAX_DEPTH: usize = 128;
+
+/// Deserializes a value from MessagePack bytes with a bounded recursion depth.
+///
+/// This is a drop-in replacement for [`rmp_serde::from_slice`] that caps nesting at
+/// [`MSGPACK_MAX_DEPTH`] to protect against stack overflows from maliciously nested payloads.
+pub fn msgpack_from_slice<'a, T>(data: &'a [u8]) -> Result<T, rmp_serde::decode::Error>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = rmp_serde::Deserializer::from_read_ref(data);
+    deserializer.set_max_depth(MSGPACK_MAX_DEPTH);
+    T::deserialize(&mut deserializer)
+}
+
 /// Deserializes only the count of a sequence ignoring all individual items.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SeqCount(pub usize);


### PR DESCRIPTION
Impose a recursion limit of 128 on message pack deserialization.

Closes INGEST-990.