### PR TITLE
chore(auth): Log cause of invalid relay signature rejection

### DIFF
--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -40,6 +40,13 @@ impl IntoResponse for SignatureError {
             _ => StatusCode::UNAUTHORIZED,
         };
 
+        if let SignatureError::BadSignature(ref error) = self {
+            relay_log::warn!(
+                error = error as &dyn std::error::Error,
+                "invalid relay signature"
+            )
+        }
+
         (status, ApiErrorResponse::from_error(&self)).into_response()
     }
 }


### PR DESCRIPTION
Follow up: INC-2449