### PR TITLE
fix(relay-log): Crash module is only required for init

### DIFF
--- a/relay-log/src/lib.rs
+++ b/relay-log/src/lib.rs
@@ -113,6 +113,8 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 #[cfg(feature = "init")]
+mod crash;
+#[cfg(feature = "init")]
 mod setup;
 #[cfg(feature = "init")]
 pub use setup::*;
@@ -122,7 +124,6 @@ mod test;
 #[cfg(feature = "test")]
 pub use test::*;
 
-mod crash;
 mod utils;
 // Expose the minimal log facade.
 #[doc(inline)]


### PR DESCRIPTION
Silences some rust warnings when building from a crate which doesn't depend on `relay-log` with the init feature enabled.