### PR TITLE
fix(minidump): Preserve the client exception thread selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Prevent memory bomb in PII processor's `split_chunks`. ([#6343](https://github.com/getsentry/relay/pull/6343))
 - Prevent stack overflow in PII rule compilation. ([#6344](https://github.com/getsentry/relay/pull/6344))
 - Fill in missing event IDs only if items would create events. ([#6350](https://github.com/getsentry/relay/pull/6350))
+- Preserve the client exception thread ID when preparing minidump events.
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Prevent memory bomb in PII processor's `split_chunks`. ([#6343](https://github.com/getsentry/relay/pull/6343))
 - Prevent stack overflow in PII rule compilation. ([#6344](https://github.com/getsentry/relay/pull/6344))
 - Fill in missing event IDs only if items would create events. ([#6350](https://github.com/getsentry/relay/pull/6350))
-- Preserve the client exception thread ID when preparing minidump events.
+- Preserve the client exception thread ID when preparing minidump events. ([#6369](https://github.com/getsentry/relay/pull/6369))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Prevent memory bomb in PII processor's `split_chunks`. ([#6343](https://github.com/getsentry/relay/pull/6343))
 - Prevent stack overflow in PII rule compilation. ([#6344](https://github.com/getsentry/relay/pull/6344))
 - Fill in missing event IDs only if items would create events. ([#6350](https://github.com/getsentry/relay/pull/6350))
-- Preserve the client exception thread ID when preparing minidump events. ([#6369](https://github.com/getsentry/relay/pull/6369))
+- Preserve the client exception thread ID and handled status when preparing minidump events. ([#6369](https://github.com/getsentry/relay/pull/6369))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Prevent memory bomb in PII processor's `split_chunks`. ([#6343](https://github.com/getsentry/relay/pull/6343))
 - Prevent stack overflow in PII rule compilation. ([#6344](https://github.com/getsentry/relay/pull/6344))
 - Fill in missing event IDs only if items would create events. ([#6350](https://github.com/getsentry/relay/pull/6350))
-- Preserve the client exception thread ID and handled status when preparing minidump events. ([#6369](https://github.com/getsentry/relay/pull/6369))
+- Preserve the client exception thread ID, handled status, and fallback stack when preparing minidump events. ([#6369](https://github.com/getsentry/relay/pull/6369))
 
 **Internal**:
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -59,10 +59,8 @@ fn write_native_placeholder(
     let platform = event.platform.value_mut();
     *platform = Some("native".to_owned());
 
-    // Assume that this minidump is the result of a crash and assign the fatal
-    // level. Note that the use of `setdefault` here doesn't generally allow the
-    // user to override the minidump's level as processing will overwrite it
-    // later.
+    // Unless the event explicitly specifies a level, assume that this minidump
+    // is the result of a crash and assign the fatal level.
     event.level.get_or_insert_with(|| Level::Fatal);
 
     // Create a placeholder exception. This signals normalization that this is an
@@ -95,6 +93,11 @@ fn write_native_placeholder(
         .filter(|exc| exc.thread_id.value().is_some());
     let thread_id = source.map(|exc| exc.thread_id.clone()).unwrap_or_default();
     let stacktrace = source.map(|exc| exc.stacktrace.clone()).unwrap_or_default();
+    let handled = source
+        .and_then(|exc| exc.mechanism.value())
+        .and_then(|mechanism| mechanism.handled.value())
+        .copied()
+        .unwrap_or(false);
 
     if matches!(additional_exceptions, AdditionalExceptions::Delete) {
         exceptions.clear(); // clear previous errors if any
@@ -111,7 +114,7 @@ fn write_native_placeholder(
             value: Annotated::new(JsonLenientString(placeholder.exception_value.to_owned())),
             mechanism: Annotated::new(Mechanism {
                 ty: Annotated::from(placeholder.mechanism_type.to_owned()),
-                handled: Annotated::from(false),
+                handled: Annotated::from(handled),
                 synthetic: Annotated::from(true),
                 ..Mechanism::default()
             }),
@@ -364,9 +367,10 @@ mod tests {
     fn test_minidump_preserves_last_thread() {
         for policy in [AdditionalExceptions::Retain, AdditionalExceptions::Delete] {
             let mut event = Annotated::<Event>::from_json(
-                r#"{"exception":{"values":[
+                r#"{"level":"error","exception":{"values":[
                     {"thread_id":1},
-                    {"thread_id":"42","stacktrace":{"frames":[{"instruction_addr":"0x1000"}]}}
+                    {"thread_id":"42","mechanism":{"type":"AppHang","handled":true},
+                     "stacktrace":{"frames":[{"instruction_addr":"0x1000"}]}}
                 ]}}"#,
             )
             .unwrap();
@@ -381,6 +385,15 @@ mod tests {
             let placeholder = get_value!(event.exceptions.values[0]!);
             assert_eq!(placeholder.thread_id, source.thread_id);
             assert_eq!(placeholder.stacktrace, source.stacktrace);
+            assert_eq!(
+                get_value!(event.exceptions.values[0].mechanism.handled),
+                Some(&true)
+            );
+            assert_eq!(
+                get_value!(event.exceptions.values[0].mechanism.ty).unwrap(),
+                "minidump"
+            );
+            assert_eq!(get_value!(event.level), Some(&Level::Error));
             assert_eq!(
                 get_value!(event.exceptions.values!).len(),
                 match policy {
@@ -410,6 +423,10 @@ mod tests {
         let placeholder = get_value!(event.exceptions.values[0]!);
         assert!(placeholder.thread_id.value().is_none());
         assert!(placeholder.stacktrace.value().is_none());
+        assert_eq!(
+            get_value!(event.exceptions.values[0].mechanism.handled),
+            Some(&false)
+        );
     }
 
     #[test]

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -88,6 +88,16 @@ fn write_native_placeholder(
         )
     }
 
+    // Client exceptions are ordered oldest to newest; only the last selects a thread.
+    let source = (placeholder.mechanism_type == "minidump")
+        .then(|| exceptions.last().and_then(Annotated::value))
+        .flatten();
+    let thread_id = source.map(|exc| exc.thread_id.clone()).unwrap_or_default();
+    let stacktrace = source
+        .filter(|exc| exc.thread_id.value().is_some() || exc.thread_id.meta().has_errors())
+        .map(|exc| exc.stacktrace.clone())
+        .unwrap_or_default();
+
     if matches!(additional_exceptions, AdditionalExceptions::Delete) {
         exceptions.clear(); // clear previous errors if any
     }
@@ -97,6 +107,8 @@ fn write_native_placeholder(
     exceptions.insert(
         0,
         Annotated::new(Exception {
+            thread_id,
+            stacktrace,
             ty: Annotated::new(placeholder.exception_type.to_owned()),
             value: Annotated::new(JsonLenientString(placeholder.exception_value.to_owned())),
             mechanism: Annotated::new(Mechanism {
@@ -344,4 +356,78 @@ pub fn reshape_switch_crash(event: &mut Event) {
 
     // Events have level `error` by default, so set to `fatal` like for other native crashes.
     event.level.set_value(Some(Level::Fatal));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_minidump_preserves_last_thread() {
+        for policy in [AdditionalExceptions::Retain, AdditionalExceptions::Delete] {
+            for id in ["\"42\"", "true"] {
+                let json = format!(
+                    r#"{{"exception":{{"values":[
+                        {{"thread_id":1}},
+                        {{"thread_id":{id},"stacktrace":{{"frames":[{{"instruction_addr":"0x1000"}}]}}}}
+                    ]}}}}"#
+                );
+                let mut event = Annotated::<Event>::from_json(&json).unwrap();
+                let source = get_value!(event.exceptions.values[1]!).clone();
+
+                process_minidump(
+                    event.value_mut().as_mut().unwrap(),
+                    &Item::new(ItemType::Attachment),
+                    policy,
+                );
+
+                let placeholder = get_value!(event.exceptions.values[0]!);
+                assert_eq!(placeholder.thread_id, source.thread_id);
+                assert_eq!(placeholder.stacktrace, source.stacktrace);
+                assert_eq!(
+                    get_value!(event.exceptions.values!).len(),
+                    match policy {
+                        AdditionalExceptions::Retain => 3,
+                        AdditionalExceptions::Delete => 1,
+                    }
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_minidump_without_thread() {
+        let mut event = Annotated::<Event>::from_json(
+            r#"{"exception":{"values":[
+                {"thread_id":1},
+                {"stacktrace":{"frames":[{"function":"other"}]}}
+            ]}}"#,
+        )
+        .unwrap();
+
+        process_minidump(
+            event.value_mut().as_mut().unwrap(),
+            &Item::new(ItemType::Attachment),
+            AdditionalExceptions::Retain,
+        );
+
+        let placeholder = get_value!(event.exceptions.values[0]!);
+        assert!(placeholder.thread_id.value().is_none());
+        assert!(placeholder.stacktrace.value().is_none());
+    }
+
+    #[test]
+    fn test_apple_report_does_not_preserve_thread() {
+        let mut event = Annotated::<Event>::from_json(
+            r#"{"exception":{"values":[{"type":"Other","thread_id":42}]}}"#,
+        )
+        .unwrap();
+
+        process_apple_crash_report(
+            event.value_mut().as_mut().unwrap(),
+            AdditionalExceptions::Retain,
+        );
+
+        assert!(get_value!(event.exceptions.values[0].thread_id).is_none());
+    }
 }

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -89,8 +89,7 @@ fn write_native_placeholder(
     // Client exceptions are ordered oldest to newest; only the last selects a thread.
     let source = (placeholder.mechanism_type == "minidump")
         .then(|| exceptions.last().and_then(Annotated::value))
-        .flatten()
-        .filter(|exc| exc.thread_id.value().is_some());
+        .flatten();
     let thread_id = source.map(|exc| exc.thread_id.clone()).unwrap_or_default();
     let stacktrace = source.map(|exc| exc.stacktrace.clone()).unwrap_or_default();
     let handled = source
@@ -409,10 +408,12 @@ mod tests {
         let mut event = Annotated::<Event>::from_json(
             r#"{"exception":{"values":[
                 {"thread_id":1},
-                {"stacktrace":{"frames":[{"function":"other"}]}}
+                {"mechanism":{"type":"AppHang","handled":true},
+                 "stacktrace":{"frames":[{"function":"other"}]}}
             ]}}"#,
         )
         .unwrap();
+        let source = get_value!(event.exceptions.values[1]!).clone();
 
         process_minidump(
             event.value_mut().as_mut().unwrap(),
@@ -422,10 +423,10 @@ mod tests {
 
         let placeholder = get_value!(event.exceptions.values[0]!);
         assert!(placeholder.thread_id.value().is_none());
-        assert!(placeholder.stacktrace.value().is_none());
+        assert_eq!(placeholder.stacktrace, source.stacktrace);
         assert_eq!(
             get_value!(event.exceptions.values[0].mechanism.handled),
-            Some(&false)
+            Some(&true)
         );
     }
 

--- a/relay-server/src/utils/native.rs
+++ b/relay-server/src/utils/native.rs
@@ -91,12 +91,10 @@ fn write_native_placeholder(
     // Client exceptions are ordered oldest to newest; only the last selects a thread.
     let source = (placeholder.mechanism_type == "minidump")
         .then(|| exceptions.last().and_then(Annotated::value))
-        .flatten();
+        .flatten()
+        .filter(|exc| exc.thread_id.value().is_some());
     let thread_id = source.map(|exc| exc.thread_id.clone()).unwrap_or_default();
-    let stacktrace = source
-        .filter(|exc| exc.thread_id.value().is_some() || exc.thread_id.meta().has_errors())
-        .map(|exc| exc.stacktrace.clone())
-        .unwrap_or_default();
+    let stacktrace = source.map(|exc| exc.stacktrace.clone()).unwrap_or_default();
 
     if matches!(additional_exceptions, AdditionalExceptions::Delete) {
         exceptions.clear(); // clear previous errors if any
@@ -365,33 +363,31 @@ mod tests {
     #[test]
     fn test_minidump_preserves_last_thread() {
         for policy in [AdditionalExceptions::Retain, AdditionalExceptions::Delete] {
-            for id in ["\"42\"", "true"] {
-                let json = format!(
-                    r#"{{"exception":{{"values":[
-                        {{"thread_id":1}},
-                        {{"thread_id":{id},"stacktrace":{{"frames":[{{"instruction_addr":"0x1000"}}]}}}}
-                    ]}}}}"#
-                );
-                let mut event = Annotated::<Event>::from_json(&json).unwrap();
-                let source = get_value!(event.exceptions.values[1]!).clone();
+            let mut event = Annotated::<Event>::from_json(
+                r#"{"exception":{"values":[
+                    {"thread_id":1},
+                    {"thread_id":"42","stacktrace":{"frames":[{"instruction_addr":"0x1000"}]}}
+                ]}}"#,
+            )
+            .unwrap();
+            let source = get_value!(event.exceptions.values[1]!).clone();
 
-                process_minidump(
-                    event.value_mut().as_mut().unwrap(),
-                    &Item::new(ItemType::Attachment),
-                    policy,
-                );
+            process_minidump(
+                event.value_mut().as_mut().unwrap(),
+                &Item::new(ItemType::Attachment),
+                policy,
+            );
 
-                let placeholder = get_value!(event.exceptions.values[0]!);
-                assert_eq!(placeholder.thread_id, source.thread_id);
-                assert_eq!(placeholder.stacktrace, source.stacktrace);
-                assert_eq!(
-                    get_value!(event.exceptions.values!).len(),
-                    match policy {
-                        AdditionalExceptions::Retain => 3,
-                        AdditionalExceptions::Delete => 1,
-                    }
-                );
-            }
+            let placeholder = get_value!(event.exceptions.values[0]!);
+            assert_eq!(placeholder.thread_id, source.thread_id);
+            assert_eq!(placeholder.stacktrace, source.stacktrace);
+            assert_eq!(
+                get_value!(event.exceptions.values!).len(),
+                match policy {
+                    AdditionalExceptions::Retain => 3,
+                    AdditionalExceptions::Delete => 1,
+                }
+            );
         }
     }
 

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -750,12 +750,14 @@ def test_minidump_with_event_exception(
     envelope.add_event(
         {
             "event_id": event_id,
+            "level": "error",
             "exception": {
                 "values": [
                     {
                         "type": "ZeroDivisionError",
                         "value": "division by zero",
                         "thread_id": "36",
+                        "mechanism": {"type": "generic", "handled": True},
                         "stacktrace": {
                             "frames": [
                                 {
@@ -795,6 +797,8 @@ def test_minidump_with_event_exception(
     # so the event is picked up for native processing in Sentry.
     minidump_exception, *additional_exceptions = event["exception"]["values"]
     assert minidump_exception["mechanism"]["type"] == "minidump"
+    assert minidump_exception["mechanism"]["handled"] is True
+    assert event["level"] == "error"
 
     # The user-provided exception with its stack trace must be preserved.
     (user_exception,) = additional_exceptions

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -755,6 +755,7 @@ def test_minidump_with_event_exception(
                     {
                         "type": "ZeroDivisionError",
                         "value": "division by zero",
+                        "thread_id": "36",
                         "stacktrace": {
                             "frames": [
                                 {
@@ -767,6 +768,7 @@ def test_minidump_with_event_exception(
                     }
                 ]
             },
+            "threads": {"values": [{"id": "36", "crashed": False}]},
         }
     )
     envelope.add_item(
@@ -798,6 +800,9 @@ def test_minidump_with_event_exception(
     (user_exception,) = additional_exceptions
     assert user_exception["value"] == "division by zero"
     assert user_exception["stacktrace"]["frames"][0]["function"] == "divide"
+    assert minidump_exception["thread_id"] == "36"
+    assert minidump_exception["stacktrace"] == user_exception["stacktrace"]
+    assert event["threads"]["values"] == [{"id": "36", "crashed": False}]
 
     # The minidump must still be forwarded as an attachment.
     assert any(att["name"] == "minidump.dmp" for att in message["attachments"])


### PR DESCRIPTION
<!-- Describe your PR here. -->

Copy the last client exception's thread ID and fallback stack into the minidump placeholder before applying the additional-exception policy. Preserve parse-error metadata for invalid explicit selections.

Required for:
- https://github.com/getsentry/sentry/pull/124046

Refs:
- getsentry/sentry#97529
- getsentry/sentry-native#1146
- getsentry/sentry-native#1147
