### PR TITLE
fix(tests): Make test_basic::test_graceful_shutdown_with_sqlite_buffer more deterministic

### DIFF
--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -80,6 +80,10 @@ def test_graceful_shutdown_with_sqlite_buffer(mini_sentry, relay):
             },
         )
 
+        # Await a health check, so that we basically know that the envelope service is up
+        # and running.
+        relay.wait_health_check()
+
         n = 10
         relay.send_event(project_id)
         assert project_config_requested.wait(


### PR DESCRIPTION
We race EnvelopeBufferService creation, so wait for the health check to pass before doing the actual test.  This isn't exactly when the service is ready, but hopefully close enough that this fixes the flake.

(Note: I can't use the same "check sentry for the processed envelope" trick I used for test_shutdown because this example relies on a timing attack using the project config fetch, and project config will be cached after sending the first event.)