### PR TITLE
ref: Fixes for Rust 1.98.0 lints

### DIFF
--- a/relay-server/src/endpoints/mod.rs
+++ b/relay-server/src/endpoints/mod.rs
@@ -3,6 +3,9 @@
 //! This module contains implementations for all supported relay endpoints, as well as a generic
 //! `forward` endpoint that sends unknown requests to the upstream.
 
+// Axum's standard `ErrorResponse` is larger than Clippy's default threshold.
+#![allow(clippy::result_large_err)]
+
 pub(crate) mod common;
 
 mod attachments;

--- a/relay-server/src/utils/stream/metered.rs
+++ b/relay-server/src/utils/stream/metered.rs
@@ -86,7 +86,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::StreamExt as _;
     use futures::stream;
     use tokio::time::Duration;
 

--- a/relay-server/src/utils/stream/rechunked.rs
+++ b/relay-server/src/utils/stream/rechunked.rs
@@ -96,7 +96,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures::StreamExt as _;
     use futures::stream;
 
     use super::*;


### PR DESCRIPTION
With Rust 1.98.0, Clippy started failing in three places, blocking CI ([example](https://github.com/getsentry/relay/actions/runs/32742440720/job/97479851141)).

Two unused imports:

```
error: unused import: `futures::StreamExt`
  --> relay-server/src/utils/stream/rechunked.rs:99:9
   |
99 |     use futures::StreamExt as _;
   |         ^^^^^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: unused import: `futures::StreamExt`
  --> relay-server/src/utils/stream/metered.rs:89:9
   |
89 |     use futures::StreamExt as _;
   |         
```

and an overly large `Err` variant (affects all endpoints, here's one example):

```
error: the `Err`-variant returned from this function is very large
   --> relay-server/src/endpoints/envelope.rs:119:6
    |
119 | ) -> axum::response::Result<impl IntoResponse> {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 128 bytes
    |
    = help: try reducing the size of `axum::response::ErrorResponse`, for example by boxing large elements or replacing it with `Box<axum::response::ErrorResponse>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#result_large_err
```

Remove the unused imports, and suppress the `Err` size lint for now.