### PR TITLE
fix(tests): Make test_shutdown.py wait for Relay to be up before proceeding

### DIFF
--- a/tests/integration/test_shutdown.py
+++ b/tests/integration/test_shutdown.py
@@ -35,6 +35,13 @@ def test_graceful_shutdown(mini_sentry, relay, storage):
             },
         )
 
+        # Send an event and wait for it--to make sure that things are stood up on the Relay side,
+        # like the EnvelopeProcessingBuffer.
+        relay.send_event(project_id)
+        event = mini_sentry.get_captured_envelope().get_event()
+        assert event["logentry"] == {"formatted": "Hello, World!"}
+
+        # At this point, we're ready to send an incomplete request.
         host, port = relay.server_address
         dsn_key = relay.get_dsn_public_key(project_id)
 


### PR DESCRIPTION
When we are in the shutting down state (and non-ephemeral), we aren't guaranteed to close the channel fast enough to reject all incoming envelopes.  Add back the shutdown handle, but also check to see if we're non-ephemeral.  Fixes a flaky test I ran into.