### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,8 +362,7 @@ jobs:
           sudo apt-get install -y llvm curl libcurl4-openssl-dev
 
       - name: Install sentry-cli
-        run: |
-          curl -sL https://sentry.io/get-cli/ | bash
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - uses: actions/checkout@v7.0.1
         with:
@@ -438,8 +437,7 @@ jobs:
           sudo apt-get install -y llvm curl libcurl4-openssl-dev
 
       - name: Install sentry-cli
-        run: |
-          curl -sL https://sentry.io/get-cli/ | bash
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - uses: actions/checkout@v7.0.1
         with:


### PR DESCRIPTION
## Summary
- Two "Install sentry-cli" steps in `ci.yml` used `curl -sL https://sentry.io/get-cli/ | bash`, piping a remote install script directly into a shell.
- Replaced both with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.

This fixes 2 of the 3 locations flagged in VULN-2359. The third (`build_binary.yml:37`) installs `rustup`, a different package via a different installer, and is being handled separately.

## Test plan
- [x] Validated `ci.yml` parses correctly
- [ ] Verify both jobs still install sentry-cli correctly on this PR

Refs VULN-2359

🤖 Generated with [Claude Code](https://claude.com/claude-code)