### PR TITLE
ref(unreal): Clean-up moved expansion logic 

### DIFF
--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -93,10 +93,6 @@ pub enum Feature {
     /// Upload non-prosperodmp playstation attachments via the upload endpoint.
     #[serde(rename = "projects:relay-playstation-uploads")]
     PlaystationUploads,
-    /// Enable experimental expansion of the unreal report in the endpoint rather than in the
-    /// processor. Only enable for organizations with sufficient attachment quota.
-    #[serde(rename = "organizations:relay-unreal-endpoint-expansion")]
-    UnrealEndpointExpansion,
     /// Stream minidumps to objectstore.
     #[serde(rename = "projects:relay-minidump-uploads")]
     MinidumpUploads,

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -17,6 +17,7 @@ processing = [
   "dep:prost-types",
   "dep:sentry_protos",
   "dep:symbolic-common",
+  "dep:symbolic-unreal",
   "relay-config/processing",
   "relay-kafka/producer",
   "relay-metrics/redis",
@@ -119,7 +120,7 @@ sqlx = { workspace = true, features = [
   "runtime-tokio",
 ], default-features = false }
 symbolic-common = { workspace = true, optional = true, default-features = false }
-symbolic-unreal = { workspace = true, default-features = false, features = [
+symbolic-unreal = { workspace = true, optional = true, default-features = false, features = [
   "serde",
 ] }
 sync_wrapper = { workspace = true }

--- a/relay-server/src/constants.rs
+++ b/relay-server/src/constants.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
 
 /// Name of the custom tag in the crash user data for Sentry event payloads.
+#[cfg(feature = "processing")]
 pub const SENTRY_CRASH_PAYLOAD_KEY: &str = "__sentry";
 
 /// Name of the event attachment.

--- a/relay-server/src/endpoints/common.rs
+++ b/relay-server/src/endpoints/common.rs
@@ -81,9 +81,6 @@ pub enum BadStoreRequest {
     #[error("missing minidump")]
     MissingMinidump,
 
-    #[error("invalid unreal crash report")]
-    InvalidUnrealReport,
-
     #[cfg(sentry)]
     #[error("invalid prosperodump")]
     InvalidProsperodump,
@@ -136,7 +133,6 @@ impl BadStoreRequest {
             Self::InvalidMultipart(_) => DiscardReason::InvalidMultipart,
             Self::InvalidMinidump => DiscardReason::InvalidMinidump,
             Self::MissingMinidump => DiscardReason::MissingMinidump,
-            Self::InvalidUnrealReport => DiscardReason::InvalidUnrealReport,
             #[cfg(sentry)]
             Self::InvalidProsperodump => DiscardReason::InvalidProsperodump,
             #[cfg(sentry)]

--- a/relay-server/src/endpoints/unreal.rs
+++ b/relay-server/src/endpoints/unreal.rs
@@ -3,7 +3,6 @@ use axum::response::IntoResponse;
 use axum::routing::{MethodRouter, post};
 use bytes::Bytes;
 use relay_config::Config;
-use relay_dynamic_config::Feature;
 use relay_event_schema::protocol::EventId;
 use serde::Deserialize;
 
@@ -13,11 +12,6 @@ use crate::envelope::{ContentType, Envelope, Item, ItemType};
 use crate::extractors::RequestMeta;
 use crate::middlewares;
 use crate::service::ServiceState;
-use crate::services::outcome::{DiscardItemType, DiscardReason};
-use crate::services::processor::ProcessingError;
-use crate::services::projects::project::ProjectState;
-use crate::statsd::RelayCounters;
-use crate::utils::extract_items;
 
 #[derive(Debug, Deserialize)]
 struct UnrealQuery {
@@ -35,61 +29,17 @@ struct UnrealParams {
 }
 
 impl UnrealParams {
-    async fn extract_envelope(
-        self,
-        state: &ServiceState,
-    ) -> Result<Box<Envelope>, BadStoreRequest> {
+    fn extract_envelope(self) -> Result<Box<Envelope>, BadStoreRequest> {
         let Self { meta, query, data } = self;
 
         if data.is_empty() {
             return Err(BadStoreRequest::EmptyBody);
         }
 
-        let public_key = meta.public_key();
         let mut envelope = Envelope::from_request(Some(EventId::new()), meta);
 
         if let Some(user_id) = query.user_id {
             envelope.set_header(UNREAL_USER_HEADER, user_id);
-        }
-
-        let global_config = state.global_config_handle().current().unwrap_or_default();
-
-        if global_config.options.endpoint_fetch_config_enabled {
-            // Ensure that we really make it here.
-            relay_statsd::metric!(counter(RelayCounters::UnrealEndpointExpansion) += 1);
-
-            let project = state
-                .project_cache_handle()
-                .ready(public_key, state.config().query_timeout())
-                .await
-                .ok_or(BadStoreRequest::ProjectUnavailable)?;
-
-            let project_config = match project.state() {
-                ProjectState::Enabled(info) => Some(info.clone()),
-                // Note: In Proxy mode we should never make it here since the endpoint_fetch_config_enabled
-                // check should already fail.
-                ProjectState::Dummy => None,
-                ProjectState::Disabled | ProjectState::Pending => {
-                    return Err(BadStoreRequest::EventRejected(DiscardReason::ProjectId));
-                }
-            };
-
-            if let Some(project_config) = project_config
-                && project_config.has_feature(Feature::UnrealEndpointExpansion)
-            {
-                for mut item in
-                    extract_items(data, state.config()).map_err(|error| match error {
-                        ProcessingError::PayloadTooLarge(_) => {
-                            BadStoreRequest::ItemTooLarge(DiscardItemType::UnrealReport)
-                        }
-                        _ => BadStoreRequest::InvalidUnrealReport,
-                    })?
-                {
-                    item.set_unreal_expanded(true);
-                    envelope.add_item(item);
-                }
-                return Ok(envelope);
-            }
         }
 
         let mut item = Item::new(ItemType::UnrealReport);
@@ -104,7 +54,7 @@ async fn handle(
     state: ServiceState,
     params: UnrealParams,
 ) -> axum::response::Result<impl IntoResponse> {
-    let envelope = params.extract_envelope(&state).await?;
+    let envelope = params.extract_envelope()?;
     let id = envelope.event_id();
 
     // Never respond with a 429 since clients often retry these

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -538,18 +538,6 @@ impl Item {
             && self.content_type() == Some(ContentType::AttachmentRef)
     }
 
-    /// Returns `true` if this item was extracted from an Unreal report.
-    pub fn is_unreal_expanded(&self) -> bool {
-        self.headers
-            .get(ItemHeaderKey::UnrealExpanded)
-            .unwrap_or(false)
-    }
-
-    /// Marks this item as having been extracted from an Unreal report.
-    pub fn set_unreal_expanded(&mut self, expanded: bool) {
-        self.headers.set(ItemHeaderKey::UnrealExpanded, expanded);
-    }
-
     /// Returns the [`AttachmentParentType`] of an attachment.
     ///
     /// For standard attachments (V1) always returns [`AttachmentParentType::Event`].
@@ -1047,8 +1035,6 @@ pub enum ItemHeaderKey {
     SentryRelease,
     /// The Sentry environment stored in a header.
     SentryEnvironment,
-    /// Whether this item was expanded from an Unreal crash report.
-    UnrealExpanded,
 }
 
 /// The value of an item header.

--- a/relay-server/src/processing/errors/errors/unreal.rs
+++ b/relay-server/src/processing/errors/errors/unreal.rs
@@ -37,7 +37,7 @@ impl SentryError for Unreal {
                 event: Box::new(utils::take_event_from_crash_items(items, &mut metrics, ctx)?),
                 attachments: utils::take_items_of_type(items, ItemType::Attachment),
                 user_reports: utils::take_items_of_type(items, ItemType::UserReport),
-                error: Self::Forward {report},
+                error: Self::Forward { report },
                 metrics,
                 fully_normalized: false,
             }

--- a/relay-server/src/processing/errors/errors/unreal.rs
+++ b/relay-server/src/processing/errors/errors/unreal.rs
@@ -9,14 +9,10 @@ use crate::processing::errors::errors::{Context, Expansion, SentryError, utils};
 use crate::utils::AdditionalExceptions;
 
 #[derive(Debug)]
-pub enum UnrealReport {
-    Report(Item),
-    Expanded(Vec<Item>),
-}
-
-#[derive(Debug)]
 pub enum Unreal {
-    Forward(UnrealReport),
+    Forward {
+        report: Item,
+    },
     #[cfg(feature = "processing")]
     Process {
         minidump: Option<Item>,
@@ -30,14 +26,8 @@ impl SentryError for Unreal {
     }
 
     fn try_expand(items: &mut Vec<Item>, ctx: Context<'_>) -> Result<Option<Expansion<Self>>> {
-        let report = if let Some(item) = utils::take_item_of_type(items, ItemType::UnrealReport) {
-            UnrealReport::Report(item)
-        } else {
-            let items: Vec<Item> = utils::take_items_by(items, |i| i.is_unreal_expanded());
-            if items.is_empty() {
-                return Ok(None);
-            }
-            UnrealReport::Expanded(items)
+        let Some(report) = utils::take_item_of_type(items, ItemType::UnrealReport) else {
+            return Ok(None);
         };
 
         let mut metrics = Default::default();
@@ -47,7 +37,7 @@ impl SentryError for Unreal {
                 event: Box::new(utils::take_event_from_crash_items(items, &mut metrics, ctx)?),
                 attachments: utils::take_items_of_type(items, ItemType::Attachment),
                 user_reports: utils::take_items_of_type(items, ItemType::UserReport),
-                error: Self::Forward(report),
+                error: Self::Forward {report},
                 metrics,
                 fully_normalized: false,
             }
@@ -55,10 +45,8 @@ impl SentryError for Unreal {
             use crate::envelope::AttachmentType;
             use crate::services::processor::ProcessingError;
 
-            let expansion = match report {
-                UnrealReport::Report(item) => crate::utils::expand_unreal(item.payload(), ctx.processing.config)?,
-                UnrealReport::Expanded(report_items) => crate::utils::expand_unreal_items(report_items.into())?,
-            };
+            // FIXME: Change this back to item.
+            let expansion = crate::utils::expand_unreal(report.payload(), ctx.processing.config)?;
 
             let event = expansion.event;
             let mut attachments = expansion.attachments.into_vec();
@@ -177,8 +165,7 @@ impl SentryError for Unreal {
 
     fn serialize_into(self, items: &mut Vec<Item>, _ctx: ForwardContext<'_>) -> Result<()> {
         match self {
-            Self::Forward(UnrealReport::Report(report)) => items.push(report),
-            Self::Forward(UnrealReport::Expanded(report_items)) => items.extend(report_items),
+            Self::Forward { report } => items.push(report),
             #[cfg(feature = "processing")]
             Self::Process {
                 minidump,
@@ -194,7 +181,7 @@ impl SentryError for Unreal {
 
     fn minidump_mut(&mut self) -> Option<&mut Item> {
         match self {
-            Self::Forward(..) => None,
+            Self::Forward { .. } => None,
             #[cfg(feature = "processing")]
             Self::Process { minidump, .. } => minidump.as_mut(),
         }
@@ -204,8 +191,7 @@ impl SentryError for Unreal {
 impl Counted for Unreal {
     fn quantities(&self) -> Quantities {
         match self {
-            Self::Forward(UnrealReport::Report(..)) => Quantities::default(),
-            Self::Forward(UnrealReport::Expanded(items)) => items.quantities(),
+            Self::Forward { .. } => Quantities::default(),
             #[cfg(feature = "processing")]
             Self::Process {
                 minidump,

--- a/relay-server/src/processing/errors/errors/unreal.rs
+++ b/relay-server/src/processing/errors/errors/unreal.rs
@@ -45,7 +45,6 @@ impl SentryError for Unreal {
             use crate::envelope::AttachmentType;
             use crate::services::processor::ProcessingError;
 
-            // FIXME: Change this back to item.
             let expansion = crate::utils::expand_unreal(report.payload(), ctx.processing.config)?;
 
             let event = expansion.event;

--- a/relay-server/src/services/processor.rs
+++ b/relay-server/src/services/processor.rs
@@ -53,7 +53,6 @@ use crate::statsd::{RelayCounters, RelayDistributions, RelayTimers};
 use crate::utils;
 use crate::{http, processing};
 use relay_threading::AsyncPool;
-use symbolic_unreal::{Unreal4Error, Unreal4ErrorKind};
 #[cfg(feature = "processing")]
 use {
     crate::services::objectstore::Objectstore,
@@ -63,6 +62,7 @@ use {
     relay_quotas::{Quota, RateLimitingError, RedisRateLimiter},
     relay_redis::RedisClients,
     std::time::Instant,
+    symbolic_unreal::{Unreal4Error, Unreal4ErrorKind},
 };
 
 mod metrics;
@@ -82,6 +82,7 @@ pub enum ProcessingError {
     #[error("event data too deeply nested")]
     NestingTooDeep,
 
+    #[cfg(feature = "processing")]
     #[error("invalid unreal crash report")]
     InvalidUnrealReport(#[source] Unreal4Error),
 
@@ -155,9 +156,11 @@ impl ProcessingError {
             Self::InvalidNintendoDyingMessage(_) => Some(Outcome::Invalid(DiscardReason::Payload)),
             #[cfg(all(sentry, feature = "processing"))]
             Self::InvalidPlaystationDump(_) => Some(Outcome::Invalid(DiscardReason::Payload)),
+            #[cfg(feature = "processing")]
             Self::InvalidUnrealReport(err) if err.kind() == Unreal4ErrorKind::BadCompression => {
                 Some(Outcome::Invalid(DiscardReason::InvalidCompression))
             }
+            #[cfg(feature = "processing")]
             Self::InvalidUnrealReport(_) => Some(Outcome::Invalid(DiscardReason::ProcessUnreal)),
             Self::SerializeFailed(_) | Self::ProcessingFailed(_) => {
                 Some(Outcome::Invalid(DiscardReason::Internal))
@@ -174,6 +177,7 @@ impl ProcessingError {
     }
 }
 
+#[cfg(feature = "processing")]
 impl From<Unreal4Error> for ProcessingError {
     fn from(err: Unreal4Error) -> Self {
         match err.kind() {

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1015,8 +1015,6 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     /// - `expansion`: What expansion was used to expand the error (e.g. unreal).
     ErrorProcessed,
-    /// The number of times the new unreal expansion logic in the endpoint is hit.
-    UnrealEndpointExpansion,
     /// The number of times that relay receives a compressed minidump.
     CompressedMinidump,
     /// The number of times a trace metric has a nil trace ID.
@@ -1088,7 +1086,6 @@ impl CounterMetric for RelayCounters {
             RelayCounters::EnvelopeWithLogs => "logs.envelope",
             RelayCounters::ProfileChunksWithoutPlatform => "profile_chunk.no_platform",
             RelayCounters::ErrorProcessed => "event.error.processed",
-            RelayCounters::UnrealEndpointExpansion => "unreal.endpoint_expansion",
             RelayCounters::CompressedMinidump => "minidump.compressed.count",
             RelayCounters::TraceMetricNilTraceId => "trace_metric.nil_trace_id",
         }

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -38,7 +38,6 @@ pub use self::multipart::*;
 #[cfg(feature = "processing")]
 pub use self::native::*;
 pub use self::param_parser::*;
-#[cfg(feature = "processing")]
 pub use self::pick::*;
 pub use self::rate_limits::*;
 pub use self::retry::*;

--- a/relay-server/src/utils/mod.rs
+++ b/relay-server/src/utils/mod.rs
@@ -25,6 +25,7 @@ mod memory;
 #[cfg(feature = "processing")]
 mod native;
 mod serde;
+#[cfg(feature = "processing")]
 mod unreal;
 
 pub use self::api::*;
@@ -37,6 +38,7 @@ pub use self::multipart::*;
 #[cfg(feature = "processing")]
 pub use self::native::*;
 pub use self::param_parser::*;
+#[cfg(feature = "processing")]
 pub use self::pick::*;
 pub use self::rate_limits::*;
 pub use self::retry::*;
@@ -48,4 +50,5 @@ pub use self::split_off::*;
 pub use self::statsd::*;
 pub use self::stream::*;
 pub use self::thread_pool::*;
+#[cfg(feature = "processing")]
 pub use self::unreal::*;

--- a/relay-server/src/utils/pick.rs
+++ b/relay-server/src/utils/pick.rs
@@ -25,7 +25,6 @@ pub fn is_rolled_out(id: u64, rate: f32) -> PickResult {
 
 impl PickResult {
     /// Returns `true` if the sampling result is [`PickResult::Keep`].
-    #[cfg(feature = "processing")]
     pub fn is_keep(self) -> bool {
         matches!(self, PickResult::Keep)
     }

--- a/relay-server/src/utils/pick.rs
+++ b/relay-server/src/utils/pick.rs
@@ -25,6 +25,7 @@ pub fn is_rolled_out(id: u64, rate: f32) -> PickResult {
 
 impl PickResult {
     /// Returns `true` if the sampling result is [`PickResult::Keep`].
+    #[cfg(feature = "processing")]
     pub fn is_keep(self) -> bool {
         matches!(self, PickResult::Keep)
     }

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -55,8 +55,10 @@ pub fn extract_items(payload: Bytes, config: &Config) -> Result<Items, Processin
     Ok(items)
 }
 
-/// Expands items previously extracted from a report in to the [`UnrealExpansion`] representation.
-pub fn expand_unreal_items(items: Items) -> Result<UnrealExpansion, ProcessingError> {
+/// Expands an Unreal 4 crash report payload and returns the expanded items.
+pub fn expand_unreal(payload: Bytes, config: &Config) -> Result<UnrealExpansion, ProcessingError> {
+    let items = extract_items(payload, config)?;
+
     let mut context = items
         .iter()
         .find(|&item| matches!(item.attachment_type(), Some(AttachmentType::UnrealContext)))
@@ -72,25 +74,15 @@ pub fn expand_unreal_items(items: Items) -> Result<UnrealExpansion, ProcessingEr
     })
 }
 
-/// Expands an Unreal 4 crash report payload and returns the expanded items.
-#[cfg_attr(not(feature = "processing"), expect(unused))]
-pub fn expand_unreal(payload: Bytes, config: &Config) -> Result<UnrealExpansion, ProcessingError> {
-    let attachments = extract_items(payload, config)?;
-    expand_unreal_items(attachments)
-}
-
 /// Expansion from an Unreal 4 report.
 pub struct UnrealExpansion {
     /// The error event if the crash contained one.
-    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub event: Option<Item>,
     /// The parsed unreal context.
     ///
     /// Note: the raw unreal context may still be in [`Self::attachments`].
-    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub context: Option<Unreal4Context>,
     /// Files of the report as attachments.
-    #[cfg_attr(not(feature = "processing"), expect(unused))]
     pub attachments: Items,
 }
 

--- a/relay-server/src/utils/unreal.rs
+++ b/relay-server/src/utils/unreal.rs
@@ -344,7 +344,6 @@ fn merge_unreal_context(event: &mut Event, context: Unreal4Context) {
 /// Processes an unreal crash report.
 ///
 /// The `user_header` should be extracted from the [`crate::constants::UNREAL_USER_HEADER`] envelope header.
-#[cfg_attr(not(feature = "processing"), expect(unused))]
 pub fn process_unreal<'a>(
     context: Option<Unreal4Context>,
     event_id: EventId,
@@ -386,7 +385,6 @@ pub fn process_unreal<'a>(
 }
 
 /// Result when processing an unreal report.
-#[cfg_attr(not(feature = "processing"), expect(unused))]
 pub struct ProcessedUnrealReport {
     /// User reports contained in the report.
     pub user_reports: Items,

--- a/tests/integration/test_unreal.py
+++ b/tests/integration/test_unreal.py
@@ -15,23 +15,15 @@ def load_dump_file(base_file_name: str):
 
 
 @pytest.mark.parametrize("dump_file_name", ["unreal_crash", "unreal_crash_apple"])
-@pytest.mark.parametrize("config_fetch", [False, True])
-def test_unreal_crash(mini_sentry, relay, dump_file_name, config_fetch):
+def test_unreal_crash(mini_sentry, relay, dump_file_name):
     """
     Asserts that non-processing Relays forward the Unreal report either as a
     single unreal_report item or as expanded attachment items depending on
     the endpoint expansion rollout rate.
     """
     project_id = 42
-    mini_sentry.global_config["options"][
-        "relay.endpoint-fetch-config.enabled"
-    ] = config_fetch
+    mini_sentry.add_full_project_config(project_id)
     relay = relay(mini_sentry)
-    project_config = mini_sentry.add_full_project_config(project_id)
-    if config_fetch:
-        project_config["config"].setdefault("features", []).extend(
-            ["organizations:relay-unreal-endpoint-expansion"]
-        )
 
     unreal_content = load_dump_file(dump_file_name)
 
@@ -43,63 +35,12 @@ def test_unreal_crash(mini_sentry, relay, dump_file_name, config_fetch):
     assert event_id == envelope.headers.get("event_id")
     items = envelope.items
 
-    if not config_fetch:
-        assert len(items) == 1
-        unreal_item = items[0]
-        assert unreal_item.headers
-        assert unreal_item.headers.get("type") == "unreal_report"
-        assert unreal_item.headers.get("content_type") == "application/octet-stream"
-        assert unreal_item.payload is not None
-    else:
-        assert len(items) == (4 if dump_file_name == "unreal_crash" else 6)
-        for item in items:
-            assert item.headers.get("type") == "attachment"
-            assert item.headers.get("unreal_expanded") is True
-
-
-@pytest.mark.parametrize("dump_file_name", ["unreal_crash", "unreal_crash_apple"])
-@pytest.mark.parametrize("config_fetch", [False, True])
-def test_unreal_crash_full_pipeline(
-    mini_sentry,
-    relay,
-    relay_with_processing,
-    relay_credentials,
-    attachments_consumer,
-    outcomes_consumer,
-    dump_file_name,
-    config_fetch,
-):
-    """
-    Even if unreal report is expanded in the endpoint the end to end logic should remain unchanged.
-    """
-    project_id = 42
-    mini_sentry.global_config["options"][
-        "relay.endpoint-fetch-config.enabled"
-    ] = config_fetch
-
-    credentials = relay_credentials()
-    processing = relay_with_processing(static_credentials=credentials)
-    pop = relay(processing, credentials=credentials)
-
-    project_config = mini_sentry.add_full_project_config(project_id)
-    if config_fetch:
-        project_config["config"].setdefault("features", []).extend(
-            ["organizations:relay-unreal-endpoint-expansion"]
-        )
-
-    attachments_consumer = attachments_consumer()
-    outcomes_consumer = outcomes_consumer()
-
-    unreal_content = load_dump_file(dump_file_name)
-    pop.send_unreal_request(project_id, unreal_content)
-
-    event, payload = attachments_consumer.get_event_only()
-
-    assert event is not None
-    assert event["type"] == "event"
-    assert "unreal" in payload.get("contexts", {})
-
-    assert len(event["attachments"]) == (4 if dump_file_name == "unreal_crash" else 6)
+    assert len(items) == 1
+    unreal_item = items[0]
+    assert unreal_item.headers
+    assert unreal_item.headers.get("type") == "unreal_report"
+    assert unreal_item.headers.get("content_type") == "application/octet-stream"
+    assert unreal_item.payload is not None
 
 
 def test_unreal_minidump_with_processing(


### PR DESCRIPTION
Partial revert of https://github.com/getsentry/relay/pull/5825 undoing the moving of the expansion logic (this was feature flagged and never rolled out). In the end we decided against pursuing large attachment support on the unreal endpoint. The reason it is only a partial revert is that some of the changes that were made are still used for the large attachment support in the `playstation` and `minidump` endpoint.