### PR TITLE
feat(upload): GA streaming minidump attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Use a out of process solution for catching crashes. ([#6158](https://github.com/getsentry/relay/pull/6158))
 - Accept a `charset=utf-8` parameters on JSON and XML content types. ([#6184](https://github.com/getsentry/relay/pull/6184))
 - Support PEM file format for signing / verification keys. ([#6155](https://github.com/getsentry/relay/pull/6155))
-- GA the `upload-endpoint` feature. ([#6171](https://github.com/getsentry/relay/pull/6171))
+- Graduate the upload endpoint and streaming attachments on the minidump endpoint. ([#6171](https://github.com/getsentry/relay/pull/6171), [#6222](https://github.com/getsentry/relay/pull/6222))
 - Add Lightpanda to web crawler filter. ([#6143](https://github.com/getsentry/relay/pull/6143))
 
 **Bug Fixes**:

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -99,9 +99,6 @@ pub enum Feature {
     /// processor. Only enable for organizations with sufficient attachment quota.
     #[serde(rename = "organizations:relay-unreal-endpoint-expansion")]
     UnrealEndpointExpansion,
-    /// Stream minidump attachments to objectstore.
-    #[serde(rename = "projects:relay-minidump-attachment-uploads")]
-    MinidumpAttachmentUploads,
     /// Stream minidumps to objectstore.
     #[serde(rename = "projects:relay-minidump-uploads")]
     MinidumpUploads,

--- a/relay-server/src/endpoints/minidump.rs
+++ b/relay-server/src/endpoints/minidump.rs
@@ -511,8 +511,6 @@ async fn upload_context<'a>(
 
     let upload_attachments = if matches!(upload_minidumps, UploadDecision::Drop(_)) {
         UploadDecision::Drop(rate_limits)
-    } else if !project_config.has_feature(Feature::MinidumpAttachmentUploads) {
-        UploadDecision::Inline
     } else if attachment_rate_limits.is_limited() {
         UploadDecision::Drop(attachment_rate_limits)
     } else {

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -74,8 +74,9 @@ def test_minidump(mini_sentry, relay):
 
 def test_minidump_attachments(mini_sentry, relay):
     project_id = 42
-    relay = relay(mini_sentry)
     mini_sentry.add_full_project_config(project_id)
+    mini_sentry.global_config["options"]["relay.attachment-inline.limit"] = 1024 * 1024
+    relay = relay(mini_sentry)
 
     event = {"event_id": "2dd132e467174db48dbaddabd3cbed57", "user": {"id": "123"}}
     breadcrumbs1 = {

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -1059,7 +1059,7 @@ def test_size_limits(mini_sentry, relay, limit, expected_status_code):
         (True, False),
         (True, True),
     ],
-    ids=["no-option", "stream-attachments", "stream-minidumps", "stream-all"],
+    ids=["no-option", "no-minidumps", "stream-minidumps"],
 )
 def test_minidump_objectstore_uploads(
     mini_sentry,

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -1053,12 +1053,11 @@ def test_size_limits(mini_sentry, relay, limit, expected_status_code):
 
 
 @pytest.mark.parametrize(
-    "config_fetch,upload_attachments,upload_minidump",
+    "config_fetch,upload_minidump",
     [
-        (False, True, True),  # if the option is not set we don't check the features
-        (True, True, False),
-        (True, False, True),
-        (True, True, True),
+        (False, True),  # if the option is not set we don't check the features
+        (True, False),
+        (True, True),
     ],
     ids=["no-option", "stream-attachments", "stream-minidumps", "stream-all"],
 )
@@ -1067,7 +1066,6 @@ def test_minidump_objectstore_uploads(
     relay,
     dummy_upload,
     config_fetch,
-    upload_attachments,
     upload_minidump,
 ):
     project_id = 42
@@ -1075,10 +1073,6 @@ def test_minidump_objectstore_uploads(
     log_content = b"\x1f\x8b Some log file content"
 
     project_config = mini_sentry.add_full_project_config(project_id)
-    if upload_attachments:
-        project_config["config"].setdefault("features", []).append(
-            "projects:relay-minidump-attachment-uploads"
-        )
     if upload_minidump:
         project_config["config"].setdefault("features", []).append(
             "projects:relay-minidump-uploads"
@@ -1123,7 +1117,7 @@ def test_minidump_objectstore_uploads(
     minidump = by_name["minidump.dmp"]
     logs = by_name["log.txt"]
 
-    if config_fetch and upload_attachments:
+    if config_fetch:
         assert (
             logs.headers["content_type"] == "application/vnd.sentry.attachment-ref+json"
         )
@@ -1178,11 +1172,6 @@ def test_minidump_objectstore_uploads_external_chain(
     log_content = b"Some log file content"
 
     project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"].setdefault("features", []).extend(
-        [
-            "projects:relay-minidump-attachment-uploads",
-        ]
-    )
 
     relay = relay(relay_with_processing(), external=True)
     project_config["config"]["trustedRelays"] = list(relay.iter_public_keys())
@@ -1219,7 +1208,6 @@ def test_minidump_objectstore_uploads_external_chain_attachment_limited(
     project_config = mini_sentry.add_full_project_config(project_id)
     project_config["config"].setdefault("features", []).extend(
         [
-            "projects:relay-minidump-attachment-uploads",
             "projects:relay-minidump-uploads",
         ]
     )
@@ -1270,10 +1258,7 @@ def test_minidump_objectstore_errors(
     minidump_content = b"MDMP content"
     log_content = b"Some log file content"
 
-    project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"].setdefault("features", []).append(
-        "projects:relay-minidump-attachment-uploads"
-    )
+    mini_sentry.add_full_project_config(project_id)
 
     @mini_sentry.app.route("/api/<project>/upload/", methods=["POST"])
     def create(**opts):
@@ -1371,7 +1356,6 @@ def test_minidump_objectstore_uploads_rate_limits(
     project_config["config"].setdefault("features", []).extend(
         [
             "projects:relay-minidump-uploads",
-            "projects:relay-minidump-attachment-uploads",
         ]
     )
     if rate_limited:
@@ -1705,10 +1689,7 @@ def test_minidump_proxy_mode(mini_sentry, relay):
 
 def test_minidump_attachment_inline_limit(mini_sentry, relay, dummy_upload):
     project_id = 42
-    project_config = mini_sentry.add_full_project_config(project_id)
-    project_config["config"].setdefault("features", []).append(
-        "projects:relay-minidump-attachment-uploads"
-    )
+    mini_sentry.add_full_project_config(project_id)
     mini_sentry.global_config["options"]["relay.endpoint-fetch-config.enabled"] = True
     mini_sentry.global_config["options"]["relay.attachment-inline.limit"] = 16
     relay = relay(mini_sentry)


### PR DESCRIPTION
Enable streaming of plain attachments from the minidump endpoint. This allows for the ingestion of larger attachments.

ref: INGEST-996