### PR TITLE
fix(trimming): Inherit trimming settings to additional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - No longer write the deprecated `sentry.transaction` and `db.system` attributes. ([#6237](https://github.com/getsentry/relay/pull/6237), [#6238](https://github.com/getsentry/relay/pull/6238))
 - Allow additional exceptions in minidump and apple crash report events. ([#6241](https://github.com/getsentry/relay/pull/6241))
 
+**Bug Fixes**:
+
+- Prevent partially trimmed transaction spans. ([#6256](https://github.com/getsentry/relay/pull/6256))
+
 **Internal**:
 
 - Limit the maximum amount of items in an envelope to 500. ([#6251](https://github.com/getsentry/relay/pull/6251))

--- a/relay-event-normalization/src/trimming.rs
+++ b/relay-event-normalization/src/trimming.rs
@@ -441,7 +441,7 @@ mod tests {
     use chrono::DateTime;
     use relay_event_schema::protocol::{
         Breadcrumb, Context, Contexts, Event, Exception, ExtraValue, FlagsContext, PairList,
-        SentryTags, Span, SpanId, TagEntry, Tags, Timestamp, TraceId, Values,
+        SentryTags, Span, SpanData, SpanId, TagEntry, Tags, Timestamp, TraceId, Values,
     };
     use relay_protocol::{FromValue, IntoValue, Map, Remark, SerializableAnnotated, get_value};
     use similar_asserts::assert_eq;
@@ -1083,6 +1083,37 @@ mod tests {
 
         // The actual spans were not touched:
         assert_eq!(trimmed_spans.as_slice(), &spans[0..5]);
+    }
+
+    #[test]
+    fn test_span_data_not_partially_trimmed() {
+        let span_data = SpanData::from([(
+            "large_attribute".to_owned(),
+            Annotated::new(Value::String("a".repeat(100 * 1024))),
+        )]);
+        let span = Span {
+            data: Annotated::new(span_data.clone()),
+            ..Default::default()
+        };
+        let spans: Vec<_> = std::iter::repeat_with(|| Annotated::new(span.clone()))
+            .take(10)
+            .collect();
+
+        let mut event = Annotated::new(Event {
+            spans: Annotated::new(spans.clone()),
+            ..Default::default()
+        });
+
+        let mut processor = TrimmingProcessor::new();
+        processor::process_value(&mut event, &mut processor, ProcessingState::root()).unwrap();
+
+        let trimmed = event.value().unwrap().spans.value().unwrap();
+        assert!(trimmed.len() < spans.len());
+        assert!(trimmed.iter().all(|span| {
+            span.value()
+                .and_then(|span| span.data.value())
+                .is_some_and(|data| data == &span_data)
+        }));
     }
 
     #[test]

--- a/relay-event-schema/src/processor/attrs.rs
+++ b/relay-event-schema/src/processor/attrs.rs
@@ -249,6 +249,12 @@ impl FieldAttrs {
         self
     }
 
+    /// Sets whether this field should be trimmed.
+    pub const fn trim(mut self, trim: bool) -> Self {
+        self.trim = trim;
+        self
+    }
+
     /// Sets the maximum number of characters allowed in the field.
     pub const fn max_chars(mut self, max_chars: Option<usize>) -> Self {
         self.max_chars = SizeMode::Static(max_chars);
@@ -287,8 +293,6 @@ impl FieldAttrs {
 }
 
 static DEFAULT_FIELD_ATTRS: FieldAttrs = FieldAttrs::new();
-static PII_TRUE_FIELD_ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::True);
-static PII_MAYBE_FIELD_ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::Maybe);
 
 impl Default for FieldAttrs {
     fn default() -> Self {
@@ -605,11 +609,33 @@ impl<'a> ProcessingState<'a> {
 
     /// Derives the attrs for recursion.
     pub fn inner_attrs(&self) -> Option<Cow<'_, FieldAttrs>> {
-        match self.attrs().pii {
-            PiiMode::Static(Pii::True) => Some(Cow::Borrowed(&PII_TRUE_FIELD_ATTRS)),
-            PiiMode::Static(Pii::False) => None,
-            PiiMode::Static(Pii::Maybe) => Some(Cow::Borrowed(&PII_MAYBE_FIELD_ATTRS)),
-            PiiMode::Dynamic(f) => Some(Cow::Owned(DEFAULT_FIELD_ATTRS.pii_dynamic(f))),
+        let current_attrs = self.attrs();
+        match (current_attrs.pii, current_attrs.trim) {
+            // Both are default -> None.
+            (PiiMode::Static(Pii::False), true) => None,
+            (PiiMode::Static(Pii::True), true) => {
+                static ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::True).trim(true);
+                Some(Cow::Borrowed(&ATTRS))
+            }
+            (PiiMode::Static(Pii::Maybe), true) => {
+                static ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::Maybe).trim(true);
+                Some(Cow::Borrowed(&ATTRS))
+            }
+            (PiiMode::Static(Pii::True), false) => {
+                static ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::True).trim(false);
+                Some(Cow::Borrowed(&ATTRS))
+            }
+            (PiiMode::Static(Pii::False), false) => {
+                static ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::False).trim(false);
+                Some(Cow::Borrowed(&ATTRS))
+            }
+            (PiiMode::Static(Pii::Maybe), false) => {
+                static ATTRS: FieldAttrs = FieldAttrs::new().pii(Pii::Maybe).trim(false);
+                Some(Cow::Borrowed(&ATTRS))
+            }
+            (PiiMode::Dynamic(f), trim) => {
+                Some(Cow::Owned(FieldAttrs::new().pii_dynamic(f).trim(trim)))
+            }
         }
     }
 


### PR DESCRIPTION
Inherits trimming settings from the parent onto `additional_properties`. This fixes a case where `SpanData` was partially trimmed. This regression was introduced by removing all fields from `SpanData` which is marked with `trim = false`.