### PR TITLE
feat(explore): Accept expansion flag from sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 - Update sentry-conventions to 0.21.0. Resource size sentry tags and measurements now use `http.response.body.size`, `http.response.body.decoded_size`, and `http.response.size`. ([#6339](https://github.com/getsentry/relay/pull/6339), [#6315](https://github.com/getsentry/relay/pull/6315))
 - Update sentry-conventions to 0.23.0. `db.query.text` is now scrubbed automatically instead of only via explicit path selectors, the `navigation.*` attributes backfill into `router.navigation.*`, and span names and descriptions are now inferred for `browser`, `cache`, `faas`, `function`, and `graphql` operations. ([#6368](https://github.com/getsentry/relay/pull/6368))
+- Accept the `organizations:relay-automatic-json-expansion` feature flag from project configs, which will control whether attributes containing a JSON object are expanded into a key-value list on EAP items.
 
 ## 26.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 - Update sentry-conventions to 0.21.0. Resource size sentry tags and measurements now use `http.response.body.size`, `http.response.body.decoded_size`, and `http.response.size`. ([#6339](https://github.com/getsentry/relay/pull/6339), [#6315](https://github.com/getsentry/relay/pull/6315))
 - Update sentry-conventions to 0.23.0. `db.query.text` is now scrubbed automatically instead of only via explicit path selectors, the `navigation.*` attributes backfill into `router.navigation.*`, and span names and descriptions are now inferred for `browser`, `cache`, `faas`, `function`, and `graphql` operations. ([#6368](https://github.com/getsentry/relay/pull/6368))
-- Accept the `organizations:relay-automatic-json-expansion` feature flag from project configs, which will control whether attributes containing a JSON object are expanded into a key-value list on EAP items.(#6372)
+- Accept the `organizations:relay-automatic-json-expansion` feature flag from project configs, which will control whether attributes containing a JSON object are expanded into a key-value list on EAP items. ([#6372](https://github.com/getsentry/relay/pull/6372))(#6372)
 
 ## 26.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 - Update sentry-conventions to 0.21.0. Resource size sentry tags and measurements now use `http.response.body.size`, `http.response.body.decoded_size`, and `http.response.size`. ([#6339](https://github.com/getsentry/relay/pull/6339), [#6315](https://github.com/getsentry/relay/pull/6315))
 - Update sentry-conventions to 0.23.0. `db.query.text` is now scrubbed automatically instead of only via explicit path selectors, the `navigation.*` attributes backfill into `router.navigation.*`, and span names and descriptions are now inferred for `browser`, `cache`, `faas`, `function`, and `graphql` operations. ([#6368](https://github.com/getsentry/relay/pull/6368))
-- Accept the `organizations:relay-automatic-json-expansion` feature flag from project configs, which will control whether attributes containing a JSON object are expanded into a key-value list on EAP items.
+- Accept the `organizations:relay-automatic-json-expansion` feature flag from project configs, which will control whether attributes containing a JSON object are expanded into a key-value list on EAP items.(#6372)
 
 ## 26.8.0
 

--- a/relay-dynamic-config/src/feature.rs
+++ b/relay-dynamic-config/src/feature.rs
@@ -66,6 +66,13 @@ pub enum Feature {
     /// Serialized as `organizations:tracemetrics-ingestion`.
     #[serde(rename = "organizations:tracemetrics-ingestion")]
     TraceMetricsIngestion,
+    /// Expand attributes containing a JSON object into a key-value list on EAP items.
+    ///
+    /// Enabling/disabling controls how these are sent to EAP.
+    ///
+    /// Serialized as `organizations:relay-automatic-json-expansion`.
+    #[serde(rename = "organizations:relay-automatic-json-expansion")]
+    AutomaticJsonExpansion,
     /// This feature has graduated ant is hard-coded for external Relays.
     #[doc(hidden)]
     #[serde(rename = "projects:profiling-ingest-unsampled-profiles")]


### PR DESCRIPTION
Adds 'relay-automatic-json-expansion' to config, will use this in a later PR to control expansion indirectly via proto type.

Associated sentry PR: https://github.com/getsentry/sentry/pull/124176

Closes EXP-1189

