### PR TITLE
fix(buffer): Rename buffer.envelopes_count to buffer.envelopes_count.gauge

### DIFF
--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -91,7 +91,7 @@ impl GaugeMetric for RelayGauges {
             Self::AsyncPoolUtilization => "async_pool.utilization",
             Self::AsyncPoolActivity => "async_pool.activity",
             Self::NetworkOutage => "upstream.network_outage",
-            Self::BufferEnvelopesCount => "buffer.envelopes_count",
+            Self::BufferEnvelopesCount => "buffer.envelopes_count.gauge",
             Self::BufferStackCount => "buffer.stack_count",
             Self::BufferDiskUsed => "buffer.disk_used",
             Self::SystemMemoryUsed => "health.system_memory.used",


### PR DESCRIPTION
We changed envelopes_count to a gauge several months ago, but datadog metric types are sticky on first submission, so dd has been dropping our data since then.  Map this metric to a new name so that we can get it to show up again.


