### PR TITLE
fix(spans): Extract client sample rate from DSC for span v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Re-parameterize a DSC when it is computed from a transaction. ([#6279](https://github.com/getsentry/relay/pull/6279))
 - Correct error and outcome for too large streams. ([#6291](https://github.com/getsentry/relay/pull/6291))
 - Validate streamed minidumps and correctly enforce size limit for buffered minidumps. ([#6282](https://github.com/getsentry/relay/pull/6282))
+- Always set `sentry.client_sample_rate` on span v2 spans, preferring the SDK-provided attribute over the DSC and falling back to `1.0`. ([#6299](https://github.com/getsentry/relay/pull/6299))
 
 ## 26.7.2
 

--- a/relay-event-normalization/src/eap/mod.rs
+++ b/relay-event-normalization/src/eap/mod.rs
@@ -541,11 +541,19 @@ pub fn normalize_trace_status(
 
 /// Normalizes the client sample rate attribute to be in the range `(0, 1]`.
 ///
+/// If the attribute is missing, it is created from the DSC sample rate, falling back to `1.0`. The
+/// resulting value is validated the same way as a client supplied one.
+///
 /// This is only relevant for spans as other eap types re not sampled.
-pub fn normalize_client_sample_rate(attributes: &mut Annotated<Attributes>) {
-    let Some(attributes) = attributes.value_mut() else {
-        return;
-    };
+pub fn normalize_client_sample_rate(
+    attributes: &mut Annotated<Attributes>,
+    dsc_sample_rate: Option<f64>,
+) {
+    let attributes = attributes.get_or_insert_with(Default::default);
+
+    if attributes.get_value(SENTRY__CLIENT_SAMPLE_RATE).is_none() {
+        attributes.insert(SENTRY__CLIENT_SAMPLE_RATE, dsc_sample_rate.unwrap_or(1.0));
+    }
 
     // This is fine if normalizations like this stay one-offs. If at some point we end up with more
     // of these structural validations or normalizations based on attributes, they should be
@@ -2978,13 +2986,72 @@ mod tests {
         )
         .unwrap();
 
-        normalize_client_sample_rate(&mut attributes);
+        normalize_client_sample_rate(&mut attributes, None);
 
         assert_annotated_snapshot!(attributes, @r#"
         {
           "sentry.client_sample_rate": {
             "type": "double",
             "value": 1.0
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_client_sample_rate_missing_uses_dsc() {
+        let mut attributes = Annotated::new(Attributes::new());
+
+        normalize_client_sample_rate(&mut attributes, Some(0.25));
+
+        assert_annotated_snapshot!(attributes, @r#"
+        {
+          "sentry.client_sample_rate": {
+            "type": "double",
+            "value": 0.25
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_client_sample_rate_missing_defaults_to_one() {
+        let mut attributes = Annotated::new(Attributes::new());
+
+        normalize_client_sample_rate(&mut attributes, None);
+
+        assert_annotated_snapshot!(attributes, @r#"
+        {
+          "sentry.client_sample_rate": {
+            "type": "double",
+            "value": 1.0
+          }
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_normalize_client_sample_rate_invalid_dsc_marked_as_error() {
+        let mut attributes = Annotated::new(Attributes::new());
+
+        normalize_client_sample_rate(&mut attributes, Some(0.0));
+
+        assert_annotated_snapshot!(attributes, @r#"
+        {
+          "sentry.client_sample_rate": null,
+          "_meta": {
+            "sentry.client_sample_rate": {
+              "": {
+                "err": [
+                  [
+                    "invalid_data",
+                    {
+                      "reason": "expected sample rate > 0.0, <= 1.0"
+                    }
+                  ]
+                ]
+              }
+            }
           }
         }
         "#);
@@ -2998,7 +3065,7 @@ mod tests {
             Annotated::new(attrs)
         };
 
-        normalize_client_sample_rate(&mut attributes);
+        normalize_client_sample_rate(&mut attributes, None);
 
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -3029,7 +3096,7 @@ mod tests {
             Annotated::new(attrs)
         };
 
-        normalize_client_sample_rate(&mut attributes);
+        normalize_client_sample_rate(&mut attributes, None);
 
         assert_annotated_snapshot!(attributes, @r#"
         {
@@ -3060,7 +3127,7 @@ mod tests {
             Annotated::new(attrs)
         };
 
-        normalize_client_sample_rate(&mut attributes);
+        normalize_client_sample_rate(&mut attributes, None);
 
         assert_annotated_snapshot!(attributes, @r#"
         {

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -283,7 +283,10 @@ fn normalize_span(
         eap::normalize_mobile_measurements(&mut span.attributes, duration);
         eap::normalize_attribute_values(&mut span.attributes, allowed_hosts);
         eap::write_legacy_attributes(&mut span.attributes);
-        eap::normalize_client_sample_rate(&mut span.attributes);
+        eap::normalize_client_sample_rate(
+            &mut span.attributes,
+            headers.dsc().and_then(|dsc| dsc.sample_rate),
+        );
         eap::normalize_pipeline_attributes(&mut span.attributes, ingress, Some(&Pipeline::SpanV2));
     };
 

--- a/tests/integration/test_spans_standalone.py
+++ b/tests/integration/test_spans_standalone.py
@@ -220,6 +220,7 @@ def test_lcp_span(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             "browser.version": {"type": "string", "value": "42.0"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -427,6 +428,7 @@ def test_cls_span(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             "browser.version": {"type": "string", "value": "42.0"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -609,6 +611,7 @@ def test_inp_span(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             "browser.version": {"type": "string", "value": "42.0"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -846,6 +849,7 @@ def test_mobile_measurements(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Firefox/42.0",
             },
             "browser.version": {"type": "string", "value": "42.0"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -967,6 +971,7 @@ def test_ua_ip_inference(
                 "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
             },
             "browser.version": {"type": "string", "value": "42.0"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
@@ -1077,6 +1082,7 @@ def test_name_inference(
                 "value": "RelayIntegrationTests/1.0.0 Firefox/42.0",
             },
             "browser.version": {"type": "string", "value": "42.0"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",

--- a/tests/integration/test_spansv2.py
+++ b/tests/integration/test_spansv2.py
@@ -129,6 +129,7 @@ def test_spansv2_basic(
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
             },
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),
@@ -246,7 +247,7 @@ def test_spansv2_trimming_basic(
             # This is sufficient for all builtin attributes not
             # to be trimmed. The span fields that aren't trimmed
             # also still count for the size limit.
-            "trimming": {"span": {"maxSize": 570}},
+            "trimming": {"span": {"maxSize": 603}},
         }
     )
 
@@ -339,6 +340,7 @@ def test_spansv2_trimming_basic(
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
             },
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.observed_timestamp_nanos": {
                 "type": "string",
                 "value": time_within(ts, expect_resolution="ns"),
@@ -350,7 +352,7 @@ def test_spansv2_trimming_basic(
         },
         "_meta": {
             "attributes": {
-                "": {"len": 643},
+                "": {"len": 676},
                 "custom.array.attribute": {
                     "value": {
                         "1": {
@@ -633,6 +635,85 @@ def test_spansv2_rate_limits(mini_sentry, relay, rate_limit):
     assert mini_sentry.captured_outcomes.empty()
 
 
+def test_spansv2_client_sample_rate(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    spans_consumer,
+):
+    """
+    The client sample rate is always set on stored spans:
+
+    - an SDK-provided `sentry.client_sample_rate` attribute takes precedence over the DSC,
+    - the DSC `sample_rate` is used when the attribute is absent,
+    - it falls back to 1.0 when neither is present.
+    """
+    spans_consumer = spans_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"].setdefault("features", []).extend(
+        ["organizations:relay-generate-billing-outcome"]
+    )
+
+    trace_id = "5b8efff798038103d269b633813fc60c"
+    public_key = project_config["publicKeys"][0]["publicKey"]
+
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+
+    ts = datetime.now(timezone.utc)
+
+    def span(span_id, **attributes):
+        return {
+            "start_timestamp": ts.timestamp(),
+            "end_timestamp": ts.timestamp() + 0.5,
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "is_segment": False,
+            "name": "some op",
+            "status": "ok",
+            "attributes": {
+                name: {"value": value, "type": "double"}
+                for name, value in attributes.items()
+            },
+        }
+
+    # The SDK-provided attribute wins over the DSC sample_rate.
+    envelope = envelope_with_spans(
+        span("aaaaaaaaaaaaaaaa", **{"sentry.client_sample_rate": 0.1}),
+        # No attribute: the DSC sample_rate is used.
+        span("bbbbbbbbbbbbbbbb"),
+        trace_info={
+            "trace_id": trace_id,
+            "public_key": public_key,
+            "sample_rate": "0.5",
+        },
+    )
+    relay.send_envelope(project_id, envelope)
+
+    # No DSC sample_rate and no attribute: falls back to 1.0.
+    envelope = envelope_with_spans(
+        span("cccccccccccccccc"),
+        trace_info={
+            "trace_id": trace_id,
+            "public_key": public_key,
+        },
+    )
+    relay.send_envelope(project_id, envelope)
+
+    client_sample_rates = {
+        span["span_id"]: span["attributes"]["sentry.client_sample_rate"]["value"]
+        for span in spans_consumer.get_spans(n=3)
+    }
+    assert client_sample_rates == {
+        "aaaaaaaaaaaaaaaa": 0.1,
+        "bbbbbbbbbbbbbbbb": 0.5,
+        "cccccccccccccccc": 1.0,
+    }
+
+    spans_consumer.assert_empty()
+
+
 def test_spansv2_ds_sampled(
     mini_sentry,
     relay,
@@ -693,6 +774,7 @@ def test_spansv2_ds_sampled(
             "trace_id": trace_id,
             "public_key": sampling_config["publicKeys"][0]["publicKey"],
             "transaction": "tx_from_root",
+            "sample_rate": "0.5",
         },
     )
 
@@ -701,6 +783,7 @@ def test_spansv2_ds_sampled(
     for span in spans_consumer.get_spans(n=2):
         assert span["span_id"] in ("aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb")
         assert span["attributes"]["sentry.server_sample_rate"]["value"] == 0.9
+        assert span["attributes"]["sentry.client_sample_rate"]["value"] == 0.5
         assert span["attributes"]["sentry.dsc.trace_id"]["value"] == trace_id
         assert span["attributes"]["sentry.dsc.transaction"]["value"] == "tx_from_root"
         assert span["attributes"]["sentry.dsc.project_id"]["value"] == "43"
@@ -1215,6 +1298,7 @@ def test_spanv2_with_string_pii_scrubbing(
                 "value": "5b8efff798038103d269b633813fc60c",
             },
             "test_pii": {"type": "string", "value": expected_scrubbed},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.ingress": {"type": "string", "value": "container"},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
@@ -1356,6 +1440,7 @@ def test_spanv2_meta_pii_scrubbing_complex_attribute(mini_sentry, relay):
                 "type": "string",
                 "value": "5b8efff798038103d269b633813fc60c",
             },
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.ingress": {"type": "string", "value": "container"},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.observed_timestamp_nanos": {
@@ -1529,6 +1614,7 @@ def test_spansv2_attribute_normalization(
                 "value": time_within(ts, expect_resolution="ns"),
             },
             "sentry.relay.ingress": {"type": "string", "value": "container"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
         },
     }
@@ -1557,6 +1643,7 @@ def test_spansv2_attribute_normalization(
                 "value": time_within(ts, expect_resolution="ns"),
             },
             "sentry.relay.ingress": {"type": "string", "value": "container"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "http.request.method": {"type": "string", "value": "GET"},
             "sentry.action": {"type": "string", "value": "GET"},
@@ -2027,6 +2114,7 @@ def test_spansv2_lcp_segment(mini_sentry, relay_with_processing, spans_consumer)
                 "value": "ui.webvital.lcp",
             },
             "sentry.relay.ingress": {"type": "string", "value": "container"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.segment.name": {
                 "type": "string",

--- a/tests/integration/test_spansv2_otel.py
+++ b/tests/integration/test_spansv2_otel.py
@@ -267,6 +267,7 @@ def test_span_ingestion(
             "sentry.trace.status": {"type": "string", "value": "ok"},
             "sentry.origin": {"type": "string", "value": "auto.otlp.spans"},
             "sentry.relay.ingress": {"type": "string", "value": "integration"},
+            "sentry.client_sample_rate": {"type": "double", "value": 1.0},
             "sentry.relay.pipeline": {"type": "string", "value": "span_v2"},
             "sentry.segment.id": {"type": "string", "value": "f0b809703e783d00"},
             "sentry.segment.name": {"type": "string", "value": "A Proto Span"},


### PR DESCRIPTION
Currently span v2 (span streaming) spans are missing `sentry.client_sample_rate` attributes. This value is [used by Sentry to set the EAP trace item's client_sample_rate](https://github.com/getsentry/sentry/blob/7b8f27f92b7e0001c6c3876e25ea73342d9a41f6/src/sentry/spans/consumers/process_segments/convert.py#L68-L70), which is used in EAP's extrapolation. This defaults all streaming spans to a client sample rate of 1.0, meaning extrapolation is frequently incorrect.

If the client sample rate is missing from attributes, try to extract it from the DSC. For consistency, default it to 1.0 here if it's missing from both places.

Even though SDKs aren't expected to set `sentry.client_sample_rate`, checking for an existing attribute value first means we can e.g. set it during the OTel -> Sentry span conversion (another case we're currently missing).

Fixes RELAY-275.