### PR TITLE
ref(attachments): Remove duplicated meta handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 **Internal**:
 
+- Avoid writing trace attachment attribute metadata twice. ([#6373](https://github.com/getsentry/relay/pull/6373))
 - Implement `Getter` for sessions so generic inbound filters can match them by `event.release` and `event.environment`. ([#6325](https://github.com/getsentry/relay/pull/6325))
 
 **Internal**:

--- a/relay-server/src/processing/trace_attachments/store.rs
+++ b/relay-server/src/processing/trace_attachments/store.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use relay_event_schema::protocol::{Attributes, SpanId, TraceAttachmentMeta};
-use relay_protocol::{Annotated, IntoValue, Value};
+use relay_protocol::{Annotated, Value};
 use relay_quotas::Scoping;
 use sentry_protos::snuba::v1::{AnyValue, TraceItem, TraceItemType, any_value};
 
@@ -10,7 +10,7 @@ use crate::managed::{Counted, Managed, Quantities, Rejected};
 use crate::processing::Retention;
 use crate::processing::trace_attachments::types::ExpandedAttachment;
 use crate::processing::utils::store::{
-    AttributeMeta, extract_client_sample_rate, extract_meta_attributes, proto_timestamp,
+    extract_client_sample_rate, extract_meta_attributes, proto_timestamp,
     quantities_to_trace_item_outcomes, uuid_to_item_id,
 };
 use crate::services::objectstore::StoreTraceAttachment;

--- a/relay-server/src/processing/trace_attachments/store.rs
+++ b/relay-server/src/processing/trace_attachments/store.rs
@@ -134,13 +134,6 @@ fn convert_attributes(
     result.reserve(attributes.0.len() + 5);
 
     for (name, attribute) in attributes {
-        let meta = AttributeMeta {
-            meta: IntoValue::extract_meta_tree(&attribute),
-        };
-        if let Some(meta) = meta.to_any_value() {
-            result.insert(format!("sentry._meta.fields.attributes.{name}"), meta);
-        }
-
         let value = attribute
             .into_value()
             .and_then(|v| v.value.value.into_value());

--- a/tests/integration/test_attachmentsv2.py
+++ b/tests/integration/test_attachmentsv2.py
@@ -178,6 +178,64 @@ def test_standalone_attachment_store(
     assert stored.metadata.content_type == "text/plain"
 
 
+def test_standalone_attachment_attribute_meta_store(
+    mini_sentry,
+    relay,
+    relay_with_processing,
+    items_consumer,
+    objectstore,
+):
+    items_consumer = items_consumer()
+
+    project_id = 42
+    project_config = mini_sentry.add_full_project_config(project_id)
+    project_config["config"]["features"] = [
+        "projects:span-v2-attachment-processing",
+        "projects:trace-attachment-processing",
+    ]
+    project_config["config"]["piiConfig"] = {
+        "rules": {"strip_ips": {"type": "ip", "redaction": {"method": "remove"}}},
+        "applications": {"**": ["strip_ips"]},
+    }
+
+    objectstore = objectstore(usecase="trace_attachments", project_id=project_id)
+    relay = relay(relay_with_processing(options=TEST_CONFIG), options=TEST_CONFIG)
+
+    attachment_metadata = create_attachment_metadata()
+    attachment_metadata["attributes"] = {
+        "user.ip": {"type": "string", "value": "192.168.1.1"},
+        "safe.attribute": {"type": "string", "value": "keep this"},
+    }
+    attachment_body = b"This is some mock attachment content"
+    metadata_bytes = json.dumps(attachment_metadata, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    combined_payload = metadata_bytes + attachment_body
+
+    envelope = create_attachment_envelope(project_config)
+    envelope.add_item(
+        Item(
+            payload=PayloadRef(bytes=combined_payload),
+            headers={
+                "content_type": "application/vnd.sentry.trace-attachment",
+                "meta_length": len(metadata_bytes),
+                "length": len(combined_payload),
+                "type": "attachment",
+            },
+        )
+    )
+    relay.send_envelope(project_id, envelope)
+
+    attributes = items_consumer.get_item()["attributes"]
+    assert attributes["safe.attribute"] == {"stringValue": "keep this"}
+    assert attributes["user.ip"] == {"stringValue": ""}
+    assert attributes["sentry._meta.fields.attributes.user.ip"] == {
+        "stringValue": '{"meta":{"value":{"":{"rem":[["strip_ips","x",0,0]],"len":11}}}}'
+    }
+    stored = objectstore.get(attachment_metadata["attachment_id"])
+    assert stored.payload.read() == attachment_body
+
+
 @pytest.mark.parametrize(
     "invalid_headers,quantity,reason",
     [


### PR DESCRIPTION
Attribute metadata for trace attachments is being written twice.

Currently, `attachment_to_trace_item` gets the metadata with `extract_meta_attributes`:
https://github.com/getsentry/relay/blob/71da7d193f3203250c6d61a9d7df3bfbefc4f86e/relay-server/src/processing/trace_attachments/store.rs#L82

`extract_meta_attributes` writes the metadata for each attribute with the expected attribute format:

https://github.com/getsentry/relay/blob/71da7d193f3203250c6d61a9d7df3bfbefc4f86e/relay-server/src/processing/utils/store.rs#L65-L110

Then we pass the hash with the meta attributes to `convert_attributes`:

https://github.com/getsentry/relay/blob/71da7d193f3203250c6d61a9d7df3bfbefc4f86e/relay-server/src/processing/trace_attachments/store.rs#L110

`convert_attributes` uses the incoming `meta` as the basis for `results`:

https://github.com/getsentry/relay/blob/71da7d193f3203250c6d61a9d7df3bfbefc4f86e/relay-server/src/processing/trace_attachments/store.rs#L133

...but then it reads, formats, and writes the attributes to the result map _again_:

https://github.com/getsentry/relay/blob/71da7d193f3203250c6d61a9d7df3bfbefc4f86e/relay-server/src/processing/trace_attachments/store.rs#L137-L142

Remove the duplicated meta writes. Adds an integration test confirming that meta attributes are still correctly written.