### PR TITLE
chore(auth): Fix log cause of invalid relay signature rejection

### DIFF
--- a/relay-server/src/extractors/signed_json.rs
+++ b/relay-server/src/extractors/signed_json.rs
@@ -40,6 +40,7 @@ impl IntoResponse for SignatureError {
             _ => StatusCode::UNAUTHORIZED,
         };
 
+        #[cfg(feature = "processing")]
         if let SignatureError::BadSignature(ref error) = self {
             relay_log::warn!(
                 error = error as &dyn std::error::Error,


### PR DESCRIPTION
Follow up to #6304 this now also logs for customer relays, which we don't want so only compile it into processing relays.