### PR TITLE
Revert "feat(build): Switch to docker hardened image"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Features**:
 
-- Switches the container base image from distroless to docker hardened. ([#6117](https://github.com/getsentry/relay/pull/6117))
 - Infer span descriptions via `sentry-conventions`. ([#6093](https://github.com/getsentry/relay/pull/6093))
 - Raises the size limit for the flags context to 64KiB. ([#6137](https://github.com/getsentry/relay/pull/6137))
 - Add segment_names field to Replay events. ([#6134](https://github.com/getsentry/relay/pull/6134))

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,16 +1,16 @@
-FROM us-docker.pkg.dev/sentryio/dhi-mirror/static:20250419-glibc-debian13 AS builder
+FROM gcr.io/distroless/cc-debian13:debug AS builder
 
-FROM us-docker.pkg.dev/sentryio/dhi-mirror/static:20250419-glibc-debian13
+RUN ["/busybox/busybox", "mkdir", "/work", "/etc/relay"]
+
+
+FROM gcr.io/distroless/cc-debian13:nonroot
 
 ARG TARGETPLATFORM
 
 EXPOSE 3000
 
-# The base image does not have a shell available, which means we cannot
-# `mkdir` the volume directories. As an alternative we can use the empty
-# home directory instead.
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot /etc/relay
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot /work
+COPY --from=builder --chown=nonroot:nonroot /etc/relay /etc/relay
+COPY --from=builder --chown=nonroot:nonroot /work /work
 
 VOLUME ["/etc/relay", "/work"]
 WORKDIR /work


### PR DESCRIPTION
Reverts getsentry/relay#6117

Apparantely cloud build is using an ancient docker version which can't deal with DHI.