### PR TITLE
fix(kafka): Downgrade rdkafka to 2.10.0 to fix stuck producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Store a normalized attachment content type in objectstore so that downloads are served with the correct type. ([#6319](https://github.com/getsentry/relay/pull/6319))
 - Reshape Nintendo Switch crashes so the issue title falls back to the crashing function instead of the raw abort result code, and raise their level to `fatal`. ([#6253](https://github.com/getsentry/relay/pull/6253))
 - Reject Nintendo Switch dying message attachments with an invalid magic number instead of panicking on a short payload. ([#6253](https://github.com/getsentry/relay/pull/6253))
+- Downgrade Kafka to prevent producers from getting stuck. ([#6336](https://github.com/getsentry/relay/pull/6336))
 
 **Internal**:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.39.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7956f9ac12b5712e50372d9749a3102f4810a8d42481c5eae3748d36d585bcf"
+checksum = "5f1856d72dbbbea0d2a5b2eaf6af7fb3847ef2746e883b11781446a51dbc85c0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -4300,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.10.0+2.12.1"
+version = "4.9.0+2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,8 +183,10 @@ psl = "2"
 quote = "1"
 rand = "0.9"
 rand_pcg = "0.9"
-rdkafka = "0.39"
-rdkafka-sys = "4"
+# Downgraded versions for rdkafka and rdkafka-sys to fix librdkafka 2.12 regression
+# https://github.com/confluentinc/librdkafka/issues/5301
+rdkafka = "=0.38"
+rdkafka-sys = "=4.9.0+2.10.0"
 redis = { version = "1", default-features = false }
 matchit = "0.8"
 regex = "1"


### PR DESCRIPTION
Another version of https://github.com/getsentry/relay/pull/6332 with pinned dependencies and a smaller diff on Cargo.lock.

Prevents https://github.com/confluentinc/librdkafka/issues/5301

Fixes https://github.com/getsentry/self-hosted/issues/4317

Fixes INGEST-1157