### PR TITLE
ref(attachment): Add verbose log for standalone attachments

### DIFF
--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -107,6 +107,7 @@ impl processing::Processor for AttachmentProcessor {
         if !has_event_id {
             relay_log::info!(
                 sdk = attachments.headers.meta().client().unwrap_or("unknown"),
+                project_id = attachments.headers.meta().project_id.unwrap_or("unknown"),
                 "attachment without EventId"
             );
             return Err(attachments.reject_err(Error::NoEventId));

--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -107,7 +107,10 @@ impl processing::Processor for AttachmentProcessor {
         if !has_event_id {
             relay_log::info!(
                 sdk = attachments.headers.meta().client().unwrap_or("unknown"),
-                project_id = attachments.headers.meta().project_id.unwrap_or("unknown"),
+                project_id = ?attachments
+                    .headers
+                    .meta()
+                    .project_id(),
                 "attachment without EventId"
             );
             return Err(attachments.reject_err(Error::NoEventId));

--- a/relay-server/src/processing/attachments/mod.rs
+++ b/relay-server/src/processing/attachments/mod.rs
@@ -105,6 +105,10 @@ impl processing::Processor for AttachmentProcessor {
         );
 
         if !has_event_id {
+            relay_log::info!(
+                sdk = attachments.headers.meta().client().unwrap_or("unknown"),
+                "attachment without EventId"
+            );
             return Err(attachments.reject_err(Error::NoEventId));
         }
 


### PR DESCRIPTION
We do have a very limited number of standalone attachments incoming without an `event_id`. This adds a verbose log so we can better pinpoint which SDK sends them.