### PR TITLE
feat(quotas): Support shadow (dual) writes for the quotas Redis pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reject spans, logs, trace metrics, replays when they are too old instead of shifting their timestamp. ([#6272](https://github.com/getsentry/relay/pull/6272))
 - Extract nvgpu dumps and create GPU events. ([#6242](https://github.com/getsentry/relay/pull/6242))
 - Preserve transaction `contexts`, `extra`, and `breadcrumbs` on the segment span as serialized attributes. ([#6286](https://github.com/getsentry/relay/pull/6286))
+- Support shadow (dual) writes for the quotas Redis pool via a `shadow` list of cluster nodes, to ease migrations between Redis deployments. ([#6294](https://github.com/getsentry/relay/pull/6294))
 
 **Bug Fixes**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,6 +4940,7 @@ dependencies = [
  "deadpool",
  "futures",
  "redis",
+ "relay-log",
  "relay-statsd",
  "relay-system",
  "serde",

--- a/relay-config/src/redis.rs
+++ b/relay-config/src/redis.rs
@@ -101,6 +101,15 @@ pub enum RedisConfig {
     Cluster {
         /// Redis nodes urls of the cluster.
         cluster_nodes: Vec<String>,
+        /// Optional shadow cluster node urls which receive duplicated writes.
+        ///
+        /// When set, every command executed against this pool is additionally sent to the shadow
+        /// cluster in a best-effort ("fail-open") fashion. Errors talking to the shadow cluster are
+        /// logged but never surfaced to the caller, and only the primary result is used.
+        ///
+        /// This is used to dual-write quota data while migrating between Redis deployments.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        shadow: Option<Vec<String>>,
         /// Options of the Redis config.
         #[serde(flatten)]
         options: PartialRedisConfigOptions,
@@ -145,6 +154,7 @@ impl From<RedisConfigFromFile> for RedisConfig {
                 options,
             } => Self::Cluster {
                 cluster_nodes,
+                shadow: None,
                 options,
             },
             RedisConfigFromFile::Single(server) => Self::Single(SingleRedisConfig::Detailed {
@@ -180,6 +190,8 @@ pub enum RedisConfigRef<'a> {
     Cluster {
         /// Reference to the Redis nodes urls of the cluster.
         cluster_nodes: &'a Vec<String>,
+        /// Optional reference to the shadow cluster node urls which receive duplicated writes.
+        shadow: Option<&'a Vec<String>>,
         /// Options of the Redis config.
         options: RedisConfigOptions,
     },
@@ -233,9 +245,11 @@ pub(super) fn build_redis_config(
     match config {
         RedisConfig::Cluster {
             cluster_nodes,
+            shadow,
             options,
         } => RedisConfigRef::Cluster {
             cluster_nodes,
+            shadow: shadow.as_ref(),
             options: build_redis_config_options(options, default_connections),
         },
         RedisConfig::Single(SingleRedisConfig::Detailed { server, options }) => {
@@ -373,6 +387,7 @@ quotas:
                     "redis://127.0.0.1:6379".to_owned(),
                     "redis://127.0.0.2:6379".to_owned(),
                 ],
+                shadow: None,
                 options: PartialRedisConfigOptions {
                     max_connections: Some(17),
                     ..Default::default()
@@ -483,6 +498,7 @@ max_connections: 10
                     "redis://127.0.0.1:6379".to_owned(),
                     "redis://127.0.0.2:6379".to_owned()
                 ],
+                shadow: None,
                 options: PartialRedisConfigOptions {
                     max_connections: Some(10),
                     ..Default::default()
@@ -510,6 +526,7 @@ max_connections: 20
                     "redis://127.0.0.1:6379".to_owned(),
                     "redis://127.0.0.2:6379".to_owned()
                 ],
+                shadow: None,
                 options: PartialRedisConfigOptions {
                     max_connections: Some(20),
                     ..Default::default()
@@ -525,6 +542,7 @@ max_connections: 20
                 "redis://127.0.0.1:6379".to_owned(),
                 "redis://127.0.0.2:6379".to_owned(),
             ],
+            shadow: None,
             options: PartialRedisConfigOptions {
                 max_connections: Some(42),
                 ..Default::default()
@@ -553,6 +571,7 @@ max_connections: 20
                 "redis://127.0.0.1:6379".to_owned(),
                 "redis://127.0.0.2:6379".to_owned(),
             ],
+            shadow: None,
             options: PartialRedisConfigOptions {
                 max_connections: Some(42),
                 ..Default::default()
@@ -589,6 +608,7 @@ max_connections: 20
                     "redis://127.0.0.1:6379".to_owned(),
                     "redis://127.0.0.2:6379".to_owned(),
                 ],
+                shadow: None,
                 options: PartialRedisConfigOptions {
                     max_connections: Some(84),
                     ..Default::default()
@@ -617,6 +637,68 @@ max_connections: 20
             "recycle_timeout": 2,
             "response_timeout": 30
           }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_redis_cluster_nodes_with_shadow() {
+        let yaml = r#"
+cluster_nodes:
+    - "redis://127.0.0.1:6379"
+    - "redis://127.0.0.2:6379"
+shadow:
+    - "redis://shadow.1:6379"
+    - "redis://shadow.2:6379"
+max_connections: 10
+"#;
+
+        let config: RedisConfig = serde_yaml::from_str(yaml)
+            .expect("Parsed processing redis config: cluster with shadow");
+
+        assert_eq!(
+            config,
+            RedisConfig::Cluster {
+                cluster_nodes: vec![
+                    "redis://127.0.0.1:6379".to_owned(),
+                    "redis://127.0.0.2:6379".to_owned()
+                ],
+                shadow: Some(vec![
+                    "redis://shadow.1:6379".to_owned(),
+                    "redis://shadow.2:6379".to_owned()
+                ]),
+                options: PartialRedisConfigOptions {
+                    max_connections: Some(10),
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_redis_cluster_shadow_serialize() {
+        let config = RedisConfig::Cluster {
+            cluster_nodes: vec!["redis://127.0.0.1:6379".to_owned()],
+            shadow: Some(vec!["redis://shadow.1:6379".to_owned()]),
+            options: PartialRedisConfigOptions {
+                max_connections: Some(42),
+                ..Default::default()
+            },
+        };
+
+        assert_json_snapshot!(config, @r#"
+        {
+          "cluster_nodes": [
+            "redis://127.0.0.1:6379"
+          ],
+          "shadow": [
+            "redis://shadow.1:6379"
+          ],
+          "max_connections": 42,
+          "idle_timeout": 60,
+          "create_timeout": 3,
+          "recycle_timeout": 2,
+          "response_timeout": 30
         }
         "#);
     }

--- a/relay-redis/Cargo.toml
+++ b/relay-redis/Cargo.toml
@@ -28,9 +28,10 @@ serde = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 thiserror = { workspace = true }
 
+relay-log = { workspace = true, optional = true }
 relay-statsd = { workspace = true, optional = true }
 relay-system = { workspace = true }
 
 [features]
 default = []
-impl = ["dep:deadpool", "dep:relay-statsd", "dep:redis"]
+impl = ["dep:deadpool", "dep:relay-log", "dep:relay-statsd", "dep:redis"]

--- a/relay-redis/src/real.rs
+++ b/relay-redis/src/real.rs
@@ -76,6 +76,19 @@ pub enum AsyncRedisClient {
     Cluster(pool::CustomClusterPool),
     /// Contains a connection pool to a single Redis instance.
     Single(pool::CustomSinglePool),
+    /// Fans out writes to a primary client and one or more shadow (secondary) clients.
+    ///
+    /// All commands are executed against the primary and, in a best-effort ("fail-open") fashion,
+    /// against every shadow client. Only the primary's result is returned to the caller; errors
+    /// talking to shadow clients are logged and swallowed.
+    ///
+    /// This is used to dual-write quota data while migrating between Redis deployments.
+    MultiWrite {
+        /// The primary client which is the source of truth for reads and results.
+        primary: Box<AsyncRedisClient>,
+        /// The shadow clients which receive duplicated writes.
+        secondaries: Vec<AsyncRedisClient>,
+    },
 }
 
 impl AsyncRedisClient {
@@ -128,16 +141,72 @@ impl AsyncRedisClient {
         Ok(AsyncRedisClient::Single(pool))
     }
 
+    /// Creates a new client which fans out writes to a `primary` and one or more `secondaries`.
+    ///
+    /// Commands executed against the returned client are sent to the primary and, best-effort, to
+    /// every shadow client. Only the primary result is returned.
+    pub fn multi_write(
+        primary: AsyncRedisClient,
+        secondaries: Vec<AsyncRedisClient>,
+    ) -> Result<Self, RedisError> {
+        if secondaries.is_empty() {
+            return Ok(primary);
+        }
+
+        Ok(AsyncRedisClient::MultiWrite {
+            primary: Box::new(primary),
+            secondaries,
+        })
+    }
+
     /// Acquires a connection from the pool.
     ///
     /// Returns a new [`AsyncRedisConnection`] that can be used to execute Redis commands.
     /// The connection is automatically returned to the pool when dropped.
     pub async fn get_connection(&self) -> Result<AsyncRedisConnection, RedisError> {
         match self {
-            Self::Cluster(pool) => pool.get().await.map(AsyncRedisConnection::Cluster),
-            Self::Single(pool) => pool.get().await.map(AsyncRedisConnection::Single),
+            Self::Cluster(pool) => pool
+                .get()
+                .await
+                .map(AsyncRedisConnection::Cluster)
+                .map_err(RedisError::Pool),
+            Self::Single(pool) => pool
+                .get()
+                .await
+                .map(AsyncRedisConnection::Single)
+                .map_err(RedisError::Pool),
+            Self::MultiWrite {
+                primary,
+                secondaries,
+            } => {
+                // Acquiring the primary connection must succeed, otherwise the whole operation
+                // fails, just like a non-shadowed client.
+                //
+                // The recursive `get_connection` calls are boxed to break the infinitely sized
+                // future that async recursion would otherwise create.
+                let primary = Box::new(Box::pin(primary.get_connection()).await?);
+
+                // Shadow connections are acquired best-effort: if a shadow instance is unavailable
+                // we log and skip it so it can never impact the primary write path.
+                let mut secondary_connections = Vec::with_capacity(secondaries.len());
+                for secondary in secondaries {
+                    match Box::pin(secondary.get_connection()).await {
+                        Ok(connection) => secondary_connections.push(connection),
+                        Err(error) => {
+                            relay_log::error!(
+                                error = &error as &dyn std::error::Error,
+                                "failed to acquire a connection to the shadow Redis instance",
+                            );
+                        }
+                    }
+                }
+
+                Ok(AsyncRedisConnection::MultiWrite {
+                    primary,
+                    secondaries: secondary_connections,
+                })
+            }
         }
-        .map_err(RedisError::Pool)
     }
 
     /// Returns statistics about the current state of the connection pool.
@@ -148,6 +217,8 @@ impl AsyncRedisClient {
         let status = match self {
             Self::Cluster(pool) => pool.status(),
             Self::Single(pool) => pool.status(),
+            // Shadow clients are transparent for stats, report the primary's state.
+            Self::MultiWrite { primary, .. } => return primary.stats(),
         };
 
         RedisClientStats {
@@ -168,6 +239,15 @@ impl AsyncRedisClient {
             }
             Self::Single(pool) => {
                 pool.retain(|_, metrics| predicate(metrics));
+            }
+            Self::MultiWrite {
+                primary,
+                secondaries,
+            } => {
+                primary.retain(&mut predicate);
+                for secondary in secondaries {
+                    secondary.retain(&mut predicate);
+                }
             }
         }
     }
@@ -207,6 +287,13 @@ impl std::fmt::Debug for AsyncRedisClient {
         match self {
             AsyncRedisClient::Cluster(_) => write!(f, "AsyncRedisPool::Cluster"),
             AsyncRedisClient::Single(_) => write!(f, "AsyncRedisPool::Single"),
+            AsyncRedisClient::MultiWrite { secondaries, .. } => {
+                write!(
+                    f,
+                    "AsyncRedisPool::MultiWrite({} shadows)",
+                    secondaries.len()
+                )
+            }
         }
     }
 }
@@ -222,15 +309,28 @@ pub enum AsyncRedisConnection {
     Cluster(pool::CustomClusterConnection),
     /// A connection to a single Redis instance.
     Single(pool::CustomSingleConnection),
+    /// A connection which fans out writes to a primary and one or more shadow connections.
+    ///
+    /// Every command is executed against the primary and, best-effort, against each shadow
+    /// connection. Only the primary's result is returned; shadow errors are logged and swallowed.
+    MultiWrite {
+        /// The primary connection which produces the returned result.
+        primary: Box<AsyncRedisConnection>,
+        /// The shadow connections which receive duplicated writes.
+        secondaries: Vec<AsyncRedisConnection>,
+    },
 }
 
 impl std::fmt::Debug for AsyncRedisConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            Self::Cluster(_) => "Cluster",
-            Self::Single(_) => "Single",
-        };
-        f.debug_tuple(name).finish()
+        match self {
+            Self::Cluster(_) => f.debug_tuple("Cluster").finish(),
+            Self::Single(_) => f.debug_tuple("Single").finish(),
+            Self::MultiWrite { secondaries, .. } => f
+                .debug_struct("MultiWrite")
+                .field("shadows", &secondaries.len())
+                .finish(),
+        }
     }
 }
 
@@ -239,6 +339,32 @@ impl redis::aio::ConnectionLike for AsyncRedisConnection {
         match self {
             Self::Cluster(conn) => conn.req_packed_command(cmd),
             Self::Single(conn) => conn.req_packed_command(cmd),
+            Self::MultiWrite {
+                primary,
+                secondaries,
+            } => Box::pin(async move {
+                // Dispatch to the primary and all shadow instances concurrently so that shadow
+                // writes do not add their latency to the primary write path.
+                let primary = primary.req_packed_command(cmd);
+                let secondaries = futures::future::join_all(
+                    secondaries
+                        .iter_mut()
+                        .map(|secondary| secondary.req_packed_command(cmd)),
+                );
+
+                let (primary_result, secondary_results) =
+                    futures::future::join(primary, secondaries).await;
+
+                for result in secondary_results {
+                    if let Err(error) = result {
+                        relay_log::error!(
+                            error = &error as &dyn std::error::Error,
+                            "sending cmd to the shadow Redis instance failed",
+                        );
+                    }
+                }
+                primary_result
+            }),
         }
     }
 
@@ -251,6 +377,32 @@ impl redis::aio::ConnectionLike for AsyncRedisConnection {
         match self {
             Self::Cluster(conn) => conn.req_packed_commands(cmd, offset, count),
             Self::Single(conn) => conn.req_packed_commands(cmd, offset, count),
+            Self::MultiWrite {
+                primary,
+                secondaries,
+            } => Box::pin(async move {
+                // Dispatch to the primary and all shadow instances concurrently so that shadow
+                // writes do not add their latency to the primary write path.
+                let primary = primary.req_packed_commands(cmd, offset, count);
+                let secondaries = futures::future::join_all(
+                    secondaries
+                        .iter_mut()
+                        .map(|secondary| secondary.req_packed_commands(cmd, offset, count)),
+                );
+
+                let (primary_result, secondary_results) =
+                    futures::future::join(primary, secondaries).await;
+
+                for result in secondary_results {
+                    if let Err(error) = result {
+                        relay_log::error!(
+                            error = &error as &dyn std::error::Error,
+                            "sending cmds to the shadow Redis instance failed",
+                        );
+                    }
+                }
+                primary_result
+            }),
         }
     }
 
@@ -258,6 +410,7 @@ impl redis::aio::ConnectionLike for AsyncRedisConnection {
         match self {
             Self::Cluster(conn) => conn.get_db(),
             Self::Single(conn) => conn.get_db(),
+            Self::MultiWrite { primary, .. } => primary.get_db(),
         }
     }
 }

--- a/relay-server/src/service.rs
+++ b/relay-server/src/service.rs
@@ -476,12 +476,19 @@ impl ServiceState {
 #[cfg(feature = "processing")]
 pub fn create_redis_clients(configs: RedisConfigsRef<'_>) -> Result<RedisClients, RedisError> {
     const PROJECT_CONFIG_REDIS_CLIENT: &str = "projectconfig";
+    const PROJECT_CONFIG_SHADOW_REDIS_CLIENT: &str = "projectconfig_shadow";
     const QUOTA_REDIS_CLIENT: &str = "quotas";
+    const QUOTA_SHADOW_REDIS_CLIENT: &str = "quotas_shadow";
     const UNIFIED_REDIS_CLIENT: &str = "unified";
+    const UNIFIED_SHADOW_REDIS_CLIENT: &str = "unified_shadow";
 
     match configs {
         RedisConfigsRef::Unified(unified) => {
-            let client = create_async_redis_client(UNIFIED_REDIS_CLIENT, &unified)?;
+            let client = create_async_redis_client(
+                UNIFIED_REDIS_CLIENT,
+                UNIFIED_SHADOW_REDIS_CLIENT,
+                &unified,
+            )?;
 
             Ok(RedisClients {
                 project_configs: client.clone(),
@@ -492,9 +499,13 @@ pub fn create_redis_clients(configs: RedisConfigsRef<'_>) -> Result<RedisClients
             project_configs,
             quotas,
         } => {
-            let project_configs =
-                create_async_redis_client(PROJECT_CONFIG_REDIS_CLIENT, &project_configs)?;
-            let quotas = create_async_redis_client(QUOTA_REDIS_CLIENT, &quotas)?;
+            let project_configs = create_async_redis_client(
+                PROJECT_CONFIG_REDIS_CLIENT,
+                PROJECT_CONFIG_SHADOW_REDIS_CLIENT,
+                &project_configs,
+            )?;
+            let quotas =
+                create_async_redis_client(QUOTA_REDIS_CLIENT, QUOTA_SHADOW_REDIS_CLIENT, &quotas)?;
 
             Ok(RedisClients {
                 project_configs,
@@ -507,13 +518,33 @@ pub fn create_redis_clients(configs: RedisConfigsRef<'_>) -> Result<RedisClients
 #[cfg(feature = "processing")]
 fn create_async_redis_client(
     name: &'static str,
+    shadow_name: &'static str,
     config: &RedisConfigRef<'_>,
 ) -> Result<AsyncRedisClient, RedisError> {
     match config {
         RedisConfigRef::Cluster {
             cluster_nodes,
+            shadow,
             options,
-        } => AsyncRedisClient::cluster(name, cluster_nodes.iter().map(|s| s.as_str()), options),
+        } => {
+            let primary =
+                AsyncRedisClient::cluster(name, cluster_nodes.iter().map(|s| s.as_str()), options)?;
+
+            match shadow {
+                // When a shadow cluster is configured, fan out writes to it in addition to the
+                // primary. This is used to dual-write quota data during Redis migrations.
+                Some(shadow_nodes) => {
+                    let secondary = AsyncRedisClient::cluster(
+                        shadow_name,
+                        shadow_nodes.iter().map(|s| s.as_str()),
+                        options,
+                    )?;
+
+                    AsyncRedisClient::multi_write(primary, vec![secondary])
+                }
+                None => Ok(primary),
+            }
+        }
         RedisConfigRef::Single { server, options } => {
             AsyncRedisClient::single(name, server, options)
         }


### PR DESCRIPTION
## Summary

Reintroduces **dual ("shadow") writes for the quotas Redis pool** so quota data can be duplicated to a second Redis/Valkey deployment during a migration. This capability existed previously as the `MultiWrite` client (#4064) but was lost during the async Redis migration (#4552) and formally removed from config (#4656). This re-implements it on the current async (`AsyncRedisClient`) stack, scoped to quotas.

## Config

Add an optional `shadow` list of cluster nodes next to `cluster_nodes` on the quotas pool:

```yaml
redis:
  project_configs:
    cluster_nodes:
      - redis://rc-memorystore-relay-projectconfigs.sentry.:6379
  quotas:
    cluster_nodes:
      - redis://rc-memorystore-relay-quotas.sentry.:6379
    shadow:
      - redis://relay-quotas.valkey.sentry.:6379
```

When `shadow` is set, every command executed against the pool is sent to the primary and, best-effort, to the shadow cluster.

## Implementation

- **`relay-config`**: optional `shadow: Option<Vec<String>>` on the cluster Redis config, threaded through `RedisConfigRef` and `build_redis_config`.
- **`relay-redis`**: `MultiWrite { primary, secondaries }` variant on `AsyncRedisClient` and `AsyncRedisConnection`. The `ConnectionLike` impl dispatches the command to the primary **and all shadows concurrently** (via `futures::join`/`join_all`), returns only the primary's result, and logs + swallows shadow errors. Connection acquisition for shadows is best-effort so a down shadow never blocks the primary path. `stats()` reports the primary only; `retain()` (pool maintenance) fans out to all pools. Added `relay-log` as an optional dep under the `impl` feature.
- **`relay-server`**: `create_async_redis_client` builds the shadow cluster (same options, metrics tag `quotas_shadow`) and wraps the pool via `multi_write` when `shadow` is set. Script preloading needs no change — `SCRIPT LOAD` is fanned out through the same connection, so the rate-limiting Lua script is loaded on the primary and shadow at startup.

## Behavior / trade-offs (fail-open)

- Shadow failures never affect live rate limiting — errors are logged and dropped.
- If the shadow is unavailable at startup its `SCRIPT LOAD` is skipped; later `EVALSHA` on the shadow returns `NOSCRIPT` (logged/dropped) until the next relay restart re-primes it. Acceptable for a migration shadow.

## Tests

- Added config parse/serialize tests for the `shadow` field.
- `relay-config` / `relay-redis` / `relay-quotas` build & tests pass; `relay-server` builds with and without `processing`; clippy + fmt clean.
