### PR TITLE
ref(relay): Factor monitor checkin processing

### DIFF
--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -335,8 +335,8 @@ mod tests {
     #[test]
     fn process_simple() {
         let json = r#"{"check_in_id":"a460c25ff2554577b920fcfacae4e5eb","monitor_slug":"my-monitor","status":"ok"}"#;
-        let mut check_in = serde_json::from_str(json).unwrap();
-        let rh = routing_hint(&mut check_in, &ProjectId::new(1));
+        let check_in = serde_json::from_str(json).unwrap();
+        let rh = routing_hint(&check_in, &ProjectId::new(1));
 
         // The routing_hint should be consistent for the (project_id, monitor_slug, environment)
         let expected_uuid = Uuid::parse_str("9aa99731-a8e3-5594-9f00-c3e8a62c2b11").unwrap();
@@ -350,9 +350,8 @@ mod tests {
             let json = format!(
                 r#"{{"check_in_id":"a460c25ff2554577b920fcfacae4e5eb","monitor_slug":"my-monitor","environment":"{env}","status":"ok"}}"#
             );
-            let mut check_in = serde_json::from_str(&json).unwrap();
-            let rh = routing_hint(&mut check_in, &ProjectId::new(1));
-            rh
+            let check_in = serde_json::from_str(&json).unwrap();
+            routing_hint(&check_in, &ProjectId::new(1))
         };
 
         // The consumer groups on (project, slug, environment) and only guarantees order within a
@@ -374,8 +373,8 @@ mod tests {
                 ),
                 None => r#"{"check_in_id":"a460c25ff2554577b920fcfacae4e5eb","monitor_slug":"my-monitor","status":"ok"}"#.to_owned(),
             };
-            let mut check_in = serde_json::from_str(&json).unwrap();
-            routing_hint(&mut check_in, &ProjectId::new(1))
+            let check_in = serde_json::from_str(&json).unwrap();
+            routing_hint(&check_in, &ProjectId::new(1))
         };
 
         // Sentry resolves all three to the same monitor environment, so they have to share a

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -164,25 +164,8 @@ pub struct CheckIn {
     pub contexts: Option<CheckInContexts>,
 }
 
-/// The result from calling process_check_in
-pub struct ProcessedCheckInResult {
-    /// The routing key to be used for the check-in payload.
-    ///
-    /// Important to help ensure monitor check-ins are processed in order by routing check-ins from
-    /// the same monitor to the same place.
-    pub routing_hint: Uuid,
-
-    /// The JSON payload of the processed check-in.
-    pub payload: Vec<u8>,
-}
-
 /// Normalizes a monitor check-in payload.
