### PR TITLE
feat(gocd): Add soak-time stage to s4s2, de, and us2

### DIFF
--- a/gocd/templates/pipelines/processing.libsonnet
+++ b/gocd/templates/pipelines/processing.libsonnet
@@ -16,6 +16,7 @@ local monitors_for(region) =
   if std.objectHas(datadog_monitors, region) then datadog_monitors[region] else datadog_monitors.default;
 
 local canary_regions = ['us', 'de', 'us2', 's4s2'];
+local saas_regions = ['us', 'de', 'us2', 's4s2'];
 
 local sentry_deploy_vars(region) = {
   SENTRY_REGION: region,
@@ -38,7 +39,7 @@ local sentry_create_env_vars(region) = {
 // The purpose of this stage is to let the deployment soak for a while and
 // detect any issues that might have been introduced.
 local soak_time(region) =
-  if region == 'us' then
+  if std.member(saas_regions, region) then
     [
       {
         'soak-time': {


### PR DESCRIPTION
Add soak-time stage to s4s2, de, and us2 to pause the `relay-processing` pipeline if dd monitors start failing. Currently, only us has a soak stage - better to pause the pipeline already at s4s2 or de if something goes wrong. This will slow down deployments (5 min per region) but is worth it imo.