### PR TITLE
Revert "build(deps-dev): Bump setuptools from 80.10.2 to 83.0.0"

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,10 +691,10 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "83.0.0"
+version = "80.10.2"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts getsentry/relay#6321

I confirmed what cursor said:

> Bumping setuptools to 83.0.0 removes pkg_resources (gone since 82.0.0), but locked supervisor 4.2.5 still imports it at runtime. That breaks devservices, which depends on supervisor, with an ImportError on startup after uv sync.

https://github.com/getsentry/relay/pull/6321#discussion_r3853067943