### PR TITLE
fix(build): Fix mypy type errors

### DIFF
--- a/py/sentry_relay/consts.py
+++ b/py/sentry_relay/consts.py
@@ -203,8 +203,8 @@ def _check_category_unit_generated():
 
 _check_category_unit_generated()
 
-SPAN_STATUS_CODE_TO_NAME = {}
-SPAN_STATUS_NAME_TO_CODE = {}
+SPAN_STATUS_CODE_TO_NAME: dict[int, str] = {}
+SPAN_STATUS_NAME_TO_CODE: dict[str, int] = {}
 
 
 def _make_span_statuses():

--- a/py/sentry_relay/exceptions.py
+++ b/py/sentry_relay/exceptions.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from sentry_relay._lowlevel import lib
 
 __all__ = ["RelayError"]
-exceptions_by_code = {}
+exceptions_by_code: dict[int, Exception] = {}
 
 
 class RelayError(Exception):


### PR DESCRIPTION
The `mypy` bump in https://github.com/getsentry/relay/pull/6219 seems to have made typing stricter.