### PR TITLE
fix(pii): Make `RedactPair` only match on keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**:
 
 - Defer dynamic sampling until metrics config is valid. ([#6246](https://github.com/getsentry/relay/pull/6246))
+- Make "sensitive fields" in PII rules only match field names. ([#6264](https://github.com/getsentry/relay/pull/6264))
 
 ## 26.7.1
 

--- a/relay-pii/src/regexes.rs
+++ b/relay-pii/src/regexes.rs
@@ -58,7 +58,7 @@ pub fn get_regex_for_rule_type(
     match ty {
         RuleType::RedactPair(redact_pair) => {
             if let Ok(pattern) = redact_pair.key_pattern.compiled() {
-                smallvec![(kv, pattern, ReplaceBehavior::replace_value())]
+                smallvec![(k, pattern, ReplaceBehavior::replace_value())]
             } else {
                 smallvec![]
             }

--- a/relay-pii/src/snapshots/relay_pii__convert__tests__breadcrumb_message-2.snap
+++ b/relay-pii/src/snapshots/relay_pii__convert__tests__breadcrumb_message-2.snap
@@ -6,29 +6,8 @@ expression: data
   "breadcrumbs": {
     "values": [
       {
-        "message": "[Filtered]"
+        "message": "SELECT session_key FROM django_session WHERE session_key = 'abcdefg'"
       }
     ]
-  },
-  "_meta": {
-    "breadcrumbs": {
-      "values": {
-        "0": {
-          "message": {
-            "": {
-              "rem": [
-                [
-                  "strip-fields",
-                  "s",
-                  0,
-                  10
-                ]
-              ],
-              "len": 68
-            }
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
The field naming and docs on `RedactPairRule` imply that it's intended to only match keys:
```rust
pub struct RedactPairRule {
    /// A pattern to match for keys.
    pub key_pattern: LazyPattern,
}
```
Moreover, since "sensitive fields" get turned into a `RedactPair`, matching on the value as well has unexpected effects (although those effects were, apparently, at one point expected—see the changed test).