### PR TITLE
fix(error): Remove leftover formdata from envelopes

### DIFF
--- a/relay-server/src/processing/errors/errors/utils/mod.rs
+++ b/relay-server/src/processing/errors/errors/utils/mod.rs
@@ -189,18 +189,36 @@ pub fn take_event_from_crash_items(
     metrics: &mut Metrics,
     ctx: Context<'_>,
 ) -> Result<Annotated<Event>> {
+    // Remove other event creating items to make sure there are no leftovers.
+    let remove_other_event_items = |items: &mut Vec<Item>| {
+        items
+            .extract_if(.., |item| {
+                let is_ev_item = matches!(item.ty(), ItemType::FormData);
+                let is_ev_attachment = matches!(
+                    item.attachment_type(),
+                    Some(AttachmentType::EventPayload | AttachmentType::Breadcrumbs)
+                );
+
+                is_ev_item || is_ev_attachment
+            })
+            .for_each(drop);
+    };
+
     let event = take_parsed_event(items, metrics, ctx)?;
     if event.0.is_some() {
+        remove_other_event_items(items);
         return Ok(event);
     }
 
     let event = take_event_from_attachments(items, metrics, ctx)?;
     if event.0.is_some() {
+        remove_other_event_items(items);
         return Ok(event);
     }
 
     let event = take_event_from_formdata(items, metrics)?;
     if event.0.is_some() {
+        remove_other_event_items(items);
         return Ok(event);
     }
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -100,9 +100,15 @@ def test_minidump_attachments(mini_sentry, relay):
         ("attachment1", "attach1.txt", "attachment content"),
     ]
 
-    relay.send_minidump(project_id=project_id, files=attachments)
+    relay.send_minidump(
+        project_id=project_id,
+        files=attachments,
+        params=[("guid", "dd46bb04-bb27-448c-aad0-0deb0c134bdb")],
+    )
     envelope = mini_sentry.get_captured_envelope()
     assert envelope
+
+    assert all(item.headers.get("type") != "form_data" for item in envelope.items)
 
     # Check that the envelope assumes the given event id
     assert envelope.headers.get("event_id") == "2dd132e467174db48dbaddabd3cbed57"


### PR DESCRIPTION
It was possible that `FormData` and `EventPayload` existed in the same envelope, this change makes sure the `FormData` isn't kept around unnecessarily and incorrectly.