### PR TITLE
chore(conventions): Bump sentry conventions to 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Raise the size limit for the flags context to 128 KiB. ([#6310](https://github.com/getsentry/relay/pull/6310))
 
+**Internal**:
+
+- Update sentry-conventions to 0.20.0. ([#6315](https://github.com/getsentry/relay/pull/6315))
+
 ## 26.8.0
 
 **Features**:

--- a/relay-pii/src/snapshots/relay_pii__eap__tests__scrub_attributes_pii_default_rules.snap
+++ b/relay-pii/src/snapshots/relay_pii__eap__tests__scrub_attributes_pii_default_rules.snap
@@ -69,7 +69,7 @@ expression: SerializableAnnotated(&data)
   },
   "sentry.description": {
     "type": "string",
-    "value": "[Filtered]"
+    "value": "secret123"
   },
   "sentry.release": {
     "type": "string",
@@ -293,21 +293,6 @@ expression: SerializableAnnotated(&data)
       }
     },
     "secret": {
-      "value": {
-        "": {
-          "rem": [
-            [
-              "@password:filter",
-              "s",
-              0,
-              10
-            ]
-          ],
-          "len": 9
-        }
-      }
-    },
-    "sentry.description": {
       "value": {
         "": {
           "rem": [

--- a/relay-server/src/processing/spans/process.rs
+++ b/relay-server/src/processing/spans/process.rs
@@ -517,7 +517,7 @@ mod tests {
         {
           "sentry.description": {
             "type": "string",
-            "value": "[Filtered]"
+            "value": "secret123"
           },
           "sentry.release": {
             "type": "string",
@@ -536,21 +536,6 @@ mod tests {
             "value": "[Filtered]"
           },
           "_meta": {
-            "sentry.description": {
-              "value": {
-                "": {
-                  "rem": [
-                    [
-                      "@password:filter",
-                      "s",
-                      0,
-                      10
-                    ]
-                  ],
-                  "len": 9
-                }
-              }
-            },
             "url.path": {
               "value": {
                 "": {

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -104,7 +104,7 @@ def test_trace_metric_multiple_containers_not_allowed(
         # If an external Relay/Client makes modifications, sizes can change,
         # this is fuzzy due to slight changes in sizes due to added timestamps
         # and may need to be adjusted when changing normalization.
-        ("managed", 189),
+        ("managed", 222),
     ],
 )
 def test_trace_metric_extraction(

--- a/tests/integration/test_trace_metrics.py
+++ b/tests/integration/test_trace_metrics.py
@@ -203,6 +203,7 @@ def test_trace_metric_extraction(
             "sentry.client_sample_rate": {"doubleValue": 0.25},
             "http.request.method": {"stringValue": "GET"},
             "http.status_code": {"intValue": "200"},
+            "http.response.status_code": {"intValue": "200"},
             "sentry._internal.cooccuring.name.http.request.duration_seconds": {
                 "boolValue": True
             },


### PR DESCRIPTION
Bumps the sentry-convention sub module to [0.20.0](https://github.com/getsentry/sentry-conventions/releases/tag/0.20.0).

Other changes:
- Since `sentry.description` no longer is auto-scrubbed, the snapshot asserting on `sentry.description` needed an update
- 0.20.0 [added](https://github.com/getsentry/sentry-conventions/pull/571) missing `backfill` status to a lot of attributes, which required a test update to add `http.response.status_code` which is now backfilled for `http.status_code`.  