### PR TITLE
fix(otel): Add alias for platform js => javascript

### DIFF
--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -154,8 +154,7 @@ pub fn otel_resource_to_platform(resource: &Resource) -> Option<&str> {
     Some(match language.as_str() {
         "dotnet" => "csharp",
         "nodejs" => "node",
-        "webjs" => "javascript",
-        "js" => "javascript",
+        "js" | "webjs" => "javascript",
         _ => language,
     })
 }

--- a/relay-otel/src/lib.rs
+++ b/relay-otel/src/lib.rs
@@ -155,6 +155,7 @@ pub fn otel_resource_to_platform(resource: &Resource) -> Option<&str> {
         "dotnet" => "csharp",
         "nodejs" => "node",
         "webjs" => "javascript",
+        "js" => "javascript",
         _ => language,
     })
 }


### PR DESCRIPTION
- We've been getting some spans with platform `js` from OTEL instrumentation on Cloudflare Workers - this doesn't fit into any of our existing platform names