### PR TITLE
feat(metrics): Disable emission of generic metrics

### DIFF
--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -177,6 +177,14 @@ pub struct Options {
     )]
     pub attachment_inline_limit: usize,
 
+    /// Kill-switch for suppressing generic metrics.
+    #[serde(
+        rename = "relay.generic-metrics.disabled",
+        deserialize_with = "default_on_error",
+        skip_serializing_if = "is_default"
+    )]
+    pub generic_metrics_enabled: bool,
+
     /// All other unknown options.
     #[serde(flatten)]
     other: HashMap<String, Value>,

--- a/relay-dynamic-config/src/global.rs
+++ b/relay-dynamic-config/src/global.rs
@@ -183,7 +183,7 @@ pub struct Options {
         deserialize_with = "default_on_error",
         skip_serializing_if = "is_default"
     )]
-    pub generic_metrics_enabled: bool,
+    pub generic_metrics_disabled: bool,
 
     /// All other unknown options.
     #[serde(flatten)]

--- a/relay-server/src/services/store.rs
+++ b/relay-server/src/services/store.rs
@@ -1121,7 +1121,15 @@ impl StoreService {
                 );
                 return Ok(());
             }
-            _ => KafkaTopic::MetricsGeneric,
+
+            MetricNamespace::Spans | MetricNamespace::Transactions => {
+                if let Some(global_config) = self.global_config.current()
+                    && global_config.options.generic_metrics_disabled
+                {
+                    return Ok(());
+                }
+                KafkaTopic::MetricsGeneric
+            }
         };
 
         let headers = BTreeMap::from([("namespace".to_owned(), namespace.to_string())]);

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -463,7 +463,14 @@ def test_global_metrics_batching(mini_sentry, relay):
     ]
 
 
-def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_consumer):
+@pytest.mark.parametrize("generic_metrics_disabled", [False, True])
+def test_metrics_with_processing(
+    mini_sentry, relay_with_processing, metrics_consumer, generic_metrics_disabled
+):
+    mini_sentry.global_config["options"][
+        "relay.generic-metrics.disabled"
+    ] = generic_metrics_disabled
+
     relay = relay_with_processing(options=TEST_CONFIG)
     metrics_consumer = metrics_consumer()
 
@@ -473,6 +480,10 @@ def test_metrics_with_processing(mini_sentry, relay_with_processing, metrics_con
     timestamp = int(datetime.now(tz=timezone.utc).timestamp())
     metrics_payload = f"spans/foo:42|c\ntransactions/bar@second:17|c|T{timestamp}"
     relay.send_metrics(project_id, metrics_payload)
+
+    if generic_metrics_disabled:
+        assert metrics_consumer.poll(timeout=2) is None
+        return
 
     metrics = metrics_by_name(metrics_consumer, 2)
 


### PR DESCRIPTION
Suppress production of transaction & span metrics to Kafka, depending on a global option.

Code for extraction and aggregation will be removed in a follow-up.

ref: TET-2981