### PR TITLE
ref(perfetto): Rework perfetto conversions

### DIFF
--- a/relay-profiling/src/perfetto/convert/build.rs
+++ b/relay-profiling/src/perfetto/convert/build.rs
@@ -1,0 +1,232 @@
+use std::hash::BuildHasher as _;
+
+use hashbrown::{DefaultHashBuilder, HashTable};
+use relay_event_schema::protocol::Addr;
+
+use crate::ProfileError;
+use crate::debug_image::{DebugImage, ImageType};
+use crate::perfetto::convert::{consts, intern, utils};
+use crate::perfetto::proto;
+use crate::sample::Frame;
+use crate::sample::v2::{FrameId, StackId};
+
+#[derive(Debug, Default)]
+pub struct Images {
+    images: Vec<DebugImage>,
+    image_index: HashTable<usize>,
+    hasher: DefaultHashBuilder,
+}
+
+impl Images {
+    pub fn add(&mut self, mapping: &proto::Mapping, code_file: &str, tables: &intern::Tables) {
+        if utils::is_java_mapping(code_file) {
+            return;
+        }
+
+        let image_addr = mapping.start.map(Addr);
+
+        // The closure is here to make sure the hash is always calculated from the same inputs.
+        let do_hash = |code_file: Option<&str>, image: Option<Addr>| {
+            debug_assert!(code_file.is_some());
+            self.hasher.hash_one((code_file, image))
+        };
+
+        let hash = do_hash(Some(code_file), image_addr);
+        let already_exists = self
+            .image_index
+            .find(hash, |idx| {
+                self.images.get(*idx).is_some_and(|image| {
+                    let cf = image.code_file.as_ref().map(|cf| cf.as_str());
+                    cf.is_some_and(|cf| cf == code_file) && image.image_addr == image_addr
+                })
+            })
+            .is_some();
+        if already_exists {
+            return;
+        }
+
+        let Some(debug_id) = tables
+            .resolve_build_id(mapping.build_id)
+            .and_then(utils::build_id_to_debug_id)
+        else {
+            return;
+        };
+
+        let image_size = mapping
+            .end
+            .unwrap_or(0)
+            .saturating_sub(mapping.start.unwrap_or(0));
+        let image_vmaddr = mapping.load_bias.map(Addr);
+
+        let idx = self.images.len();
+        self.images.push(DebugImage {
+            code_file: Some(code_file.to_owned().into()),
+            debug_id: Some(debug_id),
+            image_type: ImageType::Symbolic,
+            image_addr,
+            image_vmaddr,
+            image_size,
+            uuid: None,
+        });
+        self.image_index.insert_unique(hash, idx, |x| {
+            let image = self.images.get(*x);
+            let code_file = image
+                .and_then(|d| d.code_file.as_ref())
+                .map(|cf| cf.as_str());
+            let image_addr = image.and_then(|d| d.image_addr);
+            do_hash(code_file, image_addr)
+        });
+    }
+
+    pub fn into_images(self) -> Vec<DebugImage> {
+        self.images
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Frames {
+    frames: Vec<Frame>,
+    frame_index: HashTable<usize>,
+    hasher: DefaultHashBuilder,
+}
+
+impl Frames {
+    pub fn add(
+        &mut self,
+        function_name: Option<&str>,
+        mapping_path: Option<&str>,
+        pf: &proto::Frame,
+        mapping: Option<&proto::Mapping>,
+    ) -> Result<FrameId, ProfileError> {
+        let instruction_addr = {
+            let start = mapping.and_then(|m| m.start).unwrap_or(0);
+            pf.rel_pc.and_then(|rel_pc| rel_pc.checked_add(start))
+        };
+        let fr = FrameRef::new(function_name, mapping_path, instruction_addr);
+
+        // Make sure the hash is always calculated from the same inputs.
+        let do_hash = |fr: Option<FrameRef<'_>>| {
+            debug_assert!(fr.is_some());
+            self.hasher.hash_one(fr)
+        };
+
+        let index = *self
+            .frame_index
+            .entry(
+                do_hash(Some(fr)),
+                |&i| Some(fr) == self.frames.get(i).map(FrameRef::from_frame),
+                |&i| do_hash(self.frames.get(i).map(FrameRef::from_frame)),
+            )
+            .or_insert_with(|| {
+                let next_idx = self.frames.len();
+                self.frames.push(fr.to_owned());
+                next_idx
+            })
+            .get();
+
+        if index >= consts::MAX_UNIQUE_FRAMES {
+            return Err(ProfileError::ExceedSizeLimit);
+        }
+
+        Ok(FrameId(index))
+    }
+
+    pub fn into_frames(self) -> Vec<Frame> {
+        self.frames
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Stacks {
+    stacks: Vec<Vec<FrameId>>,
+    stack_index: HashTable<usize>,
+    hasher: DefaultHashBuilder,
+}
+
+impl Stacks {
+    pub fn add(&mut self, frames: Vec<FrameId>) -> StackId {
+        let do_hash = |frames: &[FrameId]| self.hasher.hash_one(frames);
+
+        let index = *self
+            .stack_index
+            .entry(
+                do_hash(&frames),
+                |&i| Some(&frames) == self.stacks.get(i),
+                |&i| do_hash(self.stacks.get(i).map(Vec::as_slice).unwrap_or(&[])),
+            )
+            .or_insert_with(|| {
+                let next_idx = self.stacks.len();
+                self.stacks.push(frames);
+                next_idx
+            })
+            .get();
+
+        StackId(index)
+    }
+
+    pub fn into_stacks(self) -> Vec<Vec<FrameId>> {
+        self.stacks
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct FrameRef<'a> {
+    function: Option<&'a str>,
+    module: Option<&'a str>,
+    package: Option<&'a str>,
+    instruction_addr: Option<u64>,
+}
+
+impl<'a> FrameRef<'a> {
+    fn new(
+        function: Option<&'a str>,
+        package: Option<&'a str>,
+        mut instruction_addr: Option<u64>,
+    ) -> Self {
+        let is_java = package.is_some_and(utils::is_java_mapping);
+        let (module, function) = match is_java {
+            false => (None, function),
+            true => match function {
+                // For Java frames, split "com.example.MyClass.myMethod" into
+                // module="com.example.MyClass" and function="myMethod".
+                Some(name) => match name.rsplit_once('.') {
+                    Some((class, method)) => (Some(class), Some(method)),
+                    None => (None, Some(name)),
+                },
+                None => (None, None),
+            },
+        };
+
+        if is_java {
+            instruction_addr = None;
+        }
+
+        Self {
+            function,
+            module,
+            package,
+            instruction_addr,
+        }
+    }
+
+    fn from_frame(frame: &'a Frame) -> Self {
+        Self {
+            function: frame.function.as_deref(),
+            module: frame.module.as_deref(),
+            package: frame.package.as_deref(),
+            instruction_addr: frame.instruction_addr.map(|addr| addr.0),
+        }
+    }
+
+    fn to_owned(self) -> Frame {
+        let is_java = self.package.is_some_and(utils::is_java_mapping);
+        Frame {
+            function: self.function.map(str::to_owned),
+            module: self.module.map(str::to_owned),
+            package: self.package.map(str::to_owned),
+            instruction_addr: self.instruction_addr.map(Addr),
+            platform: Some(if is_java { "java" } else { "native" }.to_owned()),
+            ..Default::default()
+        }
+    }
+}

--- a/relay-profiling/src/perfetto/convert/cache.rs
+++ b/relay-profiling/src/perfetto/convert/cache.rs
@@ -1,0 +1,68 @@
+use hashbrown::HashMap;
+
+use crate::perfetto::convert::utils::{self, SequenceId};
+use crate::perfetto::convert::{consts, intern};
+use crate::perfetto::proto;
+use crate::sample::v2::{FrameId, StackId};
+
+#[derive(Debug, Default)]
+pub struct Database {
+    cache: HashMap<SequenceId, Caches>,
+}
+
+impl Database {
+    pub fn for_packet(&mut self, packet: &proto::TracePacket) -> &mut Caches {
+        let seq_id = SequenceId::new(packet);
+
+        let cache = self.cache.entry(seq_id).or_default();
+        if utils::has_incremental_state_cleared(packet) {
+            *cache = Default::default();
+        }
+        cache
+    }
+}
+
+/// List of caches used to cache intermediate artifacts for a single sequence id.
+#[derive(Debug, Default)]
+pub struct Caches {
+    /// Computed mapping paths.
+    pub mapping_paths: MappingPathCache,
+    /// Computed frames.
+    pub frames: HashMap<u64, FrameId>,
+    /// Computed call-stacks.
+    pub callstacks: HashMap<u64, StackId>,
+}
+
+#[derive(Debug, Default)]
+pub struct MappingPathCache(HashMap<u64, Option<String>>);
+
+impl MappingPathCache {
+    /// Resolves a mapping path from the cache or computes it if necessary.
+    pub fn resolve(
+        &mut self,
+        id: Option<u64>,
+        mapping: Option<&proto::Mapping>,
+        tables: &intern::Tables,
+    ) -> Option<&str> {
+        let id = id?;
+
+        self.0
+            .entry(id)
+            .or_insert_with(|| {
+                let mapping =
+                    mapping.filter(|m| m.path_string_ids.len() <= consts::MAX_PATH_SEGMENTS)?;
+
+                let path = mapping
+                    .path_string_ids
+                    .iter()
+                    .filter_map(|id| tables.resolve_mapping_path(*id));
+                let path: String = itertools::Itertools::intersperse(path, "/").collect();
+
+                match path.is_empty() {
+                    true => None,
+                    false => Some(path),
+                }
+            })
+            .as_deref()
+    }
+}

--- a/relay-profiling/src/perfetto/convert/consts.rs
+++ b/relay-profiling/src/perfetto/convert/consts.rs
@@ -1,0 +1,43 @@
+/// See <https://perfetto.dev/docs/reference/trace-packet-proto#SequenceFlags>.
+pub const SEQ_INCREMENTAL_STATE_CLEARED: u32 = 1;
+
+/// Perfetto builtin real time clock ID.
+///
+/// See <https://perfetto.dev/docs/concepts/clock-sync>.
+pub const CLOCK_REALTIME: u32 = 1;
+/// Perfetto builtin boot time clock ID.
+///
+/// See <https://perfetto.dev/docs/concepts/clock-sync>.
+pub const CLOCK_BOOTTIME: u32 = 6;
+
+/// Maximum number of raw samples we collect from a Perfetto trace before
+/// bailing out. At 100 Hz across multiple threads, a 66-second chunk
+/// produces at most ~6 600 samples per thread; 100 000 provides generous
+/// headroom while bounding memory usage against adversarial input.
+pub const MAX_SAMPLES: usize = 100_000;
+
+/// Maximum number of top-level Perfetto trace packets we decode before
+/// bailing out.
+///
+/// `MAX_SAMPLES` only counts useful `PerfSample` packets. Valid traces also
+/// need clock snapshots, interned data updates, incremental state resets, and
+/// other metadata packets. The extra 10 000 packets are allocation headroom for
+/// that metadata while keeping the top-level packet vector bounded.
+pub const MAX_TRACE_PACKETS: usize = MAX_SAMPLES + 10_000;
+
+/// Maximum encoded size of a single top-level Perfetto trace packet.
+///
+/// This bounds allocations from repeated fields inside an individual packet
+/// before handing the packet body to prost for decoding.
+pub const MAX_TRACE_PACKET_BYTES: usize = 4 * 1024 * 1024;
+
+/// Upper bound on the number of frames in a call stack.
+pub const MAX_CALLSTACK_DEPTH: usize = 1000;
+
+/// Upper bound on joinable path segments.
+///
+/// Prevents excessive string joins.
+pub const MAX_PATH_SEGMENTS: usize = 100;
+
+/// Maximum amount of unique frames in a single profile.
+pub const MAX_UNIQUE_FRAMES: usize = 1_000_000;

--- a/relay-profiling/src/perfetto/convert/intern.rs
+++ b/relay-profiling/src/perfetto/convert/intern.rs
@@ -71,8 +71,8 @@ impl Tables {
             mappings,
         } = data;
 
-        self.function_names.extend(intern_strings(function_names));
-        self.mapping_paths.extend(intern_strings(mapping_paths));
+        self.function_names.extend(interned_strings(function_names));
+        self.mapping_paths.extend(interned_strings(mapping_paths));
         self.build_ids.extend(
             build_ids
                 .into_iter()
@@ -87,7 +87,7 @@ impl Tables {
     }
 }
 
-fn intern_strings(strings: Vec<proto::InternedString>) -> impl Iterator<Item = (u64, String)> {
+fn interned_strings(strings: Vec<proto::InternedString>) -> impl Iterator<Item = (u64, String)> {
     strings
         .into_iter()
         .filter_map(|is| Some((is.iid?, String::from_utf8(is.r#str?).ok()?)))

--- a/relay-profiling/src/perfetto/convert/intern.rs
+++ b/relay-profiling/src/perfetto/convert/intern.rs
@@ -1,0 +1,94 @@
+use hashbrown::HashMap;
+
+use crate::perfetto::convert::utils::{self, SequenceId};
+use crate::perfetto::proto;
+
+#[derive(Debug, Default)]
+pub struct Database {
+    inner: HashMap<SequenceId, Tables>,
+}
+
+impl Database {
+    /// Removes and merges intern information contained in the `packet` into the database.
+    pub fn intern(&mut self, packet: &mut proto::TracePacket) -> &Tables {
+        let data = packet.interned_data.take();
+        let seq_id = SequenceId::new(packet);
+
+        let tables = self.inner.entry(seq_id).or_default();
+        if utils::has_incremental_state_cleared(packet) {
+            *tables = Default::default();
+        }
+        if let Some(data) = data {
+            tables.merge(data);
+        };
+        tables
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Tables {
+    function_names: HashMap<u64, String>,
+    mapping_paths: HashMap<u64, String>,
+    build_ids: HashMap<u64, Vec<u8>>,
+    frames: HashMap<u64, proto::Frame>,
+    callstacks: HashMap<u64, proto::Callstack>,
+    mappings: HashMap<u64, proto::Mapping>,
+}
+
+impl Tables {
+    pub fn resolve_callstack(&self, id: u64) -> Option<&proto::Callstack> {
+        self.callstacks.get(&id)
+    }
+
+    pub fn resolve_frame(&self, id: u64) -> Option<&proto::Frame> {
+        self.frames.get(&id)
+    }
+
+    pub fn resolve_function_name(&self, id: Option<u64>) -> Option<&str> {
+        id.and_then(|id| self.function_names.get(&id))
+            .map(String::as_str)
+    }
+
+    pub fn resolve_mapping(&self, id: Option<u64>) -> Option<&proto::Mapping> {
+        id.and_then(|id| self.mappings.get(&id))
+    }
+
+    pub fn resolve_mapping_path(&self, id: u64) -> Option<&str> {
+        self.mapping_paths.get(&id).map(String::as_str)
+    }
+
+    pub fn resolve_build_id(&self, id: Option<u64>) -> Option<&[u8]> {
+        id.and_then(|id| self.build_ids.get(&id)).map(Vec::as_slice)
+    }
+
+    fn merge(&mut self, data: proto::InternedData) {
+        let proto::InternedData {
+            function_names,
+            mapping_paths,
+            build_ids,
+            frames,
+            callstacks,
+            mappings,
+        } = data;
+
+        self.function_names.extend(intern_strings(function_names));
+        self.mapping_paths.extend(intern_strings(mapping_paths));
+        self.build_ids.extend(
+            build_ids
+                .into_iter()
+                .filter_map(|is| Some((is.iid?, is.r#str?))),
+        );
+        self.frames
+            .extend(frames.into_iter().filter_map(|f| Some((f.iid?, f))));
+        self.callstacks
+            .extend(callstacks.into_iter().filter_map(|c| Some((c.iid?, c))));
+        self.mappings
+            .extend(mappings.into_iter().filter_map(|m| Some((m.iid?, m))));
+    }
+}
+
+fn intern_strings(strings: Vec<proto::InternedString>) -> impl Iterator<Item = (u64, String)> {
+    strings
+        .into_iter()
+        .filter_map(|is| Some((is.iid?, String::from_utf8(is.r#str?).ok()?)))
+}

--- a/relay-profiling/src/perfetto/convert/mod.rs
+++ b/relay-profiling/src/perfetto/convert/mod.rs
@@ -201,11 +201,10 @@ fn visit_trace_packets(
                     return Err(ProfileError::ExceedSizeLimit);
                 }
 
-                if len > perfetto_bytes.remaining() {
-                    return Err(ProfileError::InvalidSampledProfile);
-                }
-
-                let packet = proto::TracePacket::decode(&perfetto_bytes[..len])
+                let data = perfetto_bytes
+                    .get(..len)
+                    .ok_or(ProfileError::InvalidSampledProfile)?;
+                let packet = proto::TracePacket::decode(data)
                     .map_err(|_| ProfileError::InvalidSampledProfile)?;
                 perfetto_bytes.advance(len);
 

--- a/relay-profiling/src/perfetto/convert/mod.rs
+++ b/relay-profiling/src/perfetto/convert/mod.rs
@@ -4,126 +4,192 @@
 //! interned data) into the Sample v2 profile format.
 
 use std::collections::BTreeMap;
-use std::hash::BuildHasher;
 
 use bytes::Buf;
-use hashbrown::hash_table::Entry;
-use hashbrown::{DefaultHashBuilder, HashMap, HashSet, HashTable};
 use prost::Message;
 use prost::encoding::{self, WireType};
-
-use relay_event_schema::protocol::{Addr, DebugId};
-use relay_protocol::FiniteF64;
-
-use crate::debug_image::{DebugImage, ImageType};
-use crate::error::ProfileError;
-use crate::sample::v2::{ProfileData, Sample};
-use crate::sample::{Frame, ThreadMetadata};
-
-use crate::perfetto::proto;
-
 use proto::trace_packet::Data;
 
-/// Maximum number of raw samples we collect from a Perfetto trace before
-/// bailing out. At 100 Hz across multiple threads, a 66-second chunk
-/// produces at most ~6 600 samples per thread; 100 000 provides generous
-/// headroom while bounding memory usage against adversarial input.
-const MAX_SAMPLES: usize = 100_000;
+use relay_protocol::FiniteF64;
 
-/// Maximum number of top-level Perfetto trace packets we decode before
-/// bailing out.
-///
-/// `MAX_SAMPLES` only counts useful `PerfSample` packets. Valid traces also
-/// need clock snapshots, interned data updates, incremental state resets, and
-/// other metadata packets. The extra 10 000 packets are allocation headroom for
-/// that metadata while keeping the top-level packet vector bounded.
-const MAX_TRACE_PACKETS: usize = MAX_SAMPLES + 10_000;
+use crate::debug_image::DebugImage;
+use crate::error::ProfileError;
+use crate::perfetto::proto;
+use crate::sample::ThreadMetadata;
+use crate::sample::v2::{ProfileData, Sample, StackId};
 
-/// Maximum encoded size of a single top-level Perfetto trace packet.
-///
-/// This bounds allocations from repeated fields inside an individual packet
-/// before handing the packet body to prost for decoding.
-const MAX_TRACE_PACKET_BYTES: usize = 4 * 1024 * 1024;
+mod build;
+mod cache;
+mod consts;
+mod intern;
+mod utils;
 
-/// Upper bound on the number of frames in a call stack.
-///
-/// Resolved frame indices are used as keys in a hash map so we should avoid excessive hashing.
-const MAX_CALLSTACK_DEPTH: usize = 1000;
+/// Converts a Perfetto binary trace into Sample v2 [`ProfileData`] and debug images.
+pub fn convert(perfetto_bytes: &[u8]) -> Result<(ProfileData, Vec<DebugImage>), ProfileError> {
+    let mut clock_offset: Option<FiniteF64> = None;
+    let mut observed_pid: Option<u32> = None;
 
-/// Upper bound on joinable path segments.
-///
-/// Prevents excessive string joins.
-const MAX_PATH_SEGMENTS: usize = 100;
+    let mut samples = Vec::new();
 
-const MAX_UNIQUE_FRAMES: usize = 1_000_000;
+    let mut intern_db = intern::Database::default();
+    let mut cache_db = cache::Database::default();
+    let mut images = build::Images::default();
+    let mut frames = build::Frames::default();
+    let mut stacks = build::Stacks::default();
 
-/// See <https://perfetto.dev/docs/reference/trace-packet-proto#SequenceFlags>.
-const SEQ_INCREMENTAL_STATE_CLEARED: u32 = 1;
+    visit_trace_packets(perfetto_bytes, |mut packet| {
+        let tables = intern_db.intern(&mut packet);
+        let caches = cache_db.for_packet(&packet);
 
-/// Perfetto builtin real time clock ID.
-///
-/// See <https://perfetto.dev/docs/concepts/clock-sync>.
-const CLOCK_REALTIME: u32 = 1;
-/// Perfetto builtin boot time clock ID.
-///
-/// See <https://perfetto.dev/docs/concepts/clock-sync>.
-const CLOCK_BOOTTIME: u32 = 6;
+        match packet.data {
+            Some(Data::ClockSnapshot(cs)) if clock_offset.is_none() => {
+                clock_offset = utils::extract_clock_offset(&cs).map(utils::ns_to_secs);
+            }
+            Some(Data::PerfSample(sample)) if let Some(callstack_iid) = sample.callstack_iid => {
+                let timestamp_ns = packet.timestamp.unwrap_or(0);
+                let thread_id = sample.tid.unwrap_or(0);
+                if observed_pid.is_none() {
+                    observed_pid = sample.pid;
+                }
 
-fn has_incremental_state_cleared(packet: &proto::TracePacket) -> bool {
-    packet
-        .sequence_flags
-        .is_some_and(|f| f & SEQ_INCREMENTAL_STATE_CLEARED != 0)
-}
-
-fn trusted_packet_sequence_id(packet: &proto::TracePacket) -> u32 {
-    match packet.optional_trusted_packet_sequence_id {
-        Some(proto::trace_packet::OptionalTrustedPacketSequenceId::TrustedPacketSequenceId(id)) => {
-            id
-        }
-        None => 0,
-    }
-}
-
-fn extract_clock_offset(cs: &proto::ClockSnapshot) -> Option<i128> {
-    let primary_clock = cs.primary_trace_clock.unwrap_or(CLOCK_BOOTTIME);
-
-    if primary_clock == CLOCK_REALTIME {
-        return Some(0);
-    }
-
-    let mut primary_ns: Option<u64> = None;
-    let mut realtime_ns: Option<u64> = None;
-
-    for clock in &cs.clocks {
-        match clock.clock_id {
-            Some(CLOCK_REALTIME) => realtime_ns = clock.timestamp,
-            Some(clock_id) if clock_id == primary_clock => primary_ns = clock.timestamp,
+                let mut seq = SequenceState {
+                    images: &mut images,
+                    frames: &mut frames,
+                    stacks: &mut stacks,
+                    caches,
+                    tables,
+                };
+                if let Some(stack_id) = seq.resolve_callstack(callstack_iid)? {
+                    samples.push(Sample {
+                        timestamp: utils::ns_to_secs(timestamp_ns as i128),
+                        stack_id,
+                        thread_id: thread_id.to_string(),
+                    });
+                }
+            }
             _ => {}
         }
+
+        Ok(())
+    })?;
+
+    if samples.is_empty() {
+        return Err(ProfileError::NotEnoughSamples);
     }
 
-    match (realtime_ns, primary_ns) {
-        (Some(rt), Some(primary)) => Some(rt as i128 - primary as i128),
-        _ => None,
+    let clock_offset = clock_offset.ok_or(ProfileError::InvalidSampledProfile)?;
+
+    for sample in &mut samples {
+        sample.timestamp += clock_offset;
+    }
+    samples.sort_unstable_by_key(|s| s.timestamp);
+
+    // On Android/Linux the main thread's tid equals the process pid.
+    // Label it "main" so the UI can identify it.
+    let thread_metadata = observed_pid
+        .map(|pid| {
+            BTreeMap::from([(
+                pid.to_string(),
+                ThreadMetadata {
+                    name: Some("main".to_owned()),
+                    priority: None,
+                },
+            )])
+        })
+        .unwrap_or_default();
+
+    Ok((
+        ProfileData {
+            samples,
+            stacks: stacks.into_stacks(),
+            frames: frames.into_frames(),
+            thread_metadata,
+        },
+        images.into_images(),
+    ))
+}
+
+/// All state required to process a single perf data packet.
+#[derive(Debug)]
+struct SequenceState<'a> {
+    images: &'a mut build::Images,
+    frames: &'a mut build::Frames,
+    stacks: &'a mut build::Stacks,
+    caches: &'a mut cache::Caches,
+    tables: &'a intern::Tables,
+}
+
+impl SequenceState<'_> {
+    /// Resolves a call-stack id from a perf trace packet.
+    ///
+    /// This will incrementally collect found images, frames and the stack.
+    /// Returns the stack id if the stack could be resolved.
+    fn resolve_callstack(&mut self, cs_iid: u64) -> Result<Option<StackId>, ProfileError> {
+        if let Some(&stack_id) = self.caches.callstacks.get(&cs_iid) {
+            return Ok(Some(stack_id));
+        }
+
+        let Some(callstack) = self.tables.resolve_callstack(cs_iid) else {
+            return Ok(None);
+        };
+
+        if callstack.frame_ids.len() > consts::MAX_CALLSTACK_DEPTH {
+            return Err(ProfileError::ExceedSizeLimit);
+        }
+        let mut resolved_frames = Vec::with_capacity(callstack.frame_ids.len());
+
+        for &frame_iid in &callstack.frame_ids {
+            if let Some(&idx) = self.caches.frames.get(&frame_iid) {
+                resolved_frames.push(idx);
+                continue;
+            }
+
+            let Some(pf) = self.tables.resolve_frame(frame_iid) else {
+                continue;
+            };
+
+            let function_name = self.tables.resolve_function_name(pf.function_name_id);
+            let mapping = self.tables.resolve_mapping(pf.mapping_id);
+            let path = self
+                .caches
+                .mapping_paths
+                .resolve(pf.mapping_id, mapping, self.tables);
+
+            if let (Some(mapping), Some(path)) = (mapping, path) {
+                self.images.add(mapping, path, self.tables);
+            }
+
+            let frame_id = self.frames.add(function_name, path, pf, mapping)?;
+            self.caches.frames.insert(frame_iid, frame_id);
+            resolved_frames.push(frame_id);
+        }
+
+        // Perfetto stacks are root-first, Sample v2 is leaf-first.
+        resolved_frames.reverse();
+
+        let stack_id = self.stacks.add(resolved_frames);
+        self.caches.callstacks.insert(cs_iid, stack_id);
+
+        Ok(Some(stack_id))
     }
 }
 
 /// Parse trace packets, passing each decoded packet to `visit`.
-///
-/// This avoids holding all decoded packet allocations at once. The packet count
-/// and per-packet byte limits still bound adversarial traces.
 fn visit_trace_packets(
     mut perfetto_bytes: &[u8],
     mut visit: impl FnMut(proto::TracePacket) -> Result<(), ProfileError>,
 ) -> Result<(), ProfileError> {
     let mut packet_count = 0;
+    let mut sample_count = 0;
+
     while perfetto_bytes.has_remaining() {
         let (tag, wire_type) = encoding::decode_key(&mut perfetto_bytes)
             .map_err(|_| ProfileError::InvalidSampledProfile)?;
 
         match (tag, wire_type) {
             (1, WireType::LengthDelimited) => {
-                if packet_count >= MAX_TRACE_PACKETS {
+                packet_count += 1;
+                if packet_count >= consts::MAX_TRACE_PACKETS {
                     return Err(ProfileError::ExceedSizeLimit);
                 }
 
@@ -131,7 +197,7 @@ fn visit_trace_packets(
                     .map_err(|_| ProfileError::InvalidSampledProfile)?;
                 let len = usize::try_from(len).map_err(|_| ProfileError::ExceedSizeLimit)?;
 
-                if len > MAX_TRACE_PACKET_BYTES {
+                if len > consts::MAX_TRACE_PACKET_BYTES {
                     return Err(ProfileError::ExceedSizeLimit);
                 }
 
@@ -142,7 +208,12 @@ fn visit_trace_packets(
                 let packet = proto::TracePacket::decode(&perfetto_bytes[..len])
                     .map_err(|_| ProfileError::InvalidSampledProfile)?;
                 perfetto_bytes.advance(len);
-                packet_count += 1;
+
+                sample_count += matches!(packet.data, Some(Data::PerfSample(_))) as usize;
+                if sample_count >= consts::MAX_SAMPLES {
+                    return Err(ProfileError::ExceedSizeLimit);
+                }
+
                 visit(packet)?;
             }
             (1, _) => return Err(ProfileError::InvalidSampledProfile),
@@ -159,527 +230,11 @@ fn visit_trace_packets(
     Ok(())
 }
 
-/// Per-sequence interned data tables, mirroring Perfetto's incremental state.
-///
-/// Perfetto traces use interned IDs to avoid repeating large strings and
-/// structures in every packet. Each trusted packet sequence maintains its
-/// own set of intern tables that can be cleared on state resets.
-///
-/// Per the Perfetto spec, each `InternedData` field constructs its **own**
-/// interning index — IDs are scoped per field, not shared across string types.
-/// See <https://android.googlesource.com/platform/external/perfetto/+/refs/heads/master/protos/perfetto/trace/interned_data/interned_data.proto>.
-#[derive(Debug, Default)]
-struct InternTables {
-    // HashMap over BTreeMap: these tables can grow large (one entry per interned symbol).
-    function_names: HashMap<u64, String>,
-    mapping_paths: HashMap<u64, String>,
-    build_ids: HashMap<u64, Vec<u8>>,
-    frames: HashMap<u64, proto::Frame>,
-    callstacks: HashMap<u64, proto::Callstack>,
-    mappings: HashMap<u64, proto::Mapping>,
-    mapping_path_cache: HashMap<u64, Option<String>>,
-    frame_cache: HashMap<u64, usize>,
-    callstack_cache: HashMap<u64, usize>,
-}
-
-impl InternTables {
-    fn merge(&mut self, data: proto::InternedData) {
-        self.mapping_path_cache.clear();
-        self.frame_cache.clear();
-        self.callstack_cache.clear();
-
-        let proto::InternedData {
-            function_names,
-            mapping_paths,
-            build_ids,
-            frames,
-            callstacks,
-            mappings,
-        } = data;
-
-        self.function_names.extend(intern_strings(function_names));
-        self.mapping_paths.extend(intern_strings(mapping_paths));
-        self.build_ids.extend(
-            build_ids
-                .into_iter()
-                .filter_map(|is| Some((is.iid?, is.r#str?))),
-        );
-        self.frames
-            .extend(frames.into_iter().filter_map(|f| Some((f.iid?, f))));
-        self.callstacks
-            .extend(callstacks.into_iter().filter_map(|c| Some((c.iid?, c))));
-        self.mappings
-            .extend(mappings.into_iter().filter_map(|m| Some((m.iid?, m))));
-    }
-}
-
-/// Resolves and caches the joined path of a mapping, returning a reference
-/// into the cache.
-fn mapping_path<'a>(
-    mapping_id: u64,
-    mappings: &HashMap<u64, proto::Mapping>,
-    mapping_paths: &HashMap<u64, String>,
-    mapping_path_cache: &'a mut HashMap<u64, Option<String>>,
-) -> Option<&'a str> {
-    mapping_path_cache
-        .entry(mapping_id)
-        .or_insert_with(|| {
-            mappings
-                .get(&mapping_id)
-                .and_then(|mapping| resolve_mapping_path(mapping, mapping_paths))
-        })
-        .as_deref()
-}
-
-fn intern_strings(strings: Vec<proto::InternedString>) -> impl Iterator<Item = (u64, String)> {
-    strings
-        .into_iter()
-        .filter_map(|is| Some((is.iid?, String::from_utf8(is.r#str?).ok()?)))
-}
-
-/// Deduplication key for resolved stack frames.
-///
-/// Two Perfetto frames that resolve to the same function, module, package,
-/// and instruction address are considered identical and share a single index
-/// in the output frame list.
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct FrameCandidate<'a> {
-    function: Option<&'a str>,
-    module: Option<&'a str>,
-    package: Option<&'a str>,
-    instruction_addr: Option<u64>,
-}
-
-impl<'a> FrameCandidate<'a> {
-    fn new(frame: &'a Frame) -> Self {
-        Self {
-            function: frame.function.as_deref(),
-            module: frame.module.as_deref(),
-            package: frame.package.as_deref(),
-            instruction_addr: frame.instruction_addr.map(|addr| addr.0),
-        }
-    }
-}
-
-/// Mutable context for callstack resolution, collecting frames, stacks,
-/// and debug images during a single conversion pass.
-#[derive(Default)]
-struct ResolveContext {
-    /// Indexes into `frames`, keyed by the [`FrameCandidate`].
-    frame_index: HashTable<usize>,
-    /// Hasher used to access [`Self::frame_index`].
-    hasher: DefaultHashBuilder,
-    frames: Vec<Frame>,
-    stack_index: HashMap<Vec<usize>, usize>,
-    debug_images: Vec<DebugImage>,
-    seen_images: HashSet<(String, u64)>,
-}
-
-/// Converts a Perfetto binary trace into Sample v2 [`ProfileData`] and debug images.
-pub fn convert(perfetto_bytes: &[u8]) -> Result<(ProfileData, Vec<DebugImage>), ProfileError> {
-    let mut tables_by_seq: HashMap<u32, InternTables> = HashMap::new();
-    let mut thread_meta: BTreeMap<u32, ThreadMetadata> = BTreeMap::new();
-    let mut clock_offset_ns: Option<i128> = None;
-    let mut observed_pid: Option<u32> = None;
-
-    // Samples are resolved eagerly during packet iteration (single-pass) so
-    // that incremental state resets don't cause earlier samples to be resolved
-    // against a post-reset intern table. We collect (ts_ns, tid, stack_id)
-    // tuples and apply clock offset + sorting after the loop.
-    let mut ctx = ResolveContext::default();
-    let mut resolved_samples: Vec<ResolvedSample> = Vec::new();
-    let mut sample_count: usize = 0;
-
-    visit_trace_packets(perfetto_bytes, |packet| {
-        let seq_id = trusted_packet_sequence_id(&packet);
-
-        let intern_tables = tables_by_seq.entry(seq_id).or_default();
-
-        if has_incremental_state_cleared(&packet) {
-            *intern_tables = Default::default();
-        }
-
-        if let Some(interned_data) = packet.interned_data {
-            intern_tables.merge(interned_data);
-        }
-
-        match packet.data {
-            Some(Data::ClockSnapshot(cs)) if clock_offset_ns.is_none() => {
-                clock_offset_ns = extract_clock_offset(&cs);
-            }
-            Some(Data::PerfSample(sample)) => {
-                if let Some(callstack_iid) = sample.callstack_iid {
-                    let timestamp_ns = packet.timestamp.unwrap_or(0);
-                    let thread_id = sample.tid.unwrap_or(0);
-                    if observed_pid.is_none() {
-                        observed_pid = sample.pid;
-                    }
-                    sample_count += 1;
-                    if sample_count > MAX_SAMPLES {
-                        return Err(ProfileError::ExceedSizeLimit);
-                    }
-
-                    if let Some(stack_id) =
-                        resolve_callstack(callstack_iid, intern_tables, &mut ctx)?
-                    {
-                        resolved_samples.push(ResolvedSample {
-                            timestamp_ns,
-                            thread_id,
-                            stack_id,
-                        });
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        Ok(())
-    })?;
-
-    if resolved_samples.is_empty() {
-        return Err(ProfileError::NotEnoughSamples);
-    }
-
-    // On Android/Linux the main thread's tid equals the process pid.
-    // Label it "main" so the UI can identify it.
-    if let Some(pid) = observed_pid {
-        thread_meta.entry(pid).or_insert_with(|| ThreadMetadata {
-            name: Some("main".to_owned()),
-            priority: None,
-        });
-    }
-
-    let clock_offset_ns = clock_offset_ns.ok_or(ProfileError::InvalidSampledProfile)?;
-
-    resolved_samples.sort_by_key(|s| s.timestamp_ns);
-
-    let mut samples: Vec<Sample> = Vec::with_capacity(resolved_samples.len());
-    for ResolvedSample {
-        timestamp_ns,
-        thread_id,
-        stack_id,
-    } in resolved_samples
-    {
-        // Compute absolute timestamp in integer nanoseconds first, then convert
-        // to f64 seconds once to avoid precision loss from adding large floats.
-        let abs_ns = timestamp_ns as i128 + clock_offset_ns;
-        let ts_secs = abs_ns as f64 / 1_000_000_000.0;
-        let ts_secs = (ts_secs * 1000.0).round() / 1000.0;
-
-        if let Some(ts) = FiniteF64::new(ts_secs) {
-            samples.push(Sample {
-                timestamp: ts,
-                stack_id,
-                thread_id: thread_id.to_string(),
-            });
-        }
-    }
-
-    if samples.is_empty() {
-        return Err(ProfileError::NotEnoughSamples);
-    }
-
-    // Convert u32 thread keys to String for the output format.
-    let thread_metadata = thread_meta
-        .into_iter()
-        .map(|(tid, meta)| (tid.to_string(), meta))
-        .collect();
-
-    // Stacks are stored only as `stack_index` keys during conversion;
-    // materialize them into the id-ordered output vector.
-    let mut stacks = vec![Vec::new(); ctx.stack_index.len()];
-    for (stack, id) in ctx.stack_index {
-        stacks[id] = stack;
-    }
-
-    Ok((
-        ProfileData {
-            samples,
-            stacks,
-            frames: ctx.frames,
-            thread_metadata,
-        },
-        ctx.debug_images,
-    ))
-}
-
-struct ResolvedSample {
-    timestamp_ns: u64,
-    thread_id: u32,
-    stack_id: usize,
-}
-
-/// Resolves a callstack iid against the current intern tables, deduplicating
-/// frames and stacks, and collecting debug images for native mappings.
-///
-/// Returns `Some(stack_id)` if the callstack was resolved, or `None` if the
-/// callstack iid was not found in the tables.
-fn resolve_callstack(
-    cs_iid: u64,
-    tables: &mut InternTables,
-    ctx: &mut ResolveContext,
-) -> Result<Option<usize>, ProfileError> {
-    let InternTables {
-        function_names,
-        mapping_paths,
-        build_ids,
-        frames,
-        callstacks,
-        mappings,
-        mapping_path_cache,
-        frame_cache,
-        callstack_cache,
-    } = tables;
-
-    if let Some(&stack_id) = callstack_cache.get(&cs_iid) {
-        return Ok(Some(stack_id));
-    }
-
-    let Some(callstack) = callstacks.get(&cs_iid) else {
-        return Ok(None);
-    };
-
-    if callstack.frame_ids.len() > MAX_CALLSTACK_DEPTH {
-        return Err(ProfileError::ExceedSizeLimit);
-    }
-
-    let mut resolved_frame_indices: Vec<usize> = Vec::with_capacity(callstack.frame_ids.len());
-
-    for &frame_iid in &callstack.frame_ids {
-        if let Some(&idx) = frame_cache.get(&frame_iid) {
-            resolved_frame_indices.push(idx);
-            continue;
-        }
-
-        let Some(&pf) = frames.get(&frame_iid) else {
-            continue;
-        };
-
-        let function_name = pf
-            .function_name_id
-            .and_then(|id| function_names.get(&id))
-            .map(String::as_str);
-
-        let mapping = pf.mapping_id.and_then(|mid| mappings.get(&mid));
-        let path = pf
-            .mapping_id
-            .and_then(|mid| mapping_path(mid, mappings, mapping_paths, mapping_path_cache));
-
-        if let Some(mapping) = mapping
-            && let Some(image) = collect_debug_image(mapping, path, build_ids, &mut ctx.seen_images)
-        {
-            ctx.debug_images.push(image);
-        }
-
-        let candidate = frame_candidate(function_name, path, &pf, mapping);
-
-        let idx = match ctx.frame_index.entry(
-            ctx.hasher.hash_one(&candidate),
-            |&i| candidate == FrameCandidate::new(&ctx.frames[i]),
-            |&i| ctx.hasher.hash_one(FrameCandidate::new(&ctx.frames[i])),
-        ) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let next_idx = ctx.frames.len();
-                if next_idx >= MAX_UNIQUE_FRAMES {
-                    return Err(ProfileError::ExceedSizeLimit);
-                }
-                ctx.frames.push(build_frame(&candidate));
-                entry.insert(next_idx);
-                next_idx
-            }
-        };
-
-        frame_cache.insert(frame_iid, idx);
-        resolved_frame_indices.push(idx);
-    }
-
-    // Perfetto stacks are root-first, Sample v2 is leaf-first.
-    resolved_frame_indices.reverse();
-
-    let next_id = ctx.stack_index.len();
-    let stack_id = *ctx
-        .stack_index
-        .entry(resolved_frame_indices)
-        .or_insert(next_id);
-
-    callstack_cache.insert(cs_iid, stack_id);
-
-    Ok(Some(stack_id))
-}
-
-/// Builds a debug image from a native mapping if not already seen.
-///
-/// Returns `Some(DebugImage)` for new native mappings with a valid build ID,
-/// or `None` if the mapping has no path, is Java-only, already seen, or lacks
-/// a valid debug ID.
-fn collect_debug_image(
-    mapping: &proto::Mapping,
-    code_file: Option<&str>,
-    build_ids: &HashMap<u64, Vec<u8>>,
-    seen_images: &mut HashSet<(String, u64)>,
-) -> Option<DebugImage> {
-    let code_file = code_file?;
-
-    if is_java_mapping(code_file) {
-        return None;
-    }
-
-    let image_addr = mapping.start;
-
-    let debug_id = mapping
-        .build_id
-        .and_then(|bid| build_ids.get(&bid))
-        .and_then(|bytes| build_id_to_debug_id(bytes))?;
-
-    // Insert into dedup set only after validating we have a valid debug_id,
-    // so that a mapping first seen without a build_id doesn't block a later
-    // valid encounter from a different packet sequence.
-    if !seen_images.insert((code_file.to_owned(), image_addr.unwrap_or(0))) {
-        return None;
-    }
-
-    let image_size = mapping
-        .end
-        .unwrap_or(0)
-        .saturating_sub(image_addr.unwrap_or(0));
-    let image_vmaddr = mapping.load_bias;
-
-    Some(DebugImage {
-        code_file: Some(code_file.to_owned().into()),
-        debug_id: Some(debug_id),
-        image_type: ImageType::Symbolic,
-        image_addr: image_addr.map(Addr),
-        image_vmaddr: image_vmaddr.map(Addr),
-        image_size,
-        uuid: None,
-    })
-}
-
-/// Resolves a Perfetto frame into a borrowed [`FrameCandidate`] dedup view.
-///
-/// Java frames (identified by mapping path) have their fully-qualified name
-/// split into module and function. Native frames compute an absolute
-/// instruction address from `rel_pc` and the mapping start address.
-fn frame_candidate<'a>(
-    function_name: Option<&'a str>,
-    mapping_path: Option<&'a str>,
-    pf: &proto::Frame,
-    mapping: Option<&proto::Mapping>,
-) -> FrameCandidate<'a> {
-    let is_java = mapping_path.is_some_and(is_java_mapping);
-
-    if is_java {
-        // For Java frames, split "com.example.MyClass.myMethod" into
-        // module="com.example.MyClass" and function="myMethod".
-        let (module, function) = match function_name {
-            Some(name) => match name.rsplit_once('.') {
-                Some((class, method)) => (Some(class), Some(method)),
-                None => (None, Some(name)),
-            },
-            None => (None, None),
-        };
-
-        FrameCandidate {
-            function,
-            module,
-            package: mapping_path,
-            instruction_addr: None,
-        }
-    } else {
-        FrameCandidate {
-            function: function_name,
-            module: None,
-            package: mapping_path,
-            instruction_addr: frame_instruction_addr(pf, mapping),
-        }
-    }
-}
-
-/// Materializes an owned Sample v2 [`Frame`] from a borrowed [`FrameCandidate`].
-///
-/// The platform is derived from the package: a Java mapping path implies a
-/// Java frame (Java candidates never carry an instruction address).
-fn build_frame(candidate: &FrameCandidate<'_>) -> Frame {
-    let is_java = candidate.package.is_some_and(is_java_mapping);
-
-    Frame {
-        function: candidate.function.map(str::to_owned),
-        module: candidate.module.map(str::to_owned),
-        package: candidate.package.map(str::to_owned),
-        instruction_addr: candidate.instruction_addr.map(Addr),
-        platform: Some(if is_java { "java" } else { "native" }.to_owned()),
-        ..Default::default()
-    }
-}
-
-fn frame_instruction_addr(pf: &proto::Frame, mapping: Option<&proto::Mapping>) -> Option<u64> {
-    let rel_pc = pf.rel_pc?;
-
-    match mapping.and_then(|m| m.start) {
-        Some(start) => start.checked_add(rel_pc),
-        None => Some(rel_pc),
-    }
-}
-
-/// Joins a mapping's interned path segments with `/` into a single file path.
-///
-/// Returns `None` if the mapping has no resolvable path segments.
-fn resolve_mapping_path(
-    mapping: &proto::Mapping,
-    mapping_paths: &HashMap<u64, String>,
-) -> Option<String> {
-    if mapping.path_string_ids.len() > MAX_PATH_SEGMENTS {
-        return None;
-    }
-
-    let mut path = String::new();
-    let mut has_segment = false;
-    for id in &mapping.path_string_ids {
-        let Some(segment) = mapping_paths.get(id) else {
-            continue;
-        };
-
-        if has_segment {
-            path.push('/');
-        }
-        path.push_str(segment);
-        has_segment = true;
-    }
-
-    if path.is_empty() { None } else { Some(path) }
-}
-
-/// Returns `true` if the mapping path indicates a JVM/ART runtime mapping.
-fn is_java_mapping(path: &str) -> bool {
-    const JVM_EXTENSIONS: &[&str] = &[".oat", ".odex", ".vdex", ".jar", ".dex"];
-
-    if path.contains("dalvik-jit-code-cache") {
-        return true;
-    }
-    JVM_EXTENSIONS.iter().any(|ext| path.ends_with(ext))
-}
-
-/// Converts a raw ELF build ID into a Sentry [`DebugId`].
-///
-/// The first 16 bytes of the build ID are interpreted as a little-endian UUID.
-/// If the build ID is shorter than 16 bytes it is zero-padded on the right.
-fn build_id_to_debug_id(raw: &[u8]) -> Option<DebugId> {
-    if raw.is_empty() {
-        return None;
-    }
-
-    let mut buf = [0u8; 16];
-    let len = raw.len().min(16);
-    buf[..len].copy_from_slice(&raw[..len]);
-
-    let uuid = uuid::Uuid::from_bytes_le(buf);
-    Some(DebugId::from(uuid))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use consts::*;
 
     const CLOCK_MONOTONIC: u32 = 3;
     const TEST_BOOTTIME_NS: u64 = 1_000_000_000;
@@ -1230,7 +785,7 @@ mod tests {
 
     #[test]
     fn test_convert_android_pftrace() {
-        let bytes = include_bytes!("../../tests/fixtures/android/perfetto/android.pftrace");
+        let bytes = include_bytes!("../../../tests/fixtures/android/perfetto/android.pftrace");
 
         let result = convert(bytes.as_slice());
         assert!(result.is_ok(), "conversion failed: {result:?}");
@@ -1242,20 +797,13 @@ mod tests {
 
         // All samples must reference valid stacks.
         for sample in &data.samples {
-            assert!(
-                sample.stack_id < data.stacks.len(),
-                "sample references out-of-bounds stack_id {}",
-                sample.stack_id
-            );
+            assert!(sample.stack_id.0 < data.stacks.len());
         }
 
         // All stacks must reference valid frames.
         for stack in &data.stacks {
             for &frame_idx in stack {
-                assert!(
-                    frame_idx < data.frames.len(),
-                    "stack references out-of-bounds frame index {frame_idx}",
-                );
+                assert!(frame_idx.0 < data.frames.len());
             }
         }
 
@@ -1343,23 +891,6 @@ mod tests {
         assert_eq!(data.frames.len(), 1);
         assert_eq!(data.stacks.len(), 1); // Same single-frame stack, also deduped.
         assert_eq!(data.samples.len(), 2);
-    }
-
-    #[test]
-    fn test_is_java_mapping() {
-        // JVM mappings.
-        assert!(is_java_mapping("system/framework/arm64/boot-framework.oat"));
-        assert!(is_java_mapping("data/app/.../oat/arm64/base.odex"));
-        assert!(is_java_mapping("base.vdex"));
-        assert!(is_java_mapping("system/framework/framework.jar"));
-        assert!(is_java_mapping("classes.dex"));
-        assert!(is_java_mapping("[anon_shmem:dalvik-jit-code-cache]"));
-
-        // Native mappings.
-        assert!(!is_java_mapping("libc.so"));
-        assert!(!is_java_mapping("libhwui.so"));
-        assert!(!is_java_mapping("apex/com.android.art/lib64/libart.so"));
-        assert!(!is_java_mapping("app_process64"));
     }
 
     #[test]
@@ -1498,36 +1029,6 @@ mod tests {
 
         assert_eq!(data.frames.len(), 1);
         assert!(data.frames[0].instruction_addr.is_none());
-    }
-
-    #[test]
-    fn test_build_id_to_debug_id() {
-        // 20-byte ELF build ID (common for GNU build IDs).
-        let raw = &[
-            0xb0, 0x3e, 0x4a, 0x7f, 0x5e, 0x88, 0x4c, 0x8d, 0xa0, 0x4b, 0x05, 0xfa, 0x32, 0xcc,
-            0x4c, 0xbd, 0x69, 0xfa, 0xff, 0x51,
-        ];
-        let debug_id = build_id_to_debug_id(raw).unwrap();
-        // First 16 bytes interpreted as little-endian UUID:
-        //   time_low  (0..4)  reversed: 7f4a3eb0
-        //   time_mid  (4..6)  reversed: 885e
-        //   time_hi   (6..8)  reversed: 8d4c
-        //   rest      (8..16) unchanged: a04b05fa32cc4cbd
-        assert_eq!(debug_id.to_string(), "7f4a3eb0-885e-8d4c-a04b-05fa32cc4cbd");
-    }
-
-    #[test]
-    fn test_build_id_to_debug_id_short() {
-        // Build ID shorter than 16 bytes → zero-padded.
-        let debug_id = build_id_to_debug_id(&[0xaa, 0xbb, 0xcc, 0xdd]).unwrap();
-        // Bytes: aa bb cc dd 00 00 00 00 00 00 00 00 00 00 00 00
-        // After swap: ddccbbaa-0000-0000-0000-000000000000
-        assert_eq!(debug_id.to_string(), "ddccbbaa-0000-0000-0000-000000000000");
-    }
-
-    #[test]
-    fn test_build_id_to_debug_id_empty() {
-        assert!(build_id_to_debug_id(&[]).is_none());
     }
 
     #[test]

--- a/relay-profiling/src/perfetto/convert/utils.rs
+++ b/relay-profiling/src/perfetto/convert/utils.rs
@@ -1,0 +1,145 @@
+use relay_event_schema::protocol::DebugId;
+use relay_protocol::FiniteF64;
+
+use crate::perfetto::convert::consts;
+use crate::perfetto::proto;
+use crate::perfetto::proto::trace_packet::OptionalTrustedPacketSequenceId;
+
+/// A Perfetto trusted sequence id extracted from a [`proto::TracePacket`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SequenceId(u32);
+
+impl SequenceId {
+    /// Creates a new [`Self`] from a [`proto::TracePacket`].
+    pub fn new(packet: &proto::TracePacket) -> Self {
+        let seq_id = packet
+            .optional_trusted_packet_sequence_id
+            .map(|OptionalTrustedPacketSequenceId::TrustedPacketSequenceId(id)| id)
+            // Default to `0` here, semantically this is equivalent to an invalid id,
+            // which is good enough for our purposes.
+            .unwrap_or(0);
+
+        Self(seq_id)
+    }
+}
+
+/// Returns `true` if the [`proto::TracePacket`] has its internal state cleared flag set.
+pub fn has_incremental_state_cleared(packet: &proto::TracePacket) -> bool {
+    packet
+        .sequence_flags
+        .is_some_and(|f| f & consts::SEQ_INCREMENTAL_STATE_CLEARED != 0)
+}
+
+pub fn extract_clock_offset(cs: &proto::ClockSnapshot) -> Option<i128> {
+    let primary_clock = cs.primary_trace_clock.unwrap_or(consts::CLOCK_BOOTTIME);
+
+    if primary_clock == consts::CLOCK_REALTIME {
+        return Some(0);
+    }
+
+    let mut primary_ns: Option<u64> = None;
+    let mut realtime_ns: Option<u64> = None;
+
+    for clock in &cs.clocks {
+        match clock.clock_id {
+            Some(consts::CLOCK_REALTIME) => realtime_ns = clock.timestamp,
+            Some(clock_id) if clock_id == primary_clock => primary_ns = clock.timestamp,
+            _ => {}
+        }
+    }
+
+    match (realtime_ns, primary_ns) {
+        (Some(rt), Some(primary)) => Some(rt as i128 - primary as i128),
+        _ => None,
+    }
+}
+
+/// Returns `true` if the mapping path indicates a JVM/ART runtime mapping.
+pub fn is_java_mapping(path: &str) -> bool {
+    const JVM_EXTENSIONS: &[&str] = &[".oat", ".odex", ".vdex", ".jar", ".dex"];
+
+    if path.contains("dalvik-jit-code-cache") {
+        return true;
+    }
+    JVM_EXTENSIONS.iter().any(|ext| path.ends_with(ext))
+}
+
+/// Converts a raw ELF build ID into a Sentry [`DebugId`].
+///
+/// The first 16 bytes of the build ID are interpreted as a little-endian UUID.
+/// If the build ID is shorter than 16 bytes it is zero-padded on the right.
+pub fn build_id_to_debug_id(raw: &[u8]) -> Option<DebugId> {
+    if raw.is_empty() {
+        return None;
+    }
+
+    let mut buf = [0u8; 16];
+    let len = raw.len().min(16);
+    buf[..len].copy_from_slice(&raw[..len]);
+
+    let uuid = uuid::Uuid::from_bytes_le(buf);
+    Some(DebugId::from(uuid))
+}
+
+/// Converts nanoseconds to a float (seconds) with minimal precision loss.
+pub fn ns_to_secs(ns: i128) -> FiniteF64 {
+    const NANOS_PER_SEC: i128 = 1_000_000_000;
+    let secs = ns.div_euclid(NANOS_PER_SEC);
+    let frac = ns.rem_euclid(NANOS_PER_SEC);
+    let res = FiniteF64::new(secs as f64 + (frac as f64) / 1e9);
+    // This can't actually be ever infinite or NaN.
+    debug_assert!(res.is_some());
+    res.unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_id_to_debug_id() {
+        // 20-byte ELF build ID (common for GNU build IDs).
+        let raw = &[
+            0xb0, 0x3e, 0x4a, 0x7f, 0x5e, 0x88, 0x4c, 0x8d, 0xa0, 0x4b, 0x05, 0xfa, 0x32, 0xcc,
+            0x4c, 0xbd, 0x69, 0xfa, 0xff, 0x51,
+        ];
+        let debug_id = build_id_to_debug_id(raw).unwrap();
+        // First 16 bytes interpreted as little-endian UUID:
+        //   time_low  (0..4)  reversed: 7f4a3eb0
+        //   time_mid  (4..6)  reversed: 885e
+        //   time_hi   (6..8)  reversed: 8d4c
+        //   rest      (8..16) unchanged: a04b05fa32cc4cbd
+        assert_eq!(debug_id.to_string(), "7f4a3eb0-885e-8d4c-a04b-05fa32cc4cbd");
+    }
+
+    #[test]
+    fn test_build_id_to_debug_id_short() {
+        // Build ID shorter than 16 bytes → zero-padded.
+        let debug_id = build_id_to_debug_id(&[0xaa, 0xbb, 0xcc, 0xdd]).unwrap();
+        // Bytes: aa bb cc dd 00 00 00 00 00 00 00 00 00 00 00 00
+        // After swap: ddccbbaa-0000-0000-0000-000000000000
+        assert_eq!(debug_id.to_string(), "ddccbbaa-0000-0000-0000-000000000000");
+    }
+
+    #[test]
+    fn test_build_id_to_debug_id_empty() {
+        assert!(build_id_to_debug_id(&[]).is_none());
+    }
+
+    #[test]
+    fn test_is_java_mapping() {
+        // JVM mappings.
+        assert!(is_java_mapping("system/framework/arm64/boot-framework.oat"));
+        assert!(is_java_mapping("data/app/.../oat/arm64/base.odex"));
+        assert!(is_java_mapping("base.vdex"));
+        assert!(is_java_mapping("system/framework/framework.jar"));
+        assert!(is_java_mapping("classes.dex"));
+        assert!(is_java_mapping("[anon_shmem:dalvik-jit-code-cache]"));
+
+        // Native mappings.
+        assert!(!is_java_mapping("libc.so"));
+        assert!(!is_java_mapping("libhwui.so"));
+        assert!(!is_java_mapping("apex/com.android.art/lib64/libart.so"));
+        assert!(!is_java_mapping("app_process64"));
+    }
+}

--- a/relay-profiling/src/perfetto/convert/utils.rs
+++ b/relay-profiling/src/perfetto/convert/utils.rs
@@ -23,7 +23,7 @@ impl SequenceId {
     }
 }
 
-/// Returns `true` if the [`proto::TracePacket`] has its internal state cleared flag set.
+/// Returns `true` if the [`proto::TracePacket`] has its "internal state cleared" flag set.
 pub fn has_incremental_state_cleared(packet: &proto::TracePacket) -> bool {
     packet
         .sequence_flags
@@ -57,11 +57,7 @@ pub fn extract_clock_offset(cs: &proto::ClockSnapshot) -> Option<i128> {
 /// Returns `true` if the mapping path indicates a JVM/ART runtime mapping.
 pub fn is_java_mapping(path: &str) -> bool {
     const JVM_EXTENSIONS: &[&str] = &[".oat", ".odex", ".vdex", ".jar", ".dex"];
-
-    if path.contains("dalvik-jit-code-cache") {
-        return true;
-    }
-    JVM_EXTENSIONS.iter().any(|ext| path.ends_with(ext))
+    path.contains("dalvik-jit-code-cache") || JVM_EXTENSIONS.iter().any(|ext| path.ends_with(ext))
 }
 
 /// Converts a raw ELF build ID into a Sentry [`DebugId`].

--- a/relay-profiling/src/perfetto/snapshots/relay_profiling__perfetto__tests__parse_perfetto.snap
+++ b/relay-profiling/src/perfetto/snapshots/relay_profiling__perfetto__tests__parse_perfetto.snap
@@ -144,422 +144,422 @@ expression: chunk.inner
   "profile": {
     "samples": [
       {
-        "timestamp": 1771278043.846,
+        "timestamp": 1771278043.846089,
         "stack_id": 1,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278043.856,
+        "timestamp": 1771278043.8560715,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278043.947,
+        "timestamp": 1771278043.9471922,
         "stack_id": 2,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278043.998,
+        "timestamp": 1771278043.9976053,
         "stack_id": 3,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.048,
+        "timestamp": 1771278044.048167,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.129,
+        "timestamp": 1771278044.1290238,
         "stack_id": 5,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278044.23,
+        "timestamp": 1771278044.2298582,
         "stack_id": 6,
         "thread_id": "24803"
       },
       {
-        "timestamp": 1771278044.23,
+        "timestamp": 1771278044.230061,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.281,
+        "timestamp": 1771278044.280579,
         "stack_id": 8,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.331,
+        "timestamp": 1771278044.3310332,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.462,
+        "timestamp": 1771278044.4623744,
         "stack_id": 9,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278044.513,
+        "timestamp": 1771278044.5128255,
         "stack_id": 10,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.563,
+        "timestamp": 1771278044.5632527,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.614,
+        "timestamp": 1771278044.6137655,
         "stack_id": 11,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.664,
+        "timestamp": 1771278044.6643343,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.715,
+        "timestamp": 1771278044.7147775,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.745,
+        "timestamp": 1771278044.7451155,
         "stack_id": 12,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.745,
+        "timestamp": 1771278044.7451718,
         "stack_id": 14,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278044.796,
+        "timestamp": 1771278044.795645,
         "stack_id": 13,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.846,
+        "timestamp": 1771278044.8461037,
         "stack_id": 15,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278044.846,
+        "timestamp": 1771278044.8463876,
         "stack_id": 16,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.897,
+        "timestamp": 1771278044.8965912,
         "stack_id": 17,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.947,
+        "timestamp": 1771278044.947238,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278044.998,
+        "timestamp": 1771278044.9977036,
         "stack_id": 18,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.048,
+        "timestamp": 1771278045.048318,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.099,
+        "timestamp": 1771278045.0986078,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.18,
+        "timestamp": 1771278045.1795697,
         "stack_id": 19,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.23,
+        "timestamp": 1771278045.2300177,
         "stack_id": 20,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.28,
+        "timestamp": 1771278045.2804577,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.301,
+        "timestamp": 1771278045.3007536,
         "stack_id": 21,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.331,
+        "timestamp": 1771278045.3308196,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.432,
+        "timestamp": 1771278045.4319417,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.462,
+        "timestamp": 1771278045.4624014,
         "stack_id": 19,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.513,
+        "timestamp": 1771278045.5126648,
         "stack_id": 22,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.563,
+        "timestamp": 1771278045.5631418,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.614,
+        "timestamp": 1771278045.6136446,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.664,
+        "timestamp": 1771278045.664433,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.715,
+        "timestamp": 1771278045.7147737,
         "stack_id": 24,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.765,
+        "timestamp": 1771278045.7653713,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.795,
+        "timestamp": 1771278045.7954855,
         "stack_id": 23,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.816,
+        "timestamp": 1771278045.8156703,
         "stack_id": 25,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278045.846,
+        "timestamp": 1771278045.8459847,
         "stack_id": 26,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.897,
+        "timestamp": 1771278045.8966463,
         "stack_id": 10,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.947,
+        "timestamp": 1771278045.947191,
         "stack_id": 27,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278045.998,
+        "timestamp": 1771278045.9976945,
         "stack_id": 28,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.099,
+        "timestamp": 1771278046.0987484,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.129,
+        "timestamp": 1771278046.1290393,
         "stack_id": 29,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278046.18,
+        "timestamp": 1771278046.1796257,
         "stack_id": 30,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278046.23,
+        "timestamp": 1771278046.229877,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.23,
+        "timestamp": 1771278046.2299218,
         "stack_id": 31,
         "thread_id": "24803"
       },
       {
-        "timestamp": 1771278046.28,
+        "timestamp": 1771278046.2803156,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.331,
+        "timestamp": 1771278046.3308222,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.462,
+        "timestamp": 1771278046.4621394,
         "stack_id": 32,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278046.483,
+        "timestamp": 1771278046.4825423,
         "stack_id": 33,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.513,
+        "timestamp": 1771278046.5128262,
         "stack_id": 34,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278046.614,
+        "timestamp": 1771278046.6137938,
         "stack_id": 7,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.614,
+        "timestamp": 1771278046.6139276,
         "stack_id": 31,
         "thread_id": "24804"
       },
       {
-        "timestamp": 1771278046.664,
+        "timestamp": 1771278046.6643958,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.846,
+        "timestamp": 1771278046.8460248,
         "stack_id": 10,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278046.897,
+        "timestamp": 1771278046.8965824,
         "stack_id": 36,
         "thread_id": "24803"
       },
       {
-        "timestamp": 1771278046.917,
+        "timestamp": 1771278046.9166775,
         "stack_id": 35,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.048,
+        "timestamp": 1771278047.0483384,
         "stack_id": 37,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.149,
+        "timestamp": 1771278047.1492703,
         "stack_id": 38,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.2,
+        "timestamp": 1771278047.199614,
         "stack_id": 39,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.23,
+        "timestamp": 1771278047.2299235,
         "stack_id": 40,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.381,
+        "timestamp": 1771278047.381436,
         "stack_id": 41,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.432,
+        "timestamp": 1771278047.4319444,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.462,
+        "timestamp": 1771278047.4622607,
         "stack_id": 42,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278047.513,
+        "timestamp": 1771278047.5126357,
         "stack_id": 43,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.563,
+        "timestamp": 1771278047.5633042,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.664,
+        "timestamp": 1771278047.6644158,
         "stack_id": 44,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278047.715,
+        "timestamp": 1771278047.7148435,
         "stack_id": 46,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.765,
+        "timestamp": 1771278047.7651818,
         "stack_id": 4,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.795,
+        "timestamp": 1771278047.7954636,
         "stack_id": 45,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278047.816,
+        "timestamp": 1771278047.8156853,
         "stack_id": 47,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.846,
+        "timestamp": 1771278047.8460736,
         "stack_id": 8,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.866,
+        "timestamp": 1771278047.8661695,
         "stack_id": 48,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278047.947,
+        "timestamp": 1771278047.9472022,
         "stack_id": 0,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278048.129,
+        "timestamp": 1771278048.12904,
         "stack_id": 49,
         "thread_id": "24791"
       },
       {
-        "timestamp": 1771278048.2,
+        "timestamp": 1771278048.1996746,
         "stack_id": 50,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278048.25,
+        "timestamp": 1771278048.250255,
         "stack_id": 51,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278048.331,
+        "timestamp": 1771278048.331032,
         "stack_id": 52,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278048.483,
+        "timestamp": 1771278048.482544,
         "stack_id": 53,
         "thread_id": "24820"
       },
       {
-        "timestamp": 1771278048.513,
+        "timestamp": 1771278048.512983,
         "stack_id": 10,
         "thread_id": "24820"
       }

--- a/relay-profiling/src/sample/v2.rs
+++ b/relay-profiling/src/sample/v2.rs
@@ -58,13 +58,18 @@ impl relay_protocol::Getter for ProfileMetadata {
     }
 }
 
+/// Index of the stack in the `stacks` field of the profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StackId(pub usize);
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Sample {
     /// Unix timestamp in seconds with millisecond precision when the sample
     /// was captured.
     pub timestamp: FiniteF64,
     /// Index of the stack in the `stacks` field of the profile.
-    pub stack_id: usize,
+    pub stack_id: StackId,
     /// Thread or queue identifier
     pub thread_id: String,
 }
@@ -126,6 +131,10 @@ impl relay_protocol::Getter for ProfileChunk {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FrameId(pub usize);
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ProfileData {
     /// `samples` contains the list of samples referencing a stack and thread identifier.
@@ -134,7 +143,7 @@ pub struct ProfileData {
     pub samples: Vec<Sample>,
     /// `stacks` contains a list of stacks indicating the index of the frame in the `frames` field.
     /// We do this to not have to repeat frames in different stacks.
-    pub stacks: Vec<Vec<usize>>,
+    pub stacks: Vec<Vec<FrameId>>,
     /// `frames` contains a list of unique frames found in the profile.
     pub frames: Vec<Frame>,
 
@@ -224,7 +233,7 @@ impl ProfileData {
     fn all_stacks_referenced_by_samples_exist(&self) -> bool {
         self.samples
             .iter()
-            .all(|sample| self.stacks.get(sample.stack_id).is_some())
+            .all(|sample| self.stacks.get(sample.stack_id.0).is_some())
     }
 
     /// Checks that all frames referenced by the stacks exist in the frames.
@@ -232,7 +241,7 @@ impl ProfileData {
         self.stacks.iter().all(|stack| {
             stack
                 .iter()
-                .all(|frame_id| self.frames.get(*frame_id).is_some())
+                .all(|frame_id| self.frames.get(frame_id.0).is_some())
         })
     }
 
@@ -251,7 +260,7 @@ impl ProfileData {
         let mut sample_count_by_thread_id: hashbrown::HashMap<String, u32> = HashMap::new();
 
         for s in &self.samples {
-            if let Some(stack) = self.stacks.get(s.stack_id) {
+            if let Some(stack) = self.stacks.get(s.stack_id.0) {
                 // We only count non-idle samples
                 if stack.is_empty() {
                     continue;
@@ -291,17 +300,17 @@ mod tests {
         let mut chunk = ProfileData {
             samples: vec![
                 Sample {
-                    stack_id: 0,
+                    stack_id: StackId(0),
                     thread_id: "1".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 0,
+                    stack_id: StackId(0),
                     thread_id: "1".to_owned(),
                     timestamp: FiniteF64::new(30.0).unwrap(),
                 },
             ],
-            stacks: vec![vec![0]],
+            stacks: vec![vec![FrameId(0)]],
             frames: vec![Default::default()],
             ..Default::default()
         };
@@ -330,17 +339,17 @@ mod tests {
                 profile: ProfileData {
                     samples: vec![
                         Sample {
-                            stack_id: 0,
+                            stack_id: StackId(0),
                             thread_id: "1".into(),
                             timestamp: FiniteF64::new(30.0).unwrap(),
                         },
                         Sample {
-                            stack_id: 0,
+                            stack_id: StackId(0),
                             thread_id: "1".to_owned(),
                             timestamp: FiniteF64::new(60.0).unwrap(),
                         },
                     ],
-                    stacks: vec![vec![0]],
+                    stacks: vec![vec![FrameId(0)]],
                     frames: vec![Default::default()],
                     ..Default::default()
                 },
@@ -351,17 +360,17 @@ mod tests {
                 profile: ProfileData {
                     samples: vec![
                         Sample {
-                            stack_id: 0,
+                            stack_id: StackId(0),
                             thread_id: "1".into(),
                             timestamp: FiniteF64::new(10.0).unwrap(),
                         },
                         Sample {
-                            stack_id: 0,
+                            stack_id: StackId(0),
                             thread_id: "1".to_owned(),
                             timestamp: FiniteF64::new(80.0).unwrap(),
                         },
                     ],
-                    stacks: vec![vec![0]],
+                    stacks: vec![vec![FrameId(0)]],
                     frames: vec![Default::default()],
                     ..Default::default()
                 },
@@ -372,17 +381,17 @@ mod tests {
                 profile: ProfileData {
                     samples: vec![
                         Sample {
-                            stack_id: 0,
+                            stack_id: StackId(0),
                             thread_id: "1".into(),
                             timestamp: FiniteF64::new(50.0).unwrap(),
                         },
                         Sample {
-                            stack_id: 0,
+                            stack_id: StackId(0),
                             thread_id: "1".to_owned(),
                             timestamp: FiniteF64::new(20.0).unwrap(),
                         },
                     ],
-                    stacks: vec![vec![0]],
+                    stacks: vec![vec![FrameId(0)]],
                     frames: vec![Default::default()],
                     ..Default::default()
                 },
@@ -404,62 +413,62 @@ mod tests {
         let mut chunk = ProfileData {
             samples: vec![
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "1".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "1".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 0,
+                    stack_id: StackId(0),
                     thread_id: "1".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "1".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 0,
+                    stack_id: StackId(0),
                     thread_id: "2".to_owned(),
                     timestamp: FiniteF64::new(30.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "2".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "2".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 0,
+                    stack_id: StackId(0),
                     thread_id: "3".to_owned(),
                     timestamp: FiniteF64::new(30.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 0,
+                    stack_id: StackId(0),
                     thread_id: "3".to_owned(),
                     timestamp: FiniteF64::new(30.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "3".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
                 Sample {
-                    stack_id: 1,
+                    stack_id: StackId(1),
                     thread_id: "3".into(),
                     timestamp: FiniteF64::new(60.0).unwrap(),
                 },
             ],
-            stacks: vec![vec![0], vec![]],
+            stacks: vec![vec![FrameId(0)], vec![]],
             frames: vec![Default::default()],
             ..Default::default()
         };

--- a/tests/integration/fixtures/profile_chunks_perfetto/profile_chunk.output.json
+++ b/tests/integration/fixtures/profile_chunks_perfetto/profile_chunk.output.json
@@ -2560,1992 +2560,1992 @@
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358020.894
+        "timestamp": 1777358020.8943977
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358020.894
+        "timestamp": 1777358020.8944435
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358020.904
+        "timestamp": 1777358020.9043984
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358020.904
+        "timestamp": 1777358020.9044409
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358020.914
+        "timestamp": 1777358020.9144037
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358020.914
+        "timestamp": 1777358020.914439
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358020.924
+        "timestamp": 1777358020.9243946
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358020.924
+        "timestamp": 1777358020.9244382
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358020.934
+        "timestamp": 1777358020.9344335
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358020.934
+        "timestamp": 1777358020.9344437
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358020.944
+        "timestamp": 1777358020.9444017
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358020.944
+        "timestamp": 1777358020.9444385
       },
       {
         "stack_id": 5,
         "thread_id": "14935",
-        "timestamp": 1777358020.954
+        "timestamp": 1777358020.954342
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358020.954
+        "timestamp": 1777358020.9543965
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358020.954
+        "timestamp": 1777358020.954441
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358020.964
+        "timestamp": 1777358020.964399
       },
       {
         "stack_id": 10,
         "thread_id": "14997",
-        "timestamp": 1777358020.964
+        "timestamp": 1777358020.9644418
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358020.974
+        "timestamp": 1777358020.9743946
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358020.974
+        "timestamp": 1777358020.974439
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358020.984
+        "timestamp": 1777358020.9844089
       },
       {
         "stack_id": 8,
         "thread_id": "14926",
-        "timestamp": 1777358020.984
+        "timestamp": 1777358020.9844537
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358020.984
+        "timestamp": 1777358020.9844635
       },
       {
         "stack_id": 7,
         "thread_id": "14996",
-        "timestamp": 1777358020.994
+        "timestamp": 1777358020.9943948
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358020.994
+        "timestamp": 1777358020.9944406
       },
       {
         "stack_id": 6,
         "thread_id": "14941",
-        "timestamp": 1777358021.004
+        "timestamp": 1777358021.0043387
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.004
+        "timestamp": 1777358021.0044177
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.004
+        "timestamp": 1777358021.0044584
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.014
+        "timestamp": 1777358021.0143964
       },
       {
         "stack_id": 9,
         "thread_id": "14935",
-        "timestamp": 1777358021.014
+        "timestamp": 1777358021.0144925
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.015
+        "timestamp": 1777358021.0145397
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.024
+        "timestamp": 1777358021.024396
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.024
+        "timestamp": 1777358021.0244415
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358021.034
+        "timestamp": 1777358021.0344083
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358021.034
+        "timestamp": 1777358021.0344503
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.044
+        "timestamp": 1777358021.044398
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.044
+        "timestamp": 1777358021.0444531
       },
       {
         "stack_id": 11,
         "thread_id": "14941",
-        "timestamp": 1777358021.054
+        "timestamp": 1777358021.0543413
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.054
+        "timestamp": 1777358021.0543973
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.054
+        "timestamp": 1777358021.0544953
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.064
+        "timestamp": 1777358021.0643957
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.064
+        "timestamp": 1777358021.064445
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.074
+        "timestamp": 1777358021.0743992
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.074
+        "timestamp": 1777358021.074439
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.084
+        "timestamp": 1777358021.0843961
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.084
+        "timestamp": 1777358021.0844395
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.094
+        "timestamp": 1777358021.0943975
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.094
+        "timestamp": 1777358021.0944383
       },
       {
         "stack_id": 12,
         "thread_id": "14941",
-        "timestamp": 1777358021.104
+        "timestamp": 1777358021.1043396
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.104
+        "timestamp": 1777358021.1044202
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.104
+        "timestamp": 1777358021.1044674
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.114
+        "timestamp": 1777358021.114394
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.114
+        "timestamp": 1777358021.1144407
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.124
+        "timestamp": 1777358021.124396
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.124
+        "timestamp": 1777358021.1244671
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.134
+        "timestamp": 1777358021.1344054
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.134
+        "timestamp": 1777358021.1344588
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.144
+        "timestamp": 1777358021.1443977
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.144
+        "timestamp": 1777358021.1444383
       },
       {
         "stack_id": 14,
         "thread_id": "14941",
-        "timestamp": 1777358021.154
+        "timestamp": 1777358021.1543424
       },
       {
         "stack_id": 16,
         "thread_id": "14996",
-        "timestamp": 1777358021.154
+        "timestamp": 1777358021.1544182
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.154
+        "timestamp": 1777358021.1544757
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.164
+        "timestamp": 1777358021.164394
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.164
+        "timestamp": 1777358021.164495
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.174
+        "timestamp": 1777358021.1743963
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.174
+        "timestamp": 1777358021.174439
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358021.184
+        "timestamp": 1777358021.1844013
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.184
+        "timestamp": 1777358021.1844516
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.194
+        "timestamp": 1777358021.1943977
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.194
+        "timestamp": 1777358021.1944382
       },
       {
         "stack_id": 15,
         "thread_id": "14941",
-        "timestamp": 1777358021.204
+        "timestamp": 1777358021.2043397
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.205
+        "timestamp": 1777358021.204542
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.205
+        "timestamp": 1777358021.2045538
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.214
+        "timestamp": 1777358021.214394
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.214
+        "timestamp": 1777358021.214439
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.224
+        "timestamp": 1777358021.2243943
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.224
+        "timestamp": 1777358021.2244387
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358021.234
+        "timestamp": 1777358021.2343943
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.234
+        "timestamp": 1777358021.2344434
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.244
+        "timestamp": 1777358021.2443972
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.244
+        "timestamp": 1777358021.2444384
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.254
+        "timestamp": 1777358021.2544148
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.254
+        "timestamp": 1777358021.2544413
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.264
+        "timestamp": 1777358021.2643955
       },
       {
         "stack_id": 18,
         "thread_id": "14997",
-        "timestamp": 1777358021.264
+        "timestamp": 1777358021.2644382
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.274
+        "timestamp": 1777358021.274395
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.274
+        "timestamp": 1777358021.2744415
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.284
+        "timestamp": 1777358021.2843964
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.284
+        "timestamp": 1777358021.2844381
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.294
+        "timestamp": 1777358021.2943943
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.294
+        "timestamp": 1777358021.2944403
       },
       {
         "stack_id": 12,
         "thread_id": "14941",
-        "timestamp": 1777358021.304
+        "timestamp": 1777358021.3043444
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.304
+        "timestamp": 1777358021.3044178
       },
       {
         "stack_id": 16,
         "thread_id": "14997",
-        "timestamp": 1777358021.304
+        "timestamp": 1777358021.3044655
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.314
+        "timestamp": 1777358021.3143945
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.314
+        "timestamp": 1777358021.3144383
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.324
+        "timestamp": 1777358021.3244119
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.324
+        "timestamp": 1777358021.324438
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.334
+        "timestamp": 1777358021.334401
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.334
+        "timestamp": 1777358021.3344455
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.344
+        "timestamp": 1777358021.344395
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.344
+        "timestamp": 1777358021.3444393
       },
       {
         "stack_id": 12,
         "thread_id": "14941",
-        "timestamp": 1777358021.354
+        "timestamp": 1777358021.3543422
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.354
+        "timestamp": 1777358021.3544078
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.354
+        "timestamp": 1777358021.354471
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.364
+        "timestamp": 1777358021.364394
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.364
+        "timestamp": 1777358021.364478
       },
       {
         "stack_id": 18,
         "thread_id": "14996",
-        "timestamp": 1777358021.374
+        "timestamp": 1777358021.3743973
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.374
+        "timestamp": 1777358021.3744395
       },
       {
         "stack_id": 19,
         "thread_id": "14926",
-        "timestamp": 1777358021.384
+        "timestamp": 1777358021.3843417
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.384
+        "timestamp": 1777358021.384395
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.384
+        "timestamp": 1777358021.3844385
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358021.394
+        "timestamp": 1777358021.394395
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.394
+        "timestamp": 1777358021.3944383
       },
       {
         "stack_id": 20,
         "thread_id": "14941",
-        "timestamp": 1777358021.404
+        "timestamp": 1777358021.4043465
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.404
+        "timestamp": 1777358021.4044266
       },
       {
         "stack_id": 21,
         "thread_id": "14997",
-        "timestamp": 1777358021.404
+        "timestamp": 1777358021.4044678
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.414
+        "timestamp": 1777358021.4143984
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.414
+        "timestamp": 1777358021.414442
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.424
+        "timestamp": 1777358021.4243948
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.424
+        "timestamp": 1777358021.4244473
       },
       {
         "stack_id": 7,
         "thread_id": "14996",
-        "timestamp": 1777358021.434
+        "timestamp": 1777358021.4343946
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.434
+        "timestamp": 1777358021.434441
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.444
+        "timestamp": 1777358021.4443965
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.444
+        "timestamp": 1777358021.4444396
       },
       {
         "stack_id": 22,
         "thread_id": "14941",
-        "timestamp": 1777358021.454
+        "timestamp": 1777358021.454374
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.454
+        "timestamp": 1777358021.454403
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.454
+        "timestamp": 1777358021.4544525
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.464
+        "timestamp": 1777358021.464395
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.464
+        "timestamp": 1777358021.464447
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.474
+        "timestamp": 1777358021.4743946
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.474
+        "timestamp": 1777358021.4744384
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.484
+        "timestamp": 1777358021.4843943
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.484
+        "timestamp": 1777358021.4844387
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.494
+        "timestamp": 1777358021.494394
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.494
+        "timestamp": 1777358021.4944384
       },
       {
         "stack_id": 23,
         "thread_id": "14941",
-        "timestamp": 1777358021.504
+        "timestamp": 1777358021.5043392
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358021.504
+        "timestamp": 1777358021.504418
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.504
+        "timestamp": 1777358021.5044792
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.514
+        "timestamp": 1777358021.5143948
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.514
+        "timestamp": 1777358021.5144408
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.524
+        "timestamp": 1777358021.5243983
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.524
+        "timestamp": 1777358021.5244536
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.534
+        "timestamp": 1777358021.534395
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358021.534
+        "timestamp": 1777358021.5344388
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.544
+        "timestamp": 1777358021.5443945
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.544
+        "timestamp": 1777358021.5444386
       },
       {
         "stack_id": 24,
         "thread_id": "14941",
-        "timestamp": 1777358021.554
+        "timestamp": 1777358021.5543401
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.554
+        "timestamp": 1777358021.5544379
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.554
+        "timestamp": 1777358021.5544815
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.564
+        "timestamp": 1777358021.5643938
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.564
+        "timestamp": 1777358021.5644379
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.574
+        "timestamp": 1777358021.5743966
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.574
+        "timestamp": 1777358021.5744388
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.584
+        "timestamp": 1777358021.5843978
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.584
+        "timestamp": 1777358021.5844383
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.594
+        "timestamp": 1777358021.5943973
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.594
+        "timestamp": 1777358021.5944388
       },
       {
         "stack_id": 25,
         "thread_id": "14941",
-        "timestamp": 1777358021.604
+        "timestamp": 1777358021.604339
       },
       {
         "stack_id": 16,
         "thread_id": "14996",
-        "timestamp": 1777358021.604
+        "timestamp": 1777358021.6044004
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.604
+        "timestamp": 1777358021.6044986
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.614
+        "timestamp": 1777358021.614394
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.614
+        "timestamp": 1777358021.6144378
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358021.624
+        "timestamp": 1777358021.6243951
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.624
+        "timestamp": 1777358021.62445
       },
       {
         "stack_id": 26,
         "thread_id": "14926",
-        "timestamp": 1777358021.634
+        "timestamp": 1777358021.6343396
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.634
+        "timestamp": 1777358021.6343968
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.634
+        "timestamp": 1777358021.6344395
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.644
+        "timestamp": 1777358021.6443942
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.644
+        "timestamp": 1777358021.64444
       },
       {
         "stack_id": 27,
         "thread_id": "14941",
-        "timestamp": 1777358021.654
+        "timestamp": 1777358021.6543405
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.654
+        "timestamp": 1777358021.6544013
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.654
+        "timestamp": 1777358021.6544418
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.664
+        "timestamp": 1777358021.6643941
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.664
+        "timestamp": 1777358021.6644413
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.674
+        "timestamp": 1777358021.6744003
       },
       {
         "stack_id": 29,
         "thread_id": "14997",
-        "timestamp": 1777358021.674
+        "timestamp": 1777358021.6744385
       },
       {
         "stack_id": 28,
         "thread_id": "14996",
-        "timestamp": 1777358021.684
+        "timestamp": 1777358021.6843982
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.684
+        "timestamp": 1777358021.6844401
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.694
+        "timestamp": 1777358021.694394
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.694
+        "timestamp": 1777358021.694439
       },
       {
         "stack_id": 20,
         "thread_id": "14941",
-        "timestamp": 1777358021.704
+        "timestamp": 1777358021.7043483
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358021.704
+        "timestamp": 1777358021.7043977
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.704
+        "timestamp": 1777358021.7044744
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.714
+        "timestamp": 1777358021.714397
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.714
+        "timestamp": 1777358021.7144382
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.724
+        "timestamp": 1777358021.724396
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.724
+        "timestamp": 1777358021.724442
       },
       {
         "stack_id": 30,
         "thread_id": "14926",
-        "timestamp": 1777358021.734
+        "timestamp": 1777358021.7343407
       },
       {
         "stack_id": 29,
         "thread_id": "14996",
-        "timestamp": 1777358021.734
+        "timestamp": 1777358021.7344003
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.734
+        "timestamp": 1777358021.734442
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.744
+        "timestamp": 1777358021.744395
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.744
+        "timestamp": 1777358021.7444384
       },
       {
         "stack_id": 31,
         "thread_id": "14941",
-        "timestamp": 1777358021.754
+        "timestamp": 1777358021.7543387
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.754
+        "timestamp": 1777358021.754419
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358021.754
+        "timestamp": 1777358021.754468
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358021.764
+        "timestamp": 1777358021.7643948
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.764
+        "timestamp": 1777358021.7644415
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358021.774
+        "timestamp": 1777358021.774397
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.774
+        "timestamp": 1777358021.7744842
       },
       {
         "stack_id": 21,
         "thread_id": "14996",
-        "timestamp": 1777358021.784
+        "timestamp": 1777358021.7843943
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.784
+        "timestamp": 1777358021.7844431
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.794
+        "timestamp": 1777358021.7943943
       },
       {
         "stack_id": 16,
         "thread_id": "14997",
-        "timestamp": 1777358021.794
+        "timestamp": 1777358021.7944396
       },
       {
         "stack_id": 6,
         "thread_id": "14941",
-        "timestamp": 1777358021.804
+        "timestamp": 1777358021.804339
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.804
+        "timestamp": 1777358021.8044078
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.804
+        "timestamp": 1777358021.8044393
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.814
+        "timestamp": 1777358021.8143952
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.814
+        "timestamp": 1777358021.81444
       },
       {
         "stack_id": 16,
         "thread_id": "14996",
-        "timestamp": 1777358021.824
+        "timestamp": 1777358021.824395
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.824
+        "timestamp": 1777358021.8244526
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358021.834
+        "timestamp": 1777358021.8343952
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.834
+        "timestamp": 1777358021.8344388
       },
       {
         "stack_id": 7,
         "thread_id": "14996",
-        "timestamp": 1777358021.844
+        "timestamp": 1777358021.8443944
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358021.844
+        "timestamp": 1777358021.8444383
       },
       {
         "stack_id": 32,
         "thread_id": "14941",
-        "timestamp": 1777358021.854
+        "timestamp": 1777358021.8543391
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.854
+        "timestamp": 1777358021.854402
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.854
+        "timestamp": 1777358021.8544874
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.864
+        "timestamp": 1777358021.8643951
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.864
+        "timestamp": 1777358021.864472
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.874
+        "timestamp": 1777358021.8743951
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.874
+        "timestamp": 1777358021.8744407
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.884
+        "timestamp": 1777358021.8844266
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.885
+        "timestamp": 1777358021.884536
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.894
+        "timestamp": 1777358021.8944197
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.894
+        "timestamp": 1777358021.8944454
       },
       {
         "stack_id": 33,
         "thread_id": "14941",
-        "timestamp": 1777358021.904
+        "timestamp": 1777358021.904341
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.904
+        "timestamp": 1777358021.9044135
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.904
+        "timestamp": 1777358021.9044383
       },
       {
         "stack_id": 29,
         "thread_id": "14996",
-        "timestamp": 1777358021.914
+        "timestamp": 1777358021.9143956
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358021.914
+        "timestamp": 1777358021.91444
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.924
+        "timestamp": 1777358021.9243982
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.924
+        "timestamp": 1777358021.9244564
       },
       {
         "stack_id": 34,
         "thread_id": "14926",
-        "timestamp": 1777358021.934
+        "timestamp": 1777358021.934339
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.934
+        "timestamp": 1777358021.9343956
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.934
+        "timestamp": 1777358021.9344392
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358021.944
+        "timestamp": 1777358021.9443953
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358021.944
+        "timestamp": 1777358021.9444432
       },
       {
         "stack_id": 35,
         "thread_id": "14941",
-        "timestamp": 1777358021.954
+        "timestamp": 1777358021.9543407
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.954
+        "timestamp": 1777358021.9543953
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358021.954
+        "timestamp": 1777358021.9544942
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358021.964
+        "timestamp": 1777358021.964399
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.964
+        "timestamp": 1777358021.9644392
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358021.974
+        "timestamp": 1777358021.9743953
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358021.974
+        "timestamp": 1777358021.97448
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358021.984
+        "timestamp": 1777358021.9844055
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358021.984
+        "timestamp": 1777358021.9844387
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358021.994
+        "timestamp": 1777358021.9943936
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358021.994
+        "timestamp": 1777358021.9944384
       },
       {
         "stack_id": 36,
         "thread_id": "14941",
-        "timestamp": 1777358022.004
+        "timestamp": 1777358022.0043414
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.004
+        "timestamp": 1777358022.0044038
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.004
+        "timestamp": 1777358022.0044432
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.014
+        "timestamp": 1777358022.0144007
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.014
+        "timestamp": 1777358022.0144389
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.024
+        "timestamp": 1777358022.0243955
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.024
+        "timestamp": 1777358022.024438
       },
       {
         "stack_id": 16,
         "thread_id": "14996",
-        "timestamp": 1777358022.034
+        "timestamp": 1777358022.0343971
       },
       {
         "stack_id": 16,
         "thread_id": "14997",
-        "timestamp": 1777358022.034
+        "timestamp": 1777358022.0344732
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.044
+        "timestamp": 1777358022.0443952
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358022.044
+        "timestamp": 1777358022.0444393
       },
       {
         "stack_id": 37,
         "thread_id": "14941",
-        "timestamp": 1777358022.054
+        "timestamp": 1777358022.0543406
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.054
+        "timestamp": 1777358022.0543993
       },
       {
         "stack_id": 29,
         "thread_id": "14997",
-        "timestamp": 1777358022.054
+        "timestamp": 1777358022.054441
       },
       {
         "stack_id": 10,
         "thread_id": "14996",
-        "timestamp": 1777358022.064
+        "timestamp": 1777358022.0644028
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.064
+        "timestamp": 1777358022.0644464
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.074
+        "timestamp": 1777358022.074439
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.074
+        "timestamp": 1777358022.0744932
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.084
+        "timestamp": 1777358022.084399
       },
       {
         "stack_id": 16,
         "thread_id": "14997",
-        "timestamp": 1777358022.084
+        "timestamp": 1777358022.0844386
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.094
+        "timestamp": 1777358022.0943947
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.094
+        "timestamp": 1777358022.0944383
       },
       {
         "stack_id": 12,
         "thread_id": "14941",
-        "timestamp": 1777358022.104
+        "timestamp": 1777358022.1043408
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.104
+        "timestamp": 1777358022.104418
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.104
+        "timestamp": 1777358022.104487
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.114
+        "timestamp": 1777358022.1144154
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.114
+        "timestamp": 1777358022.1144834
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.124
+        "timestamp": 1777358022.1243968
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.124
+        "timestamp": 1777358022.1244504
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.134
+        "timestamp": 1777358022.1343954
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.134
+        "timestamp": 1777358022.1344404
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358022.144
+        "timestamp": 1777358022.144397
       },
       {
         "stack_id": 10,
         "thread_id": "14997",
-        "timestamp": 1777358022.144
+        "timestamp": 1777358022.144439
       },
       {
         "stack_id": 38,
         "thread_id": "14941",
-        "timestamp": 1777358022.154
+        "timestamp": 1777358022.1543381
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.154
+        "timestamp": 1777358022.1544144
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.154
+        "timestamp": 1777358022.1544564
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.164
+        "timestamp": 1777358022.1643968
       },
       {
         "stack_id": 16,
         "thread_id": "14997",
-        "timestamp": 1777358022.164
+        "timestamp": 1777358022.164447
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.174
+        "timestamp": 1777358022.1743965
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.174
+        "timestamp": 1777358022.1744761
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.184
+        "timestamp": 1777358022.1844058
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.184
+        "timestamp": 1777358022.1844387
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.194
+        "timestamp": 1777358022.1943944
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.194
+        "timestamp": 1777358022.194481
       },
       {
         "stack_id": 14,
         "thread_id": "14941",
-        "timestamp": 1777358022.204
+        "timestamp": 1777358022.204342
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.204
+        "timestamp": 1777358022.204411
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358022.204
+        "timestamp": 1777358022.2044756
       },
       {
         "stack_id": 21,
         "thread_id": "14996",
-        "timestamp": 1777358022.214
+        "timestamp": 1777358022.2143977
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358022.214
+        "timestamp": 1777358022.2144382
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.224
+        "timestamp": 1777358022.2244089
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358022.224
+        "timestamp": 1777358022.2244375
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.234
+        "timestamp": 1777358022.2344089
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.234
+        "timestamp": 1777358022.2344425
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.244
+        "timestamp": 1777358022.2443945
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.244
+        "timestamp": 1777358022.244445
       },
       {
         "stack_id": 35,
         "thread_id": "14941",
-        "timestamp": 1777358022.254
+        "timestamp": 1777358022.254338
       },
       {
         "stack_id": 29,
         "thread_id": "14996",
-        "timestamp": 1777358022.254
+        "timestamp": 1777358022.2543967
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.254
+        "timestamp": 1777358022.2544825
       },
       {
         "stack_id": 7,
         "thread_id": "14996",
-        "timestamp": 1777358022.264
+        "timestamp": 1777358022.264394
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.264
+        "timestamp": 1777358022.2644396
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358022.274
+        "timestamp": 1777358022.2743971
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358022.274
+        "timestamp": 1777358022.2744386
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.284
+        "timestamp": 1777358022.284396
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.285
+        "timestamp": 1777358022.2845259
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.294
+        "timestamp": 1777358022.2943943
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.294
+        "timestamp": 1777358022.2944386
       },
       {
         "stack_id": 22,
         "thread_id": "14941",
-        "timestamp": 1777358022.304
+        "timestamp": 1777358022.3043385
       },
       {
         "stack_id": 7,
         "thread_id": "14996",
-        "timestamp": 1777358022.304
+        "timestamp": 1777358022.3044174
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.304
+        "timestamp": 1777358022.3044398
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358022.314
+        "timestamp": 1777358022.3143942
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358022.314
+        "timestamp": 1777358022.3144379
       },
       {
         "stack_id": 16,
         "thread_id": "14996",
-        "timestamp": 1777358022.324
+        "timestamp": 1777358022.324395
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.324
+        "timestamp": 1777358022.3244412
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.334
+        "timestamp": 1777358022.3343978
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.334
+        "timestamp": 1777358022.3344417
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.344
+        "timestamp": 1777358022.3443935
       },
       {
         "stack_id": 1,
         "thread_id": "14997",
-        "timestamp": 1777358022.344
+        "timestamp": 1777358022.3444376
       },
       {
         "stack_id": 40,
         "thread_id": "14941",
-        "timestamp": 1777358022.354
+        "timestamp": 1777358022.3543403
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.354
+        "timestamp": 1777358022.3544025
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358022.354
+        "timestamp": 1777358022.3544579
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.364
+        "timestamp": 1777358022.3643937
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.364
+        "timestamp": 1777358022.3644457
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.374
+        "timestamp": 1777358022.3743937
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.374
+        "timestamp": 1777358022.374439
       },
       {
         "stack_id": 1,
         "thread_id": "14996",
-        "timestamp": 1777358022.384
+        "timestamp": 1777358022.3843946
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.384
+        "timestamp": 1777358022.3844385
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.394
+        "timestamp": 1777358022.3943937
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358022.394
+        "timestamp": 1777358022.394438
       },
       {
         "stack_id": 14,
         "thread_id": "14941",
-        "timestamp": 1777358022.404
+        "timestamp": 1777358022.4043434
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.404
+        "timestamp": 1777358022.4044044
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.404
+        "timestamp": 1777358022.4044468
       },
       {
         "stack_id": 7,
         "thread_id": "14996",
-        "timestamp": 1777358022.414
+        "timestamp": 1777358022.414394
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.414
+        "timestamp": 1777358022.4144385
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.424
+        "timestamp": 1777358022.4243953
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358022.424
+        "timestamp": 1777358022.4244516
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.434
+        "timestamp": 1777358022.4344056
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.434
+        "timestamp": 1777358022.4344385
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.444
+        "timestamp": 1777358022.444394
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.444
+        "timestamp": 1777358022.444438
       },
       {
         "stack_id": 20,
         "thread_id": "14941",
-        "timestamp": 1777358022.454
+        "timestamp": 1777358022.4543388
       },
       {
         "stack_id": 42,
         "thread_id": "14996",
-        "timestamp": 1777358022.454
+        "timestamp": 1777358022.4544706
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.455
+        "timestamp": 1777358022.4545388
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358022.464
+        "timestamp": 1777358022.464396
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.464
+        "timestamp": 1777358022.4644518
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.474
+        "timestamp": 1777358022.4743984
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.474
+        "timestamp": 1777358022.4744422
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.484
+        "timestamp": 1777358022.4843948
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.484
+        "timestamp": 1777358022.484441
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.494
+        "timestamp": 1777358022.4943938
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358022.494
+        "timestamp": 1777358022.4944377
       },
       {
         "stack_id": 41,
         "thread_id": "14941",
-        "timestamp": 1777358022.504
+        "timestamp": 1777358022.504341
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.504
+        "timestamp": 1777358022.504435
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358022.505
+        "timestamp": 1777358022.5045903
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.514
+        "timestamp": 1777358022.5144
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.514
+        "timestamp": 1777358022.514439
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.524
+        "timestamp": 1777358022.5243955
       },
       {
         "stack_id": 3,
         "thread_id": "14997",
-        "timestamp": 1777358022.524
+        "timestamp": 1777358022.524454
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.534
+        "timestamp": 1777358022.5343993
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.534
+        "timestamp": 1777358022.5344396
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358022.544
+        "timestamp": 1777358022.544394
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.544
+        "timestamp": 1777358022.544438
       },
       {
         "stack_id": 35,
         "thread_id": "14941",
-        "timestamp": 1777358022.554
+        "timestamp": 1777358022.5543406
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.554
+        "timestamp": 1777358022.5544221
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.554
+        "timestamp": 1777358022.55444
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.564
+        "timestamp": 1777358022.5643969
       },
       {
         "stack_id": 44,
         "thread_id": "14908",
-        "timestamp": 1777358022.564
+        "timestamp": 1777358022.56444
       },
       {
         "stack_id": 13,
         "thread_id": "14997",
-        "timestamp": 1777358022.564
+        "timestamp": 1777358022.5644457
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358022.574
+        "timestamp": 1777358022.574399
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358022.574
+        "timestamp": 1777358022.5744393
       },
       {
         "stack_id": 43,
         "thread_id": "14926",
-        "timestamp": 1777358022.584
+        "timestamp": 1777358022.584342
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.584
+        "timestamp": 1777358022.5844004
       },
       {
         "stack_id": 45,
         "thread_id": "14941",
-        "timestamp": 1777358022.584
+        "timestamp": 1777358022.5844593
       },
       {
         "stack_id": 2,
         "thread_id": "14997",
-        "timestamp": 1777358022.584
+        "timestamp": 1777358022.5844905
       },
       {
         "stack_id": 2,
         "thread_id": "14996",
-        "timestamp": 1777358022.594
+        "timestamp": 1777358022.594394
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.594
+        "timestamp": 1777358022.5944386
       },
       {
         "stack_id": 16,
         "thread_id": "14996",
-        "timestamp": 1777358022.604
+        "timestamp": 1777358022.6043954
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.604
+        "timestamp": 1777358022.6044438
       },
       {
         "stack_id": 13,
         "thread_id": "14996",
-        "timestamp": 1777358022.614
+        "timestamp": 1777358022.6143932
       },
       {
         "stack_id": 4,
         "thread_id": "14997",
-        "timestamp": 1777358022.614
+        "timestamp": 1777358022.6144407
       },
       {
         "stack_id": 4,
         "thread_id": "14996",
-        "timestamp": 1777358022.624
+        "timestamp": 1777358022.624396
       },
       {
         "stack_id": 7,
         "thread_id": "14997",
-        "timestamp": 1777358022.624
+        "timestamp": 1777358022.6244411
       },
       {
         "stack_id": 46,
         "thread_id": "14941",
-        "timestamp": 1777358022.634
+        "timestamp": 1777358022.6343393
       },
       {
         "stack_id": 3,
         "thread_id": "14996",
-        "timestamp": 1777358022.634
+        "timestamp": 1777358022.634405
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.634
+        "timestamp": 1777358022.63444
       },
       {
         "stack_id": 0,
         "thread_id": "14996",
-        "timestamp": 1777358022.644
+        "timestamp": 1777358022.6443942
       },
       {
         "stack_id": 0,
         "thread_id": "14997",
-        "timestamp": 1777358022.644
+        "timestamp": 1777358022.6444383
       },
       {
         "stack_id": 50,
         "thread_id": "14941",
-        "timestamp": 1777358022.654
+        "timestamp": 1777358022.6544437
       },
       {
         "stack_id": 48,
         "thread_id": "14908",
-        "timestamp": 1777358022.684
+        "timestamp": 1777358022.6843688
       },
       {
         "stack_id": 51,
         "thread_id": "14941",
-        "timestamp": 1777358022.734
+        "timestamp": 1777358022.7344232
       },
       {
         "stack_id": 14,
         "thread_id": "14941",
-        "timestamp": 1777358022.854
+        "timestamp": 1777358022.8544257
       }
     ],
     "stacks": [


### PR DESCRIPTION
No (or very minimal) functional changes intended.

- Better de-duplication, slightly more efficient through `HashTable` use for images, frames and stacks, instead of just frames.
- Slightly less allocations, again through `HashTable` referencing strings already allocated elsewhere.
- Introduction of `build`er types, used to build up our own sample format.
- Introduction of `cache` types, used just to cache data for a single sequence id
- `InternTables` is no longer also abused for caches.
- More modules to have proper type visibility, important for a follow-up to introduce better/stricter limits.
- Rework of most of the Rust code to actually make it Rusty not Codex Rust.
- Introduces a `StackId` and `FrameId` new-type wrapper instead of passing indices around, may prevent a bug at some point.
- Removes a bunch of useless extra intermediate types (like `ResolvedFrame`)
- Also happens to fix the precision for some timestamps, less precision loss (even if ms precision is enough).
- Caches are retained until there is a clear flag, instead of always clearing.

And yes there are some off-by-ones when it comes to the limits, they don't matter, if it messes with someone's OCD, I can fix them.