-pub fn process_check_in(
-    payload: &[u8],
-    project_id: ProjectId,
-) -> Result<ProcessedCheckInResult, ProcessCheckInError> {
-    let mut check_in = serde_json::from_slice::<CheckIn>(payload)?;
-
+pub fn normalize(check_in: &mut CheckIn) -> Result<(), ProcessCheckInError> {
     // Missed status cannot be ingested, this is computed on the server.
     if check_in.status == CheckInStatus::Missed {
         check_in.status = CheckInStatus::Unknown;
@@ -202,6 +185,11 @@ pub fn process_check_in(
         return Err(ProcessCheckInError::InvalidEnvironment);
     }
 
+    Ok(())
+}
+
+/// Produce a routing hint UUID from a checkin and project id.
+pub fn routing_hint(check_in: &CheckIn, project_id: &ProjectId) -> Uuid {
     static NAMESPACE: OnceLock<Uuid> = OnceLock::new();
     let namespace = NAMESPACE
         .get_or_init(|| Uuid::new_v5(&Uuid::NAMESPACE_URL, b"https://sentry.io/crons/#did"));
@@ -217,8 +205,7 @@ pub fn process_check_in(
     // https://github.com/getsentry/sentry/blob/master/src/sentry/monitors/models.py
     // We translate empty environments to `production`. This needs to be consistent here or we can
     // end up with checkins for the same monitor/env routed to different partitions.
-    //
-    // Only the routing key is normalized here, the payload is forwarded untouched.
+
     let slug = &check_in.monitor_slug;
     let environment = match check_in.environment.as_deref() {
         Some(environment) if !environment.is_empty() => environment,
@@ -226,12 +213,7 @@ pub fn process_check_in(
     };
     let routing_key = format!("{project_id}:{slug}:{environment}");
 
-    let routing_hint = Uuid::new_v5(namespace, routing_key.as_bytes());
-
-    Ok(ProcessedCheckInResult {
-        routing_hint,
-        payload: serde_json::to_vec(&check_in)?,
-    })
+    Uuid::new_v5(namespace, routing_key.as_bytes())
 }
 
 fn trim_slug(slug: &mut String) {
@@ -353,18 +335,13 @@ mod tests {
     #[test]
     fn process_simple() {
         let json = r#"{"check_in_id":"a460c25ff2554577b920fcfacae4e5eb","monitor_slug":"my-monitor","status":"ok"}"#;
-
-        let result = process_check_in(json.as_bytes(), ProjectId::new(1));
+        let mut check_in = serde_json::from_str(json).unwrap();
+        let rh = routing_hint(&mut check_in, &ProjectId::new(1));
 
         // The routing_hint should be consistent for the (project_id, monitor_slug, environment)
         let expected_uuid = Uuid::parse_str("9aa99731-a8e3-5594-9f00-c3e8a62c2b11").unwrap();
 
-        if let Ok(processed_result) = result {
-            assert_eq!(String::from_utf8(processed_result.payload).unwrap(), json);
-            assert_eq!(processed_result.routing_hint, expected_uuid);
-        } else {
-            panic!("Failed to process check-in")
-        }
+        assert_eq!(rh, expected_uuid);
     }
 
     #[test]
@@ -373,9 +350,9 @@ mod tests {
             let json = format!(
                 r#"{{"check_in_id":"a460c25ff2554577b920fcfacae4e5eb","monitor_slug":"my-monitor","environment":"{env}","status":"ok"}}"#
             );
-            process_check_in(json.as_bytes(), ProjectId::new(1))
-                .unwrap()
-                .routing_hint
+            let mut check_in = serde_json::from_str(&json).unwrap();
+            let rh = routing_hint(&mut check_in, &ProjectId::new(1));
+            rh
         };
 
         // The consumer groups on (project, slug, environment) and only guarantees order within a
@@ -397,9 +374,8 @@ mod tests {
                 ),
                 None => r#"{"check_in_id":"a460c25ff2554577b920fcfacae4e5eb","monitor_slug":"my-monitor","status":"ok"}"#.to_owned(),
             };
-            process_check_in(json.as_bytes(), ProjectId::new(1))
-                .unwrap()
-                .routing_hint
+            let mut check_in = serde_json::from_str(&json).unwrap();
+            routing_hint(&mut check_in, &ProjectId::new(1))
         };
 
         // Sentry resolves all three to the same monitor environment, so they have to share a
@@ -415,8 +391,9 @@ mod tests {
           "monitor_slug": "",
           "status": "in_progress"
         }"#;
+        let mut check_in = serde_json::from_str(json).unwrap();
 
-        let result = process_check_in(json.as_bytes(), ProjectId::new(1));
+        let result = normalize(&mut check_in);
         assert!(matches!(result, Err(ProcessCheckInError::EmptySlug)));
     }
 
@@ -428,8 +405,9 @@ mod tests {
           "status": "in_progress",
           "environment": "1234567890123456789012345678901234567890123456789012345678901234567890"
         }"#;
+        let mut check_in = serde_json::from_str(json).unwrap();
 
-        let result = process_check_in(json.as_bytes(), ProjectId::new(1));
+        let result = normalize(&mut check_in);
         assert!(matches!(
             result,
             Err(ProcessCheckInError::InvalidEnvironment)

--- a/relay-monitors/src/lib.rs
+++ b/relay-monitors/src/lib.rs
@@ -29,7 +29,7 @@ const SLUG_LENGTH: usize = 50;
 /// Maximum length of environment names.
 const ENVIRONMENT_LENGTH: usize = 64;
 
-/// Error returned from [`process_check_in`].
+/// Error returned during monitor normalization/processing.
 #[derive(Debug, thiserror::Error)]
 pub enum ProcessCheckInError {
     /// Failed to deserialize the payload.

--- a/relay-server/src/processing/check_ins/mod.rs
+++ b/relay-server/src/processing/check_ins/mod.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use relay_cogs::{AppFeature, FeatureWeights};
+use relay_monitors::{CheckIn, ProcessCheckInError};
 use relay_quotas::{DataCategory, RateLimits};
 
 use crate::Envelope;
-use crate::envelope::{EnvelopeHeaders, Item, ItemType, Items};
+use crate::envelope::{ContentType, EnvelopeHeaders, Item, ItemType};
 use crate::managed::{Counted, Managed, ManagedEnvelope, OutcomeError, Quantities, Rejected};
+use crate::processing::check_ins::process::expand_check_in;
 use crate::processing::{self, Context, CountRateLimited, Forward, Output, QuotaRateLimiter};
 use crate::services::outcome::{DiscardReason, Outcome};
 
@@ -21,6 +23,14 @@ pub enum Error {
     /// Failed to process the check-in.
     #[error("failed to process checkin: {0}")]
     Processing(#[from] relay_monitors::ProcessCheckInError),
+}
+
+/// An expanded/deserialized CheckIn, including the originating item.
+#[derive(Debug)]
+pub struct ExpandedCheckIn {
+    headers: EnvelopeHeaders,
+    check_in: CheckIn,
+    item: Item,
 }
 
 impl OutcomeError for Error {
@@ -86,31 +96,52 @@ impl processing::Processor for CheckInsProcessor {
 
     async fn process(
         &self,
-        mut check_ins: Managed<Self::Input>,
+        input: Managed<Self::Input>,
         ctx: Context<'_>,
     ) -> Result<Output<Self::Output>, Rejected<Self::Error>> {
+        let mut ex_check_in = input.try_map(expand_check_in)?;
+
+        process::normalize(&mut ex_check_in)?;
+
         if ctx.is_processing() {
-            process::normalize(&mut check_ins);
+            let routing_hint = relay_monitors::routing_hint(
+                &ex_check_in.check_in,
+                &ex_check_in.scoping().project_id,
+            );
+
+            ex_check_in.try_modify(|e, _| {
+                e.item.set_routing_hint(routing_hint);
+                let s = serde_json::to_vec(&e.check_in)
+                    .map_err(ProcessCheckInError::from)
+                    .map_err(Error::from)?;
+                e.item.set_payload(ContentType::Json, s);
+
+                Ok::<_, Error>(())
+            })?;
         }
+        let ex_check_in = self.limiter.enforce_quotas(ex_check_in, ctx).await?;
 
-        let check_ins = self.limiter.enforce_quotas(check_ins, ctx).await?;
-
-        Ok(Output::just(CheckInsOutput(check_ins)))
+        Ok(Output::just(CheckInsOutput(ex_check_in)))
     }
 }
 
 /// Output produced by the [`CheckInsProcessor`].
 #[derive(Debug)]
-pub struct CheckInsOutput(Managed<SerializedCheckIns>);
+pub struct CheckInsOutput(Managed<ExpandedCheckIn>);
 
 impl Forward for CheckInsOutput {
     fn serialize_envelope(
         self,
         _: processing::ForwardContext<'_>,
     ) -> Result<Managed<Box<Envelope>>, Rejected<()>> {
-        let envelope = self.0.map(|SerializedCheckIns { headers, check_ins }, _| {
-            Envelope::from_parts(headers, Items::from_vec(check_ins))
-        });
+        let envelope = self.0.map(
+            |ExpandedCheckIn {
+                 headers,
+                 check_in: _,
+                 item,
+             },
+             _| { Envelope::from_parts(headers, smallvec::smallvec![item]) },
+        );
 
         Ok(envelope)
     }
@@ -126,13 +157,11 @@ impl Forward for CheckInsOutput {
         let sdk = self.0.headers.meta().client().map(str::to_owned);
         let retention_days = ctx.event_retention().standard;
 
-        for check_in in self.0.split(|work| work.check_ins.into_iter()) {
-            s.send_to_store(check_in.map(|check_in, _| StoreCheckIn {
-                check_in,
-                sdk: sdk.clone(),
-                retention_days,
-            }));
-        }
+        s.send_to_store(self.0.map(|ser_check_in, _| StoreCheckIn {
+            check_in: ser_check_in.item,
+            sdk: sdk.clone(),
+            retention_days,
+        }));
 
         Ok(())
     }
@@ -156,6 +185,16 @@ impl Counted for SerializedCheckIns {
     }
 }
 
+impl Counted for ExpandedCheckIn {
+    fn quantities(&self) -> Quantities {
+        smallvec::smallvec![(DataCategory::Monitor, 1)]
+    }
+}
+
 impl CountRateLimited for Managed<SerializedCheckIns> {
+    type Error = Error;
+}
+
+impl CountRateLimited for Managed<ExpandedCheckIn> {
     type Error = Error;
 }

--- a/relay-server/src/processing/check_ins/process.rs
+++ b/relay-server/src/processing/check_ins/process.rs
@@ -1,29 +1,46 @@
-use crate::envelope::ContentType;
-use crate::managed::Managed;
-use crate::processing::check_ins::{Error, SerializedCheckIns};
+use crate::managed::{Managed, RecordKeeper, Rejected};
+use crate::processing::check_ins::{Error, ExpandedCheckIn, SerializedCheckIns};
+use crate::services::outcome::{DiscardReason, Outcome};
+use relay_monitors::ProcessCheckInError;
 
 /// Normalizes all check-ins using the [`relay_monitors`] module.
 ///
 /// Individual, invalid check-ins will be discarded.
-pub fn normalize(check_ins: &mut Managed<SerializedCheckIns>) {
-    let scoping = check_ins.scoping();
+pub fn normalize(check_in: &mut Managed<ExpandedCheckIn>) -> Result<(), Rejected<Error>> {
+    check_in.try_modify(|c, _| {
+        relay_monitors::normalize(&mut c.check_in).inspect_err(|err| {
+            relay_log::debug!(
+                error = err as &dyn std::error::Error,
+                "dropped invalid monitor check-in"
+            )
+        })?;
 
-    check_ins.retain(
-        |check_ins| &mut check_ins.check_ins,
-        |check_in, _| {
-            let payload = check_in.payload();
-            let result = relay_monitors::process_check_in(&payload, scoping.project_id)
-                .inspect_err(|err| {
-                    relay_log::debug!(
-                        error = err as &dyn std::error::Error,
-                        "dropped invalid monitor check-in"
-                    )
-                })?;
+        Ok::<_, Error>(())
+    })
+}
 
-            check_in.set_routing_hint(result.routing_hint);
-            check_in.set_payload(ContentType::Json, result.payload);
+/// Deserializes a SerializedCheckIns into a single ExpandedCheckIn.  Extra checkins items are
+/// discarded as invalid outcomes.
+pub fn expand_check_in(
+    sc: SerializedCheckIns,
+    record_keeper: &mut RecordKeeper<'_>,
+) -> Result<ExpandedCheckIn, Error> {
+    let SerializedCheckIns { headers, check_ins } = sc;
 
-            Ok::<_, Error>(())
-        },
-    );
+    let mut check_ins = check_ins.into_iter();
+
+    // We know that we have at least one check-in, due to guards.
+    let item = check_ins.next().unwrap();
+    for extra in check_ins {
+        record_keeper.reject_err(Outcome::Invalid(DiscardReason::TooManyItems), extra);
+    }
+    let check_in = serde_json::from_slice(&item.payload())
+        .map_err(ProcessCheckInError::from)
+        .map_err(Error::from)?;
+
+    Ok(ExpandedCheckIn {
+        headers,
+        check_in,
+        item,
+    })
 }

--- a/relay-server/src/services/outcome/mod.rs
+++ b/relay-server/src/services/outcome/mod.rs
@@ -483,7 +483,7 @@ impl DiscardReason {
             DiscardReason::InvalidDynamicSamplingContext => "invalid_dsc",
             DiscardReason::UploadFailed => "upload_failed",
             DiscardReason::NestingTooDeep => "nesting_too_deep",
-            DiscardReason::TooManyItems => "too many items in envelope",
+            DiscardReason::TooManyItems => "too_many_items",
         }
     }
 }

--- a/relay-server/src/services/outcome/mod.rs
+++ b/relay-server/src/services/outcome/mod.rs
@@ -411,6 +411,9 @@ pub enum DiscardReason {
 
     /// (Relay) The payload's data is too deeply nested.
     NestingTooDeep,
+
+    /// (Relay) Too many items in the envelope.
+    TooManyItems,
 }
 
 impl DiscardReason {
@@ -480,6 +483,7 @@ impl DiscardReason {
             DiscardReason::InvalidDynamicSamplingContext => "invalid_dsc",
             DiscardReason::UploadFailed => "upload_failed",
             DiscardReason::NestingTooDeep => "nesting_too_deep",
+            DiscardReason::TooManyItems => "too many items in envelope",
         }
     }
 }


### PR DESCRIPTION
This brings monitor checkin processing more in-line with how we do processing everywhere else, and is needed for the forthcoming monitor rate-limiting changes (to avoid double-deserialization.)

We also now explicitly drop extra monitor check-ins (since checkins are only supposed to one item per-envelope.)



