### PR TITLE
fix(store): Change processor<->store thread ration from 12:1 to 8:1

### DIFF
--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -136,7 +136,7 @@ fn create_store_pool(config: &Config) -> Result<StoreServicePool> {
     //
     // Ideally in the future the store will be single threaded again, after we move
     // all the heavy processing (de- and re-serialization) into the processor.
-    let thread_count = config.cpu_concurrency().div_ceil(12);
+    let thread_count = config.cpu_concurrency().div_ceil(8);
     relay_log::info!("starting {thread_count} store workers");
 
     let pool = crate::utils::ThreadPoolBuilder::new("store", tokio::runtime::Handle::current())


### PR DESCRIPTION
With the recent changes to the processor we've moved more and more serialization into the store service, increasing its hunger for CPU.