### PR TITLE
feat(ai): Preserve attached span costs

### DIFF
--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -153,7 +153,7 @@ fn normalize_context_utilization(
 /// Calculates model costs and serializes them into attributes.
 fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&ModelMetadata>) {
     // Preserve existing total cost instead of recalculating and overwriting it.
-    if attributes.contains_key(GEN_AI__COST__TOTAL_TOKENS) {
+    if ai::has_valid_total_cost(attributes.get_value(GEN_AI__COST__TOTAL_TOKENS)) {
         return;
     }
 

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -153,7 +153,7 @@ fn normalize_context_utilization(
 /// Calculates model costs and serializes them into attributes.
 fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&ModelMetadata>) {
     // Preserve existing total cost instead of recalculating and overwriting it.
-    if ai::has_valid_total_cost(attributes.get_value(GEN_AI__COST__TOTAL_TOKENS)) {
+    if ai::has_valid_total_cost(attributes) {
         return;
     }
 

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -152,6 +152,7 @@ fn normalize_context_utilization(
 
 /// Calculates model costs and serializes them into attributes.
 fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&ModelMetadata>) {
+    // Preserve existing total cost instead of recalculating and overwriting it.
     if attributes.contains_key(GEN_AI__COST__TOTAL_TOKENS) {
         return;
     }

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -152,7 +152,8 @@ fn normalize_context_utilization(
 
 /// Calculates model costs and serializes them into attributes.
 fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&ModelMetadata>) {
-    // Preserve existing total cost instead of recalculating and overwriting it.
+    // Preserve a valid attached total cost because Relay cannot calculate costs for self-hosted or
+    // otherwise unknown models.
     if ai::has_valid_total_cost(attributes) {
         return;
     }

--- a/relay-event-normalization/src/eap/ai.rs
+++ b/relay-event-normalization/src/eap/ai.rs
@@ -10,12 +10,8 @@ use crate::statsd::{Counters, map_origin_to_integration, platform_tag};
 
 /// Normalizes AI attributes.
 ///
-/// This aggressively overwrites existing AI attributes, in order to guarantee a consistent data
-/// set for the AI product module.
-///
-/// As an example, an OTeL user may be manually instrumenting AI request costs on spans but in a
-/// local currency. Sentry's AI model requires a consistent cost value, independent of local
-/// currencies.
+/// This aggressively overwrites existing AI attributes, except for existing model costs, in order
+/// to guarantee a consistent data set for the AI product module.
 ///
 /// Callers may choose to only run this normalization in processing mode to not have the
 /// normalization run multiple times.
@@ -156,6 +152,10 @@ fn normalize_context_utilization(
 
 /// Calculates model costs and serializes them into attributes.
 fn normalize_ai_costs(attributes: &mut Attributes, model_metadata: Option<&ModelMetadata>) {
+    if attributes.contains_key(GEN_AI__COST__TOTAL_TOKENS) {
+        return;
+    }
+
     let origin = extract_string_value(attributes, SENTRY__ORIGIN);
     let platform = extract_string_value(attributes, SENTRY__PLATFORM);
 
@@ -578,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_ai_overwrite_costs() {
+    fn test_normalize_ai_preserves_costs() {
         let mut attributes = Annotated::new(attributes! {
             "gen_ai.operation.type" => "ai_client".to_owned(),
             "gen_ai.usage.input_tokens" => 1000,
@@ -602,29 +602,17 @@ mod tests {
 
         assert_annotated_snapshot!(attributes, @r#"
         {
-          "gen_ai.cost.cache_creation.input_tokens": {
-            "type": "double",
-            "value": 0.0
-          },
-          "gen_ai.cost.cache_read.input_tokens": {
-            "type": "double",
-            "value": 0.0
-          },
           "gen_ai.cost.input_tokens": {
             "type": "double",
-            "value": 90.0
+            "value": 99.0
           },
           "gen_ai.cost.output_tokens": {
             "type": "double",
-            "value": 100.0
-          },
-          "gen_ai.cost.reasoning.output_tokens": {
-            "type": "double",
-            "value": 0.0
+            "value": 99.0
           },
           "gen_ai.cost.total_tokens": {
             "type": "double",
-            "value": 190.0
+            "value": 123.0
           },
           "gen_ai.operation.type": {
             "type": "string",

--- a/relay-event-normalization/src/eap/attribute_like.rs
+++ b/relay-event-normalization/src/eap/attribute_like.rs
@@ -17,6 +17,14 @@ pub trait AttributesLike {
     /// Access this container through the underlying [`Object`] mutably.
     fn as_object_mut(&mut self) -> &mut Object<Self::Value>;
 
+    /// Returns an attribute value.
+    fn get_value(&self, key: &str) -> Option<&Value> {
+        self.as_object()
+            .get(key)
+            .and_then(Annotated::value)
+            .and_then(AttributeLike::as_value)
+    }
+
     /// Checks whether this collection contains an attribute with the given `key`.
     fn contains_key(&self, key: &str) -> bool {
         self.as_object().contains_key(key)

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -207,6 +207,11 @@ fn extract_ai_model_cost_data(
     origin: Option<&str>,
     platform: Option<&str>,
 ) {
+    // Preserve existing total cost instead of recalculating and overwriting it.
+    if data.contains(GEN_AI__COST__TOTAL_TOKENS) {
+        return;
+    }
+
     let integration = map_origin_to_integration(origin);
     let platform = platform_tag(platform);
 
@@ -695,6 +700,26 @@ mod tests {
             reasoning_output: 30.0,
         }
         ");
+    }
+
+    #[test]
+    fn test_existing_cost_is_not_overwritten() {
+        let mut span = ai_span_with_data(json!({
+            "gen_ai.response.model": "claude-2.1",
+            "gen_ai.usage.input_tokens": 1000.0,
+            "gen_ai.cost.input_tokens": 99.0,
+            "gen_ai.cost.total_tokens": 123.0,
+        }));
+
+        enrich_ai_span(&mut span, Some(&metadata_with_context_size()));
+
+        let data = span.data.value().unwrap();
+        assert_eq!(
+            data.get_value(GEN_AI__COST__TOTAL_TOKENS)
+                .and_then(Value::as_f64),
+            Some(123.0)
+        );
+        assert!(data.get_value(GEN_AI__COST__OUTPUT_TOKENS).is_none());
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -200,7 +200,7 @@ pub fn infer_ai_operation_type(op_name: &str) -> Option<&'static str> {
 }
 
 /// Returns whether a valid total cost is attached.
-pub(crate) fn has_valid_total_cost(value: Option<&Value>) -> bool {
+pub fn has_valid_total_cost(value: Option<&Value>) -> bool {
     value.and_then(Value::as_f64).is_some()
 }
 

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -1,5 +1,6 @@
 //! AI cost calculation.
 
+use crate::eap::AttributesLike;
 use crate::statsd::{Counters, map_origin_to_integration, platform_tag};
 use crate::{ModelCostV2, ModelMetadata};
 use relay_conventions::attributes::*;
@@ -200,8 +201,11 @@ pub fn infer_ai_operation_type(op_name: &str) -> Option<&'static str> {
 }
 
 /// Returns whether a valid total cost is attached.
-pub fn has_valid_total_cost(value: Option<&Value>) -> bool {
-    value.and_then(Value::as_f64).is_some()
+pub fn has_valid_total_cost(attributes: &impl AttributesLike) -> bool {
+    attributes
+        .get_value(GEN_AI__COST__TOTAL_TOKENS)
+        .and_then(Value::as_f64)
+        .is_some()
 }
 
 /// Calculates the cost of an AI model based on the model cost and the tokens used.
@@ -213,7 +217,7 @@ fn extract_ai_model_cost_data(
     platform: Option<&str>,
 ) {
     // Preserve existing total cost instead of recalculating and overwriting it.
-    if has_valid_total_cost(data.get_value(GEN_AI__COST__TOTAL_TOKENS)) {
+    if has_valid_total_cost(data) {
         return;
     }
 
@@ -553,9 +557,13 @@ mod tests {
 
     #[test]
     fn test_has_valid_total_cost() {
-        assert!(!has_valid_total_cost(None));
-        assert!(!has_valid_total_cost(Some(&Value::Bool(false))));
-        assert!(has_valid_total_cost(Some(&Value::F64(1.0))));
+        let missing = ai_span_with_data(json!({}));
+        let invalid = ai_span_with_data(json!({"gen_ai.cost.total_tokens": false}));
+        let valid = ai_span_with_data(json!({"gen_ai.cost.total_tokens": 1.0}));
+
+        assert!(!has_valid_total_cost(missing.data.value().unwrap()));
+        assert!(!has_valid_total_cost(invalid.data.value().unwrap()));
+        assert!(has_valid_total_cost(valid.data.value().unwrap()));
     }
 
     #[test]

--- a/relay-event-normalization/src/normalize/span/ai.rs
+++ b/relay-event-normalization/src/normalize/span/ai.rs
@@ -199,6 +199,11 @@ pub fn infer_ai_operation_type(op_name: &str) -> Option<&'static str> {
     Some(ai_op)
 }
 
+/// Returns whether a valid total cost is attached.
+pub(crate) fn has_valid_total_cost(value: Option<&Value>) -> bool {
+    value.and_then(Value::as_f64).is_some()
+}
+
 /// Calculates the cost of an AI model based on the model cost and the tokens used.
 /// Calculated cost is in US dollars.
 fn extract_ai_model_cost_data(
@@ -208,7 +213,7 @@ fn extract_ai_model_cost_data(
     platform: Option<&str>,
 ) {
     // Preserve existing total cost instead of recalculating and overwriting it.
-    if data.contains(GEN_AI__COST__TOTAL_TOKENS) {
+    if has_valid_total_cost(data.get_value(GEN_AI__COST__TOTAL_TOKENS)) {
         return;
     }
 
@@ -544,6 +549,13 @@ mod tests {
             data: SpanData::from_value(data.into()),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_has_valid_total_cost() {
+        assert!(!has_valid_total_cost(None));
+        assert!(!has_valid_total_cost(Some(&Value::Bool(false))));
+        assert!(has_valid_total_cost(Some(&Value::F64(1.0))));
     }
 
     #[test]

--- a/tests/integration/test_ai.py
+++ b/tests/integration/test_ai.py
@@ -79,6 +79,7 @@ def test_ai_spans_example_transaction(
                     "gen_ai.usage.output_tokens": 65,
                     "gen_ai.usage.input_tokens": 245,
                     "gen_ai.usage.total_tokens": 310,
+                    "gen_ai.cost.total_tokens": None,
                     "gen_ai.response.text": "True. \n\n- London: 61°F \n- San Francisco: 13°C",
                     "gen_ai.conversation.id": "resp_0c1c943ef2dc8bf9006909e7b8e3e88197bffb4d0e80187ca1",
                     "vercel.ai.operationId": "ai.generateText",


### PR DESCRIPTION
Relay now preserves SDK-provided Gen AI costs when `gen_ai.cost.total_tokens` is already present, normalization skips model cost calculation instead of overwriting attached total and component costs.

There are now more and more self-hosted models, or models we don't know the costs for, so we want to allow customers to attach their own costs to be able use all of the product offerings we have (e.g. dashboards, and conversations table).

Closes [TET-2913: accept reported costs in span attributes](https://linear.app/getsentry/issue/TET-2913/accept-reported-costs-in-span-attributes)
