### PR TITLE
feat(filters): report custom-filter outcome reason for inbound filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Reject spans, logs, trace metrics, replays when they are too old instead of shifting their timestamp. ([#6272](https://github.com/getsentry/relay/pull/6272))
 - Extract nvgpu dumps and create GPU events. ([#6242](https://github.com/getsentry/relay/pull/6242))
 - Preserve transaction `contexts`, `extra`, and `breadcrumbs` on the segment span as serialized attributes. ([#6286](https://github.com/getsentry/relay/pull/6286))
-- Report `custom-filter` as the outcome reason for customer defined inbound filters, instead of the filter identifier. ([#XXXX](https://github.com/getsentry/relay/pull/XXXX))
+- Report `custom-filter` as the outcome reason for customer defined inbound filters, instead of the filter identifier. ([#6301](https://github.com/getsentry/relay/pull/6301))
 
 **Bug Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reject spans, logs, trace metrics, replays when they are too old instead of shifting their timestamp. ([#6272](https://github.com/getsentry/relay/pull/6272))
 - Extract nvgpu dumps and create GPU events. ([#6242](https://github.com/getsentry/relay/pull/6242))
 - Preserve transaction `contexts`, `extra`, and `breadcrumbs` on the segment span as serialized attributes. ([#6286](https://github.com/getsentry/relay/pull/6286))
+- Report `custom-filter` as the outcome reason for customer defined inbound filters, instead of the filter identifier. ([#XXXX](https://github.com/getsentry/relay/pull/XXXX))
 
 **Bug Fixes**:
 

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -51,9 +51,6 @@ pub enum FilterStatKey {
     GenericFilter(String),
 
     /// Filtered due to a customer defined inbound filter.
-    ///
-    /// These filters have an identifier which is unique per project. The identifier is not
-    /// reported, so that the set of outcome reasons stays bounded.
     CustomFilter,
 }
 

--- a/relay-filter/src/common.rs
+++ b/relay-filter/src/common.rs
@@ -49,6 +49,12 @@ pub enum FilterStatKey {
 
     /// Filtered due to a generic filter.
     GenericFilter(String),
+
+    /// Filtered due to a customer defined inbound filter.
+    ///
+    /// These filters have an identifier which is unique per project. The identifier is not
+    /// reported, so that the set of outcome reasons stays bounded.
+    CustomFilter,
 }
 
 // An event grouped to a removed group.
@@ -63,7 +69,19 @@ pub enum FilterStatKey {
 // that is why it was commented here and moved to OutcomeInvalidReason enum
 // Cors,
 
+/// Prefix that Sentry gives to the identifiers of customer defined inbound filters.
+const CUSTOM_FILTER_PREFIX: &str = "cif-";
+
 impl FilterStatKey {
+    /// Returns the stat key for a generic filter with the given identifier.
+    pub fn from_generic_filter_id(id: &str) -> Self {
+        if id.starts_with(CUSTOM_FILTER_PREFIX) {
+            FilterStatKey::CustomFilter
+        } else {
+            FilterStatKey::GenericFilter(id.to_owned())
+        }
+    }
+
     /// Returns the string identifier of the filter stat key.
     pub fn name(self) -> Cow<'static, str> {
         Cow::Borrowed(match self {
@@ -79,6 +97,7 @@ impl FilterStatKey {
             FilterStatKey::DeniedName => "denied-name",
             FilterStatKey::DisabledNamespace => "disabled-namespace",
             FilterStatKey::Discarded => "discarded",
+            FilterStatKey::CustomFilter => "custom-filter",
             FilterStatKey::GenericFilter(filter_identifier) => {
                 return Cow::Owned(filter_identifier);
             }
@@ -106,7 +125,8 @@ impl<'a> TryFrom<&'a str> for FilterStatKey {
             "web-crawlers" => FilterStatKey::WebCrawlers,
             "invalid-csp" => FilterStatKey::InvalidCsp,
             "filtered-transaction" => FilterStatKey::FilteredTransactions,
-            other => FilterStatKey::GenericFilter(other.to_owned()),
+            "custom-filter" => FilterStatKey::CustomFilter,
+            other => FilterStatKey::from_generic_filter_id(other),
         })
     }
 }

--- a/relay-filter/src/generic.rs
+++ b/relay-filter/src/generic.rs
@@ -50,7 +50,7 @@ pub(crate) fn should_filter<F: Getter>(
 
     for filter_config in filters {
         if filter_config.is_enabled && matches(item, filter_config.condition) {
-            return Err(FilterStatKey::GenericFilter(filter_config.id.to_owned()));
+            return Err(FilterStatKey::from_generic_filter_id(filter_config.id));
         }
     }
 
@@ -221,6 +221,28 @@ mod tests {
         assert_eq!(
             should_filter(&event, &config, None),
             Err(FilterStatKey::GenericFilter("helloTransactions".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_should_filter_custom_filter() {
+        let config = GenericFiltersConfig {
+            version: 1,
+            filters: vec![GenericFilterConfig {
+                id: "cif-42".to_owned(),
+                is_enabled: true,
+                condition: Some(RuleCondition::eq("event.release", "1.0")),
+            }]
+            .into(),
+        };
+
+        let event = Event {
+            release: Annotated::new(LenientString("1.0".to_owned())),
+            ..Default::default()
+        };
+        assert_eq!(
+            should_filter(&event, &config, None),
+            Err(FilterStatKey::CustomFilter)
         );
     }
 


### PR DESCRIPTION
- Report `custom-filter` reason in outcomes for the new inbound filters v2
- This is for global tracking; the per-filter tracking is probably a separate mechanism, can we use outcomes for this as well?

Contributes to TET-2842