### PR TITLE
chore(objectstore): Clean up artifact of objectstore auth rollout

### DIFF
--- a/relay-server/src/services/objectstore.rs
+++ b/relay-server/src/services/objectstore.rs
@@ -396,22 +396,11 @@ impl ObjectstoreService {
             let mut builder = Client::builder(objectstore_url);
 
             if let Some(auth) = auth {
-                // TODO(FS-313): when Objectstore starts enforcing auth, propagate error with ?
                 let token_generator = TokenGenerator::new(SigningKey {
                     kid: auth.key_id.clone(),
                     secret_key: auth.signing_key.clone(),
-                });
-
-                builder = match token_generator {
-                    Ok(token_generator) => builder.token(token_generator),
-                    Err(error) => {
-                        relay_log::error!(
-                            error = &error as &dyn std::error::Error,
-                            "failed to configure objectstore auth"
-                        );
-                        builder
-                    }
-                };
+                })?;
+                builder = builder.token(token_generator);
             }
 
             builder.build()?


### PR DESCRIPTION
ezpz

Ref FS-313

In the PR that added this code (https://github.com/getsentry/relay/pull/5720) I promised to follow up after auth was enabled to propagate errors here with `?`. Now that auth has been enabled for a while, I'm following up.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
