### PR TITLE
ref(instr): Count standalone attachments by SDK

### DIFF
--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -10,6 +10,8 @@ use crate::processing::{self, CountRateLimited, Output, QuotaRateLimiter};
 #[cfg(feature = "processing")]
 use crate::services::outcome::DiscardReason;
 use crate::services::outcome::Outcome;
+use crate::statsd::RelayCounters;
+use crate::utils::client_name_tag;
 
 mod forward;
 mod process;
@@ -96,7 +98,14 @@ impl processing::Processor for AttachmentProcessor {
         mut attachments: Managed<Self::Input>,
         ctx: processing::Context<'_>,
     ) -> Result<processing::Output<Self::Output>, Rejected<Self::Error>> {
+        // Temporary counter to figure out which SDKs are still sending standalone attachments.
+        relay_statsd::metric!(
+            counter(RelayCounters::StandaloneAttachment) += 1,
+            sdk = client_name_tag(attachments.headers.meta().client_name())
+        );
+
         attachments::validate_attachments(&mut attachments, |a| &mut a.attachments, ctx);
+
         let mut attachments = self.limiter.enforce_quotas(attachments, ctx).await?;
         process::scrub(&mut attachments, ctx)?;
 

--- a/relay-server/src/statsd.rs
+++ b/relay-server/src/statsd.rs
@@ -1022,6 +1022,11 @@ pub enum RelayCounters {
     /// This metric is tagged with:
     /// - `sdk`: low-cardinality client name
     TraceMetricNilTraceId,
+    /// Amount of standalone attachments processed.
+    ///
+    /// This metric is tagged with:
+    /// - `sdk`: low-cardinality client name
+    StandaloneAttachment,
 }
 
 impl CounterMetric for RelayCounters {
@@ -1088,6 +1093,7 @@ impl CounterMetric for RelayCounters {
             RelayCounters::ErrorProcessed => "event.error.processed",
             RelayCounters::CompressedMinidump => "minidump.compressed.count",
             RelayCounters::TraceMetricNilTraceId => "trace_metric.nil_trace_id",
+            RelayCounters::StandaloneAttachment => "processing.standalone_attachment",
         }
     }
 }


### PR DESCRIPTION
Temporarily count how many standalone attachments are sent by SDK.