### PR TITLE
fix(attachments): Store the normalized content type in objectstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Raise the size limit for the flags context to 128 KiB. ([#6310](https://github.com/getsentry/relay/pull/6310))
 
+**Bug Fixes**:
+
+- Store a normalized attachment content type in objectstore so that downloads are served with the correct type. ([#6319](https://github.com/getsentry/relay/pull/6319))
+
 ## 26.8.0
 
 **Features**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,6 +5027,7 @@ dependencies = [
  "lz4_flex",
  "matchit",
  "mime",
+ "mime_guess",
  "minidump",
  "multer",
  "objectstore-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ md5 = "0.8"
 memchr = "2"
 mimalloc = { version = "0.1", features = ["v3"] }
 mime = "0.3"
+mime_guess = "2.0.5"
 minidump = "0.26"
 minidumper-child = "0.4.1"
 multer = "3"

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [features]
 default = []
 processing = [
+  "dep:mime_guess",
   "dep:minidump",
   "dep:prost-types",
   "dep:sentry_protos",
@@ -58,6 +59,7 @@ liblzma = { workspace = true }
 lz4_flex = { workspace = true }
 matchit = { workspace = true }
 mime = { workspace = true }
+mime_guess = { workspace = true, optional = true }
 minidump = { workspace = true, optional = true }
 multer = { workspace = true }
 objectstore-client = { workspace = true }

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -251,7 +251,6 @@ impl Item {
     }
 
     /// Returns the content type of this item's payload.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn content_type(&self) -> Option<ContentType> {
         self.headers.get(ItemHeaderKey::ContentType)
     }
@@ -262,7 +261,6 @@ impl Item {
     }
 
     /// Sets the raw content type, overriding the one specified by the SDK.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn set_raw_content_type<S>(&mut self, content_type: S)
     where
         S: Into<String>,
@@ -370,7 +368,6 @@ impl Item {
     }
 
     /// Returns the file name of this item, if it is an attachment.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn filename(&self) -> Option<&str> {
         self.headers.get(ItemHeaderKey::Filename)
     }

--- a/relay-server/src/envelope/item.rs
+++ b/relay-server/src/envelope/item.rs
@@ -261,6 +261,16 @@ impl Item {
         self.headers.get(ItemHeaderKey::ContentType)
     }
 
+    /// Sets the raw content type, overriding the one specified by the SDK.
+    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
+    pub fn set_raw_content_type<S>(&mut self, content_type: S)
+    where
+        S: Into<String>,
+    {
+        self.headers
+            .set(ItemHeaderKey::ContentType, content_type.into());
+    }
+
     /// Sets the content type if there isn't already one set.
     pub fn set_default_content_type(&mut self, content_type: ContentType) {
         if !self.headers.contains(ItemHeaderKey::ContentType) {

--- a/relay-server/src/envelope/mod.rs
+++ b/relay-server/src/envelope/mod.rs
@@ -476,7 +476,6 @@ impl Envelope {
     }
 
     /// Returns the specified header value, if present.
-    #[cfg_attr(not(feature = "processing"), allow(dead_code))]
     pub fn get_header<K>(&self, name: &K) -> Option<&Value>
     where
         String: Borrow<K>,

--- a/relay-server/src/processing/trace_attachments/store.rs
+++ b/relay-server/src/processing/trace_attachments/store.rs
@@ -16,6 +16,9 @@ use crate::processing::utils::store::{
 use crate::services::objectstore::StoreTraceAttachment;
 use crate::services::outcome::{DiscardReason, Outcome};
 
+/// The trace item attribute that carries the content type of the attachment.
+pub const CONTENT_TYPE_ATTRIBUTE: &str = "sentry.content-type";
+
 /// Converts an expanded attachment to a storable unit.
 pub fn convert(
     attachment: Managed<ExpandedAttachment>,
@@ -39,6 +42,7 @@ pub fn convert(
             retention,
             server_sample_rate,
         };
+        let content_type = meta.value().and_then(|m| m.content_type.value().cloned());
         let filename = meta.value().and_then(|m| m.filename.value().cloned());
         let trace_item = attachment_to_trace_item(meta, quantities, ctx)
             .ok_or(Outcome::Invalid(DiscardReason::InvalidTraceAttachment))?;
@@ -46,6 +50,7 @@ pub fn convert(
         Ok::<_, Outcome>(StoreTraceAttachment {
             trace_item,
             body,
+            content_type,
             filename,
             retention: retention.standard,
         })
@@ -168,7 +173,7 @@ fn convert_attributes(
     } = fields;
 
     result.insert(
-        "sentry.content-type".to_owned(),
+        CONTENT_TYPE_ATTRIBUTE.to_owned(),
         AnyValue {
             value: Some(any_value::Value::StringValue(
                 content_type.as_str().to_owned(),

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -1204,7 +1204,8 @@ fn normalize_content_type(raw: Option<&str>, filename: Option<&str>) -> Cow<'sta
         Some(content_type) => Cow::Owned(content_type),
         None => filename
             .and_then(|filename| mime_guess::from_path(filename).first_raw())
-            .map_or(Cow::Borrowed(octet_stream), Cow::Borrowed),
+            .unwrap_or(octet_stream)
+            .into(),
     }
 }
 

--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -1,5 +1,6 @@
 //! Objectstore service for uploading attachments.
 use std::array::TryFromSliceError;
+use std::borrow::Cow;
 use std::fmt;
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::sync::Arc;
@@ -9,6 +10,7 @@ use async_compression::tokio::bufread::ZstdEncoder;
 use bytes::Bytes;
 use futures::StreamExt;
 use http::StatusCode;
+use mime::Mime;
 use objectstore_client::{
     Client, Compression, ExpirationPolicy, SecretKey as SigningKey, Session, TokenGenerator,
     UploadId, Usecase,
@@ -22,12 +24,13 @@ use relay_quotas::Scoping;
 use relay_system::{
     Addr, AsyncResponse, FromMessage, Interface, LoadShed, NoResponse, Sender, SimpleService,
 };
-use sentry_protos::snuba::v1::TraceItem;
+use sentry_protos::snuba::v1::{AnyValue, TraceItem, any_value};
 use tokio_util::io::{ReaderStream, StreamReader};
 
 use crate::constants::DEFAULT_ATTACHMENT_RETENTION;
 use crate::envelope::{ContentType, Item, ItemType};
 use crate::managed::{Counted, Managed, ManagedResult, OutcomeError, Quantities, Rejected};
+use crate::processing::trace_attachments::store::CONTENT_TYPE_ATTRIBUTE;
 use crate::processing::utils::store::item_id_to_uuid;
 use crate::services::outcome::DiscardReason;
 use crate::services::store::{
@@ -179,6 +182,8 @@ pub struct StoreTraceAttachment {
     pub body: Bytes,
     /// The trace item to be published via Kafka.
     pub trace_item: TraceItem,
+    /// The content type of the attachment body.
+    pub content_type: Option<String>,
     /// The file name that downloads of this attachment are named after.
     pub filename: Option<String>,
     /// Data retention in days for this attachment.
@@ -565,7 +570,12 @@ impl ObjectstoreServiceInner {
         });
 
         for mut attachment in attachments.split(|e| e) {
+            let content_type =
+                normalize_content_type(attachment.raw_content_type(), attachment.filename());
+            attachment.modify(|a, _| a.set_raw_content_type(content_type.clone()));
+
             let attributes = ObjectAttributes {
+                content_type: Some(content_type),
                 filename: attachment.filename().map(String::from),
                 ..Default::default()
             };
@@ -619,10 +629,17 @@ impl ObjectstoreServiceInner {
             scoping.project_id,
         );
 
+        let content_type = normalize_content_type(
+            attachment.attachment.raw_content_type(),
+            attachment.attachment.filename(),
+        );
+        attachment.modify(|a, _| a.attachment.set_raw_content_type(content_type.clone()));
+
         let upload_result = match session {
             Err(error) => Err(error),
             Ok(session) => {
                 let attributes = ObjectAttributes {
+                    content_type: Some(content_type),
                     filename: attachment.attachment.filename().map(String::from),
                     ..Default::default()
                 };
@@ -674,17 +691,29 @@ impl ObjectstoreServiceInner {
         let body = Bytes::clone(&managed.body);
         let retention = managed.retention;
         let filename = managed.filename.clone();
+        let content_type =
+            normalize_content_type(managed.content_type.as_deref(), filename.as_deref());
 
         // Make sure that the attachment can be converted into a trace item:
-        let trace_item = managed.try_map(|attachment, _record_keeper| {
+        let mut trace_item = managed.try_map(|attachment, _record_keeper| {
             let StoreTraceAttachment {
                 trace_item,
                 body: _,
+                content_type: _,
                 filename: _,
                 retention: _,
             } = attachment;
             Ok::<_, Error>(StoreTraceItem { trace_item })
         })?;
+
+        // Write back the normalized content type for the `Store` service:
+        trace_item.modify(|item, _| {
+            let value = any_value::Value::StringValue(content_type.clone().into_owned());
+            item.trace_item.attributes.insert(
+                CONTENT_TYPE_ATTRIBUTE.to_owned(),
+                AnyValue { value: Some(value) },
+            );
+        });
 
         // Upload the attachment:
         if !body.is_empty() {
@@ -700,8 +729,8 @@ impl ObjectstoreServiceInner {
 
             let attributes = ObjectAttributes {
                 key: Some(key),
+                content_type: Some(content_type),
                 filename,
-                ..Default::default()
             };
 
             let _stored_key = self
@@ -775,7 +804,7 @@ impl ObjectstoreServiceInner {
             .session(&self.objectstore_client)?;
 
         let attributes = ObjectAttributes {
-            content_type: Some(content_type),
+            content_type: Some(Cow::Borrowed(content_type.as_str())),
             ..Default::default()
         };
 
@@ -935,7 +964,7 @@ impl ObjectstoreServiceInner {
             } => {
                 let mut request = session.put(body);
                 if let Some(content_type) = content_type {
-                    request = request.content_type(content_type.as_str());
+                    request = request.content_type(content_type);
                 }
                 if let Some(filename) = filename {
                     request = request.filename(filename);
@@ -1050,7 +1079,9 @@ struct ObjectAttributes {
     /// If this is `None`, objectstore assigns a random key.
     key: Option<String>,
     /// The content type of the payload.
-    content_type: Option<ContentType>,
+    ///
+    /// If this is `None`, objectstore assumes `application/octet-stream`.
+    content_type: Option<Cow<'static, str>>,
     /// The file name that downloads of this object are named after.
     ///
     /// Objectstore only sends a `Content-Disposition` header for objects that were stored with a
@@ -1066,7 +1097,7 @@ enum Upload {
         body: Bytes,
         key: Option<String>,
         retention_hours: Option<u16>,
-        content_type: Option<ContentType>,
+        content_type: Option<Cow<'static, str>>,
         filename: Option<String>,
     },
     Stream {
@@ -1089,7 +1120,7 @@ impl Upload {
                 body: body.clone(),
                 key: key.clone(),
                 retention_hours: *retention_hours,
-                content_type: *content_type,
+                content_type: content_type.clone(),
                 filename: filename.clone(),
             }),
             Self::Stream {
@@ -1113,7 +1144,7 @@ enum UploadAttempt {
         body: Bytes,
         key: Option<String>,
         retention_hours: Option<u16>,
-        content_type: Option<ContentType>,
+        content_type: Option<Cow<'static, str>>,
         filename: Option<String>,
     },
     Stream {
@@ -1152,6 +1183,29 @@ fn is_user_error(error: &(dyn std::error::Error + 'static)) -> bool {
             std::io::ErrorKind::FileTooLarge | std::io::ErrorKind::UnexpectedEof
         )
     })
+}
+
+/// Normalizes the content type of an attachment into an IANA media type.
+///
+/// Content types of attachments are arbitrary strings supplied by SDKs, and most SDKs default to
+/// the generic `application/octet-stream`. Media type parameters such as `charset` are stripped,
+/// and the type is guessed from the file name if it is missing, generic, or not a valid media
+/// type. This matches how Sentry normalizes content types when it serves attachments.
+fn normalize_content_type(raw: Option<&str>, filename: Option<&str>) -> Cow<'static, str> {
+    let octet_stream = ContentType::OctetStream.as_str();
+
+    // Parsing as a media type validates the content type and strips parameters such as `charset`.
+    let declared = raw
+        .and_then(|content_type| content_type.parse::<Mime>().ok())
+        .map(|media_type| media_type.essence_str().to_ascii_lowercase())
+        .filter(|essence| essence != octet_stream);
+
+    match declared {
+        Some(content_type) => Cow::Owned(content_type),
+        None => filename
+            .and_then(|filename| mime_guess::from_path(filename).first_raw())
+            .map_or(Cow::Borrowed(octet_stream), Cow::Borrowed),
+    }
 }
 
 fn should_upload(item: &Item) -> bool {
@@ -1298,6 +1352,47 @@ mod tests {
             &Outcome::Invalid(DiscardReason::UploadFailed),
             DataCategory::AttachmentItem,
             1,
+        );
+    }
+
+    #[test]
+    fn content_type_normalizes_declared() {
+        assert_eq!(normalize_content_type(Some("Image/PNG"), None), "image/png");
+        assert_eq!(
+            normalize_content_type(Some("text/plain; charset=utf-8"), None),
+            "text/plain"
+        );
+    }
+
+    #[test]
+    fn content_type_guessed_from_filename() {
+        // Most SDKs send the generic octet stream, which is less specific than the file name.
+        let declared = Some("application/octet-stream");
+        assert_eq!(
+            normalize_content_type(declared, Some("screenshot.png")),
+            "image/png"
+        );
+        assert_eq!(normalize_content_type(None, Some("view.txt")), "text/plain");
+    }
+
+    #[test]
+    fn content_type_falls_back_to_octet_stream() {
+        assert_eq!(
+            normalize_content_type(None, None),
+            ContentType::OctetStream.as_str()
+        );
+        assert_eq!(
+            normalize_content_type(None, Some("crash.unknown-extension")),
+            ContentType::OctetStream.as_str()
+        );
+        // Content types are arbitrary strings from SDKs, invalid ones must not reach objectstore.
+        assert_eq!(
+            normalize_content_type(Some("not a media type"), Some("view.txt")),
+            "text/plain"
+        );
+        assert_eq!(
+            normalize_content_type(Some("image"), None),
+            ContentType::OctetStream.as_str()
         );
     }
 

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -651,6 +651,7 @@ def test_event_with_attachment(
             type="attachment",
             payload=PayloadRef(bytes=b"event attachment"),
             filename="event.txt",
+            content_type="text/plain",
         )
     )
 
@@ -667,7 +668,7 @@ def test_event_with_attachment(
         {
             "name": "event.txt",
             "rate_limited": False,
-            "content_type": "application/octet-stream",
+            "content_type": "text/plain",
             "attachment_type": "event.attachment",
             "size": len(b"event attachment"),
             "retention_days": 90,
@@ -681,6 +682,7 @@ def test_event_with_attachment(
         assert stored.payload.read() == b"event attachment"
         # The file name is required for `Content-Disposition` on downloads.
         assert stored.metadata.filename == "event.txt"
+        assert stored.metadata.content_type == "text/plain"
 
     # transaction attachments are sent as individual attachments,
     # either using chunks by default, or contents inlined
@@ -699,7 +701,8 @@ def test_event_with_attachment(
     expected_attachment = {
         "name": "transaction.txt",
         "rate_limited": False,
-        "content_type": "application/octet-stream",
+        # Uploads normalize the generic content type by guessing from the file name.
+        "content_type": "text/plain" if use_objectstore else "application/octet-stream",
         "attachment_type": "event.attachment",
         "size": len(b"transaction attachment"),
         "retention_days": 90,
@@ -718,6 +721,7 @@ def test_event_with_attachment(
         stored = objectstore.get(stored_id)
         assert stored.payload.read() == b"transaction attachment"
         assert stored.metadata.filename == "transaction.txt"
+        assert stored.metadata.content_type == "text/plain"
 
     assert attachment == {
         "type": "attachment",

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -167,6 +167,8 @@ def test_attachments_with_objectstore(
             "id": matches_any(),
             "name": "foo.txt",
             "rate_limited": False,
+            # Uploads guess the content type from the file name.
+            "content_type": "text/plain",
             "attachment_type": "event.attachment",
             "size": len(chunked_contents),
             "retention_days": 90,
@@ -175,8 +177,8 @@ def test_attachments_with_objectstore(
         "project_id": project_id,
     }
 
-    # Empty attachments are still transmitted with zero chunks,
-    # and not stored on objectstore
+    # Empty attachments are still transmitted with zero chunks, and not stored on
+    # objectstore, so their content type remains unset
     empty = attachments_by_name["foobar.txt"]
     assert empty == {
         "type": "attachment",

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -171,10 +171,10 @@ def test_standalone_attachment_store(
     }
 
     objectstore = objectstore(usecase="trace_attachments", project_id=project_id)
-    assert (
-        objectstore.get(attachment_metadata["attachment_id"]).payload.read()
-        == attachment_body
-    )
+    stored = objectstore.get(attachment_metadata["attachment_id"])
+    assert stored.payload.read() == attachment_body
+    assert stored.metadata.filename == "myfile.txt"
+    assert stored.metadata.content_type == "text/plain"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Attachments in objectstore are currently stored without a content type. Since https://github.com/getsentry/sentry/pull/120958, Sentry redirects to Objectstore for downloads, and these are now missing the `content-type` header.

This PR ports over content type normalization from Sentry and then sets the header on objectstore. We now also pass the normalized version into Sentry, so that all consumers can rely on a normalized header.

Ref FS-491
Ref https://github.com/getsentry/sentry-mcp/issues/1267