### PR TITLE
fix(ds): Strip transactions if they above the tag length limit

### DIFF
--- a/relay-event-normalization/src/event.rs
+++ b/relay-event-normalization/src/event.rs
@@ -356,7 +356,7 @@ fn normalize(event: &mut Event, meta: &mut Meta, config: &NormalizationConfig) {
     normalize_contexts(&mut event.contexts);
 
     if config.normalize_spans && event.ty.value() == Some(&EventType::Transaction) {
-        span::normalize_dsc_for_event_spans(event, config.dsc);
+        span::normalize_dsc_for_event_spans(event, config);
         span::normalize_app_start_spans(event);
         span::exclusive_time::compute_span_exclusive_time(event);
     }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -122,8 +122,10 @@ pub fn normalize_dsc_for_span_data(
     if let Some(transaction) = &dsc.transaction {
         // To match the behaviour of the `count_per_root` metric, which had its tags
         // removed if they were over the limit.
-        if transaction.len() <= config.max_tag_value_length {
-            data.insert_value(SENTRY__DSC__TRANSACTION, transaction.to_string());
+        match transaction.len() <= config.max_tag_value_length {
+            true => data.insert_value(SENTRY__DSC__TRANSACTION, transaction.clone()),
+            // Keep an empty value around for the DS job
+            false => data.insert_value(SENTRY__DSC__TRANSACTION, "".to_owned()),
         }
     }
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -6,8 +6,9 @@ use relay_conventions::attributes::{
 };
 use relay_event_schema::protocol::{Event, SpanData, TraceContext};
 use relay_protocol::Annotated;
-use relay_sampling::DynamicSamplingContext;
 use std::sync::LazyLock;
+
+use crate::NormalizationConfig;
 
 pub mod ai;
 pub mod country_subregion;
@@ -86,14 +87,14 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 ///
 /// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
 /// that span.
-pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&DynamicSamplingContext>) {
+pub fn normalize_dsc_for_event_spans(event: &mut Event, config: &NormalizationConfig) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
-        normalize_dsc_for_span_data(&mut ctx.data, dsc);
+        normalize_dsc_for_span_data(&mut ctx.data, config);
     }
     if let Some(spans) = event.spans.value_mut() {
         for span in spans {
             if let Some(span) = span.value_mut() {
-                normalize_dsc_for_span_data(&mut span.data, dsc);
+                normalize_dsc_for_span_data(&mut span.data, config);
             }
         }
     }
@@ -104,9 +105,9 @@ pub fn normalize_dsc_for_event_spans(event: &mut Event, dsc: Option<&DynamicSamp
 /// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
-    dsc: Option<&DynamicSamplingContext>,
+    config: &NormalizationConfig,
 ) {
-    let Some(dsc) = dsc else {
+    let Some(dsc) = config.dsc else {
         return;
     };
 
@@ -119,6 +120,10 @@ pub fn normalize_dsc_for_span_data(
         data.insert_value(SENTRY__DSC__PROJECT_ID, project_id.to_string());
     }
     if let Some(transaction) = &dsc.transaction {
-        data.insert_value(SENTRY__DSC__TRANSACTION, transaction.to_string());
+        // To match the behaviour of the `count_per_root` metric, which had its tags
+        // removed if they were over the limit.
+        if transaction.len() <= config.max_tag_value_length {
+            data.insert_value(SENTRY__DSC__TRANSACTION, transaction.to_string());
+        }
     }
 }

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -965,6 +965,7 @@ def get_transaction_envelope(
     child_id_2: str,
     dsc: Literal["dsc_with_tx", "dsc_no_tx", "no_dsc"],
     sampling_project_config: dict,
+    dsc_transaction: str = "/dsc/",
 ):
     ts = datetime.now(timezone.utc)
 
@@ -1021,7 +1022,7 @@ def get_transaction_envelope(
             "sampled": "true",
             "release": "some_release",
             "environment": "some_environment",
-            **({"transaction": "/dsc/"} if dsc == "dsc_with_tx" else {}),
+            **({"transaction": dsc_transaction} if dsc == "dsc_with_tx" else {}),
             "org_id": sampling_project_config["organizationId"],
         }
 
@@ -1254,3 +1255,48 @@ def test_dsc_normalization(
             "value": 1.0,
         },
     ]
+
+
+@pytest.mark.parametrize(
+    ("dsc_transaction", "expected_transaction"),
+    [
+        pytest.param("t" * 10, "t" * 10, id="at-limit"),
+        pytest.param("t" * 11, None, id="over-limit"),
+    ],
+)
+def test_dsc_transaction_tag_length(
+    mini_sentry,
+    relay,
+    dsc_transaction,
+    expected_transaction,
+):
+    project_id = 42
+
+    project_config = mini_sentry.add_full_project_config(project_id)
+    relay = relay(
+        mini_sentry,
+        options={
+            "aggregator": {"max_tag_value_length": 10},
+            "normalization": {"level": "full"},
+        },
+    )
+
+    envelope = get_transaction_envelope(
+        trace_id="a0fa8803753e40fd8124b21eeb2986b5",
+        segment_id="a" * 16,
+        child_id_1="b" * 16,
+        child_id_2="c" * 16,
+        dsc="dsc_with_tx",
+        sampling_project_config=project_config,
+        dsc_transaction=dsc_transaction,
+    )
+
+    relay.send_envelope(project_id, envelope)
+    event = mini_sentry.get_captured_envelope().get_transaction_event()
+
+    for data in (
+        event["contexts"]["trace"]["data"],
+        event["spans"][0]["data"],
+        # The second span has an intentionally different dsc
+    ):
+        assert data.get("sentry.dsc.transaction") == expected_transaction

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -1261,7 +1261,7 @@ def test_dsc_normalization(
     ("dsc_transaction", "expected_transaction"),
     [
         pytest.param("t" * 10, "t" * 10, id="at-limit"),
-        pytest.param("t" * 11, None, id="over-limit"),
+        pytest.param("t" * 11, "", id="over-limit"),
     ],
 )
 def test_dsc_transaction_tag_length(


### PR DESCRIPTION
Our goal for the moment is parity, the metrics which power dynamic sampling have the transaction stripped if they are too long, so let's also do it for EAP.

This _only_ covers the transaction pipeline, it intentionally does not touch the standalone span pipeline for now.