### PR TITLE
fix(pii): Skip overlapping remarks in `split_chunks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Reshape Nintendo Switch crashes so the issue title falls back to the crashing function instead of the raw abort result code, and raise their level to `fatal`. ([#6253](https://github.com/getsentry/relay/pull/6253))
 - Reject Nintendo Switch dying message attachments with an invalid magic number instead of panicking on a short payload. ([#6253](https://github.com/getsentry/relay/pull/6253))
 - Downgrade Kafka to prevent producers from getting stuck. ([#6336](https://github.com/getsentry/relay/pull/6336))
+- Prevent memory bomb in PII processor's `split_chunks`. ([#6343](https://github.com/getsentry/relay/pull/6343))
 
 **Internal**:
 

--- a/relay-event-schema/src/processor/chunks.rs
+++ b/relay-event-schema/src/processor/chunks.rs
@@ -89,12 +89,10 @@ where
     let mut pos = 0;
 
     for remark in remarks {
-        let (mut from, to) = match remark.range() {
+        let (from, to) = match remark.range() {
             Some(range) => *range,
             None => continue,
         };
-
-        from = from.max(pos);
 
         if from > pos {
             if let Some(piece) = text.get(pos..from) {
@@ -104,8 +102,9 @@ where
             } else {
                 break;
             }
+            pos = from;
         }
-        if let Some(piece) = text.get(from..to) {
+        if let Some(piece) = text.get(pos..to) {
             rv.push(Chunk::Redaction {
                 text: Cow::Borrowed(piece),
                 rule_id: remark.rule_id().into(),

--- a/relay-event-schema/src/processor/chunks.rs
+++ b/relay-event-schema/src/processor/chunks.rs
@@ -89,9 +89,8 @@ where
     let mut pos = 0;
 
     for remark in remarks {
-        let (from, to) = match remark.range() {
-            Some(range) => *range,
-            None => continue,
+        let Some((from, to)) = remark.range().cloned() else {
+            continue;
         };
 
         if from > pos {
@@ -102,6 +101,7 @@ where
             } else {
                 break;
             }
+            pos = from;
         } else if from < pos {
             break;
         }

--- a/relay-event-schema/src/processor/chunks.rs
+++ b/relay-event-schema/src/processor/chunks.rs
@@ -89,10 +89,12 @@ where
     let mut pos = 0;
 
     for remark in remarks {
-        let (from, to) = match remark.range() {
+        let (mut from, to) = match remark.range() {
             Some(range) => *range,
             None => continue,
         };
+
+        from = from.max(pos);
 
         if from > pos {
             if let Some(piece) = text.get(pos..from) {

--- a/relay-event-schema/src/processor/chunks.rs
+++ b/relay-event-schema/src/processor/chunks.rs
@@ -102,9 +102,10 @@ where
             } else {
                 break;
             }
-            pos = from;
+        } else if from < pos {
+            break;
         }
-        if let Some(piece) = text.get(pos..to) {
+        if let Some(piece) = text.get(from..to) {
             rv.push(Chunk::Redaction {
                 text: Cow::Borrowed(piece),
                 rule_id: remark.rule_id().into(),

--- a/relay-event-schema/src/processor/chunks.rs
+++ b/relay-event-schema/src/processor/chunks.rs
@@ -103,6 +103,7 @@ where
             }
             pos = from;
         } else if from < pos {
+            // A lower `from` would duplicate parts of the string and is therefore illegal.
             break;
         }
         if let Some(piece) = text.get(from..to) {

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -678,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scrub_preexisting_meta() {
+    fn test_remark_overlap() {
         let mut data = Annotated::<Event>::from_json_bytes(
             br#"{
                 "extra": {"foo": "bar"},
@@ -686,13 +686,14 @@ mod tests {
                     "extra": {
                         "foo":{
                             "":{
-                                "rem":[["some_rule","s",0,3],["some_rule","s",0,3],["some_rule","s",0,0]]
+                                "rem":[["some_rule","s",0,3],["some_rule","s",0,3]]
                             }
                         }
                     }
                 }
             }"#,
-        ).unwrap();
+        )
+        .unwrap();
 
         let scrubbing_config = DataScrubbingConfig {
             scrub_data: true,
@@ -708,6 +709,43 @@ mod tests {
 
         // Verify that overlapping remarks do not make the string longer:
         assert_eq!(get_value!(data.extra["foo"]!).0.as_str(), Some("bar"));
+    }
+
+    #[test]
+    fn test_resume_after_gap() {
+        let mut data = Annotated::<Event>::from_json_bytes(
+            br#"{
+                "extra": {"foo": "abcdefghijklmnopqrstuvwxyz"},
+                "_meta":{
+                    "extra": {
+                        "foo":{
+                            "":{
+                                "rem":[["some_rule","s",0,3],["some_rule","s",6,5]]
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let scrubbing_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_ip_addresses: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+
+        let pii_config = to_pii_config(&scrubbing_config).unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+
+        // Verify that an invalid remark after a gap does not repeat the gap:
+        assert_eq!(
+            get_value!(data.extra["foo"]!).0.as_str(),
+            Some("abcdefghijklmnopqrstuvwxyz")
+        );
     }
 
     #[test]

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -686,14 +686,13 @@ mod tests {
                     "extra": {
                         "foo":{
                             "":{
-                                "rem":[["some_rule","s",0,3],["some_rule","s",0,3],["some_rule","s",0,1]]
+                                "rem":[["some_rule","s",0,3],["some_rule","s",0,3],["some_rule","s",0,0]]
                             }
                         }
                     }
                 }
             }"#,
         ).unwrap();
-        dbg!(&data);
 
         let scrubbing_config = DataScrubbingConfig {
             scrub_data: true,
@@ -707,7 +706,8 @@ mod tests {
 
         process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
 
-        println!("{}", data.to_json().unwrap());
+        // Verify that overlapping remarks do not make the string longer:
+        assert_eq!(get_value!(data.extra["foo"]!).0.as_str(), Some("bar"));
     }
 
     #[test]

--- a/relay-pii/src/processor.rs
+++ b/relay-pii/src/processor.rs
@@ -678,6 +678,39 @@ mod tests {
     }
 
     #[test]
+    fn test_scrub_preexisting_meta() {
+        let mut data = Annotated::<Event>::from_json_bytes(
+            br#"{
+                "extra": {"foo": "bar"},
+                "_meta":{
+                    "extra": {
+                        "foo":{
+                            "":{
+                                "rem":[["some_rule","s",0,3],["some_rule","s",0,3],["some_rule","s",0,1]]
+                            }
+                        }
+                    }
+                }
+            }"#,
+        ).unwrap();
+        dbg!(&data);
+
+        let scrubbing_config = DataScrubbingConfig {
+            scrub_data: true,
+            scrub_ip_addresses: true,
+            scrub_defaults: true,
+            ..Default::default()
+        };
+
+        let pii_config = to_pii_config(&scrubbing_config).unwrap();
+        let mut pii_processor = PiiProcessor::new(pii_config.compiled());
+
+        process_value(&mut data, &mut pii_processor, ProcessingState::root()).unwrap();
+
+        println!("{}", data.to_json().unwrap());
+    }
+
+    #[test]
     fn test_sentry_user() {
         let mut data = Event::from_value(
             json!({


### PR DESCRIPTION
Fixes INGEST-1137