### PR TITLE
ref: Remove all uses of `db.system`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- No longer write the deprecated `sentry.transaction` attribute. ([#6237](https://github.com/getsentry/relay/pull/6237))
+- No longer write the deprecated `sentry.transaction` and `db.system` attributes. ([#6237](https://github.com/getsentry/relay/pull/6237), [#6238](https://github.com/getsentry/relay/pull/6238))
 
 ## 26.7.0
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -955,15 +955,10 @@ pub fn write_legacy_attributes(attributes: &mut Annotated<Attributes>) {
     };
 
     // Map of new sentry conventions attributes to legacy SpanV1 attributes
-    #[allow(
-        deprecated,
-        reason = "Writing possibly deprecated legacy attributes is the point of this function."
-    )]
     let current_to_legacy_attributes = [
         // DB attributes
         (SENTRY__NORMALIZED_DB_QUERY, SENTRY__NORMALIZED_DESCRIPTION),
         (DB__OPERATION__NAME, SENTRY__ACTION),
-        (DB__SYSTEM__NAME, DB__SYSTEM),
         // HTTP attributes
         (SERVER__ADDRESS, SENTRY__DOMAIN),
         (HTTP__REQUEST__METHOD, SENTRY__ACTION),
@@ -2487,10 +2482,6 @@ mod tests {
           "db.query.text": {
             "type": "string",
             "value": "{\"find\": \"documents\", \"foo\": \"bar\"}"
-          },
-          "db.system": {
-            "type": "string",
-            "value": "mongodb"
           },
           "db.system.name": {
             "type": "string",

--- a/relay-event-schema/src/protocol/span.rs
+++ b/relay-event-schema/src/protocol/span.rs
@@ -958,7 +958,7 @@ mod tests {
         let data = r#"{
         "foo": 2,
         "bar": "3",
-        "db.system": "mysql",
+        "db.system.name": "mysql",
         "code.filepath": "task.py",
         "code.lineno": 123,
         "code.function": "fn()",
@@ -1003,7 +1003,7 @@ mod tests {
                 "code.namespace": String(
                     "ns",
                 ),
-                "db.system": String(
+                "db.system.name": String(
                     "mysql",
                 ),
                 "foo": I64(
@@ -1070,7 +1070,7 @@ mod tests {
         );
         assert!(!data.contains("string"));
         assert_eq!(
-            Getter::get_value(&data, "db\\.system"),
+            Getter::get_value(&data, "db\\.system\\.name"),
             Some(Val::String("mysql"))
         );
         assert_eq!(

--- a/relay-server/src/metrics_extraction/event.rs
+++ b/relay-server/src/metrics_extraction/event.rs
@@ -419,7 +419,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "SELECT"
                     }
                 },
@@ -443,7 +443,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "INSERT"
                     }
                 },
@@ -457,7 +457,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "INSERT"
                     }
                 },
@@ -481,7 +481,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "SELECT"
                     }
                 },
@@ -495,7 +495,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "SELECT"
                     }
                 },
@@ -509,7 +509,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -522,7 +522,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -535,7 +535,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -619,7 +619,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "mongodb",
+                        "db.system.name": "mongodb",
                         "db.operation": "count"
                     }
                 },
@@ -633,7 +633,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -657,7 +657,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -670,7 +670,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "redis"
+                        "db.system.name": "redis"
                     }
                 },
                 {
@@ -911,7 +911,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "SELECT"
                     }
                 },
@@ -935,7 +935,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "INSERT"
                     }
                 },
@@ -949,7 +949,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "INSERT"
                     }
                 },
@@ -973,7 +973,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "SELECT"
                     }
                 },
@@ -987,7 +987,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "postgresql",
+                        "db.system.name": "postgresql",
                         "db.operation": "SELECT"
                     }
                 },
@@ -1001,7 +1001,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -1014,7 +1014,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {
@@ -1027,7 +1027,7 @@ mod tests {
                     "trace_id": "ff62a8b040f340bda5d830223def1d81",
                     "status": "ok",
                     "data": {
-                        "db.system": "MyDatabase"
+                        "db.system.name": "MyDatabase"
                     }
                 },
                 {

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -1087,7 +1087,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated, reason = "This test is meant to access legacy attributes.")]
     fn test_insights_backend_queries_support_modern() {
         let (mut span, headers, geo_lookup, ctx) = prepare_normalize_span_params(
             &[
@@ -1115,7 +1114,6 @@ mod tests {
                     "SELECT * FROM users WHERE id = %s",
                 ),
                 (SENTRY__CATEGORY, "db"),
-                (DB__SYSTEM, "postgresql"),
                 (SENTRY__ACTION, "SELECT"),
                 (SENTRY__DOMAIN, ",users,"),
             ],

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1492,7 +1492,6 @@ def test_spansv2_attribute_normalization(
         "attributes": {
             "sentry.category": {"type": "string", "value": "db"},
             "sentry.op": {"type": "string", "value": "db"},
-            "db.system": {"type": "string", "value": "mysql"},
             "db.system.name": {"type": "string", "value": "mysql"},
             "db.operation.name": {"type": "string", "value": "SELECT"},
             "sentry.action": {"type": "string", "value": "SELECT"},


### PR DESCRIPTION
Like #6237, but for `db.system`.