### PR TITLE
chore(gocd): Use GitHub App credentials

### DIFF
--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -37,7 +37,7 @@ pipelines:
               elastic_profile_id: relay
               tasks:
                 - script: |
-                    checks-githubactions-checkruns \
+                    checks-githubactions-checkruns2 \
                     getsentry/relay \
                     ${GO_REVISION_RELAY_REPO} \
                     "Integration Tests" \

--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -30,7 +30,7 @@ pipelines:
           jobs:
             checks:
               environment_variables:
-                # Required for checkruns.
+                # Required for checkruns2.
                 GITHUB_APP_ID: "{{SECRET:[devinfra-github][app_id]}}"
                 GITHUB_APP_PRIVATE_KEY: "{{SECRET:[devinfra-github][private_key]}}"
               timeout: 1800

--- a/gocd/pipelines/relay-experimental.yaml
+++ b/gocd/pipelines/relay-experimental.yaml
@@ -31,7 +31,8 @@ pipelines:
             checks:
               environment_variables:
                 # Required for checkruns.
-                GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
+                GITHUB_APP_ID: "{{SECRET:[devinfra-github][app_id]}}"
+                GITHUB_APP_PRIVATE_KEY: "{{SECRET:[devinfra-github][private_key]}}"
               timeout: 1800
               elastic_profile_id: relay
               tasks:

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-checks-githubactions-checkruns \
+checks-githubactions-checkruns2 \
     getsentry/relay \
     "${GO_REVISION_RELAY_REPO}" \
     "Integration Tests" \

--- a/gocd/templates/libs/utils.libsonnet
+++ b/gocd/templates/libs/utils.libsonnet
@@ -18,7 +18,8 @@ local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libs
         jobs: {
           checks: {
             environment_variables: {
-              GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+              GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+              GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
             },
             timeout: 1800,
             elastic_profile_id: 'relay',


### PR DESCRIPTION
Replace GoCD GitHub token references with GitHub App credentials.

- Pass GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to GoCD jobs.
- Preserve legacy runtime compatibility where the existing helper supports it.