### PR TITLE
ref(clippy): Clippy Beta as_chunks_mut

### DIFF
--- a/relay-pii/src/attachments.rs
+++ b/relay-pii/src/attachments.rs
@@ -193,8 +193,8 @@ impl StringMods for WStr<LittleEndian> {
         unsafe {
             let chunks = self
                 .as_bytes_mut()
-                .chunks_exact_mut(std::mem::size_of::<u16>());
-            for chunk in chunks {
+                .as_chunks_mut::<{ std::mem::size_of::<u16>() }>();
+            for chunk in chunks.0 {
                 chunk.copy_from_slice(&fill_buf);
             }
         }
@@ -228,8 +228,8 @@ impl StringMods for WStr<LittleEndian> {
 
         unsafe {
             let remainder_bytes = &mut self.as_bytes_mut()[offset..];
-            let chunks = remainder_bytes.chunks_exact_mut(std::mem::size_of::<u16>());
-            for chunk in chunks {
+            let chunks = remainder_bytes.as_chunks_mut::<{ std::mem::size_of::<u16>() }>();
+            for chunk in chunks.0 {
                 chunk.copy_from_slice(&fill_buf);
             }
         }


### PR DESCRIPTION
Fixes some of the lints, the other ones I expect to still change as it affects all of Axum:

```
error: using `chunks_exact_mut` with a constant chunk size
   --> relay-pii/src/attachments.rs:196:18
    |
196 |                 .chunks_exact_mut(std::mem::size_of::<u16>());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
help: consider using `as_chunks_mut::<std::mem::size_of::<u16>()>()` instead
   --> relay-pii/src/attachments.rs:196:18
    |
196 |                 .chunks_exact_mut(std::mem::size_of::<u16>());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: you can access the chunks using `chunks.0.iter()`, and the remainder using `chunks.1`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#chunks_exact_to_as_chunks
    = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::chunks_exact_to_as_chunks)]`
```