### PR TITLE
ref(managed): No longer track the event id

### DIFF
--- a/relay-server/src/managed/managed.rs
+++ b/relay-server/src/managed/managed.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::{DateTime, Utc};
 use itertools::Either;
-use relay_event_schema::protocol::EventId;
 use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use smallvec::SmallVec;
@@ -161,7 +160,6 @@ impl Managed<Box<Envelope>> {
             outcome_aggregator,
             received_at: envelope.received_at(),
             scoping: envelope.meta().get_partial_scoping().into_scoping(),
-            event_id: envelope.event_id(),
             remote_addr: envelope.meta().remote_addr(),
         });
 
@@ -198,7 +196,6 @@ impl<T: Counted> Managed<T> {
                 outcome_aggregator: envelope.outcome_aggregator().clone(),
                 received_at: envelope.received_at(),
                 scoping: envelope.scoping(),
-                event_id: envelope.envelope().event_id(),
                 remote_addr: envelope.meta().remote_addr(),
             }),
         )
@@ -216,7 +213,6 @@ impl<T: Counted> Managed<T> {
                 outcome_aggregator: outcome_aggregator.clone(),
                 received_at: request_meta.received_at(),
                 scoping: request_meta.get_partial_scoping().into_scoping(),
-                event_id: None,
                 remote_addr: request_meta.remote_addr(),
             }),
         )
@@ -777,8 +773,6 @@ struct Meta {
     received_at: DateTime<Utc>,
     /// Data scoping information of the contained item.
     scoping: Scoping,
-    /// Optional event id associated with the contained data.
-    event_id: Option<EventId>,
     /// Optional remote addr from where the data was received.
     remote_addr: Option<IpAddr>,
 }
@@ -789,7 +783,7 @@ impl Meta {
             timestamp: self.received_at,
             scoping: self.scoping,
             outcome,
-            event_id: self.event_id,
+            event_id: None,
             remote_addr: self.remote_addr,
             category,
             quantity: quantity as _,

--- a/relay-server/src/managed/managed/test.rs
+++ b/relay-server/src/managed/managed/test.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use relay_base_schema::organization::OrganizationId;
 use relay_base_schema::project::{ProjectId, ProjectKey};
-use relay_event_schema::protocol::EventId;
 use relay_quotas::{DataCategory, Scoping};
 use relay_system::Addr;
 use tokio::sync::mpsc::{UnboundedReceiver, error::TryRecvError};
@@ -27,7 +26,6 @@ pub struct ManagedTestBuilder<T> {
     outcome_aggregator_rx: UnboundedReceiver<TrackOutcome>,
     received_at: DateTime<Utc>,
     scoping: Scoping,
-    event_id: Option<EventId>,
     remote_addr: Option<IpAddr>,
 }
 
@@ -46,7 +44,6 @@ impl<T> ManagedTestBuilder<T> {
                 project_key: ProjectKey::parse("a94ae32be2584e0bbd7a4cbb95971fee").unwrap(),
                 key_id: Some(3),
             },
-            event_id: None,
             remote_addr: None,
         }
     }
@@ -68,7 +65,6 @@ impl<T> ManagedTestBuilder<T> {
                 outcome_aggregator: self.outcome_aggregator,
                 received_at: self.received_at,
                 scoping: self.scoping,
-                event_id: self.event_id,
                 remote_addr: self.remote_addr,
             }),
         );
@@ -76,7 +72,6 @@ impl<T> ManagedTestBuilder<T> {
             outcomes: self.outcome_aggregator_rx,
             received_at: self.received_at,
             scoping: self.scoping,
-            event_id: self.event_id,
             remote_addr: self.remote_addr,
         };
 
@@ -89,7 +84,6 @@ pub struct ManagedTestHandle {
     outcomes: UnboundedReceiver<TrackOutcome>,
     received_at: DateTime<Utc>,
     scoping: Scoping,
-    event_id: Option<EventId>,
     remote_addr: Option<IpAddr>,
 }
 
@@ -113,7 +107,7 @@ impl ManagedTestHandle {
                 assert_eq!(next.quantity, quantity);
                 assert_eq!(next.timestamp, self.received_at);
                 assert_eq!(next.scoping, self.scoping);
-                assert_eq!(next.event_id, self.event_id);
+                assert_eq!(next.event_id, None);
                 assert_eq!(next.remote_addr, self.remote_addr);
             }
             Err(TryRecvError::Empty | TryRecvError::Disconnected) => panic!(


### PR DESCRIPTION
 This was effectively already the case, outcomes stopped carrying an event id a long time ago. Removing the event id resolves some headaches when it comes to splitting envelopes into two separate envelopes.