### PR TITLE
build: Install `uv` through `brew`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
 brew 'librdkafka'
 
 brew 'rustup'
+
+brew 'uv'

--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -1,14 +1,2 @@
 [devenv]
 minimum_version = 1.22.1
-
-[uv]
-darwin_arm64 = https://github.com/astral-sh/uv/releases/download/0.11.6/uv-aarch64-apple-darwin.tar.gz
-darwin_arm64_sha256 = 4b69a4e366ec38cd5f305707de95e12951181c448679a00dce2a78868dfc9f5b
-darwin_x86_64 = https://github.com/astral-sh/uv/releases/download/0.11.6/uv-x86_64-apple-darwin.tar.gz
-darwin_x86_64_sha256 = 8e0ed5035eaa28c7c8cd2a46b5b9a05bfff1ef01dbdc090a010eb8fdf193a457
-linux_arm64 = https://github.com/astral-sh/uv/releases/download/0.11.6/uv-aarch64-unknown-linux-gnu.tar.gz
-linux_arm64_sha256 = d5be4bf7015ea000378cb3c3aba53ba81a8673458ace9c7fa25a0be005b74802
-linux_x86_64 = https://github.com/astral-sh/uv/releases/download/0.11.6/uv-x86_64-unknown-linux-gnu.tar.gz
-linux_x86_64_sha256 = 0c6bab77a67a445dc849ed5e8ee8d3cb333b6e2eba863643ce1e228075f27943
-# used for autoupdate
-version = 0.11.6

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,11 +1,15 @@
 from devenv import constants
-from devenv.lib import brew, proc
+from devenv.lib import brew, fs, proc, uv
 
 import shutil
 
 
 def main(context: dict[str, str]) -> int:
     reporoot = context["reporoot"]
+
+    # clean up leftover devenv uv install
+    binroot = fs.ensure_binroot(reporoot)
+    uv.uninstall(binroot)
 
     brew.install()
 

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,12 +1,11 @@
 from devenv import constants
-from devenv.lib import brew, config, proc, uv
+from devenv.lib import brew, proc
 
 import shutil
 
 
 def main(context: dict[str, str]) -> int:
     reporoot = context["reporoot"]
-    cfg = config.get_repo(reporoot)
 
     brew.install()
 
@@ -38,17 +37,14 @@ def main(context: dict[str, str]) -> int:
     print("updating submodules")
     proc.run(("git", "submodule", "update", "--init", "--recursive"))
 
-    uv.install(
-        cfg["uv"]["version"],
-        cfg["uv"][constants.SYSTEM_MACHINE],
-        cfg["uv"][f"{constants.SYSTEM_MACHINE}_sha256"],
-        reporoot,
-    )
-
     print("syncing .venv ...")
+
+    if not shutil.which("uv"):
+        raise SystemExit("uv not on PATH. Did you run `direnv allow`?")
+
     proc.run(
         (
-            f"{reporoot}/.devenv/bin/uv",
+            "uv",
             "sync",
             "--frozen",
             "--quiet",


### PR DESCRIPTION
I'm getting a warning on every `devenv sync` saying that installing `uv` through `devenv` is no longer supported:
```
❯ devenv sync
[…]
!!! devenv-managed uv is deprecated! run `brew install uv` !!!
```

So I'm removing that code and adding `uv` to the brewfile instead.