### PR TITLE
chore(conventions): Bump sentry-conventions to 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 **Internal**:
 
 - Update sentry-conventions to 0.21.0. Resource size sentry tags and measurements now use `http.response.body.size`, `http.response.body.decoded_size`, and `http.response.size`. ([#6339](https://github.com/getsentry/relay/pull/6339), [#6315](https://github.com/getsentry/relay/pull/6315))
-- Update sentry-conventions to 0.23.0. `db.query.text` is now scrubbed automatically instead of only via explicit path selectors, the `navigation.*` attributes backfill into `router.navigation.*`, and span names and descriptions are now inferred for `browser`, `cache`, `faas`, `function`, and `graphql` operations. ([#6363](https://github.com/getsentry/relay/pull/6363))
+- Update sentry-conventions to 0.23.0. `db.query.text` is now scrubbed automatically instead of only via explicit path selectors, the `navigation.*` attributes backfill into `router.navigation.*`, and span names and descriptions are now inferred for `browser`, `cache`, `faas`, `function`, and `graphql` operations. ([#6368](https://github.com/getsentry/relay/pull/6368))
 
 ## 26.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 **Internal**:
 
 - Update sentry-conventions to 0.21.0. Resource size sentry tags and measurements now use `http.response.body.size`, `http.response.body.decoded_size`, and `http.response.size`. ([#6339](https://github.com/getsentry/relay/pull/6339), [#6315](https://github.com/getsentry/relay/pull/6315))
+- Update sentry-conventions to 0.23.0. `db.query.text` is now scrubbed automatically instead of only via explicit path selectors, the `navigation.*` attributes backfill into `router.navigation.*`, and span names and descriptions are now inferred for `browser`, `cache`, `faas`, `function`, and `graphql` operations. ([#6363](https://github.com/getsentry/relay/pull/6363))
 
 ## 26.8.0
 


### PR DESCRIPTION
✔️ Bumped and Deployed in Snuba and Sentry BE. Good to go whenever we deploy Relay.

Bumps sentry-conventions from 0.21.0 to 0.23.0. 0.22.0 was not skipped but I had to release 0.23.0 shortly after due to a bug in 0.22.0. 