### PR TITLE
feat(transactions): Preserve contexts, extra, and breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Reject spans, logs, trace metrics, replays when they are too old instead of shifting their timestamp. ([#6272](https://github.com/getsentry/relay/pull/6272))
 - Extract nvgpu dumps and create GPU events. ([#6242](https://github.com/getsentry/relay/pull/6242))
+- Preserve transaction `contexts`, `extra`, and `breadcrumbs` on the segment span as serialized attributes. ([#6286](https://github.com/getsentry/relay/pull/6286))
 
 **Bug Fixes**:
 

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -65,6 +65,13 @@ pub mod attributes {
         // TODO(buenaflor): Add as sentry convention once mobile SDKs can migrate to it.
         // Tracking issue: https://github.com/getsentry/sentry-conventions/issues/318
         pub const APP__VITALS__START__VALUE: &str = "app.vitals.start.value";
+
+        /// The transaction event's `contexts`, serialized as a JSON string.
+        pub const SENTRY__TRANSACTION__CONTEXTS: &str = "sentry.transaction.contexts";
+        /// The transaction event's `breadcrumbs`, serialized as a JSON string.
+        pub const SENTRY__TRANSACTION__BREADCRUMBS: &str = "sentry.transaction.breadcrumbs";
+        /// The transaction event's `extra`, serialized as a JSON string.
+        pub const SENTRY__TRANSACTION__EXTRA: &str = "sentry.transaction.extra";
     }
     pub use self::not_yet_defined::*;
 }

--- a/relay-conventions/src/lib.rs
+++ b/relay-conventions/src/lib.rs
@@ -65,13 +65,6 @@ pub mod attributes {
         // TODO(buenaflor): Add as sentry convention once mobile SDKs can migrate to it.
         // Tracking issue: https://github.com/getsentry/sentry-conventions/issues/318
         pub const APP__VITALS__START__VALUE: &str = "app.vitals.start.value";
-
-        /// The transaction event's `contexts`, serialized as a JSON string.
-        pub const SENTRY__TRANSACTION__CONTEXTS: &str = "sentry.transaction.contexts";
-        /// The transaction event's `breadcrumbs`, serialized as a JSON string.
-        pub const SENTRY__TRANSACTION__BREADCRUMBS: &str = "sentry.transaction.breadcrumbs";
-        /// The transaction event's `extra`, serialized as a JSON string.
-        pub const SENTRY__TRANSACTION__EXTRA: &str = "sentry.transaction.extra";
     }
     pub use self::not_yet_defined::*;
 }

--- a/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__extracts_searchable_contexts_into_segment_span.snap
+++ b/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__extracts_searchable_contexts_into_segment_span.snap
@@ -13,9 +13,9 @@ expression: segment_span.to_json_pretty().unwrap()
   "description": "foo",
   "data": {
     "browser.name": "Chrome",
+    "sentry.event.serialized_contexts": "{\"app\":{\"app_start_time\":\"2025-04-07T13:33:38Z\",\"device_app_hash\":\"3e06efaccaec678afef02f3fc2b5289ee5f613d5\",\"build_type\":\"simulator\",\"app_identifier\":\"io.sentry.sample.iOS-Swift\",\"app_name\":\"iOS-Swift\",\"app_version\":\"8.48.0\",\"app_build\":\"1\",\"app_memory\":17793024,\"in_foreground\":true,\"app_id\":\"33410C22-5CBB-3C1C-8453-62311FADEF1A\",\"type\":\"app\"},\"browser\":{\"browser\":\"Chrome 134\",\"name\":\"Chrome\",\"version\":\"134\",\"type\":\"browser\"},\"device\":{\"family\":\"K\",\"model\":\"Generic_Android\",\"type\":\"device\"},\"runtime\":{\"runtime\":\"CPython 3.13.1\",\"name\":\"CPython\",\"version\":\"3.13.1\",\"type\":\"runtime\"}}",
     "sentry.name": "foo",
-    "sentry.segment.name": "foo",
-    "sentry.transaction.contexts": "{\"app\":{\"app_start_time\":\"2025-04-07T13:33:38Z\",\"device_app_hash\":\"3e06efaccaec678afef02f3fc2b5289ee5f613d5\",\"build_type\":\"simulator\",\"app_identifier\":\"io.sentry.sample.iOS-Swift\",\"app_name\":\"iOS-Swift\",\"app_version\":\"8.48.0\",\"app_build\":\"1\",\"app_memory\":17793024,\"in_foreground\":true,\"app_id\":\"33410C22-5CBB-3C1C-8453-62311FADEF1A\",\"type\":\"app\"},\"browser\":{\"browser\":\"Chrome 134\",\"name\":\"Chrome\",\"version\":\"134\",\"type\":\"browser\"},\"device\":{\"family\":\"K\",\"model\":\"Generic_Android\",\"type\":\"device\"},\"runtime\":{\"runtime\":\"CPython 3.13.1\",\"name\":\"CPython\",\"version\":\"3.13.1\",\"type\":\"runtime\"}}"
+    "sentry.segment.name": "foo"
   },
   "sentry_tags": {
     "device.family": "K",

--- a/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__extracts_searchable_contexts_into_segment_span.snap
+++ b/relay-event-normalization/src/normalize/span/snapshots/relay_event_normalization__normalize__span__tag_extraction__tests__extracts_searchable_contexts_into_segment_span.snap
@@ -14,7 +14,8 @@ expression: segment_span.to_json_pretty().unwrap()
   "data": {
     "browser.name": "Chrome",
     "sentry.name": "foo",
-    "sentry.segment.name": "foo"
+    "sentry.segment.name": "foo",
+    "sentry.transaction.contexts": "{\"app\":{\"app_start_time\":\"2025-04-07T13:33:38Z\",\"device_app_hash\":\"3e06efaccaec678afef02f3fc2b5289ee5f613d5\",\"build_type\":\"simulator\",\"app_identifier\":\"io.sentry.sample.iOS-Swift\",\"app_name\":\"iOS-Swift\",\"app_version\":\"8.48.0\",\"app_build\":\"1\",\"app_memory\":17793024,\"in_foreground\":true,\"app_id\":\"33410C22-5CBB-3C1C-8453-62311FADEF1A\",\"type\":\"app\"},\"browser\":{\"browser\":\"Chrome 134\",\"name\":\"Chrome\",\"version\":\"134\",\"type\":\"browser\"},\"device\":{\"family\":\"K\",\"model\":\"Generic_Android\",\"type\":\"device\"},\"runtime\":{\"runtime\":\"CPython 3.13.1\",\"name\":\"CPython\",\"version\":\"3.13.1\",\"type\":\"runtime\"}}"
   },
   "sentry_tags": {
     "device.family": "K",

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -5,11 +5,37 @@ use relay_conventions::attributes::{
     SENTRY__SDK__VERSION, SENTRY__SEGMENT__NAME, SENTRY__TRANSACTION__BREADCRUMBS,
     SENTRY__TRANSACTION__CONTEXTS, SENTRY__TRANSACTION__EXTRA, URL__QUERY,
 };
-use relay_protocol::{Annotated, IntoValue};
+use relay_protocol::{IntoValue, Object, SerializePayload, SkipSerialization};
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 use crate::protocol::{
-    BrowserContext, DefaultContext, Event, ProfileContext, Span, SpanData, TraceContext,
+    BrowserContext, ContextInner, DefaultContext, Event, ProfileContext, Span, SpanData,
+    TraceContext,
 };
+
+/// Serializes a borrowed contexts map, skipping the given key.
+struct ContextsWithout<'a> {
+    contexts: &'a Object<ContextInner>,
+    skip_key: &'a str,
+}
+
+impl Serialize for ContextsWithout<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let behavior = SkipSerialization::default();
+        let mut map = serializer.serialize_map(None)?;
+        for (key, value) in self.contexts {
+            if key == self.skip_key || value.skip_serialization(behavior) {
+                continue;
+            }
+            map.serialize_entry(key, &SerializePayload(value, behavior))?;
+        }
+        map.end()
+    }
+}
 
 impl From<&Event> for Span {
     fn from(event: &Event) -> Self {
@@ -82,12 +108,18 @@ impl From<&Event> for Span {
         }
 
         if let Some(contexts) = contexts.value() {
-            let mut contexts = contexts.clone();
-            contexts.0.remove(TraceContext::default_key());
-            if !contexts.0.is_empty()
-                && let Ok(json) = Annotated::new(contexts).payload_to_json()
-            {
-                span_data.insert_value(SENTRY__TRANSACTION__CONTEXTS, json);
+            let has_other = contexts.0.iter().any(|(key, value)| {
+                key != TraceContext::default_key()
+                    && !value.skip_serialization(SkipSerialization::default())
+            });
+            if has_other {
+                let payload = ContextsWithout {
+                    contexts: &contexts.0,
+                    skip_key: TraceContext::default_key(),
+                };
+                if let Ok(json) = serde_json::to_string(&payload) {
+                    span_data.insert_value(SENTRY__TRANSACTION__CONTEXTS, json);
+                }
             }
         }
         if breadcrumbs

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -1,9 +1,9 @@
 //! This module defines bidirectional field mappings between spans and transactions.
 
 use relay_conventions::attributes::{
-    BROWSER__NAME, HTTP__QUERY, SENTRY__ENVIRONMENT, SENTRY__RELEASE, SENTRY__SDK__NAME,
-    SENTRY__SDK__VERSION, SENTRY__SEGMENT__NAME, SENTRY__TRANSACTION__BREADCRUMBS,
-    SENTRY__TRANSACTION__CONTEXTS, SENTRY__TRANSACTION__EXTRA, URL__QUERY,
+    BROWSER__NAME, HTTP__QUERY, SENTRY__ENVIRONMENT, SENTRY__EVENT__SERIALIZED_BREADCRUMBS,
+    SENTRY__EVENT__SERIALIZED_CONTEXTS, SENTRY__EVENT__SERIALIZED_EXTRA, SENTRY__RELEASE,
+    SENTRY__SDK__NAME, SENTRY__SDK__VERSION, SENTRY__SEGMENT__NAME, URL__QUERY,
 };
 use relay_protocol::{IntoValue, Object, SerializePayload, SkipSerialization};
 use serde::ser::SerializeMap;
@@ -118,7 +118,7 @@ impl From<&Event> for Span {
                     skip_key: TraceContext::default_key(),
                 };
                 if let Ok(json) = serde_json::to_string(&payload) {
-                    span_data.insert_value(SENTRY__TRANSACTION__CONTEXTS, json);
+                    span_data.insert_value(SENTRY__EVENT__SERIALIZED_CONTEXTS, json);
                 }
             }
         }
@@ -128,12 +128,12 @@ impl From<&Event> for Span {
             .is_some_and(|v| !v.is_empty())
             && let Ok(json) = breadcrumbs.payload_to_json()
         {
-            span_data.insert_value(SENTRY__TRANSACTION__BREADCRUMBS, json);
+            span_data.insert_value(SENTRY__EVENT__SERIALIZED_BREADCRUMBS, json);
         }
         if extra.value().is_some_and(|e| !e.is_empty())
             && let Ok(json) = extra.payload_to_json()
         {
-            span_data.insert_value(SENTRY__TRANSACTION__EXTRA, json);
+            span_data.insert_value(SENTRY__EVENT__SERIALIZED_EXTRA, json);
         }
 
         Self {
@@ -273,6 +273,15 @@ mod tests {
                     "sentry.environment": String(
                         "prod",
                     ),
+                    "sentry.event.serialized_breadcrumbs": String(
+                        "{\"values\":[{\"type\":\"default\",\"category\":\"auth\",\"message\":\"login\"}]}",
+                    ),
+                    "sentry.event.serialized_contexts": String(
+                        "{\"browser\":{\"name\":\"Chrome\",\"type\":\"browser\"},\"profile\":{\"profile_id\":\"a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab\",\"type\":\"profile\"}}",
+                    ),
+                    "sentry.event.serialized_extra": String(
+                        "{\"my_key\":1,\"some_other_value\":\"foo bar\"}",
+                    ),
                     "sentry.name": String(
                         "my 1st transaction",
                     ),
@@ -287,15 +296,6 @@ mod tests {
                     ),
                     "sentry.segment.name": String(
                         "my 1st transaction",
-                    ),
-                    "sentry.transaction.breadcrumbs": String(
-                        "{\"values\":[{\"type\":\"default\",\"category\":\"auth\",\"message\":\"login\"}]}",
-                    ),
-                    "sentry.transaction.contexts": String(
-                        "{\"browser\":{\"name\":\"Chrome\",\"type\":\"browser\"},\"profile\":{\"profile_id\":\"a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab\",\"type\":\"profile\"}}",
-                    ),
-                    "sentry.transaction.extra": String(
-                        "{\"my_key\":1,\"some_other_value\":\"foo bar\"}",
                     ),
                     "url.query": String(
                         "project=1&sort=date",
@@ -365,15 +365,15 @@ mod tests {
         let data = span.data.value().unwrap();
 
         assert_eq!(
-            data.get_str(SENTRY__TRANSACTION__CONTEXTS),
+            data.get_str(SENTRY__EVENT__SERIALIZED_CONTEXTS),
             Some(r#"{"browser":{"name":"Chrome","type":"browser"}}"#)
         );
         assert_eq!(
-            data.get_str(SENTRY__TRANSACTION__BREADCRUMBS),
+            data.get_str(SENTRY__EVENT__SERIALIZED_BREADCRUMBS),
             Some(r#"{"values":[{"type":"default","category":"auth","message":"login"}]}"#)
         );
         assert_eq!(
-            data.get_str(SENTRY__TRANSACTION__EXTRA),
+            data.get_str(SENTRY__EVENT__SERIALIZED_EXTRA),
             Some(r#"{"my_key":1,"some_other_value":"foo bar"}"#)
         );
     }
@@ -393,9 +393,9 @@ mod tests {
         let span = Span::from(&event);
 
         if let Some(data) = span.data.value() {
-            assert!(!data.contains(SENTRY__TRANSACTION__CONTEXTS));
-            assert!(!data.contains(SENTRY__TRANSACTION__BREADCRUMBS));
-            assert!(!data.contains(SENTRY__TRANSACTION__EXTRA));
+            assert!(!data.contains(SENTRY__EVENT__SERIALIZED_CONTEXTS));
+            assert!(!data.contains(SENTRY__EVENT__SERIALIZED_BREADCRUMBS));
+            assert!(!data.contains(SENTRY__EVENT__SERIALIZED_EXTRA));
         }
     }
 
@@ -417,9 +417,9 @@ mod tests {
         let span = Span::from(&event);
 
         if let Some(data) = span.data.value() {
-            assert!(!data.contains(SENTRY__TRANSACTION__CONTEXTS));
-            assert!(!data.contains(SENTRY__TRANSACTION__BREADCRUMBS));
-            assert!(!data.contains(SENTRY__TRANSACTION__EXTRA));
+            assert!(!data.contains(SENTRY__EVENT__SERIALIZED_CONTEXTS));
+            assert!(!data.contains(SENTRY__EVENT__SERIALIZED_BREADCRUMBS));
+            assert!(!data.contains(SENTRY__EVENT__SERIALIZED_EXTRA));
         }
     }
 }

--- a/relay-event-schema/src/protocol/span/convert.rs
+++ b/relay-event-schema/src/protocol/span/convert.rs
@@ -2,11 +2,14 @@
 
 use relay_conventions::attributes::{
     BROWSER__NAME, HTTP__QUERY, SENTRY__ENVIRONMENT, SENTRY__RELEASE, SENTRY__SDK__NAME,
-    SENTRY__SDK__VERSION, SENTRY__SEGMENT__NAME, URL__QUERY,
+    SENTRY__SDK__VERSION, SENTRY__SEGMENT__NAME, SENTRY__TRANSACTION__BREADCRUMBS,
+    SENTRY__TRANSACTION__CONTEXTS, SENTRY__TRANSACTION__EXTRA, URL__QUERY,
 };
-use relay_protocol::IntoValue;
+use relay_protocol::{Annotated, IntoValue};
 
-use crate::protocol::{BrowserContext, Event, ProfileContext, Span, SpanData, TraceContext};
+use crate::protocol::{
+    BrowserContext, DefaultContext, Event, ProfileContext, Span, SpanData, TraceContext,
+};
 
 impl From<&Event> for Span {
     fn from(event: &Event) -> Self {
@@ -20,7 +23,9 @@ impl From<&Event> for Span {
             release,
             environment,
             tags,
-
+            contexts,
+            breadcrumbs,
+            extra,
             measurements,
             _metrics,
             ..
@@ -74,6 +79,29 @@ impl From<&Event> for Span {
         {
             span_data.insert_value(HTTP__QUERY, format!("?{qs}"));
             span_data.insert_value(URL__QUERY, qs);
+        }
+
+        if let Some(contexts) = contexts.value() {
+            let mut contexts = contexts.clone();
+            contexts.0.remove(TraceContext::default_key());
+            if !contexts.0.is_empty()
+                && let Ok(json) = Annotated::new(contexts).payload_to_json()
+            {
+                span_data.insert_value(SENTRY__TRANSACTION__CONTEXTS, json);
+            }
+        }
+        if breadcrumbs
+            .value()
+            .and_then(|b| b.values.value())
+            .is_some_and(|v| !v.is_empty())
+            && let Ok(json) = breadcrumbs.payload_to_json()
+        {
+            span_data.insert_value(SENTRY__TRANSACTION__BREADCRUMBS, json);
+        }
+        if extra.value().is_some_and(|e| !e.is_empty())
+            && let Ok(json) = extra.payload_to_json()
+        {
+            span_data.insert_value(SENTRY__TRANSACTION__EXTRA, json);
         }
 
         Self {
@@ -155,6 +183,13 @@ mod tests {
                         ]
                     }
                 },
+                "breadcrumbs": [
+                    {"type": "default", "category": "auth", "message": "login"}
+                ],
+                "extra": {
+                    "my_key": 1,
+                    "some_other_value": "foo bar"
+                },
                 "request": {
                     "url": "http://example.com/api/0/organizations/",
                     "method": "GET",
@@ -221,6 +256,15 @@ mod tests {
                     "sentry.segment.name": String(
                         "my 1st transaction",
                     ),
+                    "sentry.transaction.breadcrumbs": String(
+                        "{\"values\":[{\"type\":\"default\",\"category\":\"auth\",\"message\":\"login\"}]}",
+                    ),
+                    "sentry.transaction.contexts": String(
+                        "{\"browser\":{\"name\":\"Chrome\",\"type\":\"browser\"},\"profile\":{\"profile_id\":\"a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaab\",\"type\":\"profile\"}}",
+                    ),
+                    "sentry.transaction.extra": String(
+                        "{\"my_key\":1,\"some_other_value\":\"foo bar\"}",
+                    ),
                     "url.query": String(
                         "project=1&sort=date",
                     ),
@@ -257,5 +301,93 @@ mod tests {
             other: {},
         }
         "#);
+    }
+
+    #[test]
+    fn convert_preserves_contexts_breadcrumbs_extra() {
+        let event = Annotated::<Event>::from_json(
+            r#"{
+                "type": "transaction",
+                "transaction": "my transaction",
+                "contexts": {
+                    "browser": {"name": "Chrome"},
+                    "trace": {
+                        "trace_id": "4c79f60c11214eb38604f4ae0781bfb2",
+                        "span_id": "fa90fdead5f74052"
+                    }
+                },
+                "breadcrumbs": [
+                    {"type": "default", "category": "auth", "message": "login"}
+                ],
+                "extra": {
+                    "my_key": 1,
+                    "some_other_value": "foo bar"
+                }
+            }"#,
+        )
+        .unwrap()
+        .into_value()
+        .unwrap();
+
+        let span = Span::from(&event);
+        let data = span.data.value().unwrap();
+
+        assert_eq!(
+            data.get_str(SENTRY__TRANSACTION__CONTEXTS),
+            Some(r#"{"browser":{"name":"Chrome","type":"browser"}}"#)
+        );
+        assert_eq!(
+            data.get_str(SENTRY__TRANSACTION__BREADCRUMBS),
+            Some(r#"{"values":[{"type":"default","category":"auth","message":"login"}]}"#)
+        );
+        assert_eq!(
+            data.get_str(SENTRY__TRANSACTION__EXTRA),
+            Some(r#"{"my_key":1,"some_other_value":"foo bar"}"#)
+        );
+    }
+
+    #[test]
+    fn convert_omits_absent_contexts_breadcrumbs_extra() {
+        let event = Annotated::<Event>::from_json(
+            r#"{
+                "type": "transaction",
+                "transaction": "my transaction"
+            }"#,
+        )
+        .unwrap()
+        .into_value()
+        .unwrap();
+
+        let span = Span::from(&event);
+
+        if let Some(data) = span.data.value() {
+            assert!(!data.contains(SENTRY__TRANSACTION__CONTEXTS));
+            assert!(!data.contains(SENTRY__TRANSACTION__BREADCRUMBS));
+            assert!(!data.contains(SENTRY__TRANSACTION__EXTRA));
+        }
+    }
+
+    #[test]
+    fn convert_omits_empty_contexts_breadcrumbs_extra() {
+        let event = Annotated::<Event>::from_json(
+            r#"{
+                "type": "transaction",
+                "transaction": "my transaction",
+                "contexts": {},
+                "breadcrumbs": [],
+                "extra": {}
+            }"#,
+        )
+        .unwrap()
+        .into_value()
+        .unwrap();
+
+        let span = Span::from(&event);
+
+        if let Some(data) = span.data.value() {
+            assert!(!data.contains(SENTRY__TRANSACTION__CONTEXTS));
+            assert!(!data.contains(SENTRY__TRANSACTION__BREADCRUMBS));
+            assert!(!data.contains(SENTRY__TRANSACTION__EXTRA));
+        }
     }
 }

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -333,6 +333,10 @@ def test_span_extraction(
             "sentry.segment.name": {"type": "string", "value": "hi"},
             "sentry.status": {"type": "string", "value": "ok"},
             "sentry.trace.status": {"type": "string", "value": "ok"},
+            "sentry.transaction.contexts": {
+                "type": "string",
+                "value": '{"replay":{"replay_id":"4c79f60c11214eb38604f4ae0781bfb2","type":"replay"}}',
+            },
             "sentry.transaction.op": {"type": "string", "value": "hi"},
             "sentry.user": {"type": "string", "value": f"id:{user_id}"},
             "sentry.user.geo.city": {"type": "string", "value": "Vienna"},
@@ -1445,3 +1449,85 @@ def test_outcomes_for_trimmed_spans(mini_sentry, relay):
             "timestamp": time_within_delta(),
         },
     ]
+
+
+def test_segment_span_preserves_contexts_breadcrumbs_extra(
+    mini_sentry,
+    relay_with_processing,
+    spans_consumer,
+):
+    spans_consumer = spans_consumer()
+
+    relay = relay_with_processing(options=TEST_CONFIG)
+    project_id = 42
+    mini_sentry.add_full_project_config(project_id)
+
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    event["contexts"]["gpu"] = {"name": "AMD Radeon Pro 560", "vendor_name": "Apple"}
+    event["breadcrumbs"] = [
+        {"type": "default", "category": "auth", "message": "login", "level": "info"},
+    ]
+    event["extra"] = {
+        "my_key": 1,
+        "some_other_value": "foo bar",
+    }
+
+    relay.send_event(project_id, event)
+
+    segment_span = spans_consumer.get_span()
+    attributes = segment_span["attributes"]
+
+    assert json.loads(attributes["sentry.transaction.extra"]["value"]) == {
+        "my_key": 1,
+        "some_other_value": "foo bar",
+    }
+
+    assert json.loads(attributes["sentry.transaction.breadcrumbs"]["value"]) == {
+        "values": [
+            {
+                "type": "default",
+                "category": "auth",
+                "message": "login",
+                "level": "info",
+            }
+        ]
+    }
+    contexts = json.loads(attributes["sentry.transaction.contexts"]["value"])
+    assert contexts["gpu"] == {
+        "name": "AMD Radeon Pro 560",
+        "vendor_name": "Apple",
+        "type": "gpu",
+    }
+    assert "trace" not in contexts
+
+    spans_consumer.assert_empty()
+
+
+def test_segment_span_scrubs_extra_before_serializing(
+    mini_sentry,
+    relay_with_processing,
+    spans_consumer,
+):
+    spans_consumer = spans_consumer()
+
+    relay = relay_with_processing(options=TEST_CONFIG)
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"].setdefault("datascrubbingSettings", {}).update(
+        {"scrubData": True, "scrubDefaults": True}
+    )
+
+    event = make_transaction({"event_id": "cbf6960622e14a45abc1f03b2055b186"})
+    event["extra"] = {
+        "note": "contact john.doe@company.com for details",
+    }
+
+    relay.send_event(project_id, event)
+
+    segment_span = spans_consumer.get_span()
+    extra = json.loads(segment_span["attributes"]["sentry.transaction.extra"]["value"])
+
+    assert "john.doe@company.com" not in extra["note"]
+    assert "[email]" in extra["note"]
+
+    spans_consumer.assert_empty()

--- a/tests/integration/test_spans.py
+++ b/tests/integration/test_spans.py
@@ -333,7 +333,7 @@ def test_span_extraction(
             "sentry.segment.name": {"type": "string", "value": "hi"},
             "sentry.status": {"type": "string", "value": "ok"},
             "sentry.trace.status": {"type": "string", "value": "ok"},
-            "sentry.transaction.contexts": {
+            "sentry.event.serialized_contexts": {
                 "type": "string",
                 "value": '{"replay":{"replay_id":"4c79f60c11214eb38604f4ae0781bfb2","type":"replay"}}',
             },
@@ -1477,12 +1477,12 @@ def test_segment_span_preserves_contexts_breadcrumbs_extra(
     segment_span = spans_consumer.get_span()
     attributes = segment_span["attributes"]
 
-    assert json.loads(attributes["sentry.transaction.extra"]["value"]) == {
+    assert json.loads(attributes["sentry.event.serialized_extra"]["value"]) == {
         "my_key": 1,
         "some_other_value": "foo bar",
     }
 
-    assert json.loads(attributes["sentry.transaction.breadcrumbs"]["value"]) == {
+    assert json.loads(attributes["sentry.event.serialized_breadcrumbs"]["value"]) == {
         "values": [
             {
                 "type": "default",
@@ -1492,7 +1492,7 @@ def test_segment_span_preserves_contexts_breadcrumbs_extra(
             }
         ]
     }
-    contexts = json.loads(attributes["sentry.transaction.contexts"]["value"])
+    contexts = json.loads(attributes["sentry.event.serialized_contexts"]["value"])
     assert contexts["gpu"] == {
         "name": "AMD Radeon Pro 560",
         "vendor_name": "Apple",
@@ -1525,7 +1525,9 @@ def test_segment_span_scrubs_extra_before_serializing(
     relay.send_event(project_id, event)
 
     segment_span = spans_consumer.get_span()
-    extra = json.loads(segment_span["attributes"]["sentry.transaction.extra"]["value"])
+    extra = json.loads(
+        segment_span["attributes"]["sentry.event.serialized_extra"]["value"]
+    )
 
     assert "john.doe@company.com" not in extra["note"]
     assert "[email]" in extra["note"]


### PR DESCRIPTION
The frontend is currently still relying on full transaction JSON from Nodestore to fetch transaction events' contexts, extras, and breadcrumbs in the span details pane of the trace waterfall.

A few important, defined keys in contexts are already extracted into attributes by Relay, but that does not cover custom keys or custom contexts, which are currently dropped. Extras (all custom) and breadcrumbs have no handling at all and are also dropped.

All of these features are deprecated: contexts and events have been replaced with attributes, and breadcrumbs have been replaced by logs. There is no need to make these legacy data sources searchable or have the same level of support as their replacements. Nonetheless, if a user of a transaction-based SDK sends this data, we don't want to just drop it.

Serialize contexts, extras, and breadcrumbs into JSON and store them as attributes. These attributes will be marked internal in Conventions so that they aren't displayed to users. Their only use will be on the span details pane of the trace waterfall, where they will be deserialized and shown the same way they currently are for `was_transaction: true` spans.

**Note**: I skipped serializing the `trace` context, since this is already fully extracted to make the transaction span and therefore useless duplication.

**Note 2**: This PR updates sentry-conventions to get the new constants.

Fixes BROWSE-670.

---

I'll add the attribute names to conventions after we've confirmed the approach and names here on this draft, before merging.