### PR TITLE
feat(server): Tag request metric by content encoding

### DIFF
--- a/relay-server/src/middlewares/metrics.rs
+++ b/relay-server/src/middlewares/metrics.rs
@@ -2,6 +2,7 @@ use axum::RequestExt;
 use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::Response;
+use http::header;
 use std::time::Instant;
 
 use crate::extractors::ReceivedAt;
@@ -19,11 +20,17 @@ pub async fn metrics(mut request: Request, next: Next) -> Response {
     let matched_path = request.extract_parts::<MatchedPath>().await;
     let route = matched_path.as_ref().map_or("unknown", |m| m.as_str());
     let method = request.method().clone();
+    let content_encoding = request
+        .headers()
+        .get(header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
 
     relay_statsd::metric!(
         counter(RelayCounters::Requests) += 1,
         route = route,
         method = method.as_str(),
+        content_encoding = content_encoding,
     );
 
     let response = next.run(request).await;

--- a/relay-server/src/middlewares/metrics.rs
+++ b/relay-server/src/middlewares/metrics.rs
@@ -3,6 +3,7 @@ use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::Response;
 use http::header;
+use relay_config::HttpEncoding;
 use std::time::Instant;
 
 use crate::extractors::ReceivedAt;
@@ -20,17 +21,12 @@ pub async fn metrics(mut request: Request, next: Next) -> Response {
     let matched_path = request.extract_parts::<MatchedPath>().await;
     let route = matched_path.as_ref().map_or("unknown", |m| m.as_str());
     let method = request.method().clone();
-    let content_encoding = request
-        .headers()
-        .get(header::CONTENT_ENCODING)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
 
     relay_statsd::metric!(
         counter(RelayCounters::Requests) += 1,
         route = route,
         method = method.as_str(),
-        content_encoding = content_encoding,
+        content_encoding = content_encoding_tag(&request),
     );
 
     let response = next.run(request).await;
@@ -48,4 +44,14 @@ pub async fn metrics(mut request: Request, next: Next) -> Response {
     );
 
     response
+}
+
+fn content_encoding_tag(request: &Request) -> &str {
+    request
+        .headers()
+        .get(header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .map(HttpEncoding::parse)
+        .and_then(|enc| enc.name())
+        .unwrap_or("other")
 }


### PR DESCRIPTION
Before we restrict the `/upload` endpoint, we have to know which encodings are currently being used.

ref: INGEST-1162