### PR TITLE
fix(limits): Enforce size limits consistently for all enevelope items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - No longer write the deprecated `sentry.transaction` and `db.system` attributes. ([#6237](https://github.com/getsentry/relay/pull/6237), [#6238](https://github.com/getsentry/relay/pull/6238))
 - Allow additional exceptions in minidump and apple crash report events. ([#6241](https://github.com/getsentry/relay/pull/6241))
 
+**Bug Fixes**:
+
+- Consistently enforces envelope size limits for all items. ([#6250](https://github.com/getsentry/relay/pull/6250))
+
 ## 26.7.0
 
 **Features**:

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -615,16 +615,22 @@ pub struct Limits {
     pub max_event_size: ByteSize,
     /// The maximum size for each attachment.
     pub max_attachment_size: ByteSize,
-    /// The maximum size for a TUS upload request body.
-    pub max_upload_size: ByteSize,
+    /// The maximum amount of attachments in a single envelope.
+    pub max_attachment_count: usize,
     /// The maximum combined size for all attachments in an envelope or request.
     pub max_attachments_size: ByteSize,
+    /// The maximum size for a TUS upload request body.
+    pub max_upload_size: ByteSize,
     /// The maximum combined size for all client reports in an envelope or request.
     pub max_client_reports_size: ByteSize,
+    /// The maximum number of client report items per envelope.
+    pub max_client_reports_count: usize,
     /// The maximum payload size for a monitor check-in.
     pub max_check_in_size: ByteSize,
     /// The maximum payload size for an entire envelopes. Individual limits still apply.
     pub max_envelope_size: ByteSize,
+    /// Returns the maximum combined size all sessions per envelope in bytes.
+    pub max_sessions_size: ByteSize,
     /// The maximum number of session items per envelope.
     pub max_session_count: usize,
     /// The maximum payload size for general API requests.
@@ -641,6 +647,8 @@ pub struct Limits {
     pub max_log_size: ByteSize,
     /// The maximum payload size for a span.
     pub max_span_size: ByteSize,
+    /// The maximum amount of standalone transaction spans per envelope.
+    pub max_standalone_span_count: usize,
     /// The maximum payload size for an item container.
     pub max_container_size: ByteSize,
     /// The maximum payload size for a statsd metric.
@@ -716,11 +724,14 @@ impl Default for Limits {
             max_concurrent_queries: 5,
             max_event_size: ByteSize::mebibytes(1),
             max_attachment_size: ByteSize::mebibytes(200),
-            max_upload_size: ByteSize::mebibytes(1024),
+            max_attachment_count: 30,
             max_attachments_size: ByteSize::mebibytes(200),
-            max_client_reports_size: ByteSize::kibibytes(4),
+            max_upload_size: ByteSize::mebibytes(1024),
+            max_client_reports_size: ByteSize::kibibytes(100),
+            max_client_reports_count: 100,
             max_check_in_size: ByteSize::kibibytes(100),
             max_envelope_size: ByteSize::mebibytes(200),
+            max_sessions_size: ByteSize::mebibytes(10),
             max_session_count: 100,
             max_api_payload_size: ByteSize::mebibytes(20),
             max_api_file_upload_size: ByteSize::mebibytes(40),
@@ -729,6 +740,7 @@ impl Default for Limits {
             max_trace_metric_size: ByteSize::mebibytes(1),
             max_log_size: ByteSize::mebibytes(1),
             max_span_size: ByteSize::mebibytes(10),
+            max_standalone_span_count: 25,
             max_container_size: ByteSize::mebibytes(12),
             max_statsd_size: ByteSize::mebibytes(1),
             max_metric_buckets_size: ByteSize::mebibytes(1),
@@ -2386,15 +2398,25 @@ impl Config {
         self.values.limits.max_attachment_size.as_bytes()
     }
 
-    /// Returns the maximum size of a TUS upload request body.
-    pub fn max_upload_size(&self) -> usize {
-        self.values.limits.max_upload_size.as_bytes()
+    /// The maximum amount of attachments in a single envelope.
+    pub fn max_attachment_count(&self) -> usize {
+        self.values.limits.max_attachment_count
     }
 
     /// Returns the maximum combined size of attachments or payloads containing attachments
     /// (minidump, unreal, standalone attachments) in bytes.
     pub fn max_attachments_size(&self) -> usize {
         self.values.limits.max_attachments_size.as_bytes()
+    }
+
+    /// Returns the maximum size of a TUS upload request body.
+    pub fn max_upload_size(&self) -> usize {
+        self.values.limits.max_upload_size.as_bytes()
+    }
+
+    /// Returns the maximum number of client reports per envelope.
+    pub fn max_client_reports_count(&self) -> usize {
+        self.values.limits.max_client_reports_count
     }
 
     /// Returns the maximum combined size of client reports in bytes.
@@ -2417,21 +2439,14 @@ impl Config {
         self.values.limits.max_span_size.as_bytes()
     }
 
+    /// Returns the maximum amount of standalone transaction spans per envelope.
+    pub fn max_standalone_span_count(&self) -> usize {
+        self.values.limits.max_standalone_span_count
+    }
+
     /// Returns the maximum payload size of an item container in bytes.
     pub fn max_container_size(&self) -> usize {
         self.values.limits.max_container_size.as_bytes()
-    }
-
-    /// Returns the maximum payload size for logs integration items in bytes.
-    pub fn max_logs_integration_size(&self) -> usize {
-        // Not explicitly configured, inherited from the maximum size of a log container.
-        self.max_container_size()
-    }
-
-    /// Returns the maximum payload size for spans integration items in bytes.
-    pub fn max_spans_integration_size(&self) -> usize {
-        // Not explicitly configured, inherited from the maximum size of a span container.
-        self.max_container_size()
     }
 
     /// Returns the maximum size of an envelope payload in bytes.
@@ -2444,6 +2459,11 @@ impl Config {
     /// Returns the maximum number of sessions per envelope.
     pub fn max_session_count(&self) -> usize {
         self.values.limits.max_session_count
+    }
+
+    /// Returns the maximum combined size all sessions per envelope in bytes.
+    pub fn max_sessions_size(&self) -> usize {
+        self.values.limits.max_sessions_size.as_bytes()
     }
 
     /// Returns the maximum payload size of a statsd metric in bytes.

--- a/relay-config/src/config.rs
+++ b/relay-config/src/config.rs
@@ -629,7 +629,7 @@ pub struct Limits {
     pub max_check_in_size: ByteSize,
     /// The maximum payload size for an entire envelopes. Individual limits still apply.
     pub max_envelope_size: ByteSize,
-    /// Returns the maximum combined size all sessions per envelope in bytes.
+    /// The maximum combined size for all sessions in an envelope in bytes.
     pub max_sessions_size: ByteSize,
     /// The maximum number of session items per envelope.
     pub max_session_count: usize,
@@ -2461,7 +2461,7 @@ impl Config {
         self.values.limits.max_session_count
     }
 
-    /// Returns the maximum combined size all sessions per envelope in bytes.
+    /// Returns the maximum combined size for all sessions in an envelope in bytes.
     pub fn max_sessions_size(&self) -> usize {
         self.values.limits.max_sessions_size.as_bytes()
     }

--- a/relay-server/src/endpoints/integrations/otlp.rs
+++ b/relay-server/src/endpoints/integrations/otlp.rs
@@ -57,7 +57,7 @@ mod traces {
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-        post(handle).route_layer(DefaultBodyLimit::max(config.max_spans_integration_size()))
+        post(handle).route_layer(DefaultBodyLimit::max(config.max_container_size()))
     }
 }
 
@@ -91,7 +91,7 @@ mod logs {
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-        post(handle).route_layer(DefaultBodyLimit::max(config.max_logs_integration_size()))
+        post(handle).route_layer(DefaultBodyLimit::max(config.max_container_size()))
     }
 }
 

--- a/relay-server/src/endpoints/integrations/vercel.rs
+++ b/relay-server/src/endpoints/integrations/vercel.rs
@@ -46,6 +46,6 @@ mod logs {
     }
 
     pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-        post(handle).route_layer(DefaultBodyLimit::max(config.max_logs_integration_size()))
+        post(handle).route_layer(DefaultBodyLimit::max(config.max_container_size()))
     }
 }

--- a/relay-server/src/endpoints/nel.rs
+++ b/relay-server/src/endpoints/nel.rs
@@ -42,5 +42,5 @@ async fn handle(
 }
 
 pub fn route(config: &Config) -> MethodRouter<ServiceState> {
-    post(handle).route_layer(DefaultBodyLimit::max(config.max_logs_integration_size()))
+    post(handle).route_layer(DefaultBodyLimit::max(config.max_container_size()))
 }

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -747,6 +747,12 @@ pub enum RelayCounters {
     ///  - `sdk`: The name of the Sentry SDK sending the envelope. This tag is only set for
     ///    Sentry's SDKs and defaults to "proprietary".
     EnvelopeItemBytes,
+    /// Number of envelopes rejected because of size limits.
+    ///
+    /// This metric is tagged with:
+    ///  - `item`: The type of the items being counted.
+    ///  - `limit`: Which limit was breached.
+    EnvelopeSizeLimited,
     /// Number of times an envelope from the buffer is trying to be popped.
     BufferTryPop,
     /// Number of envelopes spool to disk.
@@ -1029,6 +1035,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EnvelopeRejected => "event.rejected",
             RelayCounters::EnvelopeItems => "event.items",
             RelayCounters::EnvelopeItemBytes => "event.item_bytes",
+            RelayCounters::EnvelopeSizeLimited => "envelope.rejected.size",
             RelayCounters::BufferTryPop => "buffer.try_pop",
             RelayCounters::BufferSpooledEnvelopes => "buffer.spooled_envelopes",
             RelayCounters::BufferUnspooledEnvelopes => "buffer.unspooled_envelopes",

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -1,9 +1,10 @@
 use relay_config::Config;
 
-use crate::envelope::{Envelope, ItemType};
+use crate::envelope::{Envelope, Item, ItemType};
 use crate::integrations::Integration;
 use crate::managed::Managed;
-use crate::services::outcome::{DiscardAttachmentType, DiscardItemType};
+use crate::services::outcome::DiscardItemType;
+use crate::statsd::RelayCounters;
 
 /// Checks for size limits of items in this envelope.
 ///
@@ -11,106 +12,199 @@ use crate::services::outcome::{DiscardAttachmentType, DiscardItemType};
 /// an `Err` containing the offending item type, in which case the envelope should be discarded
 /// and a `413 Payload Too Large` response should be given.
 ///
-/// The following limits are checked:
-///
-///  - `max_attachment_size`
-///  - `max_attachments_size`
-///  - `max_check_in_size`
-///  - `max_event_size`
-///  - `max_log_size`
-///  - `max_metric_buckets_size`
-///  - `max_profile_size`
-///  - `max_replay_compressed_size`
-///  - `max_session_count`
-///  - `max_span_size`
-///  - `max_statsd_size`
-///  - `max_trace_metric_size`
-///  - `max_container_size`
+/// Each envelope item is checked against its limits defined in the [`Config`].
 pub fn check_envelope_size_limits(
     config: &Config,
     envelope: &Envelope,
 ) -> Result<(), DiscardItemType> {
-    const NO_LIMIT: usize = usize::MAX;
-
-    let mut event_size = 0;
-    let mut attachments_size = 0;
-    let mut session_count = 0;
-    let mut client_reports_size = 0;
+    // TODO(#6249 / RELAY-272): These limits are built from from the old `limits` config,
+    // we can think about reworking how limits are configured and exposing a similar structure
+    // for these size limits also in the config.
+    let mut empty = Limit {
+        item_size: 0,
+        total_count: 0,
+        total_size: 0,
+    };
+    let mut event = Limit {
+        item_size: config.max_event_size(),
+        total_count: 1,
+        total_size: config.max_event_size(),
+    };
+    let mut attachment = Limit {
+        item_size: config.max_attachment_size(),
+        total_count: config.max_attachment_count(),
+        total_size: config.max_attachments_size(),
+    };
+    let mut replay_recording = Limit {
+        item_size: config.max_replay_compressed_size(),
+        total_count: 1,
+        total_size: config.max_replay_compressed_size(),
+    };
+    let mut replay_video = Limit {
+        item_size: config.max_replay_compressed_size(),
+        total_count: 1,
+        total_size: config.max_replay_compressed_size(),
+    };
+    let mut session = Limit {
+        item_size: config.max_sessions_size(),
+        total_count: config.max_session_count(),
+        total_size: config.max_sessions_size(),
+    };
+    let mut client_report = Limit {
+        item_size: config.max_client_reports_size(),
+        total_count: config.max_client_reports_count(),
+        total_size: config.max_client_reports_size(),
+    };
+    let mut profile = Limit {
+        item_size: config.max_profile_size(),
+        total_count: 1,
+        total_size: config.max_profile_size(),
+    };
+    let mut check_in = Limit {
+        item_size: config.max_check_in_size(),
+        total_count: 1,
+        total_size: config.max_check_in_size(),
+    };
+    let mut statsd = Limit {
+        item_size: config.max_statsd_size(),
+        total_count: 1,
+        total_size: config.max_statsd_size(),
+    };
+    let mut metric_bucket = Limit {
+        item_size: config.max_metric_buckets_size(),
+        total_count: 1,
+        total_size: config.max_metric_buckets_size(),
+    };
+    let mut log = Limit {
+        item_size: config.max_log_size(),
+        total_count: 1,
+        total_size: config.max_container_size(),
+    };
+    let mut log_integration = Limit {
+        item_size: config.max_container_size(),
+        total_count: 1,
+        total_size: config.max_container_size(),
+    };
+    let mut trace_metric = Limit {
+        item_size: config.max_trace_metric_size(),
+        total_count: 1,
+        total_size: config.max_container_size(),
+    };
+    let mut span = Limit {
+        item_size: config.max_span_size(),
+        total_count: 1,
+        total_size: config.max_container_size(),
+    };
+    let mut span_integration = Limit {
+        item_size: config.max_container_size(),
+        total_count: 1,
+        total_size: config.max_container_size(),
+    };
+    let mut span_legacy = Limit {
+        item_size: config.max_span_size(),
+        total_count: config.max_standalone_span_count(),
+        total_size: config.max_container_size(),
+    };
 
     for item in envelope.items() {
-        if item.is_container() && item.len() > config.max_container_size() {
-            return Err(item.ty().into());
-        }
-
-        let max_size = match item.ty() {
+        let limit = match item.ty() {
             ItemType::Event
             | ItemType::Transaction
             | ItemType::Security
             | ItemType::ReplayEvent
             | ItemType::RawSecurity
             | ItemType::UserReportV2
-            | ItemType::FormData => {
-                event_size += item.len();
-                NO_LIMIT
-            }
-            ItemType::Attachment | ItemType::UnrealReport | ItemType::UserReport => {
-                attachments_size += item.len();
-                config.max_attachment_size()
-            }
-            ItemType::ReplayRecording => config.max_replay_compressed_size(),
-            ItemType::ReplayVideo => config.max_replay_compressed_size(),
-            ItemType::Session | ItemType::Sessions => {
-                session_count += 1;
-                NO_LIMIT
-            }
-            ItemType::ClientReport => {
-                client_reports_size += item.len();
-                NO_LIMIT
-            }
-            ItemType::Profile => config.max_profile_size(),
-            ItemType::CheckIn => config.max_check_in_size(),
-            ItemType::Statsd => config.max_statsd_size(),
-            ItemType::MetricBuckets => config.max_metric_buckets_size(),
-            ItemType::Log => config.max_log_size(),
-            ItemType::TraceMetric => config.max_trace_metric_size(),
-            ItemType::Span => config.max_span_size(),
-            ItemType::Integration => match item.integration() {
-                Some(Integration::Logs(_)) => config.max_logs_integration_size(),
-                Some(Integration::Spans(_)) => config.max_spans_integration_size(),
-                None => NO_LIMIT,
+            | ItemType::FormData => &mut event,
+            ItemType::Attachment | ItemType::UnrealReport | ItemType::UserReport => &mut attachment,
+            ItemType::ReplayRecording => &mut replay_recording,
+            ItemType::ReplayVideo => &mut replay_video,
+            ItemType::Session | ItemType::Sessions => &mut session,
+            ItemType::ClientReport => &mut client_report,
+            ItemType::Profile | ItemType::ProfileChunk => &mut profile,
+            ItemType::CheckIn => &mut check_in,
+            ItemType::Statsd => &mut statsd,
+            ItemType::MetricBuckets => &mut metric_bucket,
+            ItemType::Log => &mut log,
+            ItemType::TraceMetric => &mut trace_metric,
+            ItemType::Span => match item.is_container() {
+                true => &mut span,
+                false => &mut span_legacy,
             },
-            ItemType::ProfileChunk => config.max_profile_size(),
-            ItemType::Unknown(_) => NO_LIMIT,
+            ItemType::Integration => match item.integration() {
+                Some(Integration::Logs(_)) => &mut log_integration,
+                Some(Integration::Spans(_)) => &mut span_integration,
+                None => {
+                    // Shouldn't be possible, if it still happens due to a bug, be defensive.
+                    debug_assert!(false);
+                    &mut empty
+                }
+            },
+            // Unknown items are either filtered or forwarded as is.
+            ItemType::Unknown(_) => continue,
         };
 
-        // For item containers, we want to check that the contained items obey
-        // the size limits *on average*.
-        // For standalone items, this is just the item size itself.
-        let avg_item_size = item.len() / (item.item_count().unwrap_or(1).max(1) as usize);
-        if avg_item_size > max_size {
-            return Err(item
+        if let Err(err) = limit.apply(item) {
+            relay_statsd::metric!(
+                counter(RelayCounters::EnvelopeSizeLimited) += 1,
+                item = item.ty().name(),
+                limit = match err {
+                    Rejected::ItemSize => "item_size",
+                    Rejected::TotalCount => "total_count",
+                    Rejected::TotalSize => "total_size",
+                }
+            );
+
+            let discard_item: DiscardItemType = item
                 .attachment_type()
                 .map(|t| t.into())
-                .unwrap_or_else(|| item.ty().into()));
+                .unwrap_or_else(|| item.ty().into());
+            return Err(discard_item);
         }
     }
 
-    if event_size > config.max_event_size() {
-        return Err(DiscardItemType::Event);
-    }
-    if attachments_size > config.max_attachments_size() {
-        return Err(DiscardItemType::Attachment(
-            DiscardAttachmentType::Attachment,
-        ));
-    }
-    if session_count > config.max_session_count() {
-        return Err(DiscardItemType::Session);
-    }
-    if client_reports_size > config.max_client_reports_size() {
-        return Err(DiscardItemType::ClientReport);
-    }
-
     Ok(())
+}
+
+enum Rejected {
+    ItemSize,
+    TotalCount,
+    TotalSize,
+}
+
+struct Limit {
+    /// The maximum size of a single item.
+    item_size: usize,
+    /// The total (or remaining) amount of this item type allowed in an envelope.
+    total_count: usize,
+    /// The total (or remaining) total size of this item type in an envelope.
+    total_size: usize,
+}
+
+impl Limit {
+    fn apply(&mut self, item: &Item) -> Result<(), Rejected> {
+        let size = match item.is_container() {
+            // For container items, check that the contained items obey the size limit on average.
+            //
+            // Individual size validation must then be done again after parsing.
+            true => item.len() / item.item_count().unwrap_or(1).max(1) as usize,
+            false => item.len(),
+        };
+        if size > self.item_size {
+            return Err(Rejected::ItemSize);
+        }
+
+        self.total_count = self
+            .total_count
+            .checked_sub(1)
+            .ok_or(Rejected::TotalCount)?;
+
+        self.total_size = self
+            .total_size
+            .checked_sub(item.len())
+            .ok_or(Rejected::TotalSize)?;
+
+        Ok(())
+    }
 }
 
 /// Checks for valid envelope items.

--- a/relay-server/src/utils/sizes.rs
+++ b/relay-server/src/utils/sizes.rs
@@ -17,7 +17,7 @@ pub fn check_envelope_size_limits(
     config: &Config,
     envelope: &Envelope,
 ) -> Result<(), DiscardItemType> {
-    // TODO(#6249 / RELAY-272): These limits are built from from the old `limits` config,
+    // TODO(#6249 / RELAY-272): These limits are built from the old `limits` config,
     // we can think about reworking how limits are configured and exposing a similar structure
     // for these size limits also in the config.
     let mut empty = Limit {
@@ -174,9 +174,9 @@ enum Rejected {
 struct Limit {
     /// The maximum size of a single item.
     item_size: usize,
-    /// The total (or remaining) amount of this item type allowed in an envelope.
+    /// The remaining total count of this item type allowed in an envelope.
     total_count: usize,
-    /// The total (or remaining) total size of this item type in an envelope.
+    /// The remaining total count of this item type in an envelope.
     total_size: usize,
 }
 

--- a/tests/integration/test_ourlogs.py
+++ b/tests/integration/test_ourlogs.py
@@ -95,7 +95,8 @@ def test_ourlog_multiple_containers_not_allowed(
             )
         )
 
-    relay.send_envelope(project_id, envelope)
+    with pytest.raises(HTTPError, match="413 Client Error"):
+        relay.send_envelope(project_id, envelope)
 
     outcomes = outcomes_consumer.get_outcomes()
     outcomes.sort(key=lambda o: sorted(o.items()))
@@ -109,7 +110,7 @@ def test_ourlog_multiple_containers_not_allowed(
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": 2,
-            "reason": "duplicate_item",
+            "reason": "too_large:log",
         },
         {
             "category": DataCategory.LOG_BYTE.value,
@@ -119,7 +120,7 @@ def test_ourlog_multiple_containers_not_allowed(
             "outcome": 3,  # Invalid
             "project_id": 42,
             "quantity": matches(lambda x: 300 < x < 400),
-            "reason": "duplicate_item",
+            "reason": "too_large:log",
         },
     ]
 

--- a/tests/integration/test_outcome.py
+++ b/tests/integration/test_outcome.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import requests
+from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 from .asserts import time_within_delta
@@ -1079,20 +1080,19 @@ def test_profile_outcomes_too_many(
         return envelope
 
     envelope = make_envelope()
-    upstream.send_envelope(project_id, envelope)
+    with pytest.raises(HTTPError, match="413 Client Error"):
+        upstream.send_envelope(project_id, envelope)
 
-    outcomes = outcomes_consumer.get_outcomes(n=4)
-    outcomes.sort(key=lambda o: sorted(o.items()))
-
+    outcomes = outcomes_consumer.get_aggregated_outcomes(n=6)
     assert outcomes == [
         {
             "category": DataCategory.TRANSACTION.value,
             "key_id": 123,
             "org_id": 1,
-            "outcome": 0,
+            "outcome": 3,
             "project_id": 42,
             "quantity": 1,
-            "timestamp": time_within_delta(),
+            "reason": "too_large:profile",
         },
         {
             "category": DataCategory.PROFILE.value,
@@ -1100,9 +1100,17 @@ def test_profile_outcomes_too_many(
             "org_id": 1,
             "outcome": 3,  # Invalid
             "project_id": 42,
+            "quantity": 2,
+            "reason": "too_large:profile",
+        },
+        {
+            "category": DataCategory.TRANSACTION_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,
+            "project_id": 42,
             "quantity": 1,
-            "reason": "profiling_too_many_profiles",
-            "timestamp": time_within_delta(),
+            "reason": "too_large:profile",
         },
         {
             "category": DataCategory.PROFILE_INDEXED.value,
@@ -1110,23 +1118,30 @@ def test_profile_outcomes_too_many(
             "org_id": 1,
             "outcome": 3,  # Invalid
             "project_id": 42,
-            "quantity": 1,
-            "reason": "profiling_too_many_profiles",
-            "timestamp": time_within_delta(),
+            "quantity": 2,
+            "reason": "too_large:profile",
         },
         {
             "category": DataCategory.SPAN.value,
             "key_id": 123,
             "org_id": 1,
-            "outcome": 0,
+            "outcome": 3,
             "project_id": 42,
-            "quantity": 2,
-            "timestamp": time_within_delta(),
+            "quantity": 1,
+            "reason": "too_large:profile",
+        },
+        {
+            "category": DataCategory.SPAN_INDEXED.value,
+            "key_id": 123,
+            "org_id": 1,
+            "outcome": 3,
+            "project_id": 42,
+            "quantity": 1,
+            "reason": "too_large:profile",
         },
     ]
 
-    # One profile was accepted
-    assert profiles_consumer.get_profile()
+    profiles_consumer.assert_empty()
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone, timedelta
 
+from requests import HTTPError
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_relay.consts import DataCategory
 
@@ -1075,7 +1076,8 @@ def test_spans_v2_multiple_containers_not_allowed(
         )
     )
 
-    relay.send_envelope(project_id, envelope)
+    with pytest.raises(HTTPError, match="413 Client Error"):
+        relay.send_envelope(project_id, envelope)
 
     assert mini_sentry.get_outcomes(n=2) == [
         {
@@ -1083,14 +1085,14 @@ def test_spans_v2_multiple_containers_not_allowed(
             "timestamp": time_within_delta(),
             "outcome": 3,  # Invalid
             "quantity": 3,
-            "reason": "duplicate_item",
+            "reason": "too_large:span",
         },
         {
             "category": DataCategory.SPAN_INDEXED.value,
             "timestamp": time_within_delta(),
             "outcome": 3,  # Invalid
             "quantity": 3,
-            "reason": "duplicate_item",
+            "reason": "too_large:span",
         },
     ]
 

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -68,7 +68,8 @@ def test_trace_metric_multiple_containers_not_allowed(
         )
     )
 
-    relay.send_envelope(project_id, envelope)
+    with pytest.raises(HTTPError, match="413 Client Error"):
+        relay.send_envelope(project_id, envelope)
 
     outcomes = mini_sentry.get_outcomes(n=2)
     outcomes.sort(key=lambda o: sorted(o.items()))
@@ -79,14 +80,14 @@ def test_trace_metric_multiple_containers_not_allowed(
             "timestamp": time_within_delta(),
             "outcome": 3,  # Invalid
             "quantity": 3,
-            "reason": "duplicate_item",
+            "reason": "too_large:trace_metric",
         },
         {
             "category": DataCategory.TRACE_METRIC_BYTE.value,
             "timestamp": time_within_delta(),
             "outcome": 3,  # Invalid
             "quantity": matches(lambda x: 300 < x < 500),
-            "reason": "duplicate_item",
+            "reason": "too_large:trace_metric",
         },
     ]
 


### PR DESCRIPTION
Closes: INGEST-1057

Enforces size, total size and count limits for all envelope items, instead of only selectively. By adding these limits we effectively make accepted envelopes much stricter, it also adds a new metric to verify the limits are appropriate.

Also adds a few more limits that were missing. All limits configured to `1` are forced by the protocol to be max `1`. Items which share the same limit of `1` are mutually exclusive in an envelope.

There is a future improvement we can do in #6249 to improve how the limits are configured.