### PR TITLE
chore(conventions): Update sentry-conventions to `0.16.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Have relay generate metric billing outcomes. ([#6066](https://github.com/getsentry/relay/pull/6066))
 - Update sentry-conventions to 0.12.0.
 - Update sentry-conventions to 0.13.0. ([#6139](https://github.com/getsentry/relay/pull/6139))
+- Update sentry-conventions to 0.16.0. ([#6215](https://github.com/getsentry/relay/pull/6215))
 - Upgrade release image to Debian 13. ([#6110](https://github.com/getsentry/relay/pull/6110))
 - No longer serialize transactions into envelopes when storing them. ([#6193](https://github.com/getsentry/relay/pull/6193))
 - No longer serialize check-ins into envelopes when storing them. ([#6196](https://github.com/getsentry/relay/pull/6196))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@
 - Internally handle outcomes as metrics. ([#6107](https://github.com/getsentry/relay/pull/6107))
 - Re-introduce `projects:discard-transaction` feature flag. ([#6199](https://github.com/getsentry/relay/pull/6199))
 - Have relay generate metric billing outcomes. ([#6066](https://github.com/getsentry/relay/pull/6066))
-- Update sentry-conventions to 0.12.0.
-- Update sentry-conventions to 0.13.0. ([#6139](https://github.com/getsentry/relay/pull/6139))
 - Update sentry-conventions to 0.16.0. ([#6215](https://github.com/getsentry/relay/pull/6215))
 - Upgrade release image to Debian 13. ([#6110](https://github.com/getsentry/relay/pull/6110))
 - No longer serialize transactions into envelopes when storing them. ([#6193](https://github.com/getsentry/relay/pull/6193))


### PR DESCRIPTION
- Bumps the git submodule checkout state to [`0.16.0`](https://github.com/getsentry/sentry-conventions/releases/tag/0.16.0)
- Adds a changelog entry

To confirm by reviewers: This conventions release added deprecated attributes but I got no build time deprecation warnings. This is to be expected, right? I'd only get a warning if the attribute was previously used and now became deprecated, correct? Or do I need to do anything with the newly added deprecated attributes?