### PR TITLE
ref(kafka): Rename produced to enqueued and add a new produced metric

### DIFF
--- a/relay-kafka/src/producer/utils.rs
+++ b/relay-kafka/src/producer/utils.rs
@@ -255,6 +255,11 @@ impl ProducerContext for Context {
                     topic = message.topic(),
                     producer_name = self.producer_name.as_str(),
                 );
+                metric!(
+                    counter(KafkaCounters::ProcessingMessageProduced) += 1,
+                    topic = message.topic(),
+                    producer_name = self.producer_name.as_str(),
+                );
             }
             Err((error, message)) => {
                 relay_log::error!(

--- a/relay-kafka/src/statsd.rs
+++ b/relay-kafka/src/statsd.rs
@@ -65,6 +65,13 @@ pub enum KafkaCounters {
     /// - `producer_name`: The configured producer name/deployment identifier.
     ProduceStatusSuccess,
 
+    /// Number of messages successfully produced to Kafka brokers.
+    ///
+    /// This metric is tagged with:
+    /// - `topic`: The Kafka topic produced to.
+    /// - `producer_name`: The configured producer name/deployment identifier.
+    ProcessingMessageProduced,
+
     /// Number of failed message produce operations.
     ///
     /// This metric is tagged with:
@@ -79,6 +86,7 @@ impl CounterMetric for KafkaCounters {
             Self::ProducerEnqueueError => "producer.enqueue.error",
             Self::ProducerPartitionKeyRateLimit => "producer.partition_key.rate_limit",
             Self::ProduceStatusSuccess => "producer.produce_status.success",
+            Self::ProcessingMessageProduced => "processing.event.produced",
             Self::ProduceStatusError => "producer.produce_status.error",
         }
     }

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -908,7 +908,7 @@ impl StoreService {
                 message: metric, ..
             } => {
                 metric!(
-                    counter(RelayCounters::ProcessingMessageProduced) += 1,
+                    counter(RelayCounters::ProcessingMessageEnqueued) += 1,
                     event_type = message.variant(),
                     topic = topic_name,
                     metric_type = metric.value.variant(),
@@ -919,7 +919,7 @@ impl StoreService {
                 let has_video = replay.replay_video.is_some();
 
                 metric!(
-                    counter(RelayCounters::ProcessingMessageProduced) += 1,
+                    counter(RelayCounters::ProcessingMessageEnqueued) += 1,
                     event_type = message.variant(),
                     topic = topic_name,
                     has_video = bool_to_str(has_video),
@@ -927,7 +927,7 @@ impl StoreService {
             }
             message => {
                 metric!(
-                    counter(RelayCounters::ProcessingMessageProduced) += 1,
+                    counter(RelayCounters::ProcessingMessageEnqueued) += 1,
                     event_type = message.variant(),
                     topic = topic_name,
                 );

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -852,7 +852,7 @@ pub enum RelayCounters {
     ///  - `user_report`: A message from the user feedback dialog, sent to `ingest-events`.
     ///  - `session`: A release health session update, sent to `ingest-sessions`.
     #[cfg(feature = "processing")]
-    ProcessingMessageProduced,
+    ProcessingMessageEnqueued,
     /// Number of spans produced in the new format.
     #[cfg(feature = "processing")]
     SpanV2Produced,
@@ -1052,7 +1052,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ProjectCacheSchedule => "project_cache.schedule",
             RelayCounters::ServerStarting => "server.starting",
             #[cfg(feature = "processing")]
-            RelayCounters::ProcessingMessageProduced => "processing.event.produced",
+            RelayCounters::ProcessingMessageEnqueued => "processing.event.enqueued",
             #[cfg(feature = "processing")]
             RelayCounters::SpanV2Produced => "store.produced.span_v2",
             RelayCounters::EventProtocol => "event.protocol",


### PR DESCRIPTION
This will break dashboard that are tagged with the event, but we can just fix these, naming wise this makes more sense.

Closes: INGEST-1043