### PR TITLE
fix(typing): Make sure mypy types ffi and lib as Any to avoid typing errors

### DIFF
--- a/py/.gitignore
+++ b/py/.gitignore
@@ -1,5 +1,6 @@
 # FFI
 sentry_relay/_lowlevel*
+!sentry_relay/_lowlevel.pyi
 
 # Wheels
 dist

--- a/py/sentry_relay/ _lowlevel.pyi
+++ b/py/sentry_relay/ _lowlevel.pyi
@@ -1,0 +1,11 @@
+# Type stub for the cffi-generated native module `sentry_relay._lowlevel`.
+#
+# At runtime `_lowlevel.py` does `lib = ffi.dlopen(...)`, so `lib`/`ffi` are
+# populated dynamically from the Rust; their attributes cannot be known statically.
+# Without this stub, mypy types `lib` as cffi's generic `_cffi_backend.Lib`,
+# which declares none of the `relay_*` functions and so generates errors.
+# Here, we type them as Any to avoid these errors.
+from typing import Any
+
+ffi: Any
+lib: Any


### PR DESCRIPTION
I ran into bizarre typing errors while working on another PR, such as ` py/sentry_relay/utils.py:13: error: "Lib" has no attribute "relay_init"  [attr-defined]`

I yolo'd Claude on this one, what it found seems plausible to me: 

> your pyproject.toml lists _cffi_backend under ignore_missing_imports = true, so lib resolved to Any and every lib.relay_* call was silently accepted. But a
>   _cffi_backend-stubs package is now installed in your venv (.venv/lib/python3.14/site-packages/_cffi_backend-stubs/, shipped by recent cffi). Once a stub is found, ignore_missing_imports
>   no longer applies — it only suppresses "module not found." That stub declares:
> 
>   @final
>   class Lib:
>       def __dir__(self): ...
> 

So, looks like a recent devenv change surfaced this mypy issue.  This PR appears to address it.