### PR TITLE
fix(dynamic-sampling): Always overwrite dsc values, re-parameterize DSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Extract nvgpu dumps and create GPU events. ([#6242](https://github.com/getsentry/relay/pull/6242))
 
+**Bug Fixes**:
+
+- Re-parameterize a DSC when it is computed from a transaction. ([#6279](https://github.com/getsentry/relay/pull/6279))
+
 ## 26.7.2
 
 **Features**:

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -482,14 +482,11 @@ pub fn normalize_dsc(
 
     let attributes = attributes.get_or_insert_with(Default::default);
 
-    // Check if DSC attributes are already set, the trace id is always required and must always be set.
-    if attributes.contains_key(SENTRY__DSC__TRACE_ID) {
-        return;
-    }
     attributes.insert(SENTRY__DSC__TRACE_ID, dsc.trace_id.to_string());
 
-    if let Some(transaction) = &dsc.transaction {
-        attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone());
+    match &dsc.transaction {
+        Some(transaction) => attributes.insert(SENTRY__DSC__TRANSACTION, transaction.clone()),
+        None => drop(attributes.remove(SENTRY__DSC__TRANSACTION)),
     }
 
     if let Some(project_id) = &dsc.project_id {

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -117,6 +117,7 @@ pub fn normalize_dsc_for_span_data(
         Some(tx) if tx.len() <= config.max_tag_value_length => {
             data.insert_value(SENTRY__DSC__TRANSACTION, tx.clone())
         }
+        // Keep an empty value around for the DS job
         Some(_) => data.insert_value(SENTRY__DSC__TRANSACTION, "".to_owned()),
         None => drop(data.remove(SENTRY__DSC__TRANSACTION)),
     }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -118,6 +118,6 @@ pub fn normalize_dsc_for_span_data(
             data.insert_value(SENTRY__DSC__TRANSACTION, tx.clone())
         }
         Some(_) => data.insert_value(SENTRY__DSC__TRANSACTION, "".to_owned()),
-        None => drop(data.remove(SENTRY__DSC__TRACE_ID)),
+        None => drop(data.remove(SENTRY__DSC__TRANSACTION)),
     }
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -84,9 +84,6 @@ pub fn normalize_app_start_spans(event: &mut Event) {
 }
 
 /// Writes DSC attributes needed for dynamic sampling into the spans' `data`.
-///
-/// If `sentry.dsc.trace_id` is already present in a span's `data`, the function does nothing for
-/// that span.
 pub fn normalize_dsc_for_event_spans(event: &mut Event, config: &NormalizationConfig) {
     if let Some(ctx) = event.context_mut::<TraceContext>() {
         normalize_dsc_for_span_data(&mut ctx.data, config);
@@ -101,8 +98,6 @@ pub fn normalize_dsc_for_event_spans(event: &mut Event, config: &NormalizationCo
 }
 
 /// Writes DSC attributes needed for dynamic sampling into `span_data`.
-///
-/// If `sentry.dsc.trace_id` is already present in `span_data`, the function does nothing.
 pub fn normalize_dsc_for_span_data(
     span_data: &mut Annotated<SpanData>,
     config: &NormalizationConfig,
@@ -112,9 +107,6 @@ pub fn normalize_dsc_for_span_data(
     };
 
     let data = span_data.get_or_insert_with(SpanData::default);
-    if data.get_value(SENTRY__DSC__TRACE_ID).is_some() {
-        return;
-    }
     data.insert_value(SENTRY__DSC__TRACE_ID, dsc.trace_id.to_string());
     if let Some(project_id) = &dsc.project_id {
         data.insert_value(SENTRY__DSC__PROJECT_ID, project_id.to_string());
@@ -127,5 +119,7 @@ pub fn normalize_dsc_for_span_data(
             // Keep an empty value around for the DS job
             false => data.insert_value(SENTRY__DSC__TRANSACTION, "".to_owned()),
         }
+    } else {
+        data.remove(SENTRY__DSC__TRANSACTION);
     }
 }

--- a/relay-event-normalization/src/normalize/span/mod.rs
+++ b/relay-event-normalization/src/normalize/span/mod.rs
@@ -111,15 +111,13 @@ pub fn normalize_dsc_for_span_data(
     if let Some(project_id) = &dsc.project_id {
         data.insert_value(SENTRY__DSC__PROJECT_ID, project_id.to_string());
     }
-    if let Some(transaction) = &dsc.transaction {
+    match &dsc.transaction {
         // To match the behaviour of the `count_per_root` metric, which had its tags
         // removed if they were over the limit.
-        match transaction.len() <= config.max_tag_value_length {
-            true => data.insert_value(SENTRY__DSC__TRANSACTION, transaction.clone()),
-            // Keep an empty value around for the DS job
-            false => data.insert_value(SENTRY__DSC__TRANSACTION, "".to_owned()),
+        Some(tx) if tx.len() <= config.max_tag_value_length => {
+            data.insert_value(SENTRY__DSC__TRANSACTION, tx.clone())
         }
-    } else {
-        data.remove(SENTRY__DSC__TRANSACTION);
+        Some(_) => data.insert_value(SENTRY__DSC__TRANSACTION, "".to_owned()),
+        None => drop(data.remove(SENTRY__DSC__TRACE_ID)),
     }
 }

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -7,6 +7,7 @@ use relay_event_schema::processor::{
 };
 use relay_event_schema::protocol::{Event, Span, SpanStatus, TraceContext, TransactionSource};
 use relay_protocol::{Annotated, Meta, Remark, RemarkType, RuleCondition};
+use relay_sampling::DynamicSamplingContext;
 use serde::{Deserialize, Serialize};
 
 use crate::TransactionNameRule;
@@ -32,6 +33,25 @@ pub fn normalize_transaction_name(
     if !rules.is_empty() {
         apply_transaction_rename_rules(transaction, rules);
     }
+}
+
+/// Apply parametrization to a DSC.
+pub fn parameterize_dsc_transaction(
+    dsc: &mut DynamicSamplingContext,
+    rules: &[TransactionNameRule],
+) {
+    let Some(transaction) = dsc.transaction.as_mut() else {
+        return;
+    };
+    if !transaction.contains('/') {
+        return;
+    }
+
+    dsc.transaction = {
+        let mut transaction = Annotated::new(transaction.clone());
+        normalize_transaction_name(&mut transaction, rules);
+        transaction.into_value()
+    };
 }
 
 /// Applies the rule if any found to the transaction name.

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -45,7 +45,7 @@ pub fn parameterize_dsc_transaction(
     };
     // Ideally we would only apply transaction rules to transactions with source `url`,
     // but the DSC does not contain this information. The chance of a transaction rename rule
-    // accidentially matching a non-URL transaction should be very low.
+    // accidentally matching a non-URL transaction should be very low.
     if !transaction.contains('/') {
         return;
     }

--- a/relay-event-normalization/src/transactions/processor.rs
+++ b/relay-event-normalization/src/transactions/processor.rs
@@ -43,6 +43,9 @@ pub fn parameterize_dsc_transaction(
     let Some(transaction) = dsc.transaction.as_mut() else {
         return;
     };
+    // Ideally we would only apply transaction rules to transactions with source `url`,
+    // but the DSC does not contain this information. The chance of a transaction rename rule
+    // accidentially matching a non-URL transaction should be very low.
     if !transaction.contains('/') {
         return;
     }

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -40,7 +40,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use relay_dynamic_config::{ErrorBoundary, Feature};
-use relay_event_normalization::{TransactionNameRule, normalize_transaction_name};
+use relay_event_normalization::{TransactionNameRule, parameterize_dsc_transaction};
 use relay_event_schema::protocol::{Event, EventId};
 use relay_protocol::{Annotated, Value};
 use relay_sampling::DynamicSamplingContext;
@@ -447,20 +447,7 @@ impl Envelope {
         let Some(ErrorBoundary::Ok(dsc)) = &mut self.headers.trace else {
             return;
         };
-
-        let parametrized_transaction = match &dsc.transaction {
-            Some(transaction) if transaction.contains('/') => {
-                // Ideally we would only apply transaction rules to transactions with source `url`,
-                // but the DSC does not contain this information. The chance of a transaction rename rule
-                // accidentially matching a non-URL transaction should be very low.
-                let mut annotated = Annotated::new(transaction.clone());
-                normalize_transaction_name(&mut annotated, rules);
-                annotated.into_value()
-            }
-            _ => return,
-        };
-
-        dsc.transaction = parametrized_transaction;
+        parameterize_dsc_transaction(dsc, rules);
     }
 
     /// Returns the dynamic sampling context from envelope headers, if present.

--- a/relay-server/src/processing/transactions/process.rs
+++ b/relay-server/src/processing/transactions/process.rs
@@ -135,6 +135,10 @@ pub fn prepare_data(
         profile::remove_context_if_rate_limited(&mut work.event, scoping, *ctx);
 
         utils::dsc::validate_and_set_dsc(&mut work.headers, &work.event, ctx);
+        if let (Some(dsc), Some(config)) = (work.headers.dsc_mut(), ctx.sampling_project_info) {
+            let rules = &config.config.tx_name_rules;
+            relay_event_normalization::parameterize_dsc_transaction(dsc, rules);
+        }
 
         utils::event::finalize(
             &work.headers,

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -1116,7 +1116,7 @@ def get_v2_envelope(
     return envelope
 
 
-def test_dsc_transaction_parametrization_not_applied_to_attributes(
+def test_dsc_transaction_parametrization_applied_with_reconstructed_dsc(
     mini_sentry,
     relay,
     relay_with_processing,

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -1116,7 +1116,7 @@ def get_v2_envelope(
     return envelope
 
 
-def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
+def test_dsc_transaction_parametrization_not_applied_to_attributes(
     mini_sentry,
     relay,
     relay_with_processing,
@@ -1124,9 +1124,6 @@ def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
 ):
     project_id = 42
     sampling_project_id = 43
-    trace_id = "a0fa8803753e40fd8124b21eeb2986b5"
-    transaction = "/users/1234/"
-    parametrized_transaction = "/users/*/"
 
     mini_sentry.add_full_project_config(project_id, extra={"organizationId": 1})
     sampling_project_config = mini_sentry.add_full_project_config(
@@ -1134,6 +1131,8 @@ def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
     )
     relay = relay(relay_with_processing())
     transactions_consumer = transactions_consumer()
+
+    transaction = "/users/1234/"
 
     timestamp = datetime.now(timezone.utc).timestamp()
     envelope = Envelope()
@@ -1149,9 +1148,13 @@ def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
                     "timestamp": timestamp + 1,
                     "contexts": {
                         "trace": {
-                            "trace_id": trace_id,
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
                             "span_id": "a" * 16,
                             "op": "navigation",
+                            "data": {
+                                "sentry.dsc.trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                                "sentry.dsc.transaction": transaction,
+                            },
                         }
                     },
                     "spans": [],
@@ -1160,7 +1163,7 @@ def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
         )
     )
     envelope.headers["trace"] = {
-        "trace_id": trace_id,
+        "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
         "public_key": sampling_project_config["publicKeys"][0]["publicKey"],
         "transaction": transaction,
         "org_id": sampling_project_config["organizationId"],
@@ -1169,6 +1172,7 @@ def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
     relay.send_envelope(project_id, envelope)
     event, _ = transactions_consumer.get_event()
 
+    parametrized_transaction = "/users/*/"
     assert event["transaction"] == parametrized_transaction
     assert event["_dsc"]["transaction"] == parametrized_transaction
     assert (
@@ -1278,8 +1282,8 @@ def test_dsc_normalization(
 
     # Child span with sentry.dsc.* attributes already set in its span data
     assert spans[child_id_2]["is_segment"] is False
-    assert get_dsc_attr("transaction", child_id_2) == "/spandata/"
-    assert get_dsc_attr("project_id", child_id_2) == "41"
+    assert get_dsc_attr("transaction", child_id_2) == expected_tx
+    assert get_dsc_attr("project_id", child_id_2) == str(expected_project_id)
     assert get_dsc_attr("trace_id", child_id_2) == trace_id
 
     assert metrics == [

--- a/tests/integration/test_dynamic_sampling.py
+++ b/tests/integration/test_dynamic_sampling.py
@@ -1116,6 +1116,67 @@ def get_v2_envelope(
     return envelope
 
 
+def test_dsc_transaction_parametrization_is_consistent_across_relay_chain(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    transactions_consumer,
+):
+    project_id = 42
+    sampling_project_id = 43
+    trace_id = "a0fa8803753e40fd8124b21eeb2986b5"
+    transaction = "/users/1234/"
+    parametrized_transaction = "/users/*/"
+
+    mini_sentry.add_full_project_config(project_id, extra={"organizationId": 1})
+    sampling_project_config = mini_sentry.add_full_project_config(
+        sampling_project_id, extra={"organizationId": 2}
+    )
+    relay = relay(relay_with_processing())
+    transactions_consumer = transactions_consumer()
+
+    timestamp = datetime.now(timezone.utc).timestamp()
+    envelope = Envelope()
+    envelope.add_item(
+        Item(
+            type="transaction",
+            payload=PayloadRef(
+                json={
+                    "type": "transaction",
+                    "transaction": transaction,
+                    "transaction_info": {"source": "url"},
+                    "start_timestamp": timestamp,
+                    "timestamp": timestamp + 1,
+                    "contexts": {
+                        "trace": {
+                            "trace_id": trace_id,
+                            "span_id": "a" * 16,
+                            "op": "navigation",
+                        }
+                    },
+                    "spans": [],
+                }
+            ),
+        )
+    )
+    envelope.headers["trace"] = {
+        "trace_id": trace_id,
+        "public_key": sampling_project_config["publicKeys"][0]["publicKey"],
+        "transaction": transaction,
+        "org_id": sampling_project_config["organizationId"],
+    }
+
+    relay.send_envelope(project_id, envelope)
+    event, _ = transactions_consumer.get_event()
+
+    assert event["transaction"] == parametrized_transaction
+    assert event["_dsc"]["transaction"] == parametrized_transaction
+    assert (
+        event["contexts"]["trace"]["data"]["sentry.dsc.transaction"]
+        == parametrized_transaction
+    )
+
+
 @pytest.mark.parametrize("span_type", ["tx", "v2"])
 @pytest.mark.parametrize("org", ["same_org", "diff_org"])
 @pytest.mark.parametrize("dsc", ["dsc_with_tx", "dsc_no_tx", "no_dsc"])

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -741,10 +741,10 @@ def test_spans_standalone_dsc_normalization(
     assert spans["cccccccccccccccc"]["is_segment"] is False
     assert get_transaction("aaaaaaaaaaaaaaaa") == "/my/fancy/endpoint"
     assert get_transaction("bbbbbbbbbbbbbbbb") == "/my/fancy/endpoint"
-    assert get_transaction("cccccccccccccccc") == "/transaction/already/exists"
+    assert get_transaction("cccccccccccccccc") == "/my/fancy/endpoint"
     assert get_project_id("aaaaaaaaaaaaaaaa") == "42"
     assert get_project_id("bbbbbbbbbbbbbbbb") == "42"
-    assert get_project_id("cccccccccccccccc") == "41"
+    assert get_project_id("cccccccccccccccc") == "42"
     assert get_trace_id("aaaaaaaaaaaaaaaa") == "5b8efff798038103d269b633813fc60c"
     assert get_trace_id("bbbbbbbbbbbbbbbb") == "5b8efff798038103d269b633813fc60c"
     assert get_trace_id("cccccccccccccccc") == "5b8efff798038103d269b633813fc60c"


### PR DESCRIPTION
Two problems here:
- The DSC was not re-parameterized if it was modified in `prepare_data`
- The values could drift apart because we originally wanted to keep existing attributes around, the idea was good (and made us find this problem), but at the same time, especially for the transaction pipeline we prefer equivalency to the `_dsc` for DS.

Closes: RELAY-253