### PR TITLE
build(server): Remove unused semver metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ rand_pcg = "0.9"
 # Downgraded versions for rdkafka and rdkafka-sys to fix librdkafka 2.12 regression
 # https://github.com/confluentinc/librdkafka/issues/5301
 rdkafka = "=0.38"
-rdkafka-sys = "=4.9.0+2.10.0"
+rdkafka-sys = "=4.9.0" # +2.10.0
 redis = { version = "1", default-features = false }
 matchit = "0.8"
 regex = "1"


### PR DESCRIPTION
I originally wanted to keep the suffix because it's part of the official crate version, but got annoyed by the warning logged on every `cargo` run:

```
warning: relay-kafka/Cargo.toml: version requirement `=4.9.0+2.10.0` for dependency `rdkafka-sys` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
warning: `relay-kafka` (manifest) generated 1 warning
```

See 

> The rdkafka-sys version number is in the format X.Y.Z+RX.RY.RZ, where X.Y.Z is the version of this crate and follows SemVer conventions, while RX.RY.RZ is the version of the bundled librdkafka.

https://crates.io/crates/rdkafka-sys